### PR TITLE
spring-boot-starter: support for Spring Boot 3.x

### DIFF
--- a/framework/spring-boot-starter-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/framework/spring-boot-starter-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.occurrent.springboot.mongo.blocking.OccurrentMongoAutoConfiguration


### PR DESCRIPTION
Solution for #127

Spring Boot [2.7 release notes say](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration):

> ... you should move the registration from `spring.factories` under the `org.springframework.boot.autoconfigure.EnableAutoConfiguration` key to a new file named `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

> For backwards compatibility, entries in `spring.factories` will still be honored.

I did not touch the version of Spring Boot in occurrent repo and left `spring.factories` as is to preserve compatibility with Spring Boot 2.x. I've just added the `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` required by Spring Boot 3.x.

How did I make sure this solution should be enough For Spring Boot 3.0.0? In my project using occurrent I've just created a gradle module with a wrapper-starter containing just 2 files:

```
├── build.gradle.kts
└── src
    └── main
        └── resources
            └── META-INF
                └── spring
                    └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
```

- `build.gradle.kts` only declares an `api` dependency on `org.occurrent:spring-boot-starter-mongodb` 
- and the `org.springframework.boot.autoconfigure.AutoConfiguration.imports` has the same content as this PR

That was enough to make this starter to work with Spring Boot 3.0.0