### PR TITLE
fix for error in the sequence command composition code that leaves old events in the sequence

### DIFF
--- a/application/command-composition/src/main/kotlin/org/occurrent/application/composition/command/CompositionExtensions.kt
+++ b/application/command-composition/src/main/kotlin/org/occurrent/application/composition/command/CompositionExtensions.kt
@@ -48,10 +48,12 @@ fun <T> composeCommands(
  */
 fun <T> composeCommands(commands: Sequence<(Sequence<T>) -> Sequence<T>>): (Sequence<T>) -> Sequence<T> {
     return { initial ->
-        commands.fold(initial) { acc, cmd ->
+        val initialList = initial.toList()
+        val fold = commands.fold(initialList.asSequence()) { acc, cmd ->
             val elements = acc.toList()
             (elements + cmd(elements.asSequence())).asSequence()
         }
+        fold.drop(initialList.size)
     }
 }
 


### PR DESCRIPTION
Unlike the composeCommands function for lists, the composeCommands function for sequences doesn't drop the initial set when folding.  This causes duplicate event exceptions when composing commands for a non-empty initial stream.