### PR TITLE
Use the event id instead of stream id

### DIFF
--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentNameProjectionUpdater.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentNameProjectionUpdater.java
@@ -26,9 +26,12 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import java.time.Duration;
 
-import static io.vavr.API.*;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
 import static io.vavr.Predicates.instanceOf;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.occurrent.cloudevents.OccurrentExtensionGetter.getStreamId;
 
 @Component
 public class CurrentNameProjectionUpdater {
@@ -50,10 +53,10 @@ public class CurrentNameProjectionUpdater {
         subscription
                 .subscribe("current-name", cloudEvent -> {
                     DomainEvent domainEvent = deserializeCloudEventToDomainEvent.deserialize(cloudEvent);
-                    String eventId = cloudEvent.getId();
+                    String streamId = getStreamId(cloudEvent);
                     CurrentName currentName = Match(domainEvent).of(
-                            Case($(instanceOf(NameDefined.class)), e -> new CurrentName(eventId, e.getName())),
-                            Case($(instanceOf(NameWasChanged.class)), e -> new CurrentName(eventId, e.getName())));
+                            Case($(instanceOf(NameDefined.class)), e -> new CurrentName(streamId, e.getName())),
+                            Case($(instanceOf(NameWasChanged.class)), e -> new CurrentName(streamId, e.getName())));
                     currentNameProjection.save(currentName);
                 })
                 .waitUntilStarted(Duration.of(2, SECONDS));

--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/DomainEventStore.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/DomainEventStore.java
@@ -47,17 +47,17 @@ public class DomainEventStore {
     }
 
     public void append(UUID id, List<DomainEvent> events) {
-        eventStore.write(id.toString(), serialize(id, events));
+        eventStore.write(id.toString(), serialize(events));
     }
 
     public EventStream<DomainEvent> loadEventStream(UUID id) {
         return eventStore.read(id.toString()).map(deserializeCloudEventToDomainEvent::deserialize);
     }
 
-    private Stream<CloudEvent> serialize(UUID id, List<DomainEvent> events) {
+    private Stream<CloudEvent> serialize(List<DomainEvent> events) {
         return events.stream()
                 .map(e -> CloudEventBuilder.v1()
-                        .withId(id.toString())
+                        .withId(e.getEventId())
                         .withSource(URI.create("http://name"))
                         .withType(e.getClass().getName())
                         .withTime(toLocalDateTime(e.getTimestamp()).atOffset(UTC))

--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/NameApplicationService.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/NameApplicationService.java
@@ -34,17 +34,17 @@ public class NameApplicationService {
         this.eventStore = eventStore;
     }
 
-    public void defineName(UUID id, LocalDateTime time, String name) {
+    public void defineName(UUID streamId, LocalDateTime time, String name) {
         List<DomainEvent> events = Name.defineName(UUID.randomUUID().toString(), time, name);
-        eventStore.append(id, events);
+        eventStore.append(streamId, events);
     }
 
-    public void changeName(UUID id, LocalDateTime time, String name) {
-        EventStream<DomainEvent> eventStream = eventStore.loadEventStream(id);
+    public void changeName(UUID streamId, LocalDateTime time, String name) {
+        EventStream<DomainEvent> eventStream = eventStore.loadEventStream(streamId);
         List<DomainEvent> events = eventStream.eventList();
 
         List<DomainEvent> newEvents = Name.changeName(events, UUID.randomUUID().toString(), time, name);
 
-        eventStore.append(id, newEvents);
+        eventStore.append(streamId, newEvents);
     }
 }

--- a/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -66,7 +66,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         nameApplicationService.defineName(id, now, "John Doe");
 
         // Then
-        await().atMost(Duration.ofMillis(200L)).until(() -> currentNameProjection.findById(id.toString())
+        await().atMost(Duration.ofMillis(1000L)).until(() -> currentNameProjection.findById(id.toString())
                 .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 
@@ -82,7 +82,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         nameApplicationService.changeName(id, now, "John Doe");
 
         // Then
-        await().atMost(Duration.ofMillis(200L)).until(() -> currentNameProjection.findById(id.toString())
+        await().atMost(Duration.ofMillis(1000L)).until(() -> currentNameProjection.findById(id.toString())
                 .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 }

--- a/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -16,7 +16,6 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.changestreamedprojections;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.occurrent.example.eventstore.mongodb.spring.subscriptionprojections.CurrentName;
 import org.occurrent.example.eventstore.mongodb.spring.subscriptionprojections.CurrentNameProjection;
@@ -34,9 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.not;
 
 @SpringBootTest(classes = SubscriptionProjectionsWithSpringAndMongoDBApplication.class)
 @Testcontainers
@@ -63,13 +60,14 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         UUID id = UUID.randomUUID();
+        CurrentName notFound = new CurrentName(null, null);
 
         // When
         nameApplicationService.defineName(id, now, "John Doe");
 
         // Then
-        CurrentName currentName = await().until(() -> currentNameProjection.findById(id.toString()).orElse(null), not(Matchers.nullValue()));
-        assertThat(currentName.getName()).isEqualTo("John Doe");
+        await().atMost(Duration.ofMillis(200L)).until(() -> currentNameProjection.findById(id.toString())
+                .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 
     @Test
@@ -77,6 +75,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         UUID id = UUID.randomUUID();
+        CurrentName notFound = new CurrentName(null, null);
 
         // When
         nameApplicationService.defineName(id, now, "Jane Doe");
@@ -84,6 +83,6 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
 
         // Then
         await().atMost(Duration.ofMillis(200L)).until(() -> currentNameProjection.findById(id.toString())
-                .orElse(null), cn -> cn.getName().equals("John Doe"));
+                .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 }

--- a/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -66,7 +66,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         nameApplicationService.defineName(id, now, "John Doe");
 
         // Then
-        await().atMost(Duration.ofMillis(1000L)).until(() -> currentNameProjection.findById(id.toString())
+        await().atMost(Duration.ofMillis(2000L)).until(() -> currentNameProjection.findById(id.toString())
                 .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 
@@ -82,7 +82,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
         nameApplicationService.changeName(id, now, "John Doe");
 
         // Then
-        await().atMost(Duration.ofMillis(1000L)).until(() -> currentNameProjection.findById(id.toString())
+        await().atMost(Duration.ofMillis(2000L)).until(() -> currentNameProjection.findById(id.toString())
                 .orElse(notFound), cn -> cn.getName().equals("John Doe"));
     }
 }


### PR DESCRIPTION
The wrong id was used in the mapper, resulting in subsequent events on the same stream failing.
