### PR TITLE
Flattening POMs and disabling publishing of parent POMs

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -81,13 +81,6 @@
                             </pomElements>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>flatten-clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>1.7.2</version>
                 <executions>
                     <execution>
                         <id>flatten</id>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -46,6 +46,18 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.7.2</version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -61,6 +61,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.7.2</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>flatten</id>

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,7 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <configuration>
                     <flattenMode>ossrh</flattenMode>
+                    <skip>${is.pom.module}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,12 @@
                             <goal>flatten</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,22 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,11 @@
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.2</version>
+                </plugin>
+                <plugin>
                     <!-- See https://github.com/Kotlin/dokka#using-the-maven-plugin for more examples-->
                     <groupId>org.jetbrains.dokka</groupId>
                     <artifactId>dokka-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,10 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
                 <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,18 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>${is.pom.module}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>${is.pom.module}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <configuration>
@@ -438,6 +450,21 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+        </profile>
+        <profile>
+            <id>skip-pom-modules-deployment</id>
+            <activation>
+                <file>
+                    <exists>pom.xml</exists>
+                </file>
+                <property>
+                    <name>packaging</name>
+                    <value>pom</value>
+                </property>
+            </activation>
+            <properties>
+                <is.pom.module>true</is.pom.module>
+            </properties>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
This PR hits 2 targets:

- it flattens `pom.xml` to replace `${revision}` and `${project.version}` with real values on `install`/`deploy` (#174)
- As a side-effect of flattening POMs, references to `<parent>` get removed, so it no longer makes sense to install/publish parent POMs. After the necessary data from parent POMs got inlined (with flattening), the purpose of parents now is to maintain hierarchy of Maven projects in a multi-module build. So, I've disable publishing useless parent POMs (#180)