### PR TITLE
Prevent 'examples' and 'test-support' publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
     <version>0.16.7-SNAPSHOT</version>
     <modules>
         <module>test-support</module>
-        <module>example</module>
         <module>eventstore</module>
         <module>subscription</module>
         <module>cloudevents-extension</module>
@@ -509,6 +508,15 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>examples-module</id>
+            <modules>
+                <module>example</module>
+            </modules>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
         <profile>
             <id>release</id>
             <!-- Don't include test-support and example modules-->

--- a/pom.xml
+++ b/pom.xml
@@ -519,14 +519,6 @@
         </profile>
         <profile>
             <id>release</id>
-            <!-- Don't include test-support and example modules-->
-            <modules>
-                <module>application</module>
-                <module>eventstore</module>
-                <module>subscription</module>
-                <module>cloudevents-extension</module>
-                <module>common</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -41,4 +41,20 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Hi @johanhaleby 
This should fix #138 

I hope `skipNexusStagingDeployMojo` will work out (I do not know how to test it for sure)
The reason why I used `skipNexusStagingDeployMojo` for 'test-support' instead of just excluding it like 'examples' is because I think 'test-support' is needed when you publish (because you need to verify/execute tests)