### PR TITLE
Single place to define target JVM for compiler

### DIFF
--- a/application/cloudevent-converter/api/pom.xml
+++ b/application/cloudevent-converter/api/pom.xml
@@ -77,7 +77,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/application/cloudevent-converter/jackson/pom.xml
+++ b/application/cloudevent-converter/jackson/pom.xml
@@ -115,7 +115,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/application/cloudevent-type-mapper/api/pom.xml
+++ b/application/cloudevent-type-mapper/api/pom.xml
@@ -101,7 +101,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/application/command-composition/pom.xml
+++ b/application/command-composition/pom.xml
@@ -107,7 +107,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/application/service/blocking/pom.xml
+++ b/application/service/blocking/pom.xml
@@ -134,7 +134,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/common/filter/pom.xml
+++ b/common/filter/pom.xml
@@ -78,7 +78,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/common/retry/pom.xml
+++ b/common/retry/pom.xml
@@ -84,7 +84,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/decider-arrow/pom.xml
+++ b/dsl/decider-arrow/pom.xml
@@ -125,7 +125,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/decider/pom.xml
+++ b/dsl/decider/pom.xml
@@ -120,7 +120,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/module-dsl/blocking/pom.xml
+++ b/dsl/module-dsl/blocking/pom.xml
@@ -150,7 +150,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/query-dsl/blocking/pom.xml
+++ b/dsl/query-dsl/blocking/pom.xml
@@ -130,7 +130,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/subscription-dsl/blocking/pom.xml
+++ b/dsl/subscription-dsl/blocking/pom.xml
@@ -84,7 +84,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/dsl/view-dsl/pom.xml
+++ b/dsl/view-dsl/pom.xml
@@ -149,7 +149,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/eventstore/api/blocking/pom.xml
+++ b/eventstore/api/blocking/pom.xml
@@ -78,7 +78,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/mastermind/decider-model-kotlin/pom.xml
+++ b/example/domain/mastermind/decider-model-kotlin/pom.xml
@@ -95,7 +95,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/rps/decider-model/pom.xml
+++ b/example/domain/rps/decider-model/pom.xml
@@ -157,7 +157,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/rps/decider-web/pom.xml
+++ b/example/domain/rps/decider-web/pom.xml
@@ -167,7 +167,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>

--- a/example/domain/rps/model/pom.xml
+++ b/example/domain/rps/model/pom.xml
@@ -151,7 +151,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/rps/multiround-decider-model/pom.xml
+++ b/example/domain/rps/multiround-decider-model/pom.xml
@@ -156,7 +156,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/rps/pragmatic-model/pom.xml
+++ b/example/domain/rps/pragmatic-model/pom.xml
@@ -162,7 +162,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/uno/model/pom.xml
+++ b/example/domain/uno/model/pom.xml
@@ -89,7 +89,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/uno/mongodb/common/pom.xml
+++ b/example/domain/uno/mongodb/common/pom.xml
@@ -94,7 +94,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/uno/mongodb/native/pom.xml
+++ b/example/domain/uno/mongodb/native/pom.xml
@@ -126,7 +126,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/example/domain/word-guessing-game/model/pom.xml
+++ b/example/domain/word-guessing-game/model/pom.xml
@@ -78,7 +78,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/library/hederlig/pom.xml
+++ b/library/hederlig/pom.xml
@@ -129,7 +129,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
+        <kotlin.compiler.jvmTarget>${maven.compiler.release}</kotlin.compiler.jvmTarget>
         <junit.version>5.11.3</junit.version>
         <test-containers.version>1.20.3</test-containers.version>
         <kotlin.version>2.1.10</kotlin.version>

--- a/subscription/util/blocking/catchup-subscription/pom.xml
+++ b/subscription/util/blocking/catchup-subscription/pom.xml
@@ -176,7 +176,6 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                     </args>
-                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Hi. This PR refactors build configuration to specify target JVM for compilers in one single place.