### PR TITLE
Add missing <name> and exclude no longer needed empty parent POMs to fix release process

### DIFF
--- a/application/cloudevent-converter/api/pom.xml
+++ b/application/cloudevent-converter/api/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>cloudevent-converter-api</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>io.cloudevents</groupId>

--- a/application/cloudevent-converter/generic/pom.xml
+++ b/application/cloudevent-converter/generic/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>cloudevent-converter-generic</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/application/cloudevent-converter/jackson/pom.xml
+++ b/application/cloudevent-converter/jackson/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevent-converter-jackson</artifactId>
+
+    <name>${mavenProjectName}</name>
     <description>CloudEvent Converter for Jackson</description>
 
     <dependencies>

--- a/application/cloudevent-converter/xstream/pom.xml
+++ b/application/cloudevent-converter/xstream/pom.xml
@@ -24,6 +24,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cloudevent-converter-xstream</artifactId>
+
+    <name>${mavenProjectName}</name>
     <description>CloudEvent Converter for XStream</description>
 
     <dependencies>

--- a/application/cloudevent-type-mapper/api/pom.xml
+++ b/application/cloudevent-type-mapper/api/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>cloudevent-type-mapper-api</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/application/cloudevent-type-mapper/reflection/pom.xml
+++ b/application/cloudevent-type-mapper/reflection/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>cloudevent-type-mapper-reflection</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/application/command-composition/pom.xml
+++ b/application/command-composition/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>command-composition</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/application/service/blocking/pom.xml
+++ b/application/service/blocking/pom.xml
@@ -23,6 +23,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>${mavenProjectName}</name>
+
     <artifactId>application-service-blocking</artifactId>
 
     <dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,8 +8,6 @@
     <artifactId>occurrent-bom</artifactId>
     <packaging>pom</packaging>
     <name>Occurrent BOM</name>
-    <description>Centralized dependencyManagement for the Occurrent project</description>
-    <url>https://occurrent.org</url>
     <licenses>
         <license>
             <name>Apache 2.0</name>

--- a/cloudevents-extension/pom.xml
+++ b/cloudevents-extension/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>cloudevents-extension</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>io.cloudevents</groupId>

--- a/common/filter/pom.xml
+++ b/common/filter/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>filter</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/common/inmemory/filter-matching/pom.xml
+++ b/common/inmemory/filter-matching/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>inmemory-filter-matching</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/common/mongodb/native/filter-bsonfilter-conversion/pom.xml
+++ b/common/mongodb/native/filter-bsonfilter-conversion/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>mongodb-native-filter-bsonfilter-conversion</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/common/mongodb/specialfilterhandling/pom.xml
+++ b/common/mongodb/specialfilterhandling/pom.xml
@@ -24,6 +24,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mongodb-specialfilterhandling</artifactId>
+
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/common/mongodb/spring/filter-query-conversion/pom.xml
+++ b/common/mongodb/spring/filter-query-conversion/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>mongodb-spring-filter-query-conversion</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/common/mongodb/spring/sort-conversion/pom.xml
+++ b/common/mongodb/spring/sort-conversion/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>mongodb-spring-sort-conversion</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/common/mongodb/timerepresentation/pom.xml
+++ b/common/mongodb/timerepresentation/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>mongodb-timerepresentation</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/common/retry/pom.xml
+++ b/common/retry/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>retry</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/common/time/pom.xml
+++ b/common/time/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>time</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <!-- Test -->
         <dependency>

--- a/dsl/decider-arrow/pom.xml
+++ b/dsl/decider-arrow/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>decider-arrow</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/dsl/decider/pom.xml
+++ b/dsl/decider/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>decider</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/dsl/module-dsl/blocking/pom.xml
+++ b/dsl/module-dsl/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>module-dsl-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/dsl/query-dsl/blocking/pom.xml
+++ b/dsl/query-dsl/blocking/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>query-dsl-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/dsl/subscription-dsl/blocking/pom.xml
+++ b/dsl/subscription-dsl/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-dsl-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/dsl/view-dsl/pom.xml
+++ b/dsl/view-dsl/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>view-dsl</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/api/blocking/pom.xml
+++ b/eventstore/api/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-api-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/api/common/pom.xml
+++ b/eventstore/api/common/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-api-common</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/api/reactor/pom.xml
+++ b/eventstore/api/reactor/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-api-reactor</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/inmemory/pom.xml
+++ b/eventstore/inmemory/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-inmemory</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/mongodb/common/pom.xml
+++ b/eventstore/mongodb/common/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-mongodb-common</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/eventstore/mongodb/native/pom.xml
+++ b/eventstore/mongodb/native/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-mongodb-native</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/mongodb/spring/blocking/pom.xml
+++ b/eventstore/mongodb/spring/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>eventstore-mongodb-spring-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/eventstore/mongodb/spring/reactor/pom.xml
+++ b/eventstore/mongodb/spring/reactor/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>eventstore-mongodb-spring-reactor</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -31,32 +31,5 @@
 
     <artifactId>example</artifactId>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <configuration>
-                            <skipPublishing>true</skipPublishing>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/framework/spring-boot-starter-mongodb/pom.xml
+++ b/framework/spring-boot-starter-mongodb/pom.xml
@@ -26,6 +26,8 @@
 
     <artifactId>spring-boot-starter-mongodb</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <!-- Spring -->
         <dependency>

--- a/library/hederlig/pom.xml
+++ b/library/hederlig/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+
     <dependencies>
         <!-- DSL dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <module>bom</module>
     </modules>
 
-    <name>Occurrent</name>
+    <name>${mavenProjectName}</name>
     <description>Event Sourcing Utilities for the JVM based on the CloudEvents specification</description>
     <url>https://occurrent.org</url>
 
@@ -65,6 +65,8 @@
     </scm>
 
     <properties>
+        <mavenProjectName>Occurrent</mavenProjectName>
+
         <!--use '-Drevision=...' when invoking Maven to assign required version-->
         <revision>0.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -488,6 +488,43 @@
                             <autoPublish>true</autoPublish>
                             <excludeArtifacts>
                                 <excludeArtifact>test-support</excludeArtifact>
+
+                                <!-- empty aggregate parent POMs not needed with enabled flattening -->
+                                <excludeArtifact>application-service</excludeArtifact>
+                                <excludeArtifact>application</excludeArtifact>
+                                <excludeArtifact>cloudevent-converter</excludeArtifact>
+                                <excludeArtifact>cloudevent-type-mapper</excludeArtifact>
+                                <excludeArtifact>common</excludeArtifact>
+                                <excludeArtifact>deadline-api</excludeArtifact>
+                                <excludeArtifact>deadline</excludeArtifact>
+                                <excludeArtifact>dsl</excludeArtifact>
+                                <excludeArtifact>eventstore-api</excludeArtifact>
+                                <excludeArtifact>eventstore-mongodb-spring</excludeArtifact>
+                                <excludeArtifact>eventstore-mongodb</excludeArtifact>
+                                <excludeArtifact>eventstore</excludeArtifact>
+                                <excludeArtifact>framework</excludeArtifact>
+                                <excludeArtifact>inmemory</excludeArtifact>
+                                <excludeArtifact>library</excludeArtifact>
+                                <excludeArtifact>module-dsl</excludeArtifact>
+                                <excludeArtifact>mongodb-native</excludeArtifact>
+                                <excludeArtifact>mongodb-spring</excludeArtifact>
+                                <excludeArtifact>mongodb</excludeArtifact>
+                                <excludeArtifact>occurrent</excludeArtifact>
+                                <excludeArtifact>query-dsl</excludeArtifact>
+                                <excludeArtifact>subscription-api</excludeArtifact>
+                                <excludeArtifact>subscription-dsl</excludeArtifact>
+                                <excludeArtifact>subscription-mongodb-common-blocking</excludeArtifact>
+                                <excludeArtifact>subscription-mongodb-common</excludeArtifact>
+                                <excludeArtifact>subscription-mongodb-native</excludeArtifact>
+                                <excludeArtifact>subscription-mongodb-spring</excludeArtifact>
+                                <excludeArtifact>subscription-mongodb</excludeArtifact>
+                                <excludeArtifact>subscription-redis-spring</excludeArtifact>
+                                <excludeArtifact>subscription-redis</excludeArtifact>
+                                <excludeArtifact>subscription-util-blocking</excludeArtifact>
+                                <excludeArtifact>subscription-util-reactor</excludeArtifact>
+                                <excludeArtifact>subscription-util</excludeArtifact>
+                                <excludeArtifact>subscription</excludeArtifact>
+
                                 <!-- Examples -->
                                 <excludeArtifact>example</excludeArtifact>
                                 <excludeArtifact>example-projection</excludeArtifact>

--- a/pom.xml
+++ b/pom.xml
@@ -487,7 +487,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <autoPublish>true</autoPublish>
+                            <autoPublish>false</autoPublish>
                             <excludeArtifacts>
                                 <excludeArtifact>test-support</excludeArtifact>
 

--- a/pom.xml
+++ b/pom.xml
@@ -486,6 +486,44 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
+                            <excludeArtifacts>
+                                <excludeArtifact>test-support</excludeArtifact>
+                                <!-- Examples -->
+                                <excludeArtifact>example</excludeArtifact>
+                                <excludeArtifact>example-projection</excludeArtifact>
+                                <excludeArtifact>example-projection-spring-adhoc-evenstore-mongodb-queries</excludeArtifact>
+                                <excludeArtifact>example-projection-spring-reactor-transactional-projection-mongodb</excludeArtifact>
+                                <excludeArtifact>example-projection-spring-changedstreamed-mongodb-projections</excludeArtifact>
+                                <excludeArtifact>example-projection-spring-transactional-projection-mongodb</excludeArtifact>
+                                <excludeArtifact>example-forwarder</excludeArtifact>
+                                <excludeArtifact>example-forwarder-mongodb-subscription-to-spring-event</excludeArtifact>
+                                <excludeArtifact>example-domain</excludeArtifact>
+                                <excludeArtifact>example-mastermind</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game-model</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game-es-mongodb</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game-es-mongodb-native</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game-es-mongodb-spring</excludeArtifact>
+                                <excludeArtifact>example-number-guessing-game-es-mongodb-spring-blocking</excludeArtifact>
+                                <excludeArtifact>example-rps</excludeArtifact>
+                                <excludeArtifact>example-rps-decider-model</excludeArtifact>
+                                <excludeArtifact>example-rps-decider-web</excludeArtifact>
+                                <excludeArtifact>example-rps-model</excludeArtifact>
+                                <excludeArtifact>example-rps-multiround-decider-model</excludeArtifact>
+                                <excludeArtifact>example-pragmatic-rps-model</excludeArtifact>
+                                <excludeArtifact>example-uno</excludeArtifact>
+                                <excludeArtifact>example-uno-model</excludeArtifact>
+                                <excludeArtifact>example-uno-es-mongodb</excludeArtifact>
+                                <excludeArtifact>example-uno-es-mongodb-common</excludeArtifact>
+                                <excludeArtifact>example-uno-es-mongodb-native</excludeArtifact>
+                                <excludeArtifact>example-uno-es-mongodb-spring</excludeArtifact>
+                                <excludeArtifact>example-uno-es-mongodb-spring-blocking</excludeArtifact>
+                                <excludeArtifact>example-domain-word-guessing-game</excludeArtifact>
+                                <excludeArtifact>example-domain-word-guessing-game-model</excludeArtifact>
+                                <excludeArtifact>example-domain-word-guessing-game-es-mongodb</excludeArtifact>
+                                <excludeArtifact>example-domain-word-guessing-game-es-mongodb-spring</excludeArtifact>
+                                <excludeArtifact>example-domain-word-guessing-game-es-mongodb-spring-blocking</excludeArtifact>
+                            </excludeArtifacts>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/subscription/api/blocking/pom.xml
+++ b/subscription/api/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-api-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/api/reactor/pom.xml
+++ b/subscription/api/reactor/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>subscription-api-reactor</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/subscription/core/pom.xml
+++ b/subscription/core/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-core</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>io.cloudevents</groupId>

--- a/subscription/inmemory/pom.xml
+++ b/subscription/inmemory/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-inmemory</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/mongodb/common/base/pom.xml
+++ b/subscription/mongodb/common/base/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-base</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/pom.xml
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/pom.xml
@@ -9,6 +9,8 @@
 
     <artifactId>subscription-mongodb-common-blocking-competing-consumer-strategy</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/subscription/mongodb/native/blocking-competing-consumer-strategy/pom.xml
+++ b/subscription/mongodb/native/blocking-competing-consumer-strategy/pom.xml
@@ -9,6 +9,8 @@
 
     <artifactId>subscription-mongodb-native-blocking-competing-consumer-strategy</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/subscription/mongodb/native/blocking-position-storage/pom.xml
+++ b/subscription/mongodb/native/blocking-position-storage/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-native-blocking-position-storage</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/mongodb/native/blocking/pom.xml
+++ b/subscription/mongodb/native/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-native-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/subscription/mongodb/spring/blocking-competing-consumer-strategy/pom.xml
+++ b/subscription/mongodb/spring/blocking-competing-consumer-strategy/pom.xml
@@ -9,6 +9,8 @@
 
     <artifactId>subscription-mongodb-spring-blocking-competing-consumer-strategy</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/subscription/mongodb/spring/blocking-position-storage/pom.xml
+++ b/subscription/mongodb/spring/blocking-position-storage/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-spring-blocking-position-storage</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/subscription/mongodb/spring/blocking/pom.xml
+++ b/subscription/mongodb/spring/blocking/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-spring-blocking</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/subscription/mongodb/spring/common/pom.xml
+++ b/subscription/mongodb/spring/common/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>subscription-mongodb-spring-common</artifactId>
 
+    <name>${mavenProjectName}</name>
 
     <dependencies>
         <dependency>

--- a/subscription/mongodb/spring/reactor-position-storage/pom.xml
+++ b/subscription/mongodb/spring/reactor-position-storage/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-spring-reactor-position-storage</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/mongodb/spring/reactor/pom.xml
+++ b/subscription/mongodb/spring/reactor/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-mongodb-spring-reactor</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/redis/spring/blocking-position-storage/pom.xml
+++ b/subscription/redis/spring/blocking-position-storage/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-redis-spring-blocking-position-storage</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/subscription/util/blocking/catchup-subscription/pom.xml
+++ b/subscription/util/blocking/catchup-subscription/pom.xml
@@ -23,6 +23,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>${mavenProjectName}</name>
+
     <artifactId>catchup-subscription</artifactId>
     <dependencies>
         <dependency>

--- a/subscription/util/blocking/competing-consumer-subscription/pom.xml
+++ b/subscription/util/blocking/competing-consumer-subscription/pom.xml
@@ -9,6 +9,8 @@
 
     <artifactId>competing-consumer-subscription</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/util/blocking/durable-subscription/pom.xml
+++ b/subscription/util/blocking/durable-subscription/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>durable-subscription</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/subscription/util/predicates/pom.xml
+++ b/subscription/util/predicates/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>subscription-util-predicates</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>io.cloudevents</groupId>

--- a/subscription/util/reactor/durable-subscription/pom.xml
+++ b/subscription/util/reactor/durable-subscription/pom.xml
@@ -25,6 +25,8 @@
 
     <artifactId>reactor-durable-subscription</artifactId>
 
+    <name>${mavenProjectName}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.occurrent</groupId>

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -41,29 +41,11 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>release</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <configuration>
-                            <skipPublishing>true</skipPublishing>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
Fixes #185 

There were 2 problems with release:
- The `<name>` was missing in every package
- Parent POMs were not ignored as I expected them to be ignored with https://github.com/johanhaleby/occurrent/commit/62a28dc90f4b1dd697bb370cf964c0e33bcd3ebc

I saw it [was stated](https://central.sonatype.org/publish/requirements/#project-name-description-and-url) that `<description>` and `<url>` are also required, but there is no validation for them, so I didn't include those everywhere.