### PR TITLE
add Occurrent BOM

### DIFF
--- a/example/domain/rps/pragmatic-model/pom.xml
+++ b/example/domain/rps/pragmatic-model/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>pragmatic-rps-model</artifactId>
+    <artifactId>example-pragmatic-rps-model</artifactId>
 
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <spring-boot.version>3.0.8</spring-boot.version>
         <mongo.version>4.10.2</mongo.version>
         <dokka.version>1.8.10</dokka.version>
+        <sundrio.version>0.100.3</sundrio.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jobrunr.version>6.3.0</jobrunr.version>
     </properties>
@@ -564,6 +565,35 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.sundr</groupId>
+                        <artifactId>sundr-maven-plugin</artifactId>
+                        <version>${sundrio.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate-bom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <boms>
+                                <bom>
+                                    <artifactId>occurrent-bom</artifactId>
+                                    <name>Occurrent: BOM</name>
+                                    <description>
+                                        Centralized dependencyManagement for the Occurrent Project
+                                    </description>
+                                    <modules>
+                                        <excludes>
+                                            <exclude>org.occurrent:example*</exclude>
+                                            <exclude>org.occurrent:test-support</exclude>
+                                        </excludes>
+                                    </modules>
+                                </bom>
+                            </boms>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Hi @johanhaleby 

I've prepared the BOM (#21) which includes all the current modules (except for 'example/**' and 'test-support')

Used the following Groovy script to double-check myself:

```groovy
import groovy.ant.FileNameFinder
import groovy.xml.XmlSlurper

import java.nio.file.Paths

static void main(String[] args) {
  def scanPath = "projects/occurrent"

  def pomFilesOfInterest = new FileNameFinder().getFileNames(scanPath, '**/pom.xml', '**/example/** **/test-support/**')
  
  def jarModulePoms = []
  for (final def pomFilePath in pomFilesOfInterest) {
    def pom = new XmlSlurper().parse(pomFilePath)
    if (pom.packaging != "pom") {
      jarModulePoms << [pomFilePath, pom.artifactId]
    }
  }

  Collections.sort(jarModulePoms, (t1,t2) -> Paths.get(t1[0]) <=> Paths.get(t2[0]))

  for (final def pom in jarModulePoms) {
    println "${pom[0]} - ${pom[1]}"
  }
}
```