### PR TITLE
WIP: Spring data jpa subscription

### DIFF
--- a/eventstore/jpa/pom.xml
+++ b/eventstore/jpa/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eventstore</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modules>
+        <module>spring-data</module>
+    </modules>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>eventstore-jpa</artifactId>
+
+    <packaging>pom</packaging>
+
+
+</project>

--- a/eventstore/jpa/spring-data/pom.xml
+++ b/eventstore/jpa/spring-data/pom.xml
@@ -31,6 +31,58 @@
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
 </project>

--- a/eventstore/jpa/spring-data/pom.xml
+++ b/eventstore/jpa/spring-data/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.occurrent</groupId>
+        <artifactId>eventstore-jpa</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>eventstore-spring-data-jpa</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventAttributeEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventAttributeEntity.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import java.util.UUID;
 
 @Entity
-public class CloudEventAttributeEntity {
+class CloudEventAttributeEntity {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventAttributeEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventAttributeEntity.java
@@ -1,0 +1,24 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+public class CloudEventAttributeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "cloud_event_id", nullable = false, updatable = false)
+    private CloudEventEntity cloudEvent;
+
+    @Column(name = "attribute_name", nullable = false, updatable = false)
+    private String attributeName;
+
+    @Column(name = "attribute_value", nullable = false, updatable = false)
+    private String attributeValue;
+
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventEntity.java
@@ -1,0 +1,195 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+import io.cloudevents.core.data.BytesCloudEventData;
+import jakarta.persistence.*;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
+import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
+
+@Entity
+@Table(name = "cloud_event",
+        indexes = {
+                @Index(name = "IDX_cloud_event_stream", columnList = "stream_id"),
+                @Index(name = "IDX_cloud_event_stream_position", columnList = "stream_position"),
+                @Index(name = "U_cloud_event_event_id_source", columnList = "event_id, source", unique = true),
+                @Index(name = "U_cloud_event_stream_position", columnList = "stream_id, stream_position", unique = true),
+        })
+public class CloudEventEntity implements CloudEvent {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "spec_version", nullable = false, updatable = false)
+    @Enumerated(EnumType.STRING)
+    private SpecVersion specVersion;
+
+    @ManyToOne
+    @JoinColumn(name = "stream_id", nullable = false, updatable = false)
+    private StreamEntity stream;
+
+    @Column(name = "stream_position", nullable = false, updatable = false)
+    private Long streamPosition;
+
+    @Column(name = "event_id", nullable = false, updatable = false)
+    private String eventId;
+
+    @Column(name = "source", nullable = false)
+    private URI source;
+
+    @Column(name = "subject")
+    private String subject;
+
+    @Column(name = "type", nullable = false)
+    private String type;
+
+    @Column(name = "time")
+    private OffsetDateTime time;
+
+    @Column(name = "data_content_type")
+    private String dataContentType;
+
+    @Column(name = "data_schema")
+    private URI dataSchema;
+
+    @Column(name = "data")
+    private byte[] data;
+
+    @OneToMany(mappedBy = "cloudEvent")
+    @MapKey(name = "attributeName")
+    private Map<String, CloudEventAttributeEntity> attributes;
+
+    public UUID getPK() {
+        return id;
+    }
+
+    public void setPK(UUID aId) {
+        id = aId;
+    }
+
+    @Override
+    public CloudEventData getData() {
+        return BytesCloudEventData.wrap(data);
+    }
+
+    public void setData(byte[] aData) {
+        data = aData;
+    }
+
+    @Override
+    public SpecVersion getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(SpecVersion aSpecVersion) {
+        specVersion = aSpecVersion;
+    }
+
+    public StreamEntity getStream() {
+        return stream;
+    }
+
+    public void setStream(StreamEntity stream) {
+        this.stream = stream;
+    }
+
+    public Long getStreamPosition() {
+        return streamPosition;
+    }
+
+    public void setStreamPosition(Long streamPosition) {
+        this.streamPosition = streamPosition;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String aType) {
+        type = aType;
+    }
+
+    @Override
+    public String getId() {
+        return eventId;
+    }
+
+    public void setEventId(String aEventId) {
+        eventId = aEventId;
+    }
+
+    @Override
+    public URI getSource() {
+        return source;
+    }
+
+    public void setSource(URI aSource) {
+        source = aSource;
+    }
+
+    @Override
+    public String getDataContentType() {
+        return dataContentType;
+    }
+
+    public void setDataContentType(String aDataContentType) {
+        dataContentType = aDataContentType;
+    }
+
+    @Override
+    public URI getDataSchema() {
+        return dataSchema;
+    }
+
+    public void setDataSchema(URI aDataSchema) {
+        dataSchema = aDataSchema;
+    }
+
+    @Override
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String aSubject) {
+        subject = aSubject;
+    }
+
+    @Override
+    public OffsetDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(OffsetDateTime aTime) {
+        time = aTime;
+    }
+
+    @Override
+    public Object getAttribute(String s) throws IllegalArgumentException {
+        return null;
+    }
+
+    @Override
+    public Object getExtension(String aName) {
+        return switch (aName) {
+            case STREAM_VERSION -> getStreamPosition();
+            case STREAM_ID -> getStream().getName();
+            default -> null;
+        };
+    }
+
+    @Override
+    public Set<String> getExtensionNames() {
+        return Set.of(STREAM_ID, STREAM_VERSION);
+    }
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventEntity.java
@@ -23,7 +23,7 @@ import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERS
                 @Index(name = "U_cloud_event_event_id_source", columnList = "event_id, source", unique = true),
                 @Index(name = "U_cloud_event_stream_position", columnList = "stream_id, stream_position", unique = true),
         })
-public class CloudEventEntity implements CloudEvent {
+class CloudEventEntity implements CloudEvent {
 
     @Id
     @GeneratedValue

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventMapper.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventMapper.java
@@ -1,0 +1,28 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CloudEventMapper {
+
+    public CloudEventEntity toEntity(CloudEvent aEvent) {
+        if (aEvent == null) {
+            return null;
+        }
+        CloudEventEntity res = new CloudEventEntity();
+        res.setEventId(aEvent.getId());
+        res.setSpecVersion(aEvent.getSpecVersion());
+        res.setType(aEvent.getType());
+        res.setSource(aEvent.getSource());
+        res.setDataContentType(aEvent.getDataContentType());
+        res.setDataSchema(aEvent.getDataSchema());
+        res.setSubject(aEvent.getSubject());
+        res.setTime(aEvent.getTime());
+        if (aEvent.getData() != null) {
+            res.setData(aEvent.getData().toBytes());
+        }
+        return res;
+    }
+
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventMapper.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventMapper.java
@@ -4,7 +4,7 @@ import io.cloudevents.CloudEvent;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CloudEventMapper {
+class CloudEventMapper {
 
     public CloudEventEntity toEntity(CloudEvent aEvent) {
         if (aEvent == null) {

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventRepository.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventRepository.java
@@ -1,0 +1,25 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CloudEventRepository extends JpaRepository<CloudEventEntity, UUID>,
+        JpaSpecificationExecutor<CloudEventEntity> {
+    List<CloudEventEntity> findByStream(StreamEntity stream, Pageable aPageable);
+
+    void deleteByStream_Name(String streamId);
+
+    Optional<CloudEventEntity> findByEventIdAndSource(String cloudEventId, URI cloudEventSource);
+
+    void deleteByEventIdAndSource(String cloudEventId, URI cloudEventSource);
+
+    long countByStream_Name(String aStreamId);
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventRepository.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/CloudEventRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface CloudEventRepository extends JpaRepository<CloudEventEntity, UUID>,
+interface CloudEventRepository extends JpaRepository<CloudEventEntity, UUID>,
         JpaSpecificationExecutor<CloudEventEntity> {
     List<CloudEventEntity> findByStream(StreamEntity stream, Pageable aPageable);
 

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/EventStreamImpl.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/EventStreamImpl.java
@@ -6,7 +6,7 @@ import org.occurrent.eventstore.api.blocking.EventStream;
 import java.util.List;
 import java.util.stream.Stream;
 
-public record EventStreamImpl(
+record EventStreamImpl(
         String streamId,
         long streamVersion,
         List<CloudEvent> _events

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/EventStreamImpl.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/EventStreamImpl.java
@@ -1,0 +1,28 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import org.occurrent.eventstore.api.blocking.EventStream;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public record EventStreamImpl(
+        String streamId,
+        long streamVersion,
+        List<CloudEvent> _events
+) implements EventStream<CloudEvent> {
+    @Override
+    public String id() {
+        return streamId;
+    }
+
+    @Override
+    public long version() {
+        return streamVersion;
+    }
+
+    @Override
+    public Stream<CloudEvent> events() {
+        return _events.stream();
+    }
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/OffsetBasedPageRequest.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/OffsetBasedPageRequest.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * Adapted from <a href="https://stackoverflow.com/a/36365522">Stack Overflow</a>
  */
-public class OffsetBasedPageRequest implements Pageable, Serializable {
+class OffsetBasedPageRequest implements Pageable, Serializable {
 
     private static final long serialVersionUID = -25822477129613575L;
 

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/OffsetBasedPageRequest.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/OffsetBasedPageRequest.java
@@ -1,0 +1,117 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Adapted from <a href="https://stackoverflow.com/a/36365522">Stack Overflow</a>
+ */
+public class OffsetBasedPageRequest implements Pageable, Serializable {
+
+    private static final long serialVersionUID = -25822477129613575L;
+
+    private final int limit;
+    private final long offset;
+    private final Sort sort;
+
+    /**
+     * Creates a new {@link OffsetBasedPageRequest} with sort parameters applied.
+     *
+     * @param offset zero-based offset.
+     * @param limit  the size of the elements to be returned.
+     * @param sort   can be {@literal null}.
+     */
+    public OffsetBasedPageRequest(long offset, int limit, Sort sort) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset index must not be less than zero!");
+        }
+
+        if (limit < 1) {
+            throw new IllegalArgumentException("Limit must not be less than one!");
+        }
+        this.limit = limit;
+        this.offset = offset;
+        this.sort = sort;
+    }
+
+
+    @Override
+    public int getPageNumber() {
+        return Math.toIntExact(offset / limit);
+    }
+
+    @Override
+    public int getPageSize() {
+        return limit;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public Sort getSort() {
+        return sort;
+    }
+
+    @Override
+    public Pageable next() {
+        return new OffsetBasedPageRequest(getOffset() + getPageSize(), getPageSize(), getSort());
+    }
+
+    public OffsetBasedPageRequest previous() {
+        return hasPrevious() ? new OffsetBasedPageRequest(getOffset() - getPageSize(), getPageSize(), getSort()) : this;
+    }
+
+
+    @Override
+    public Pageable previousOrFirst() {
+        return hasPrevious() ? previous() : first();
+    }
+
+    @Override
+    public Pageable first() {
+        return new OffsetBasedPageRequest(0, getPageSize(), getSort());
+    }
+
+    @Override
+    public Pageable withPage(int pageNumber) {
+        return new OffsetBasedPageRequest(offset + (long) pageNumber * limit, limit, sort);
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return offset > limit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (!(o instanceof OffsetBasedPageRequest)) return false;
+
+        OffsetBasedPageRequest that = (OffsetBasedPageRequest) o;
+
+        return limit == that.limit &&
+                offset == that.offset &&
+                (Objects.equals(sort, that.sort));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(limit, offset, sort);
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetBasedPageRequest{" +
+                "limit=" + limit +
+                ", offset=" + offset +
+                ", sort=" + sort +
+                '}';
+    }
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
@@ -21,7 +21,7 @@ import java.util.List;
  * - SortBy
  */
 @Component
-public class QueryMapper {
+class QueryMapper {
 
     public Specification<CloudEventEntity> mapFilter(Filter aFilter) {
         if (aFilter instanceof Filter.All) {

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
@@ -1,9 +1,6 @@
 package org.occurrent.eventstore.jpa.springdata;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.Expression;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.*;
 import org.occurrent.condition.Condition;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.filter.Filter;
@@ -12,6 +9,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -44,14 +42,11 @@ class QueryMapper {
     }
 
     Expression<?> mapFieldName(Root<CloudEventEntity> root, String fieldName) {
-        return switch (fieldName) {
-            case "id" -> root.get("eventId");
-            case "datacontenttype" -> root.get("dataContentType");
-            case "dataschema" -> root.get("dataSchema");
-            case "streamid" -> root.get("stream").get("name");
-            case "streamversion" -> root.get("streamPosition");
-            default -> root.get(fieldName);
-        };
+        return Arrays.stream(mapFieldName(fieldName)
+                        .split("\\."))
+                .reduce((Path<?>) root,
+                        Path::get,
+                        (a, b) -> b);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/QueryMapper.java
@@ -1,0 +1,130 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.occurrent.condition.Condition;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.filter.Filter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * A mapper for all-things query related:
+ * - Filter
+ * - Condition
+ * - SortBy
+ */
+@Component
+public class QueryMapper {
+
+    public Specification<CloudEventEntity> mapFilter(Filter aFilter) {
+        if (aFilter instanceof Filter.All) {
+            return Specification.unrestricted();
+        } else if (aFilter instanceof Filter.SingleConditionFilter single) {
+            return (root, query, builder) -> {
+                Expression<?> field = mapFieldName(root, single.fieldName());
+                return mapCondition(field, single.condition(), builder);
+            };
+        } else if (aFilter instanceof Filter.CompositionFilter composition) {
+            List<Specification<CloudEventEntity>> specs = composition.filters().stream()
+                    .map(this::mapFilter)
+                    .toList();
+            return switch (composition.operator()) {
+                case OR -> Specification.anyOf(specs);
+                case AND -> Specification.allOf(specs);
+            };
+        }
+        throw new IllegalArgumentException("Unknown filter type: " + aFilter.getClass());
+    }
+
+    Expression<?> mapFieldName(Root<CloudEventEntity> root, String fieldName) {
+        return switch (fieldName) {
+            case "id" -> root.get("eventId");
+            case "datacontenttype" -> root.get("dataContentType");
+            case "dataschema" -> root.get("dataSchema");
+            case "streamid" -> root.get("stream").get("name");
+            case "streamversion" -> root.get("streamPosition");
+            default -> root.get(fieldName);
+        };
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Predicate mapCondition(Expression field, Condition aCondition, CriteriaBuilder builder) {
+        if (aCondition instanceof Condition.InOperandCondition<?> inOperand) {
+            var inClause = builder.in(field);
+            for (Object op : inOperand.operand()) {
+                inClause.value(op);
+            }
+            return inClause;
+        } else if (aCondition instanceof Condition.SingleOperandCondition<?> singleOperand) {
+
+
+            Comparable operandValue = (Comparable) singleOperand.operand();
+            // Special case: cast the operand back to an URI ...
+            if (field.getJavaType() == URI.class) {
+                operandValue = URI.create(singleOperand.operand().toString());
+            }
+            return switch (singleOperand.operandConditionName()) {
+                case EQ -> builder.equal(field, operandValue);
+                case NE -> builder.notEqual(field, operandValue);
+                case GT -> builder.greaterThan(field, operandValue);
+                case GTE -> builder.greaterThanOrEqualTo(field, operandValue);
+                case LT -> builder.lessThan(field, operandValue);
+                case LTE -> builder.lessThanOrEqualTo(field, operandValue);
+            };
+        } else if (aCondition instanceof Condition.MultiOperandCondition<?> multiOperand) {
+
+            Predicate[] conditions = multiOperand.operations().stream()
+                    .map(c -> mapCondition(field, c, builder))
+                    .toArray(Predicate[]::new);
+            return switch (multiOperand.operationName()) {
+                case AND -> builder.and(conditions);
+                case OR -> builder.or(conditions);
+                case NOT -> builder.not(conditions[0]);
+            };
+        }
+        throw new IllegalArgumentException("Unknown condition type: " + aCondition.getClass());
+    }
+
+    public Sort mapSortBy(SortBy aSortBy) {
+        if (aSortBy instanceof SortBy.Unsorted) {
+            return Sort.unsorted();
+        } else if (aSortBy instanceof SortBy.NaturalImpl natural) {
+            return Sort.by(mapDirection(natural.direction), "streamPosition");
+        } else if (aSortBy instanceof SortBy.SingleFieldImpl singleFieldSort) {
+            return Sort.by(mapDirection(singleFieldSort.direction), mapFieldName(singleFieldSort.fieldName));
+        } else if (aSortBy instanceof SortBy.MultipleSortStepsImpl multipleSort) {
+            Sort sort = Sort.unsorted();
+            for (SortBy sortBy : multipleSort.steps) {
+                sort = sort.and(mapSortBy(sortBy));
+            }
+            return sort;
+        }
+        throw new IllegalArgumentException("Unknown SortBy type: " + aSortBy.getClass());
+    }
+
+    String mapFieldName(String fieldName) {
+        return switch (fieldName.toLowerCase()) {
+            case "id" -> "eventId";
+            case "datacontenttype" -> "dataContentType";
+            case "dataschema" -> "dataSchema";
+            case "streamid" -> "stream.name";
+            case "streamversion" -> "streamPosition";
+            default -> fieldName;
+        };
+    }
+
+    Sort.Direction mapDirection(SortBy.SortDirection aDirection) {
+        return switch (aDirection) {
+            case ASCENDING -> Sort.Direction.ASC;
+            case DESCENDING -> Sort.Direction.DESC;
+        };
+    }
+
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStore.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStore.java
@@ -1,0 +1,200 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import jakarta.transaction.Transactional;
+import org.occurrent.condition.Condition;
+import org.occurrent.eventstore.api.*;
+import org.occurrent.eventstore.api.blocking.EventStore;
+import org.occurrent.eventstore.api.blocking.EventStoreOperations;
+import org.occurrent.eventstore.api.blocking.EventStoreQueries;
+import org.occurrent.eventstore.api.blocking.EventStream;
+import org.occurrent.filter.Filter;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * A JPA-based implementation of the {@link EventStore} interface.
+ */
+@Component
+public class SpringDataJpaEventStore implements EventStore, EventStoreOperations, EventStoreQueries {
+
+    private final CloudEventRepository itsCloudEventRepository;
+    private final StreamRepository itsStreamRepository;
+    private final CloudEventMapper itsCloudEventMapper;
+    private final QueryMapper itsQueryMapper;
+
+    public SpringDataJpaEventStore(
+            CloudEventRepository itsCloudEventRepository,
+            StreamRepository itsStreamRepository,
+            CloudEventMapper itsCloudEventMapper,
+            QueryMapper itsQueryMapper) {
+        this.itsCloudEventRepository = itsCloudEventRepository;
+        this.itsStreamRepository = itsStreamRepository;
+        this.itsCloudEventMapper = itsCloudEventMapper;
+        this.itsQueryMapper = itsQueryMapper;
+    }
+
+    @Override
+    @Transactional
+    public WriteResult write(String streamId, WriteCondition writeCondition, Stream<CloudEvent> events) {
+        // Fetch the stream Version.
+        StreamEntity stream = itsStreamRepository.getByName(streamId)
+                .orElseGet(() -> {
+                    StreamEntity newStream = new StreamEntity();
+                    newStream.setName(streamId);
+                    newStream.setVersion(0L);
+                    return itsStreamRepository.save(newStream);
+                });
+        long oldVersion = stream.getVersion();
+        // Evaluate the condition
+        if (!evaluateCondition(writeCondition, oldVersion)) {
+            throw new WriteConditionNotFulfilledException(
+                    streamId,
+                    stream.getVersion(),
+                    writeCondition,
+                    String.format("%s was not fulfilled. Expected version %s but was %s.",
+                            WriteCondition.class.getSimpleName(),
+                            writeCondition,
+                            stream.getVersion()));
+        }
+
+        // enrich the events with stream information
+        AtomicLong counter = new AtomicLong(stream.getVersion());
+        List<CloudEventEntity> newEvents = events
+                .map(e -> {
+                    var res = itsCloudEventMapper.toEntity(e);
+                    res.setStream(stream);
+                    res.setStreamPosition(counter.incrementAndGet());
+                    return res;
+                })
+                .toList();
+        // Update the stream version
+        stream.setVersion(counter.get());
+        itsStreamRepository.save(stream);
+        // Persist the events
+        try {
+            itsCloudEventRepository.saveAllAndFlush(newEvents);
+        } catch (DataIntegrityViolationException dive){
+            throw new DuplicateCloudEventException(streamId, null, null, dive);
+        }
+        return new WriteResult(streamId, oldVersion, stream.getVersion());
+    }
+
+    private boolean evaluateCondition(WriteCondition aCondition, long aVersion) {
+        if (aCondition.isAnyStreamVersion()) {
+            return true;
+        }
+
+        if (aCondition instanceof WriteCondition.StreamVersionWriteCondition condition) {
+            return LongConditionEvaluator.evaluate(condition.condition(), aVersion);
+        }
+        return false;
+
+    }
+
+    @Override
+    public boolean exists(String streamId) {
+        // Better check if events are there ?
+        return itsStreamRepository.existsByName(streamId);
+    }
+
+    @Override
+    @Transactional
+    public EventStream<CloudEvent> read(String streamId, int skip, int limit) {
+        Optional<StreamEntity> stream = itsStreamRepository.getByName(streamId);
+        if (stream.isEmpty()) {
+            return new EventStreamImpl(streamId, 0L, List.of());
+        }
+        List<? extends CloudEvent> events = itsCloudEventRepository.findByStream(
+                stream.orElse(null),
+                new OffsetBasedPageRequest(
+                        skip,
+                        limit,
+                        Sort.by(
+                                Sort.Direction.ASC,
+                                "streamPosition")));
+        return new EventStreamImpl(
+                stream.get().getName(),
+                stream.get().getVersion(),
+                (List<CloudEvent>) events);
+    }
+
+    @Override
+    public WriteResult write(String streamId, Stream<CloudEvent> events) {
+        return write(streamId, WriteCondition.anyStreamVersion(), events);
+    }
+
+    @Override
+    public Stream<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        return itsCloudEventRepository.findAll(
+                        itsQueryMapper.mapFilter(filter),
+                        new OffsetBasedPageRequest(
+                                skip,
+                                limit,
+                                itsQueryMapper.mapSortBy(sortBy)))
+                .stream()
+                .map(e -> (CloudEvent) e);
+    }
+
+    @Override
+    public long count(Filter aFilter) {
+        Specification<CloudEventEntity> spec = itsQueryMapper.mapFilter(aFilter);
+        return itsCloudEventRepository.count(spec);
+    }
+
+    @Override
+    public boolean exists(Filter filter) {
+        Specification<CloudEventEntity> spec = itsQueryMapper.mapFilter(filter);
+        return itsCloudEventRepository.exists(spec);
+    }
+
+    @Override
+    @Transactional
+    public void deleteEventStream(String streamId) {
+        itsCloudEventRepository.deleteByStream_Name(streamId);
+        itsStreamRepository.deleteByName(streamId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteEvent(String cloudEventId, URI cloudEventSource) {
+        itsCloudEventRepository.deleteByEventIdAndSource(cloudEventId, cloudEventSource);
+
+    }
+
+    @Override
+    @Transactional
+    public void delete(Filter filter) {
+        Specification<CloudEventEntity> spec = itsQueryMapper.mapFilter(filter);
+        itsCloudEventRepository.delete(spec);
+    }
+
+    @Override
+    @Transactional
+    public Optional<CloudEvent> updateEvent(String cloudEventId, URI cloudEventSource, Function<CloudEvent, CloudEvent> updateFunction) {
+        Optional<CloudEventEntity> eventOpt = itsCloudEventRepository.findByEventIdAndSource(cloudEventId, cloudEventSource);
+        if (eventOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        var event = eventOpt.get();
+        UUID oldId = event.getPK();
+        var newEvent = itsCloudEventMapper.toEntity(
+                updateFunction.apply(event));
+        if (newEvent == null) {
+            throw new IllegalArgumentException("Cloud event update function is not allowed to return null");
+        }
+        newEvent.setPK(oldId);
+        itsCloudEventRepository.save(newEvent);
+        return Optional.of(event);
+    }
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStoreConfiguration.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStoreConfiguration.java
@@ -1,0 +1,12 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories
+@ComponentScan
+public class SpringDataJpaEventStoreConfiguration {
+
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamEntity.java
@@ -10,7 +10,7 @@ import java.util.UUID;
         indexes = {
                 @Index(name = "idx_event_stream_name", columnList = "name", unique = true)
         })
-public class StreamEntity {
+class StreamEntity {
 
     @Id
     @GeneratedValue

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamEntity.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamEntity.java
@@ -1,0 +1,49 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+
+@Entity
+@Table(name = "event_stream",
+        indexes = {
+                @Index(name = "idx_event_stream_name", columnList = "name", unique = true)
+        })
+public class StreamEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "name", nullable = false, updatable = false)
+    private String name;
+
+    @Column(name = "version", nullable = false)
+    private Long version;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID aId) {
+        id = aId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String aName) {
+        name = aName;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long aVersion) {
+        version = aVersion;
+    }
+}

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamRepository.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface StreamRepository extends JpaRepository<StreamEntity, UUID> {
+interface StreamRepository extends JpaRepository<StreamEntity, UUID> {
 
     Optional<StreamEntity> getByName(String name);
 

--- a/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamRepository.java
+++ b/eventstore/jpa/spring-data/src/main/java/org/occurrent/eventstore/jpa/springdata/StreamRepository.java
@@ -1,0 +1,17 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface StreamRepository extends JpaRepository<StreamEntity, UUID> {
+
+    Optional<StreamEntity> getByName(String name);
+
+    boolean existsByName(String streamId);
+
+    void deleteByName(String streamId);
+}

--- a/eventstore/jpa/spring-data/src/test/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStoreTest.java
+++ b/eventstore/jpa/spring-data/src/test/java/org/occurrent/eventstore/jpa/springdata/SpringDataJpaEventStoreTest.java
@@ -1,0 +1,1853 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.jpa.springdata;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.PojoCloudEventData;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.domain.*;
+import org.occurrent.eventstore.api.*;
+import org.occurrent.eventstore.api.blocking.EventStream;
+import org.occurrent.filter.Filter;
+import org.occurrent.functional.CheckedFunction;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.occurrent.time.TimeConversion;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.vavr.API.*;
+import static io.vavr.Predicates.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.condition.JRE.JAVA_11;
+import static org.junit.jupiter.api.condition.JRE.JAVA_8;
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
+import static org.occurrent.condition.Condition.*;
+import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
+import static org.occurrent.eventstore.api.SortBy.SortDirection.DESCENDING;
+import static org.occurrent.filter.Filter.*;
+import static org.occurrent.time.TimeConversion.offsetDateTimeFrom;
+
+@SuppressWarnings("SameParameterValue")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringJUnitConfig(TestJpaConfig.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class SpringDataJpaEventStoreTest {
+
+
+    private static final URI NAME_SOURCE = URI.create("http://name");
+
+
+    @Inject
+    private SpringDataJpaEventStore eventStore;
+    @Inject
+    private CloudEventRepository cloudEventRepository;
+    @Inject
+    private StreamRepository streamRepository;
+
+    @Inject
+    private ObjectMapper objectMapper;
+
+    @Test
+    void can_read_and_write_single_event_to_mongo_spring_blocking_event_store() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // When
+        List<DomainEvent> events = Name.defineTheName(UUID.randomUUID().toString(), now, "name", "John Doe");
+        persist("name", WriteCondition.streamVersionEq(0), events);
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(eventStream.version()).isEqualTo(1),
+                () -> assertThat(readEvents).hasSize(1),
+                () -> assertThat(readEvents).containsExactlyElementsOf(events)
+        );
+    }
+
+    @Test
+    void can_read_and_write_multiple_events_at_once_to_mongo_spring_blocking_event_store() {
+        LocalDateTime now = LocalDateTime.now();
+        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(),now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
+
+        // When
+        persist("name", WriteCondition.streamVersionEq(0), events);
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(eventStream.version()).isEqualTo(events.size()),
+                () -> assertThat(readEvents).hasSize(2),
+                () -> assertThat(readEvents).containsExactlyElementsOf(events)
+        );
+    }
+
+    @Test
+    void does_not_change_event_store_content_when_writing_an_empty_stream_of_events_using_spring_blocking_event_store() {
+        // When
+        persist("name", Stream.empty());
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+
+        assertThat(eventStream.isEmpty()).isTrue();
+    }
+
+    @Test
+    void can_read_and_write_multiple_events_at_different_occasions_to_mongo_spring_blocking_event_store() {
+        LocalDateTime now = LocalDateTime.now();
+        NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+        NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+        NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+        // When
+        persist("name", WriteCondition.streamVersionEq(0), nameDefined);
+        persist("name", WriteCondition.streamVersionEq(1), nameWasChanged1);
+        persist("name", WriteCondition.streamVersionEq(2), nameWasChanged2);
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(eventStream.version()).isEqualTo(3),
+                () -> assertThat(readEvents).hasSize(3),
+                () -> assertThat(readEvents).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2)
+        );
+    }
+
+    @Test
+    void can_read_events_with_skip_and_limit_using_spring_mongo_event_store() {
+        LocalDateTime now = LocalDateTime.now();
+        NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+        NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+        NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+        // When
+        persist("name", WriteCondition.streamVersionEq(0), nameDefined);
+        persist("name", WriteCondition.streamVersionEq(1), nameWasChanged1);
+        persist("name", WriteCondition.streamVersionEq(2), nameWasChanged2);
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name", 1, 1);
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(eventStream.version()).isEqualTo(3),
+                () -> assertThat(readEvents).hasSize(1),
+                () -> assertThat(readEvents).containsExactly(nameWasChanged1)
+        );
+    }
+
+    @Test
+    void stream_version_is_not_updated_when_event_insertion_fails() {
+        LocalDateTime now = LocalDateTime.now();
+        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(),now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
+
+        persist("name", WriteCondition.streamVersionEq(0), events);
+
+        // When
+        Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersionEq(events.size()), events));
+
+        // Then
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(throwable).isExactlyInstanceOf(DuplicateCloudEventException.class).hasCauseExactlyInstanceOf(MongoBulkWriteException.class),
+                () -> assertThat(eventStream.version()).isEqualTo(events.size()),
+                () -> assertThat(readEvents).hasSize(2),
+                () -> assertThat(readEvents).containsExactlyElementsOf(events)
+        );
+    }
+
+    @Test
+    void read_skew_is_not_allowed_for_blocking_implementation() {
+        LocalDateTime now = LocalDateTime.now();
+        NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+        NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+        NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+        persist("name", nameDefined);
+        persist("name", nameWasChanged1);
+
+        // When
+        EventStream<CloudEvent> eventStream = eventStore.read("name");
+        persist("name", nameWasChanged2);
+
+        // Then
+        List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+        assertAll(
+                () -> assertThat(eventStream.version()).isEqualTo(2),
+                () -> assertThat(readEvents).hasSize(2),
+                () -> assertThat(readEvents).containsExactly(nameDefined, nameWasChanged1)
+        );
+    }
+
+    @Nested
+    @DisplayName("write result")
+    class WriteResultTest {
+
+        @Test
+        void spring_mongo_event_store_returns_the_new_stream_version_when_at_least_one_event_is_written_to_an_empty_stream() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+
+            // When
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            WriteResult writeResult = persist("name", Stream.of(event1, event2));
+
+            // Then
+            assertAll(
+                    () -> assertThat(writeResult.streamId()).isEqualTo("name"),
+                    () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(0L),
+                    () -> assertThat(writeResult.newStreamVersion()).isEqualTo(2L)
+            );
+        }
+
+        @Test
+        void spring_mongo_event_store_returns_the_new_stream_version_when_at_least_one_event_is_written_to_an_existing_stream() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+
+            // When
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe2");
+            persist("name", Stream.of(event1));
+            WriteResult writeResult = persist("name", Stream.of(event2, event3));
+
+            // Then
+            assertAll(
+                    () -> assertThat(writeResult.streamId()).isEqualTo("name"),
+                    () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(1L),
+                    () -> assertThat(writeResult.newStreamVersion()).isEqualTo(3L)
+            );
+        }
+
+        @Test
+        void spring_mongo_event_store_returns_0_as_version_when_no_events_are_written_to_an_empty_stream() {
+            // When
+            WriteResult writeResult = persist("name", Stream.empty());
+
+            // Then
+            assertAll(
+                    () -> assertThat(writeResult.streamId()).isEqualTo("name"),
+                    () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(0L),
+                    () -> assertThat(writeResult.newStreamVersion()).isEqualTo(0L)
+            );
+        }
+
+        @Test
+        void spring_mongo_event_store_returns_the_previous_stream_version_when_no_events_are_written_to_an_existing_stream() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+
+            // When
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            persist("name", Stream.of(event1, event2));
+            WriteResult writeResult = persist("name", Stream.empty());
+
+            // Then
+            assertAll(
+                    () -> assertThat(writeResult.streamId()).isEqualTo("name"),
+                    () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(2L),
+                    () -> assertThat(writeResult.newStreamVersion()).isEqualTo(2L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("count")
+    class CountTest {
+
+        @Test
+        void count_without_any_filter_returns_all_the_count_of_all_events_in_the_event_store() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "Hello Doe");
+            persist("name", Stream.of(event1, event2, event3).collect(Collectors.toList()));
+
+            // When
+            long count = eventStore.count();
+
+            // Then
+            assertThat(count).isEqualTo(3);
+        }
+
+        @Test
+        void count_with_filter_returns_only_events_that_matches_the_filter() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "Hello Doe");
+            persist("name", Stream.of(event1, event2, event3).collect(Collectors.toList()));
+
+            // When
+            long count = eventStore.count(type(NameDefined.class.getSimpleName()));
+
+            // Then
+            assertThat(count).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("exists")
+    class ExistsTest {
+
+        @Test
+        void returns_false_when_there_are_no_events_in_the_event_store_and_filter_is_all() {
+            // When
+            boolean exists = eventStore.exists(Filter.all());
+
+            // Then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void returns_true_when_there_are_events_in_the_event_store_and_filter_is_all() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "Hello Doe");
+            persist("name", Stream.of(event1, event2, event3).collect(Collectors.toList()));
+
+            // When
+            boolean exists = eventStore.exists(Filter.all());
+
+            // Then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void returns_false_when_there_are_no_events_in_the_event_store_and_filter_is_not_all() {
+            // When
+            boolean exists = eventStore.exists(type(NameDefined.class.getSimpleName()));
+
+            // Then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        void returns_true_when_there_are_matching_events_in_the_event_store_and_filter_not_all() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "Hello Doe");
+            persist("name", Stream.of(event1, event2, event3).collect(Collectors.toList()));
+
+            // When
+            boolean exists = eventStore.exists(type(NameDefined.class.getSimpleName()));
+
+            // Then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void returns_false_when_there_events_in_the_event_store_that_doesnt_match_filter() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "Hello Doe");
+            persist("name", Stream.of(event1, event2).collect(Collectors.toList()));
+
+            // When
+            boolean exists = eventStore.exists(type(NameWasChanged.class.getSimpleName()));
+
+            // Then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("and there are duplicate events")
+    class DuplicatesTest {
+
+        @Test
+        void no_events_are_inserted_when_batch_contains_duplicate_events() {
+            LocalDateTime now = LocalDateTime.now();
+
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name4");
+
+            // When
+            Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersionEq(0), Stream.of(nameDefined, nameWasChanged1, nameWasChanged1, nameWasChanged2)));
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+            assertAll(
+                    () -> assertThat(throwable).isExactlyInstanceOf(DuplicateCloudEventException.class).hasCauseExactlyInstanceOf(MongoBulkWriteException.class),
+                    () -> assertThat(eventStream.version()).isEqualTo(0),
+                    () -> assertThat(readEvents).isEmpty()
+            );
+        }
+
+        @Test
+        void no_events_are_inserted_when_batch_contains_event_that_has_already_been_persisted() {
+            LocalDateTime now = LocalDateTime.now();
+
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name4");
+
+            persist("name", WriteCondition.streamVersionEq(0), Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersionEq(2), Stream.of(nameWasChanged2, nameWasChanged1)));
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+            assertAll(
+                    () -> assertThat(throwable).isExactlyInstanceOf(DuplicateCloudEventException.class).hasCauseExactlyInstanceOf(MongoBulkWriteException.class),
+                    () -> assertThat(eventStream.version()).isEqualTo(2),
+                    () -> assertThat(readEvents).hasSize(2),
+                    () -> assertThat(readEvents).containsExactly(nameDefined, nameWasChanged1)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("deletion")
+    class Delete {
+
+        @Test
+        void deleteEventStream_deletes_all_events_in_event_stream() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            eventStore.deleteEventStream("name");
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+            assertAll(
+                    () -> assertThat(eventStream.version()).isZero(),
+                    () -> assertThat(readEvents).isEmpty(),
+                    () -> assertThat(eventStore.exists("name")).isFalse(),
+                    () -> assertThat(cloudEventRepository.countByStream_Name("name")).isZero(),
+                    () -> assertThat(streamRepository.existsByName("name")).isFalse()
+            );
+        }
+
+        @Test
+        void deleteEvent_deletes_only_specific_event_in_event_stream() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            eventStore.deleteEvent(nameWasChanged1.eventId(), NAME_SOURCE);
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+            assertAll(
+                    () -> assertThat(eventStream.version()).isEqualTo(2), // Stream version is not changed when deleting an event
+                    () -> assertThat(readEvents).containsExactly(nameDefined),
+                    () -> assertThat(eventStore.exists("name")).isTrue(),
+                    () -> assertThat(cloudEventRepository.countByStream_Name("name")).isEqualTo(1),
+                    () -> assertThat(streamRepository.existsByName("name")).isTrue()
+            );
+        }
+
+        @Test
+        void delete_deletes_events_according_to_the_filter() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now, "name2", "name2");
+            persist("name2", nameDefined2);
+
+            // When
+            eventStore.delete(streamId("name").and(time(lte(now.atOffset(UTC).plusMinutes(1)))));
+
+            // Then
+            List<DomainEvent> stream1 = deserialize(eventStore.read("name").events());
+            List<DomainEvent> stream2 = deserialize(eventStore.read("name2").events());
+            assertAll(
+                    () -> assertThat(stream1).containsExactly(nameWasChanged1),
+                    () -> assertThat(stream2).containsExactly(nameDefined2)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("exists")
+    class Exists {
+
+        @Test
+        void returns_true_when_stream_and_contains_events() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            boolean exists = eventStore.exists("name");
+
+            // Then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        void returns_false_when_no_events_have_been_persisted_to_stream() {
+            // When
+            boolean exists = eventStore.exists("name");
+
+            // Then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        void updates_cloud_event_when_cloud_event_exists() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            String eventId2 = UUID.randomUUID().toString();
+            NameWasChanged nameWasChanged1 = new NameWasChanged(eventId2, now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            eventStore.updateEvent(eventId2, NAME_SOURCE, cloudEvent -> {
+                NameWasChanged e = deserialize(cloudEvent);
+                NameWasChanged correctedName = new NameWasChanged(e.eventId(), e.timestamp(), "name", "name3");
+                return CloudEventBuilder.v1(cloudEvent).withData(serializeEvent(correctedName)).build();
+            });
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+            assertThat(readEvents).containsExactly(nameDefined, new NameWasChanged(eventId2, now.plusHours(1), "name", "name3"));
+        }
+
+        @Test
+        void returns_updated_cloud_event_when_cloud_event_exists() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            String eventId2 = UUID.randomUUID().toString();
+            NameWasChanged nameWasChanged1 = new NameWasChanged(eventId2, now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            Optional<NameWasChanged> updatedCloudEvent = eventStore.updateEvent(eventId2, NAME_SOURCE, cloudEvent -> {
+                NameWasChanged e = deserialize(cloudEvent);
+                NameWasChanged correctedName = new NameWasChanged(e.eventId(), e.timestamp(), "name", "name3");
+                return CloudEventBuilder.v1(cloudEvent).withData(serializeEvent(correctedName)).build();
+            }).map(SpringDataJpaEventStoreTest.this::deserialize);
+
+            // Then
+            assertThat(updatedCloudEvent).contains(new NameWasChanged(eventId2, now.plusHours(1), "name", "name3"));
+        }
+
+        @Test
+        void returns_empty_optional_when_cloud_event_does_not_exists() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            Optional<CloudEvent> updatedCloudEvent = eventStore.updateEvent(UUID.randomUUID().toString(), NAME_SOURCE, cloudEvent -> {
+                NameWasChanged e = deserialize(cloudEvent);
+                NameWasChanged correctedName = new NameWasChanged(e.eventId(), e.timestamp(), "name", "name3");
+                return CloudEventBuilder.v1(cloudEvent).withData(serializeEvent(correctedName)).build();
+            });
+            // Then
+            assertThat(updatedCloudEvent).isEmpty();
+        }
+
+        @Test
+        void throw_iae_when_update_function_returns_null() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            String eventId2 = UUID.randomUUID().toString();
+            NameWasChanged nameWasChanged1 = new NameWasChanged(eventId2, now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            Throwable throwable = catchThrowable(() -> eventStore.updateEvent(eventId2, NAME_SOURCE, cloudEvent -> null));
+
+            // Then
+            assertThat(throwable).isExactlyInstanceOf(IllegalArgumentException.class).hasMessage("Cloud event update function is not allowed to return null");
+        }
+
+        @Test
+        void when_update_function_returns_the_same_argument_then_cloud_event_is_unchanged_in_the_database() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            String eventId2 = UUID.randomUUID().toString();
+            NameWasChanged nameWasChanged1 = new NameWasChanged(eventId2, now.plusHours(1), "name", "name2");
+            persist("name", Stream.of(nameDefined, nameWasChanged1));
+
+            // When
+            eventStore.updateEvent(eventId2, NAME_SOURCE, Function.identity());
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name");
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+            assertThat(readEvents).containsExactly(nameDefined, nameWasChanged1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Conditionally Write to Blocking Spring Mongo EventStore")
+    class ConditionallyWriteToSpringMongoEventStore {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        @Nested
+        @DisplayName("parallel writes")
+        class ParallelWritesToEventStoreReturns {
+
+            @EnabledOnOs(MAC)
+            void parallel_writes_to_event_store_throws_WriteConditionNotFulfilledException_when_write_condition_is_not_any() {
+                // Given
+                CyclicBarrier cyclicBarrier = new CyclicBarrier(2);
+                WriteCondition writeCondition = WriteCondition.streamVersionEq(0);
+                AtomicReference<Throwable> exception = new AtomicReference<>();
+
+                // When
+                new Thread(() -> {
+                    NameDefined event = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                    await(cyclicBarrier);
+                    exception.set(catchThrowable(() -> persist("name", writeCondition, event)));
+                }).start();
+
+                new Thread(() -> {
+                    NameDefined event = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                    await(cyclicBarrier);
+                    exception.set(catchThrowable(() -> persist("name", writeCondition, event)));
+                }).start();
+
+                // Then
+                Awaitility.await().atMost(4, SECONDS).untilAsserted(() -> assertThat(exception).hasValue(new WriteConditionNotFulfilledException("name", 1, writeCondition, "WriteCondition was not fulfilled. Expected version to be equal to 0 but was 1.")));
+            }
+
+            @EnabledOnOs(MAC)
+            void parallel_writes_to_event_store_does_not_throw_WriteConditionNotFulfilledException_when_write_condition_is_any() {
+                // Given
+                CyclicBarrier cyclicBarrier = new CyclicBarrier(3);
+                WriteCondition writeCondition = WriteCondition.anyStreamVersion();
+                AtomicReference<Throwable> exception = new AtomicReference<>();
+
+                // When
+                new Thread(() -> {
+                    NameWasChanged event = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Ikk Doe");
+                    try {
+                        await(cyclicBarrier);
+                        persist("name", writeCondition, event);
+                    } catch (Exception e) {
+                        exception.set(e);
+                    }
+                }).start();
+
+                new Thread(() -> {
+                    NameWasChanged event = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Ikkster Doe");
+                    try {
+                        await(cyclicBarrier);
+                        persist("name", writeCondition, event);
+                    } catch (Exception e) {
+                        exception.set(e);
+                    }
+                }).start();
+
+                new Thread(() -> {
+                    NameWasChanged event = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Ikkster Doe2");
+                    try {
+                        await(cyclicBarrier);
+                        persist("name", writeCondition, event);
+                    } catch (Exception e) {
+                        exception.set(e);
+                    }
+                }).start();
+
+                // Then
+                Awaitility.await().atMost(4, SECONDS).untilAsserted(() -> {
+                    EventStream<CloudEvent> eventStream = eventStore.read("name");
+                    assertThat(deserialize(eventStream.events()))
+                            .extracting(it -> (NameWasChanged) it)
+                            .extracting(NameWasChanged::name)
+                            .contains("Ikk Doe", "Ikkster Doe", "Ikkster Doe2");
+                });
+                assertThat(exception.get()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("eq")
+        class Eq {
+
+            @Test
+            void writes_events_when_stream_version_matches_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersionEq(eventStream1.version()), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_does_not_match_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersionEq(10), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be equal to 10 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("in")
+        class In {
+
+            @Test
+            void writes_events_when_stream_version_matches_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(in(eventStream1.version(), eventStream1.version() + 1)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_does_not_match_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(in(10L, 12L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version in any of (10,12) but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("ne")
+        class Ne {
+
+            @Test
+            void writes_events_when_stream_version_does_not_match_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(ne(20L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_match_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(ne(1L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to not be equal to 1 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("lt")
+        class Lt {
+
+            @Test
+            void writes_events_when_stream_version_is_less_than_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(lt(10L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_greater_than_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(lt(0L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be less than 0 but was 1.");
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_equal_to_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(lt(1L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be less than 1 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("gt")
+        class Gt {
+
+            @Test
+            void writes_events_when_stream_version_is_greater_than_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(gt(0L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_less_than_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(gt(100L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be greater than 100 but was 1.");
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_equal_to_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(gt(1L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be greater than 1 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("lte")
+        class Lte {
+
+            @Test
+            void writes_events_when_stream_version_is_less_than_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(lte(10L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+
+            @Test
+            void writes_events_when_stream_version_is_equal_to_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(lte(1L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_greater_than_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(lte(0L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be less than or equal to 0 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("gte")
+        class Gte {
+
+            @Test
+            void writes_events_when_stream_version_is_greater_than_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(gte(0L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void writes_events_when_stream_version_is_equal_to_expected_version() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(gte(0L)), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_stream_version_is_less_than_expected_version() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(gte(100L)), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be greater than or equal to 100 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("and")
+        class And {
+
+            @Test
+            void writes_events_when_stream_version_is_when_all_conditions_match_and_expression() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(and(gte(0L), lt(100L), ne(40L))), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_any_of_the_operations_in_the_and_expression_is_not_fulfilled() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(and(gte(0L), lt(100L), ne(1L))), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be greater than or equal to 0 and to be less than 100 and to not be equal to 1 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("or")
+        class Or {
+
+            @Test
+            void writes_events_when_stream_version_is_when_any_condition_in_or_expression_matches() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(or(gte(100L), lt(0L), ne(40L))), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_none_of_the_operations_in_the_and_expression_is_fulfilled() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(or(gte(100L), lt(1L))), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version to be greater than or equal to 100 or to be less than 1 but was 1.");
+            }
+        }
+
+        @Nested
+        @DisplayName("not")
+        class Not {
+
+            @Test
+            void writes_events_when_stream_version_is_not_matching_condition() {
+                // When
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                EventStream<CloudEvent> eventStream1 = eventStore.read("name");
+                persist(eventStream1.id(), WriteCondition.streamVersion(not(eq(100L))), Stream.of(event2));
+
+                // Then
+                EventStream<CloudEvent> eventStream2 = eventStore.read("name");
+                assertThat(deserialize(eventStream2.events())).containsExactly(event1, event2);
+            }
+
+            @Test
+            void throws_write_condition_not_fulfilled_when_condition_is_fulfilled_but_should_not_be_so() {
+                // Given
+                DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+                persist("name", event1);
+
+                // When
+                DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+                Throwable throwable = catchThrowable(() -> persist("name", WriteCondition.streamVersion(not(eq(1L))), Stream.of(event2)));
+
+                // Then
+                assertThat(throwable).isExactlyInstanceOf(WriteConditionNotFulfilledException.class)
+                        .hasMessage("WriteCondition was not fulfilled. Expected version not to be equal to 1 but was 1.");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("queries")
+    class QueriesTest {
+
+        @Test
+        void all_without_skip_and_limit_returns_all_events() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", nameDefined);
+            persist("name2", nameWasChanged1);
+            persist("name3", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.all();
+            assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2);
+        }
+
+        @Test
+        void all_with_skip_and_limit_returns_all_events_within_skip_and_limit() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", Stream.of(nameWasChanged2));
+
+            // Then
+            Stream<CloudEvent> events = eventStore.all(1, 2);
+            assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2);
+        }
+
+        @Test
+        void query_with_single_filter_without_skip_and_limit() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+            persist("something", CloudEventBuilder.v1()
+                    .withId(UUID.randomUUID().toString())
+                    .withSource(URI.create("http://something"))
+                    .withType("something")
+                    .withTime(LocalDateTime.now().atOffset(UTC))
+                    .withSubject("subject")
+                    .withDataContentType("application/json")
+                    .withData("{\"hello\":\"world\"}".getBytes(UTF_8))
+                    .build()
+            );
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(source(NAME_SOURCE));
+            assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2);
+        }
+
+        @Test
+        void query_with_single_filter_with_skip_and_limit() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+            persist("something", CloudEventBuilder.v1()
+                    .withId(UUID.randomUUID().toString())
+                    .withSource(URI.create("http://something"))
+                    .withType("something")
+                    .withTime(LocalDateTime.now().atOffset(UTC))
+                    .withSubject("subject")
+                    .withDataContentType("application/json")
+                    .withData("{\"hello\":\"world\"}".getBytes(UTF_8))
+                    .build()
+            );
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(source(NAME_SOURCE), 1, 1);
+            assertThat(deserialize(events)).containsExactly(nameWasChanged1);
+        }
+
+        @Test
+        void compose_filters_using_and() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            UUID uuid = UUID.randomUUID();
+            NameDefined nameDefined = new NameDefined(uuid.toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(time(lt(OffsetDateTime.of(now.plusHours(2), UTC))).and(id(uuid.toString())));
+            assertThat(deserialize(events)).containsExactly(nameDefined);
+        }
+
+        @Test
+        void compose_filters_using_or() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(time(OffsetDateTime.of(now.plusHours(2), UTC)).or(source(NAME_SOURCE)));
+            assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2);
+        }
+
+        @Test
+        void query_filter_by_subject() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(subject("WasChanged"));
+            assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2);
+        }
+
+        @Test
+        void query_filter_by_data() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(data("name", eq("name3")));
+            assertThat(deserialize(events)).containsExactly(nameWasChanged2);
+        }
+
+        @Test
+        void query_filter_by_cloud_event() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            String eventId = UUID.randomUUID().toString();
+            NameWasChanged nameWasChanged1 = new NameWasChanged(eventId, now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(cloudEvent(eventId, NAME_SOURCE));
+            assertThat(deserialize(events)).containsExactly(nameWasChanged1);
+        }
+
+        @Test
+        void query_filter_by_type() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(type(NameDefined.class.getSimpleName()));
+            assertThat(deserialize(events)).containsExactly(nameDefined);
+        }
+
+        @SuppressWarnings("ConstantConditions")
+        @Test
+        void query_filter_by_data_schema() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+            CloudEvent cloudEvent = CloudEventBuilder.v1()
+                    .withId(UUID.randomUUID().toString())
+                    .withSource(URI.create("http://something"))
+                    .withType("something")
+                    .withTime(LocalDateTime.now().atOffset(UTC))
+                    .withSubject("subject")
+                    .withDataSchema(URI.create("urn:myschema"))
+                    .withDataContentType("application/json")
+                    .withData("{\"hello\":\"world\"}".getBytes(UTF_8))
+                    .withExtension(OccurrentCloudEventExtension.occurrent("something", 1))
+                    .build();
+            persist("something", cloudEvent);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(dataSchema(URI.create("urn:myschema")));
+            CloudEvent expectedCloudEvent = CloudEventBuilder.v1(cloudEvent).withData(PojoCloudEventData.wrap(Document.parse(new String(cloudEvent.getData().toBytes(), UTF_8)), document -> document.toJson().getBytes(UTF_8))).build();
+            assertThat(events).containsExactly(expectedCloudEvent);
+        }
+
+        @Test
+        void query_filter_by_data_content_type() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name1", Stream.of(nameDefined, nameWasChanged1));
+            persist("name2", nameWasChanged2);
+            CloudEvent cloudEvent = CloudEventBuilder.v1()
+                    .withId(UUID.randomUUID().toString())
+                    .withSource(URI.create("http://something"))
+                    .withType("something")
+                    .withTime(offsetDateTimeFrom(LocalDateTime.now(), ZoneId.of("Europe/Stockholm")))
+                    .withSubject("subject")
+                    .withDataSchema(URI.create("urn:myschema"))
+                    .withDataContentType("text/plain")
+                    .withData("text".getBytes(UTF_8))
+                    .withExtension(OccurrentCloudEventExtension.occurrent("something", 1))
+                    .build();
+            persist("something", cloudEvent);
+
+            // Then
+            Stream<CloudEvent> events = eventStore.query(dataContentType("text/plain"));
+            assertThat(events).containsExactly(cloudEvent);
+        }
+
+        @Nested
+        @DisplayName("sort")
+        class SortTest {
+
+            @Test
+            void sort_by_unsorted() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(-2), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+                persist("name1", nameDefined);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.unsorted());
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2, nameDefined);
+            }
+
+            @Test
+            void sort_by_natural_asc() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(-2), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+                persist("name1", nameDefined);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.natural(ASCENDING));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2, nameDefined);
+            }
+
+            @Test
+            void sort_by_natural_desc() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(-2), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+                persist("name1", nameDefined);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.natural(DESCENDING));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged2, nameWasChanged1);
+            }
+
+            @Test
+            void sort_by_time_asc() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(-2), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+                persist("name1", nameDefined);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(ASCENDING));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameDefined, nameWasChanged2);
+            }
+
+            @Test
+            void sort_by_time_desc() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now.plusHours(3), "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(-2), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+                persist("name1", nameDefined);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(DESCENDING));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged2, nameWasChanged1);
+            }
+
+            @Test
+            void sort_by_time_desc_and_natural_descending() {
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name1", nameDefined);
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(DESCENDING).thenNatural(DESCENDING));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged2, nameWasChanged1, nameDefined);
+            }
+
+            @Test
+            void sort_by_time_desc_and_natural_ascending() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name", nameDefined);
+                persist("name", nameWasChanged1);
+                persist("name", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(DESCENDING).thenNatural(ASCENDING));
+                // Natural ignores other sort parameters!!
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2);
+            }
+
+            @Test
+            void sort_by_time_desc_and_other_field_descending() {
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name3");
+
+                // When
+                persist("name", nameDefined);
+                persist("name", nameWasChanged1);
+                persist("name", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(DESCENDING).then(STREAM_VERSION, DESCENDING));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged2, nameWasChanged1, nameDefined);
+            }
+
+            @Test
+            void sort_by_time_desc_and_other_field_ascending() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now, "name3", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name2", "name3");
+
+                // When
+                persist("name1", nameDefined);
+                persist("name3", nameWasChanged1);
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.all(SortBy.time(DESCENDING).then(STREAM_VERSION, ASCENDING));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged2, nameDefined, nameWasChanged1);
+            }
+        }
+
+        @Nested
+        @DisplayName("when time is represented as rfc 3339 string")
+        class TimeRepresentedAsRfc3339String {
+
+            void query_filter_by_time_but_is_using_slow_string_comparison() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(lt(OffsetDateTime.of(now.plusHours(2), UTC))));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1);
+            }
+
+            void query_filter_by_time_range_is_wider_than_persisted_time_range() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gte(OffsetDateTime.of(now.plusMinutes(35), UTC)), lte(OffsetDateTime.of(now.plusHours(4), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2);
+            }
+
+            @EnabledOnJre(JAVA_8)
+            @Test
+            void query_filter_by_time_range_has_exactly_the_same_range_as_persisted_time_range_when_using_java_8() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gte(OffsetDateTime.of(now, UTC)), lte(OffsetDateTime.of(now.plusHours(2), UTC)))));
+                assertThat(deserialize(events)).isNotEmpty(); // Java 8 seem to return undeterministic results
+            }
+
+            @EnabledForJreRange(min = JAVA_11)
+            @Test
+            void query_filter_by_time_range_has_exactly_the_same_range_as_persisted_time_range_when_using_java_11_and_above() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gte(OffsetDateTime.of(now, UTC)), lte(OffsetDateTime.of(now.plusHours(2), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1); // nameWasChanged2 _should_ be included but it's not due to string comparison instead of date
+            }
+
+            @Disabled
+            @Test
+            void query_filter_by_time_range_has_a_range_smaller_as_persisted_time_range_when_rfc_3339() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gt(OffsetDateTime.of(now.plusMinutes(50), UTC)), lt(OffsetDateTime.of(now.plusMinutes(110), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1);
+            }
+        }
+
+        @Nested
+        @DisplayName("when time is represented as date")
+        class TimeRepresentedAsDate {
+
+            @Test
+            void query_filter_by_time_lt() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(lt(OffsetDateTime.of(now.plusHours(2), UTC))));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1);
+            }
+
+            @Test
+            void query_filter_by_time_range_is_wider_than_persisted_time_range() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gte(OffsetDateTime.of(now.plusMinutes(35), UTC)), lte(OffsetDateTime.of(now.plusHours(4), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1, nameWasChanged2);
+            }
+
+            @Test
+            void query_filter_by_time_range_has_exactly_the_same_range_as_persisted_time_range() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gte(OffsetDateTime.of(now, UTC)), lte(OffsetDateTime.of(now.plusHours(2), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2);
+            }
+
+            @Test
+            void query_filter_by_time_range_has_a_range_smaller_as_persisted_time_range_when_date() {
+                // Given
+                LocalDateTime now = LocalDateTime.now();
+                NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+                NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+                NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+                // When
+                persist("name1", Stream.of(nameDefined, nameWasChanged1));
+                persist("name2", nameWasChanged2);
+
+                // Then
+                Stream<CloudEvent> events = eventStore.query(time(and(gt(OffsetDateTime.of(now.plusMinutes(50), UTC)), lt(OffsetDateTime.of(now.plusMinutes(110), UTC)))));
+                assertThat(deserialize(events)).containsExactly(nameWasChanged1);
+            }
+        }
+    }
+
+    private List<DomainEvent> deserialize(Stream<CloudEvent> events) {
+        return events
+                .map(CloudEvent::getData)
+                // @formatter:off
+                .map(CheckedFunction.unchecked(data -> objectMapper.readValue(data.toBytes(), new TypeReference<Map<String, Object>>() {
+                })))
+                // @formatter:on
+                .map(event -> {
+                    Instant instant = Instant.ofEpochMilli((long) event.get("time"));
+                    LocalDateTime time = LocalDateTime.ofInstant(instant, UTC);
+                    String eventId = (String) event.get("eventId");
+                    String name = (String) event.get("name");
+                    String userId = (String) event.get("userId");
+                    return Match(event.get("type")).of(
+                            Case($(is(NameDefined.class.getSimpleName())), e -> new NameDefined(eventId, time, userId, name)),
+                            Case($(is(NameWasChanged.class.getSimpleName())), e -> new NameWasChanged(eventId, time, userId, name))
+                    );
+                })
+                .collect(Collectors.toList());
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends DomainEvent> T deserialize(CloudEvent cloudEvent) {
+        return (T) deserialize(Stream.of(cloudEvent)).get(0);
+    }
+
+    private void persist(String eventStreamId, CloudEvent event) {
+        eventStore.write(eventStreamId, Stream.of(event));
+    }
+
+    private void persist(String eventStreamId, DomainEvent event) {
+        eventStore.write(eventStreamId, Stream.of(convertDomainEventCloudEvent(event)));
+    }
+
+    private void persist(String eventStreamId, List<DomainEvent> events) {
+        persist(eventStreamId, events.stream());
+    }
+
+    private WriteResult persist(String eventStreamId, Stream<DomainEvent> events) {
+        return eventStore.write(eventStreamId, events.map(this::convertDomainEventCloudEvent));
+    }
+
+    private void persist(String eventStreamId, WriteCondition writeCondition, DomainEvent event) {
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(event);
+        persist(eventStreamId, writeCondition, events);
+    }
+
+    private void persist(String eventStreamId, WriteCondition writeCondition, List<DomainEvent> events) {
+        persist(eventStreamId, writeCondition, events.stream());
+    }
+
+    private void persist(String eventStreamId, WriteCondition writeCondition, Stream<DomainEvent> events) {
+        eventStore.write(eventStreamId, writeCondition, events.map(this::convertDomainEventCloudEvent));
+    }
+
+    private CloudEvent convertDomainEventCloudEvent(DomainEvent domainEvent) {
+        return CloudEventBuilder.v1()
+                .withId(domainEvent.eventId())
+                .withSource(NAME_SOURCE)
+                .withType(domainEvent.getClass().getSimpleName())
+                .withTime(TimeConversion.toLocalDateTime(domainEvent.timestamp()).atOffset(UTC))
+                .withSubject(domainEvent.getClass().getSimpleName().substring(4)) // Defined or WasChanged
+                .withDataContentType("application/json")
+                .withData(serializeEvent(domainEvent))
+                .build();
+    }
+
+    private byte[] serializeEvent(DomainEvent e) {
+        try {
+            return objectMapper.writeValueAsBytes(new HashMap<String, Object>() {{
+                put("type", e.getClass().getSimpleName());
+                put("eventId", e.eventId());
+                put("name", e.name());
+                put("userId", e.userId());
+                put("time", e.timestamp().getTime());
+            }});
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new RuntimeException(jsonProcessingException);
+        }
+    }
+
+    private static void await(CyclicBarrier cyclicBarrier) {
+        try {
+            cyclicBarrier.await();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/eventstore/jpa/spring-data/src/test/java/org/occurrent/eventstore/jpa/springdata/TestJpaConfig.java
+++ b/eventstore/jpa/spring-data/src/test/java/org/occurrent/eventstore/jpa/springdata/TestJpaConfig.java
@@ -1,0 +1,68 @@
+package org.occurrent.eventstore.jpa.springdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "org.occurrent.eventstore.jpa.springdata")
+@EnableTransactionManagement(proxyTargetClass = true)
+@Import(SpringDataJpaEventStoreConfiguration.class)
+public class TestJpaConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        // Simple H2 in-memory DB
+        return new org.springframework.jdbc.datasource.DriverManagerDataSource(
+                "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1", "sa", "");
+    }
+
+    @Bean
+    public JpaVendorAdapter jpaVendorAdapter() {
+        HibernateJpaVendorAdapter adapter = new HibernateJpaVendorAdapter();
+        adapter.setGenerateDdl(true);
+        adapter.setShowSql(true);
+        return adapter;
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            DataSource dataSource, JpaVendorAdapter jpaVendorAdapter) {
+
+        LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
+        emf.setDataSource(dataSource);
+        emf.setJpaVendorAdapter(jpaVendorAdapter);
+        emf.setPackagesToScan("org.occurrent.eventstore.jpa.springdata");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("hibernate.hbm2ddl.auto", "create-drop");
+        props.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+        emf.setJpaPropertyMap(props);
+
+        return emf;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(
+            EntityManagerFactory emf) {
+        return new JpaTransactionManager(emf);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/eventstore/pom.xml
+++ b/eventstore/pom.xml
@@ -30,6 +30,7 @@
         <module>api</module>
         <module>inmemory</module>
         <module>mongodb</module>
+        <module>jpa</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <cloudevents.version>4.0.1</cloudevents.version>
         <reactor-bom.version>2024.0.10</reactor-bom.version>
         <spring-boot.version>3.5.6</spring-boot.version>
+        <sping-modulith.version>1.4.5</sping-modulith.version>
         <mongo.version>5.6.1</mongo.version>
         <dokka.version>2.0.0</dokka.version>
         <awaitility.version>4.2.2</awaitility.version>
@@ -180,6 +181,14 @@
                 <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.modulith</groupId>
+                <artifactId>spring-modulith-bom</artifactId>
+                <version>${sping-modulith.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!-- Mongo -->

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModel.java
@@ -23,7 +23,7 @@ package org.occurrent.subscription.api.blocking;
  * A subscription may be used to create read models (such as views, projections, sagas, snapshots etc) or
  * forward the event to another piece of infrastructure such as a message bus or other eventing infrastructure.
  * <p>
- * A blocking subscription model also you to create and manage subscriptions that'll use blocking IO.
+ * A blocking subscription model allows you to create and manage subscriptions that'll use blocking IO.
  */
 public interface SubscriptionModel extends Subscribable, SubscriptionModelLifeCycle {
 }

--- a/subscription/jpa/pom.xml
+++ b/subscription/jpa/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.occurrent</groupId>
+        <artifactId>subscription</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>subscription-jpa</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>spring-data</module>
+    </modules>
+
+</project>

--- a/subscription/jpa/spring-data/pom.xml
+++ b/subscription/jpa/spring-data/pom.xml
@@ -17,6 +17,14 @@
             <artifactId>subscription-api-blocking</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.modulith</groupId>
+            <artifactId>spring-modulith-events-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.modulith</groupId>
+            <artifactId>spring-modulith-events-jackson</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/subscription/jpa/spring-data/pom.xml
+++ b/subscription/jpa/spring-data/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.occurrent</groupId>
+        <artifactId>subscription-jpa</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>subscription-jpa-spring-data</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-api-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/DomainEventManagement.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/DomainEventManagement.java
@@ -1,0 +1,32 @@
+package org.occurrent.subscription.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DomainEventManagement {
+
+    private final SpringDataJpaSubscriptionModel itsModel;
+
+    public DomainEventManagement(
+            SpringDataJpaSubscriptionModel itsModel) {
+        this.itsModel = itsModel;
+    }
+
+    @ApplicationModuleListener
+    public void on(CloudEvent aCloudEvent) {
+        // Spread out, one per subscriber.
+        itsModel.spreadOut(aCloudEvent);
+    }
+
+    @ApplicationModuleListener
+    public void on(SubscriptionEvent aEvent) {
+        if (itsModel.isPaused(aEvent.subscriptionId())) {
+            // don't acknowledge the event!
+            throw new SubscriptionPausedEvent(aEvent.subscriptionId());
+        }
+        itsModel.process(aEvent.subscriptionId(), aEvent.event());
+    }
+
+}

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscription.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscription.java
@@ -1,0 +1,17 @@
+package org.occurrent.subscription.jpa.springdata;
+
+import org.occurrent.subscription.api.blocking.Subscription;
+
+import java.time.Duration;
+
+public class SpringDataJpaSubscription implements Subscription {
+    @Override
+    public String id() {
+        return "";
+    }
+
+    @Override
+    public boolean waitUntilStarted(Duration timeout) {
+        return true;
+    }
+}

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscription.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscription.java
@@ -1,17 +1,47 @@
 package org.occurrent.subscription.jpa.springdata;
 
+import io.cloudevents.CloudEvent;
+import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.Subscription;
+import org.springframework.lang.NonNull;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 public class SpringDataJpaSubscription implements Subscription {
+
+    private final String itsSubscriptionId;
+    private final SubscriptionFilter itsFilter;
+    private final Consumer<CloudEvent> itsAction;
+    private final AtomicBoolean itsExecuting;
+
+    public SpringDataJpaSubscription(String subscriptionId, SubscriptionFilter filter, Consumer<CloudEvent> action) {
+        itsSubscriptionId = subscriptionId;
+        itsFilter = filter;
+        itsAction = action;
+        itsExecuting = new AtomicBoolean(false);
+    }
+
     @Override
+    @NonNull
     public String id() {
-        return "";
+        return itsSubscriptionId;
     }
 
     @Override
     public boolean waitUntilStarted(Duration timeout) {
         return true;
+    }
+
+    public void accept(CloudEvent event) {
+        if (!itsExecuting.compareAndSet(false, true)){
+            throw new SubscriptionAlreadyExecuting(itsSubscriptionId);
+        }
+        try {
+            itsAction.accept(event);
+        } finally {
+            itsExecuting.set(false);
+        }
     }
 }

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscriptionModel.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscriptionModel.java
@@ -1,0 +1,62 @@
+package org.occurrent.subscription.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.SubscriptionPosition;
+import org.occurrent.subscription.api.blocking.PositionAwareSubscriptionModel;
+import org.occurrent.subscription.api.blocking.Subscription;
+
+import java.util.function.Consumer;
+
+public class SpringDataJpaSubscriptionModel implements PositionAwareSubscriptionModel {
+    @Override
+    public SubscriptionPosition globalSubscriptionPosition() {
+        return null;
+    }
+
+    @Override
+    public Subscription subscribe(String subscriptionId, SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        return null;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void start(boolean resumeSubscriptionsAutomatically) {
+
+    }
+
+    @Override
+    public boolean isRunning() {
+        return false;
+    }
+
+    @Override
+    public boolean isRunning(String subscriptionId) {
+        return false;
+    }
+
+    @Override
+    public boolean isPaused(String subscriptionId) {
+        return false;
+    }
+
+    @Override
+    public Subscription resumeSubscription(String subscriptionId) {
+        return null;
+    }
+
+    @Override
+    public void pauseSubscription(String subscriptionId) {
+
+    }
+
+    @Override
+    public void cancelSubscription(String subscriptionId) {
+
+    }
+}

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscriptionModel.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SpringDataJpaSubscriptionModel.java
@@ -6,57 +6,118 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionPosition;
 import org.occurrent.subscription.api.blocking.PositionAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.Subscription;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+/**
+ * My Entities publish a @DomainEvent through Spring Data JPA's event system.
+ */
+
+
+@Component
 public class SpringDataJpaSubscriptionModel implements PositionAwareSubscriptionModel {
+    private final Map<String, SpringDataJpaSubscription> itsSubscriptions;
+    private final ApplicationEventPublisher itsPublisher;
+    private AtomicBoolean itsRunning;
+
+    public SpringDataJpaSubscriptionModel(ApplicationEventPublisher aPublisher) {
+        itsRunning = new AtomicBoolean(false);
+        itsPublisher = aPublisher;
+        itsSubscriptions = new HashMap<>();
+    }
+
     @Override
     public SubscriptionPosition globalSubscriptionPosition() {
+        // I like the idea of ... summing up the current version of all the streams ?
         return null;
     }
 
     @Override
+    @NonNull
     public Subscription subscribe(String subscriptionId, SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
-        return null;
+        var sub = itsSubscriptions.put(subscriptionId,
+                new SpringDataJpaSubscription(subscriptionId, filter, action));
+        // not current
+        if (!startAt.isNow()) {
+            // publish all events till now.
+        }
+        return sub;
     }
 
     @Override
     public void stop() {
-
+        itsSubscriptions.keySet()
+                .forEach(this::pauseSubscription);
+        itsRunning.set(false);
     }
 
     @Override
     public void start(boolean resumeSubscriptionsAutomatically) {
-
+        itsRunning.set(true);
+        if (resumeSubscriptionsAutomatically) {
+            itsSubscriptions.keySet()
+                    .forEach(this::resumeSubscription);
+        }
     }
 
     @Override
     public boolean isRunning() {
-        return false;
+        return itsRunning.get();
     }
 
     @Override
     public boolean isRunning(String subscriptionId) {
-        return false;
+        return !itsSubscriptions.get(subscriptionId).isPaused();
     }
 
     @Override
     public boolean isPaused(String subscriptionId) {
-        return false;
+        return itsSubscriptions.get(subscriptionId).isPaused();
     }
 
     @Override
     public Subscription resumeSubscription(String subscriptionId) {
-        return null;
+        if (isRunning(subscriptionId)) {
+            throw new IllegalArgumentException("Currently running");
+        }
+        return itsSubscriptions.get(subscriptionId).resume();
+        // TODO: re-publish the missing events
     }
 
     @Override
     public void pauseSubscription(String subscriptionId) {
-
+        if (isPaused(subscriptionId)){
+            throw new IllegalArgumentException("is paused already");
+        }
+        itsSubscriptions.get(subscriptionId).pauseNow();
     }
 
     @Override
     public void cancelSubscription(String subscriptionId) {
+        // clear all pending events ?!
+        itsSubscriptions.remove(subscriptionId).pauseNow();
+    }
 
+    /**
+     * An Event was recorded, spread it to all matching subscriptions.
+     */
+    void spreadOut(CloudEvent aCloudEvent) {
+        // Even if currently stopping, we should enqueue the subscriptions,
+        // else we'd need a mechanism to re-process those events as well,
+        // which is a bit too much for the moment.
+        itsSubscriptions.values().stream()
+                .filter(s -> s.eventMatches(aCloudEvent))
+                .map(s -> new SubscriptionEvent(s.id(), aCloudEvent))
+                .forEach(itsPublisher::publishEvent);
+    }
+
+    void process(String subscriptionId, CloudEvent event) {
+        itsSubscriptions.get(subscriptionId).accept(event);
     }
 }

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionAlreadyExecuting.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionAlreadyExecuting.java
@@ -1,0 +1,6 @@
+package org.occurrent.subscription.jpa.springdata;
+
+public class SubscriptionAlreadyExecuting extends RuntimeException {
+    public SubscriptionAlreadyExecuting(String aSubscriptionId) {
+    }
+}

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionEvent.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionEvent.java
@@ -1,0 +1,9 @@
+package org.occurrent.subscription.jpa.springdata;
+
+import io.cloudevents.CloudEvent;
+
+record SubscriptionEvent(
+        String subscriptionId,
+        CloudEvent event
+) {
+}

--- a/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionPausedEvent.java
+++ b/subscription/jpa/spring-data/src/main/java/org/occurrent/subscription/jpa/springdata/SubscriptionPausedEvent.java
@@ -1,0 +1,7 @@
+package org.occurrent.subscription.jpa.springdata;
+
+public class SubscriptionPausedEvent extends RuntimeException {
+    public SubscriptionPausedEvent(String aSubscriptionId) {
+
+    }
+}

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -32,6 +32,7 @@
         <module>redis</module>
         <module>util</module>
         <module>inmemory</module>
+        <module>jpa</module>
     </modules>
 
 </project>


### PR DESCRIPTION
A subscription implementation based on the Spring-modulith events concepts.

Works two-steps: At first a "DomainEvent" is being published by JPA upon insertion of the Entity, that event is then being spread between the matching subscriptions, this as a separate ApplicationModuleEvent.