### PR TITLE
Define MongoDB version for integration testing in one single place

### DIFF
--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreTest.java
@@ -93,7 +93,7 @@ class MongoEventStoreTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
@@ -94,7 +94,7 @@ public class SpringMongoEventStoreTest {
     private static final URI NAME_SOURCE = URI.create("http://name");
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreTest.java
@@ -100,7 +100,7 @@ public class ReactorMongoEventStoreTest {
     private static final URI NAME_SOURCE = URI.create("http://name");
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true);

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/test/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/TestBootstrap.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/test/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/TestBootstrap.java
@@ -31,7 +31,7 @@ public class TestBootstrap {
     @Bean
     @ServiceConnection
     public static MongoDBContainer mongoDBContainer() {
-        return new MongoDBContainer("mongo:7.0.9");
+        return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
     }
 
     public static void main(String[] args) {

--- a/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
@@ -56,7 +56,7 @@ public class MongoSubscriptionToSpringEventTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/test/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/SpringAdhocProjectionTest.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/test/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/SpringAdhocProjectionTest.java
@@ -40,7 +40,7 @@ public class SpringAdhocProjectionTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.setPortBindings(ports);

--- a/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -52,7 +52,7 @@ public class ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -46,7 +46,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8");
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/transactional/TransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/transactional/TransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -46,7 +46,7 @@ public class TransactionalProjectionsWithSpringAndMongoDBApplicationTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.setPortBindings(ports);

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <awaitility.version>4.2.2</awaitility.version>
         <jobrunr.version>7.4.0</jobrunr.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+        <integration-tests.mongo.version>4.2.8</integration-tests.mongo.version>
     </properties>
 
 
@@ -546,6 +547,17 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <test.mongo.version>${integration-tests.mongo.version}</test.mongo.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/subscription/mongodb/native/blocking-position-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionPositionStorageTest.java
+++ b/subscription/mongodb/native/blocking-position-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionPositionStorageTest.java
@@ -85,7 +85,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class NativeMongoSubscriptionPositionStorageTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     private static final String TIMESTAMP_TOKEN_COLLECTION = "subscriptions";
 
     @RegisterExtension

--- a/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelTest.java
@@ -85,7 +85,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class NativeMongoSubscriptionModelTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
 
     @RegisterExtension
     FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl()));

--- a/subscription/mongodb/spring/blocking-position-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionPositionStorageTest.java
+++ b/subscription/mongodb/spring/blocking-position-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionPositionStorageTest.java
@@ -88,7 +88,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class SpringMongoSubscriptionPositionStorageTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     private static final String RESUME_TOKEN_COLLECTION = "ack";
 
     @RegisterExtension

--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
@@ -91,7 +91,8 @@ import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubs
 public class SpringMongoSubscriptionModelTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     private static final String RESUME_TOKEN_COLLECTION = "ack";
 
     @RegisterExtension

--- a/subscription/mongodb/spring/reactor-position-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorSubscriptionPositionStorageTest.java
+++ b/subscription/mongodb/spring/reactor-position-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorSubscriptionPositionStorageTest.java
@@ -67,7 +67,8 @@ public class ReactorSubscriptionPositionStorageTest {
     FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl()));
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     private static final String RESUME_TOKEN_COLLECTION = "ack";
 
     private EventStore mongoEventStore;

--- a/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModelTest.java
@@ -72,7 +72,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class ReactorMongoSubscriptionModelTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
 
     private ReactorMongoEventStore mongoEventStore;
     private ReactorMongoSubscriptionModel subscription;

--- a/subscription/redis/spring/blocking-position-storage/src/test/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisSubscriptionPositionStorageTest.java
+++ b/subscription/redis/spring/blocking-position-storage/src/test/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisSubscriptionPositionStorageTest.java
@@ -75,7 +75,8 @@ import static org.hamcrest.Matchers.equalTo;
 class SpringRedisSubscriptionPositionStorageTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     @Container
     private static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:5.0.3-alpine").withExposedPorts(6379);
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
@@ -75,7 +75,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class CatchupSubscriptionModelTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
 
     @RegisterExtension
     FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl()));

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelTest.java
@@ -58,7 +58,8 @@ class CompetingConsumerSubscriptionModelTest {
     private static final Logger log = LoggerFactory.getLogger(CompetingConsumerSubscriptionModelTest.class);
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
 
     @RegisterExtension
     FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl()));
@@ -578,7 +579,7 @@ class CompetingConsumerSubscriptionModelTest {
         await().failFast("cloudEventsSubscription2 should never have more than 1 event", () -> cloudEventsSubscription2.size() > 1)
                .untilAsserted(() -> assertThat(cloudEventsSubscription2).hasSize(1));
     }
-    
+
     @Test
     void consumption_is_resumed_after_prohibited_when_lease_time_is_low() {
         // Given

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
@@ -74,7 +74,8 @@ import static org.occurrent.time.TimeConversion.toLocalDateTime;
 public class ReactorDurableSubscriptionModelTest {
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2.8").withReuse(true);
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
     private static final String RESUME_TOKEN_COLLECTION = "ack";
 
     private EventStore mongoEventStore;


### PR DESCRIPTION
This refactoring will simplify managing/upgrading of MongoDB test container version used in integration tests.

I've tested that the system property I've introduced gets also respected if tests get executed by Intellij. I guess that's because Intellij reads project's model from Maven POM and respects the property.