### PR TITLE
Add StreamReadFilter support across EventStore implementations and ApplicationService ExecuteOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ nbdist/
 
 # JQWik
 .jqwik-database
+
+# Local task tracking
+tasks/

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
@@ -41,9 +41,7 @@ public interface ApplicationService<T> {
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
      */
-    default WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
-        return execute(streamId, null, functionThatCallsDomainModel, sideEffect);
-    }
+    WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect);
 
     /**
      * Execute a function that loads the events from the event store and apply them to the {@code functionThatCallsDomainModel} and
@@ -65,7 +63,12 @@ public interface ApplicationService<T> {
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
      */
-    WriteResult execute(String streamId, @Nullable StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect);
+    default WriteResult execute(String streamId, @Nullable StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
+        if (filter == null) {
+            return execute(streamId, functionThatCallsDomainModel, sideEffect);
+        }
+        throw new UnsupportedOperationException("This ApplicationService implementation does not support StreamReadFilter. Override execute(streamId, filter, functionThatCallsDomainModel, sideEffect) to add support.");
+    }
 
     /**
      * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function, Consumer)}.

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
@@ -3,6 +3,7 @@ package org.occurrent.application.service.blocking;
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.occurrent.eventstore.api.StreamReadFilter;
 import org.occurrent.eventstore.api.WriteResult;
 
 import java.util.Objects;
@@ -40,8 +41,31 @@ public interface ApplicationService<T> {
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
      */
-    WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect);
+    default WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
+        return execute(streamId, null, functionThatCallsDomainModel, sideEffect);
+    }
 
+    /**
+     * Execute a function that loads the events from the event store and apply them to the {@code functionThatCallsDomainModel} and
+     * also execute side-effects that are executed synchronously <i>after</i> the events have been written to the event store.
+     * If the side-effects write data to the same datastore as the event store you can make use of transactions to write events
+     * and side-effects atomically.
+     * <br>
+     * <br>
+     * <p>
+     * Note that if you domain model works with {@code java.util.List} as input and output, then depend on the
+     * command composition ({@code org.occurrent:command-composition:<version>}) library to convert {@code functionThatCallsDomainModel}
+     * from {@code Function<Stream<T>, Stream<T>>} to {@code Function<List<T>, List<T>>} by using
+     * {@code org.occurrent.application.command.composition.toListCommand(functionThatCallsDomainModel)}.
+     * </p>
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param filter                       A filter to apply when reading events from the event store.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
+     *                                     if required.
+     * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
+     */
+    WriteResult execute(String streamId, @Nullable StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect);
 
     /**
      * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function, Consumer)}.
@@ -55,6 +79,21 @@ public interface ApplicationService<T> {
     default WriteResult execute(UUID streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, Consumer<Stream<T>> sideEffect) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         return execute(streamId.toString(), functionThatCallsDomainModel, sideEffect);
+    }
+
+    /**
+     * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function, Consumer)}.
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param filter                       A filter to apply when reading events from the event store.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
+     *                                     if required.
+     * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
+     * @see #execute(String, Function, Consumer)
+     */
+    default WriteResult execute(UUID streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, Consumer<Stream<T>> sideEffect) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), filter, functionThatCallsDomainModel, sideEffect);
     }
 
     /**
@@ -77,6 +116,27 @@ public interface ApplicationService<T> {
     }
 
     /**
+     *
+     * Execute a function that loads the events from the event store and apply them to the {@code functionThatCallsDomainModel}.
+     * <br>
+     * <br>
+     * <p>
+     * Note that if you domain model works with {@code java.util.List} as input and output, then depend on the
+     * command composition ({@code org.occurrent:command-composition:<version>}) library to convert {@code functionThatCallsDomainModel}
+     * from {@code Function<Stream<T>, Stream<T>>} to {@code Function<List<T>, List<T>>} by using
+     * {@code org.occurrent.application.command.composition.toListCommand(functionThatCallsDomainModel)}.
+     * </p>
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param filter                       A filter to apply when reading events from the event store.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
+     *                                     if required.
+     */
+    default WriteResult execute(String streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
+        return execute(streamId, filter, functionThatCallsDomainModel, null);
+    }
+
+    /**
      * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function)}.
      *
      * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
@@ -87,5 +147,18 @@ public interface ApplicationService<T> {
     default WriteResult execute(UUID streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         return execute(streamId.toString(), functionThatCallsDomainModel);
+    }
+
+    /**
+     * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function)}.
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
+     *                                     if required.
+     * @see #execute(String, Function)
+     */
+    default WriteResult execute(UUID streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), filter, functionThatCallsDomainModel);
     }
 }

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
@@ -23,6 +23,80 @@ import java.util.stream.Stream;
 public interface ApplicationService<T> {
 
     /**
+     * Options used when executing a command in {@link ApplicationService}.
+     * <p>
+     * Use this record to configure:
+     * <ul>
+     *     <li>a {@link StreamReadFilter} that limits which events are read before command execution</li>
+     *     <li>an optional side-effect that is invoked after events have been written</li>
+     * </ul>
+     * <p>
+     * A typical usage pattern is:
+     * <pre>{@code
+     * applicationService.execute(streamId,
+     *         ApplicationService.filter(myFilter).sideEffect(mySideEffect),
+     *         functionThatCallsDomainModel);
+     * }</pre>
+     *
+     * @param <T> The event type consumed by the side-effect stream.
+     */
+    record ExecuteOptions<T>(@Nullable StreamReadFilter filter, @Nullable Consumer<Stream<T>> sideEffect) {
+        /**
+         * Create empty options, i.e. no read filter and no side-effect.
+         */
+        public static <T> ExecuteOptions<T> empty() {
+            return new ExecuteOptions<>(null, null);
+        }
+
+        /**
+         * Set stream read filter.
+         * <p>
+         * Note that the generic type parameter may change when chaining since the side-effect type is established
+         * once {@link #sideEffect(Consumer)} is provided.
+         *
+         * @param filter The filter to use when reading the stream.
+         * @param <U>    The side-effect event type for the returned options.
+         * @return New options with filter applied.
+         */
+        public <U> ExecuteOptions<U> filter(StreamReadFilter filter) {
+            return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null);
+        }
+
+        /**
+         * Set side-effect to invoke after successful writes.
+         *
+         * @param sideEffect Side-effect that receives the newly produced domain events.
+         * @param <U>        The side-effect event type for the returned options.
+         * @return New options with side-effect applied.
+         */
+        public <U> ExecuteOptions<U> sideEffect(Consumer<Stream<U>> sideEffect) {
+            return new ExecuteOptions<>(filter, Objects.requireNonNull(sideEffect, "sideEffect cannot be null"));
+        }
+    }
+
+    /**
+     * Create {@link ExecuteOptions} with a stream read filter.
+     *
+     * @param filter The filter to use when reading the stream.
+     * @param <T>    The side-effect event type to be used if {@link ExecuteOptions#sideEffect(Consumer)} is chained.
+     * @return Filtered execute options.
+     */
+    static <T> ExecuteOptions<T> filter(StreamReadFilter filter) {
+        return ExecuteOptions.<T>empty().filter(filter);
+    }
+
+    /**
+     * Create {@link ExecuteOptions} with a side-effect.
+     *
+     * @param sideEffect Side-effect that receives the newly produced domain events.
+     * @param <T>        The side-effect event type.
+     * @return Execute options configured with side-effect.
+     */
+    static <T> ExecuteOptions<T> sideEffect(Consumer<Stream<T>> sideEffect) {
+        return ExecuteOptions.<T>empty().sideEffect(sideEffect);
+    }
+
+    /**
      * Execute a function that loads the events from the event store and apply them to the {@code functionThatCallsDomainModel} and
      * also execute side-effects that are executed synchronously <i>after</i> the events have been written to the event store.
      * If the side-effects write data to the same datastore as the event store you can make use of transactions to write events
@@ -40,7 +114,9 @@ public interface ApplicationService<T> {
      * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
+     * @deprecated Use {@link #execute(String, ExecuteOptions, Function)}.
      */
+    @Deprecated(forRemoval = true)
     WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect);
 
     /**
@@ -62,12 +138,34 @@ public interface ApplicationService<T> {
      * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
+     * @deprecated Use {@link #execute(String, ExecuteOptions, Function)}.
      */
+    @Deprecated(forRemoval = true)
     default WriteResult execute(String streamId, @Nullable StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
         if (filter == null) {
             return execute(streamId, functionThatCallsDomainModel, sideEffect);
         }
         throw new UnsupportedOperationException("This ApplicationService implementation does not support StreamReadFilter. Override execute(streamId, filter, functionThatCallsDomainModel, sideEffect) to add support.");
+    }
+
+    /**
+     * Execute a function that loads events from the event store and applies them to the domain model using {@link ExecuteOptions}.
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param executeOptions               Options that control stream read filtering and optional side-effects.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model.
+     */
+    default WriteResult execute(String streamId, ExecuteOptions<T> executeOptions, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(executeOptions, "Execute options cannot be null");
+        return execute(streamId, executeOptions.filter(), functionThatCallsDomainModel, executeOptions.sideEffect());
+    }
+
+    /**
+     * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}.
+     */
+    default WriteResult execute(UUID streamId, ExecuteOptions<T> executeOptions, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), executeOptions, functionThatCallsDomainModel);
     }
 
     /**
@@ -78,7 +176,9 @@ public interface ApplicationService<T> {
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
      * @see #execute(String, Function, Consumer)
+     * @deprecated Use {@link #execute(UUID, ExecuteOptions, Function)}.
      */
+    @Deprecated(forRemoval = true)
     default WriteResult execute(UUID streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, Consumer<Stream<T>> sideEffect) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         return execute(streamId.toString(), functionThatCallsDomainModel, sideEffect);
@@ -93,7 +193,9 @@ public interface ApplicationService<T> {
      *                                     if required.
      * @param sideEffect                   Side-effects that are executed <i>after</i> the events have been written to the event store.
      * @see #execute(String, Function, Consumer)
+     * @deprecated Use {@link #execute(UUID, ExecuteOptions, Function)}.
      */
+    @Deprecated(forRemoval = true)
     default WriteResult execute(UUID streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, Consumer<Stream<T>> sideEffect) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         return execute(streamId.toString(), filter, functionThatCallsDomainModel, sideEffect);
@@ -119,27 +221,6 @@ public interface ApplicationService<T> {
     }
 
     /**
-     *
-     * Execute a function that loads the events from the event store and apply them to the {@code functionThatCallsDomainModel}.
-     * <br>
-     * <br>
-     * <p>
-     * Note that if you domain model works with {@code java.util.List} as input and output, then depend on the
-     * command composition ({@code org.occurrent:command-composition:<version>}) library to convert {@code functionThatCallsDomainModel}
-     * from {@code Function<Stream<T>, Stream<T>>} to {@code Function<List<T>, List<T>>} by using
-     * {@code org.occurrent.application.command.composition.toListCommand(functionThatCallsDomainModel)}.
-     * </p>
-     *
-     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
-     * @param filter                       A filter to apply when reading events from the event store.
-     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
-     *                                     if required.
-     */
-    default WriteResult execute(String streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
-        return execute(streamId, filter, functionThatCallsDomainModel, null);
-    }
-
-    /**
      * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function)}.
      *
      * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
@@ -150,18 +231,5 @@ public interface ApplicationService<T> {
     default WriteResult execute(UUID streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         return execute(streamId.toString(), functionThatCallsDomainModel);
-    }
-
-    /**
-     * Convenience function that lets you specify {@code streamId} as a {@code UUID} instead of a {@code String}. Simply delegates to {@link #execute(String, Function)}.
-     *
-     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
-     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model. Use partial application ({@code org.occurrent:command-composition:<version>})
-     *                                     if required.
-     * @see #execute(String, Function)
-     */
-    default WriteResult execute(UUID streamId, StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel) {
-        Objects.requireNonNull(streamId, "Stream id cannot be null");
-        return execute(streamId.toString(), filter, functionThatCallsDomainModel);
     }
 }

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/GenericApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/GenericApplicationService.java
@@ -84,6 +84,11 @@ public class GenericApplicationService<T> implements ApplicationService<T> {
 
 
     @Override
+    public WriteResult execute(String streamId, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
+        return execute(streamId, null, functionThatCallsDomainModel, sideEffect);
+    }
+
+    @Override
     public WriteResult execute(String streamId, @Nullable StreamReadFilter filter, Function<Stream<T>, Stream<T>> functionThatCallsDomainModel, @Nullable Consumer<Stream<T>> sideEffect) {
         Objects.requireNonNull(streamId, "Stream id cannot be null");
         Objects.requireNonNull(functionThatCallsDomainModel, "Function that calls domain model cannot be null");

--- a/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
+++ b/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
@@ -58,17 +58,31 @@ fun <T : Any> ApplicationService<T>.execute(streamId: String, functionThatCallsD
  */
 @JvmName("executeList")
 fun <T : Any> ApplicationService<T>.execute(streamId: String, functionThatCallsDomainModel: (List<T>) -> List<T>): WriteResult {
-    val f = Function<Stream<T>, Stream<T>> { eventStream: Stream<T> ->
-        val currentEvents: List<T> = eventStream.toList()
-        val newEvents: Stream<T> = functionThatCallsDomainModel.invoke(currentEvents).stream()
-        newEvents
-    }
-    return execute(streamId, f)
+    return execute(streamId, functionThatCallsDomainModel, null)
 }
 
 @JvmName("executeList")
 fun <T : Any> ApplicationService<T>.execute(streamId: UUID, functionThatCallsDomainModel: (List<T>) -> List<T>): WriteResult = execute(streamId.toString(), functionThatCallsDomainModel)
 
+@JvmName("executeList")
+fun <T : Any> ApplicationService<T>.execute(streamId: UUID, functionThatCallsDomainModel: (List<T>) -> List<T>, sideEffects: ((List<T>) -> Unit)? = null): WriteResult {
+    return execute(streamId.toString(), functionThatCallsDomainModel, sideEffects)
+}
+
+@JvmName("executeList")
+fun <T : Any> ApplicationService<T>.execute(streamId: String, functionThatCallsDomainModel: (List<T>) -> List<T>, sideEffects: ((List<T>) -> Unit)? = null): WriteResult {
+    val f = Function<Stream<T>, Stream<T>> { eventStream: Stream<T> ->
+        val currentEvents: List<T> = eventStream.toList()
+        val newEvents: Stream<T> = functionThatCallsDomainModel.invoke(currentEvents).stream()
+        newEvents
+    }
+    return execute(streamId, f, sideEffects?.toStreamSideEffect())
+}
+
 private fun <T> ((Sequence<T>) -> Unit).toStreamSideEffect(): (Stream<T>) -> Unit {
     return { streamOfEvents -> this(streamOfEvents.asSequence()) }
+}
+
+private fun <T> ((List<T>) -> Unit).toStreamSideEffect(): (Stream<T>) -> Unit {
+    return { streamOfEvents -> this(streamOfEvents.toList()) }
 }

--- a/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
+++ b/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
@@ -76,13 +76,13 @@ fun <T : Any> ApplicationService<T>.execute(streamId: String, functionThatCallsD
         val newEvents: Stream<T> = functionThatCallsDomainModel.invoke(currentEvents).stream()
         newEvents
     }
-    return execute(streamId, f, sideEffects?.toStreamSideEffect())
+    return execute(streamId, f, sideEffects?.toStreamSideEffectFromList())
 }
 
 private fun <T> ((Sequence<T>) -> Unit).toStreamSideEffect(): (Stream<T>) -> Unit {
     return { streamOfEvents -> this(streamOfEvents.asSequence()) }
 }
 
-private fun <T> ((List<T>) -> Unit).toStreamSideEffect(): (Stream<T>) -> Unit {
+private fun <T> ((List<T>) -> Unit).toStreamSideEffectFromList(): (Stream<T>) -> Unit {
     return { streamOfEvents -> this(streamOfEvents.toList()) }
 }

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/generic/GenericApplicationServiceTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/generic/GenericApplicationServiceTest.java
@@ -34,14 +34,17 @@ import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.occurrent.application.composition.command.CommandConversion.toStreamCommand;
+import static org.occurrent.application.service.blocking.ApplicationService.filter;
 import static org.occurrent.application.service.blocking.PolicySideEffect.executePolicy;
 
+@SuppressWarnings("removal")
 @DisplayName("generic application service")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 public class GenericApplicationServiceTest {
@@ -75,24 +78,25 @@ public class GenericApplicationServiceTest {
     }
 
     @Test
-    void supports_stream_read_filter() {
+    void supports_execute_options() {
         // Given
         String streamId = UUID.randomUUID().toString();
-        var initialEvent = cloudEventConverter.toCloudEvents(Stream.of(
+        var initialEvents = cloudEventConverter.toCloudEvents(Stream.of(
                 new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Johan"),
                 new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Mattias"))
         );
-        eventStore.write(streamId, initialEvent);
-
+        eventStore.write(streamId, initialEvents);
+        AtomicReference<String> sideEffectPayload = new AtomicReference<>("not-called");
         // When
         WriteResult writeResult = applicationService.execute(streamId,
-                StreamReadFilter.type(NameDefined.class.getName()),
+                filter(StreamReadFilter.type(NameDefined.class.getName())).sideEffect(events -> sideEffectPayload.set(events.findFirst().map(DomainEvent::name).orElse("empty"))),
                 toStreamCommand(events -> Name.changeName(events, UUID.randomUUID().toString(), LocalDateTime.now(), "name", "New Name")));
 
         // Then
         assertAll(
                 () -> assertThat(writeResult.streamId()).isEqualTo(streamId),
-                () -> assertThat(writeResult.newStreamVersion()).isEqualTo(3L)
+                () -> assertThat(writeResult.newStreamVersion()).isEqualTo(3L),
+                () -> assertThat(sideEffectPayload.get()).isEqualTo("New Name")
         );
     }
 

--- a/doc/architecture/decisions/0011-introduce-optional-capability-interface-for-filtered-stream-reads.md
+++ b/doc/architecture/decisions/0011-introduce-optional-capability-interface-for-filtered-stream-reads.md
@@ -1,4 +1,4 @@
-# 1. Introduce optional capability interface for filtered stream reads
+# 11. Introduce optional capability interface for filtered stream reads
 
 Date: 2026-01-16
 

--- a/doc/architecture/decisions/0011-introduce-optional-capability-interface-for-filtered-stream-reads.md
+++ b/doc/architecture/decisions/0011-introduce-optional-capability-interface-for-filtered-stream-reads.md
@@ -1,0 +1,76 @@
+# 1. Introduce optional capability interface for filtered stream reads
+
+Date: 2026-01-16
+
+## Status
+
+Accepted
+
+## Context
+
+Occurrent's `EventStore` is currently composed from smaller capability interfaces:
+
+- `ReadEventStream`
+- `ConditionallyWriteToEventStream`
+- `UnconditionallyWriteToEventStream`
+- `EventStreamExists`
+
+Stream reads today are defined in `ReadEventStream` and are intentionally minimal:
+
+- `read(streamId)`
+- `read(streamId, skip, limit)`
+
+We are introducing `StreamReadFilter`, a stream-scoped filter DSL that allows filtering by CloudEvent attributes, extensions, and data while explicitly excluding stream identity and concurrency fields (streamId and streamVersion). This feature is primarily meant to reduce read amplification for certain commands and use cases.
+
+Not all underlying data stores are expected to support server-side filtering for stream reads. Examples include:
+- event stores with limited query support for stream partitioned reads
+- alternative backends where filtering requires expensive scans
+- implementations that aim to remain minimal and portable
+
+If we add `read(streamId, StreamReadFilter)` directly to `ReadEventStream`, then all `EventStore` implementations would be forced to implement it, even if only by reading everything and filtering client-side. This would:
+- create performance traps
+- blur the meaning of the API contract
+- make it harder to port Occurrent to backends that cannot support this capability efficiently
+
+At the same time, the `ApplicationService` currently depends on `EventStore`. Splitting the application service into multiple types, one requiring filtering and one not, would increase surface area and fragmentation, and complicate adoption.
+
+We want:
+- portability for event store implementations
+- a single ApplicationService abstraction
+- a clear and explicit failure mode if filtering is requested but not supported
+
+## Decision
+
+1. Keep `ReadEventStream` minimal and backend-portable.
+   - Do not add `StreamReadFilter` methods to `ReadEventStream`.
+
+2. Introduce a new optional capability interface for filtered stream reads.
+   - Name: `ReadEventStreamWithFilter` (or equivalent).
+   - Methods:
+     - `EventStream<CloudEvent> read(String streamId, StreamReadFilter filter)`
+     - `EventStream<CloudEvent> read(String streamId, StreamReadFilter filter, int skip, int limit)`
+
+3. Preserve a single `ApplicationService` type.
+   - The ApplicationService continues to depend on the baseline `EventStore` interface.
+   - When a command execution requests a `StreamReadFilter`, the ApplicationService requires that the underlying event store implements `ReadEventStreamWithFilter`.
+   - If the capability is not present, the ApplicationService fails fast with a clear exception indicating that filtered stream reads are not supported by the configured event store.
+
+4. Make filter usage explicit at the ApplicationService call site.
+   - Provide an overload or options object that includes an optional `StreamReadFilter`.
+   - If no filter is provided, the ApplicationService only uses `ReadEventStream`.
+   - If a filter is provided, the ApplicationService uses `ReadEventStreamWithFilter`.
+
+## Consequences
+
+Positive:
+- Event store implementations remain portable. Backends that cannot support stream read filtering are not forced to implement it.
+- Avoids performance traps where an implementation silently does client-side filtering.
+- A single ApplicationService abstraction is retained, avoiding API fragmentation and multiple application service variants.
+- Filtered stream reads are an explicit opt-in capability with a clear failure mode when unsupported.
+- Capability composition remains consistent with Occurrent's existing interface design approach.
+
+Negative:
+- Filtered stream reads require a runtime capability check.
+- Users may encounter a runtime error if they request filtered reads on an event store that does not implement the capability.
+- Documentation must clearly explain which features require `ReadEventStreamWithFilter` support.
+- Implementations that want to filter must implement an additional interface and associated mapping and validation logic.

--- a/eventstore/api/blocking/src/main/java/org/occurrent/eventstore/api/blocking/ReadEventStreamWithFilter.java
+++ b/eventstore/api/blocking/src/main/java/org/occurrent/eventstore/api/blocking/ReadEventStreamWithFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.StreamReadFilter;
+
+/**
+ * An interface that should be implemented by event stores that supports reading an {@link EventStream} with a filter.
+ */
+@NullMarked
+public interface ReadEventStreamWithFilter {
+
+    /**
+     * Read events from a particular event stream that matches the supplied filter.
+     *
+     * @param streamId The id of the stream to read.
+     * @param filter   The filter to apply when reading events
+     * @return An {@link EventStream} containing the events of the stream. Will return an {@link EventStream} with version {@code 0} if event stream doesn't exists.
+     */
+    default EventStream<CloudEvent> read(String streamId, StreamReadFilter filter) {
+        return read(streamId, filter, 0, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Read events from a particular event stream that matches the supplied filter from a particular position.
+     *
+     * @param streamId The id of the stream to read.
+     * @param filter   The filter to apply when reading events
+     * @return An {@link EventStream} containing the events of the stream. Will return an {@link EventStream} with version {@code 0} if event stream doesn't exists.
+     */
+    EventStream<CloudEvent> read(String streamId, StreamReadFilter filter, int skip, int limit);
+}

--- a/eventstore/api/common/pom.xml
+++ b/eventstore/api/common/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>eventstore-api</artifactId>
         <groupId>org.occurrent</groupId>
@@ -46,6 +47,11 @@
             <groupId>org.occurrent</groupId>
             <artifactId>functional-support</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test -->

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/LongConditionEvaluator.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/LongConditionEvaluator.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.eventstore.api;
 
+import org.jspecify.annotations.NullMarked;
 import org.occurrent.condition.Condition;
 import org.occurrent.condition.Condition.*;
 
@@ -26,6 +27,7 @@ import java.util.stream.Stream;
 /**
  * Evaluates {@link Condition} of type {@link Long} to {@code true} or {@code false}.
  */
+@NullMarked
 public class LongConditionEvaluator {
 
     public static boolean evaluate(Condition<Long> condition, long value) {

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
@@ -1,6 +1,7 @@
 package org.occurrent.eventstore.api;
 
 import io.cloudevents.core.v1.CloudEventV1;
+import org.jspecify.annotations.NullMarked;
 import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 
 import java.util.*;
@@ -18,6 +19,7 @@ import static org.occurrent.eventstore.api.SortBy.SortDirection.DESCENDING;
  * var allEvents = eventStoreQueries.all(SortBy.time(DESCENDING));
  * </pre>
  */
+@NullMarked
 public sealed interface SortBy {
     /**
      * Use unsorted search order.

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/StreamReadFilter.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/StreamReadFilter.java
@@ -1,0 +1,215 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api;
+
+import io.cloudevents.SpecVersion;
+import org.occurrent.condition.Condition;
+import org.occurrent.filter.Filter;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static org.occurrent.condition.Condition.eq;
+import static org.occurrent.eventstore.api.StreamReadFilter.CompositionOperator.AND;
+import static org.occurrent.eventstore.api.StreamReadFilter.CompositionOperator.OR;
+
+/**
+ * Filter DSL intended for reading events from a single stream (where streamId is provided by the API).
+ * <p>
+ * Differences vs {@link Filter}:
+ * - No "all" variant (use overloads without a filter instead).
+ * - No streamId or streamVersion convenience methods.
+ * - Supports CloudEvent core attributes, CloudEvent extensions, and data predicates.
+ */
+public sealed interface StreamReadFilter permits StreamReadFilter.AttributeFilter,
+        StreamReadFilter.ExtensionFilter,
+        StreamReadFilter.DataFilter,
+        StreamReadFilter.CompositionFilter {
+
+    // CloudEvent core attributes (mirrors Filter constants)
+    String SPEC_VERSION = Filter.SPEC_VERSION;
+    String ID = Filter.ID;
+    String TYPE = Filter.TYPE;
+    String TIME = Filter.TIME;
+    String SOURCE = Filter.SOURCE;
+    String SUBJECT = Filter.SUBJECT;
+    String DATA_SCHEMA = Filter.DATA_SCHEMA;
+    String DATA_CONTENT_TYPE = Filter.DATA_CONTENT_TYPE;
+
+    /**
+     * CloudEvent core attribute filter.
+     */
+    record AttributeFilter<T>(String attributeName, Condition<T> condition) implements StreamReadFilter {
+        public AttributeFilter {
+            requireNonNull(attributeName, "Attribute name cannot be null");
+            requireNonNull(condition, "Condition cannot be null");
+        }
+    }
+
+    /**
+     * CloudEvent extension attribute filter.
+     */
+    record ExtensionFilter<T>(String extensionName, Condition<T> condition) implements StreamReadFilter {
+        public ExtensionFilter {
+            requireNonNull(extensionName, "Extension name cannot be null");
+            requireNonNull(condition, "Condition cannot be null");
+        }
+    }
+
+    /**
+     * CloudEvent data field filter. The path is interpreted the same way as {@link Filter#data(String, Condition)}.
+     */
+    record DataFilter<T>(String path, Condition<T> condition) implements StreamReadFilter {
+        public DataFilter {
+            requireNonNull(path, "Data path cannot be null");
+            requireNonNull(condition, "Condition cannot be null");
+        }
+    }
+
+    record CompositionFilter(CompositionOperator operator, List<StreamReadFilter> filters) implements StreamReadFilter {
+        public CompositionFilter {
+            requireNonNull(operator, "Operator cannot be null");
+            requireNonNull(filters, "Filters cannot be null");
+        }
+    }
+
+    enum CompositionOperator {
+        AND, OR
+    }
+
+
+    static <T> StreamReadFilter attribute(String name, Condition<T> condition) {
+        return new AttributeFilter<>(name, condition);
+    }
+
+    static <T> StreamReadFilter extension(String name, Condition<T> condition) {
+        return new ExtensionFilter<>(name, condition);
+    }
+
+    static <T> StreamReadFilter data(String path, Condition<T> condition) {
+        return new DataFilter<>(path, condition);
+    }
+
+
+    default StreamReadFilter and(StreamReadFilter other, StreamReadFilter... more) {
+        return compose(AND, this, other, more);
+    }
+
+    default StreamReadFilter or(StreamReadFilter other, StreamReadFilter... more) {
+        return compose(OR, this, other, more);
+    }
+
+    private static StreamReadFilter compose(CompositionOperator op, StreamReadFilter first, StreamReadFilter second, StreamReadFilter[] more) {
+        requireNonNull(first, "First filter cannot be null");
+        requireNonNull(second, "Second filter cannot be null");
+
+        List<StreamReadFilter> all = new ArrayList<>(2 + (more == null ? 0 : more.length));
+        all.add(first);
+        all.add(second);
+        if (more != null) {
+            Collections.addAll(all, more);
+        }
+        return new CompositionFilter(op, all);
+    }
+
+    // ----------- Convenience methods for core attributes -----------
+
+    static StreamReadFilter id(String value) {
+        return id(eq(value));
+    }
+
+    static StreamReadFilter id(Condition<String> condition) {
+        return attribute(ID, condition);
+    }
+
+    static StreamReadFilter type(String value) {
+        return type(eq(value));
+    }
+
+    static StreamReadFilter type(Condition<String> condition) {
+        return attribute(TYPE, condition);
+    }
+
+    static StreamReadFilter subject(String value) {
+        return subject(eq(value));
+    }
+
+    static StreamReadFilter subject(Condition<String> condition) {
+        return attribute(SUBJECT, condition);
+    }
+
+    static StreamReadFilter time(OffsetDateTime value) {
+        return time(eq(value));
+    }
+
+    static StreamReadFilter time(Condition<OffsetDateTime> condition) {
+        return attribute(TIME, condition);
+    }
+
+    static StreamReadFilter source(URI value) {
+        return source(eq(value));
+    }
+
+    static StreamReadFilter source(Condition<URI> condition) {
+        // Match Filter.source mapping to string
+        return attribute(SOURCE, condition.map(URI::toString));
+    }
+
+    static StreamReadFilter dataSchema(URI value) {
+        return dataSchema(eq(value));
+    }
+
+    static StreamReadFilter dataSchema(Condition<URI> condition) {
+        return attribute(DATA_SCHEMA, condition.map(URI::toString));
+    }
+
+    static StreamReadFilter dataContentType(String value) {
+        return dataContentType(eq(value));
+    }
+
+    static StreamReadFilter dataContentType(Condition<String> condition) {
+        return attribute(DATA_CONTENT_TYPE, condition);
+    }
+
+    static StreamReadFilter specVersion(SpecVersion value) {
+        return specVersion(value.toString());
+    }
+
+    static StreamReadFilter specVersion(String value) {
+        return specVersion(eq(value));
+    }
+
+    static StreamReadFilter specVersion(Condition<String> condition) {
+        return attribute(SPEC_VERSION, condition);
+    }
+
+    static StreamReadFilter extension(String name, String value) {
+        return extension(name, eq(value));
+    }
+
+    static StreamReadFilter extensionStringIn(String name, Set<String> values) {
+        requireNonNull(values, "values cannot be null");
+        // Users can also use Condition.in(...) directly if they prefer.
+        return extension(name, org.occurrent.condition.Condition.in(values));
+    }
+}

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/StreamReadFilter.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/StreamReadFilter.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static org.occurrent.condition.Condition.eq;
@@ -34,7 +33,8 @@ import static org.occurrent.eventstore.api.StreamReadFilter.CompositionOperator.
 import static org.occurrent.eventstore.api.StreamReadFilter.CompositionOperator.OR;
 
 /**
- * Filter DSL intended for reading events from a single stream (where streamId is provided by the API).
+ * Filter DSL intended for reading events from a single stream.
+ *
  * <p>
  * Differences vs {@link Filter}:
  * - No "all" variant (use overloads without a filter instead).
@@ -109,7 +109,6 @@ public sealed interface StreamReadFilter permits StreamReadFilter.AttributeFilte
     static <T> StreamReadFilter data(String path, Condition<T> condition) {
         return new DataFilter<>(path, condition);
     }
-
 
     default StreamReadFilter and(StreamReadFilter other, StreamReadFilter... more) {
         return compose(AND, this, other, more);
@@ -205,11 +204,5 @@ public sealed interface StreamReadFilter permits StreamReadFilter.AttributeFilte
 
     static StreamReadFilter extension(String name, String value) {
         return extension(name, eq(value));
-    }
-
-    static StreamReadFilter extensionStringIn(String name, Set<String> values) {
-        requireNonNull(values, "values cannot be null");
-        // Users can also use Condition.in(...) directly if they prefer.
-        return extension(name, org.occurrent.condition.Condition.in(values));
     }
 }

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
@@ -16,6 +16,8 @@
 
 package org.occurrent.eventstore.api;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -25,6 +27,7 @@ import java.util.StringJoiner;
  * this is effectively the same as an optimistic locking exception and a retry is appropriate. For more advanced
  * write conditions this may not be the case though.
  */
+@NullMarked
 public class WriteConditionNotFulfilledException extends RuntimeException {
     public final String eventStreamId;
     public final long eventStreamVersion;

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteResult.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteResult.java
@@ -17,11 +17,14 @@
 
 package org.occurrent.eventstore.api;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.util.Objects;
 
 /**
  * The result of a write operation to the event store.
  */
+@NullMarked
 public record WriteResult(String streamId, long oldStreamVersion, long newStreamVersion) {
 
     public WriteResult {

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
@@ -1,0 +1,85 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.internal;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.condition.Condition;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import org.occurrent.eventstore.api.StreamReadFilter.AttributeFilter;
+import org.occurrent.eventstore.api.StreamReadFilter.DataFilter;
+import org.occurrent.eventstore.api.StreamReadFilter.ExtensionFilter;
+import org.occurrent.filter.Filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Maps {@link StreamReadFilter} to {@link Filter} so existing datastore mapping logic can be reused.
+ * <p>
+ * This mapper does NOT validate. Call {@link StreamReadFilterValidator#validate(StreamReadFilter)} in the stream-read path.
+ */
+@NullMarked
+public final class StreamReadFilterToFilterMapper {
+
+    private StreamReadFilterToFilterMapper() {
+    }
+
+    /**
+     * Map {@link StreamReadFilter} into {@link Filter}.
+     * <p>
+     * Note: This does not apply the streamId constraint. The caller typically does:
+     * Filter.streamId(streamId).and(StreamReadFilterToFilterMapper.map(streamReadFilter))
+     */
+    public static Filter map(StreamReadFilter filter) {
+        requireNonNull(filter, "StreamReadFilter cannot be null");
+        return mapInternal(filter);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Filter mapInternal(StreamReadFilter filter) {
+        if (filter instanceof AttributeFilter<?> af) {
+            return Filter.filter(af.attributeName(), (Condition) af.condition());
+        }
+
+        if (filter instanceof ExtensionFilter<?> ef) {
+            return Filter.filter(ef.extensionName(), (Condition) ef.condition());
+        }
+
+        if (filter instanceof DataFilter<?> df) {
+            return Filter.data(df.path(), (Condition) df.condition());
+        }
+
+        if (filter instanceof StreamReadFilter.CompositionFilter cf) {
+
+            List<Filter> mapped = new ArrayList<>(cf.filters().size());
+            for (StreamReadFilter f : cf.filters()) {
+                mapped.add(mapInternal(f));
+            }
+
+            Filter.CompositionOperator op = cf.operator() == StreamReadFilter.CompositionOperator.AND
+                    ? Filter.CompositionOperator.AND
+                    : Filter.CompositionOperator.OR;
+
+            return new Filter.CompositionFilter(op, mapped);
+        }
+
+        throw new IllegalArgumentException("Unknown StreamReadFilter implementation: " + filter.getClass().getName());
+    }
+}

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
@@ -47,17 +47,17 @@ public final class StreamReadFilterToFilterMapper {
      * Note: This does not apply the streamId constraint. The caller typically does:
      * Filter.streamId(streamId).and(StreamReadFilterToFilterMapper.map(streamReadFilter))
      */
-    public static Filter map(String streamId, @Nullable StreamReadFilter filter) {
+    public static Filter mapWithStreamId(String streamId, @Nullable StreamReadFilter filter) {
         requireNonNull(streamId, "streamId cannot be null");
         Filter streamIdFilter = Filter.streamId(streamId);
         if (filter == null) {
             return streamIdFilter;
         }
-        return streamIdFilter.and(mapInternal(filter));
+        return streamIdFilter.and(map(filter));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static Filter mapInternal(StreamReadFilter filter) {
+    public static Filter map(StreamReadFilter filter) {
         requireNonNull(filter, "StreamReadFilter cannot be null");
         if (filter instanceof AttributeFilter<?> af) {
             return Filter.filter(af.attributeName(), (Condition) af.condition());
@@ -75,7 +75,7 @@ public final class StreamReadFilterToFilterMapper {
 
             List<Filter> mapped = new ArrayList<>(cf.filters().size());
             for (StreamReadFilter f : cf.filters()) {
-                mapped.add(mapInternal(f));
+                mapped.add(map(f));
             }
 
             Filter.CompositionOperator op = cf.operator() == StreamReadFilter.CompositionOperator.AND

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
@@ -18,6 +18,7 @@
 package org.occurrent.eventstore.api.internal;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.condition.Condition;
 import org.occurrent.eventstore.api.StreamReadFilter;
 import org.occurrent.eventstore.api.StreamReadFilter.AttributeFilter;
@@ -40,20 +41,24 @@ public final class StreamReadFilterToFilterMapper {
 
     private StreamReadFilterToFilterMapper() {
     }
-
     /**
      * Map {@link StreamReadFilter} into {@link Filter}.
      * <p>
      * Note: This does not apply the streamId constraint. The caller typically does:
      * Filter.streamId(streamId).and(StreamReadFilterToFilterMapper.map(streamReadFilter))
      */
-    public static Filter map(StreamReadFilter filter) {
-        requireNonNull(filter, "StreamReadFilter cannot be null");
-        return mapInternal(filter);
+    public static Filter map(String streamId, @Nullable StreamReadFilter filter) {
+        requireNonNull(streamId, "streamId cannot be null");
+        Filter streamIdFilter = Filter.streamId(streamId);
+        if (filter == null) {
+            return streamIdFilter;
+        }
+        return streamIdFilter.and(mapInternal(filter));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static Filter mapInternal(StreamReadFilter filter) {
+    public static Filter mapInternal(StreamReadFilter filter) {
+        requireNonNull(filter, "StreamReadFilter cannot be null");
         if (filter instanceof AttributeFilter<?> af) {
             return Filter.filter(af.attributeName(), (Condition) af.condition());
         }

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidator.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidator.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.internal;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import org.occurrent.eventstore.api.StreamReadFilter.AttributeFilter;
+import org.occurrent.eventstore.api.StreamReadFilter.ExtensionFilter;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Validates {@link StreamReadFilter} for stream read contexts.
+ * <p>
+ * Ensures that reserved Occurrent extensions for stream identity and stream concurrency are not constrained
+ * via attribute(...) or extension(...).
+ */
+@NullMarked
+public final class StreamReadFilterValidator {
+
+    private StreamReadFilterValidator() {
+    }
+
+    /**
+     * Verify that the provided {@link StreamReadFilter} does not constrain reserved Occurrent fields.
+     *
+     * @throws IllegalArgumentException if invalid
+     */
+    public static void validate(StreamReadFilter filter) {
+        requireNonNull(filter, "StreamReadFilter cannot be null");
+        validateInternal(filter);
+    }
+
+    private static void validateInternal(StreamReadFilter filter) {
+        if (filter instanceof AttributeFilter<?> af) {
+            verifyForbiddenName(normalize(af.attributeName()), "attribute");
+            return;
+        }
+
+        if (filter instanceof ExtensionFilter<?> ef) {
+            verifyForbiddenName(normalize(ef.extensionName()), "extension");
+            return;
+        }
+
+        if (filter instanceof StreamReadFilter.DataFilter) {
+            // Allowed
+            return;
+        }
+
+        if (filter instanceof StreamReadFilter.CompositionFilter cf) {
+            List<StreamReadFilter> filters = cf.filters();
+            for (StreamReadFilter f : filters) {
+                requireNonNull(f, "StreamReadFilter composition cannot contain null");
+                validateInternal(f);
+            }
+            return;
+        }
+
+        throw new IllegalArgumentException("Unknown StreamReadFilter implementation: " + filter.getClass().getName());
+    }
+
+    private static void verifyForbiddenName(String normalizedName, String kind) {
+        String streamIdName = normalize(OccurrentCloudEventExtension.STREAM_ID);
+        String streamVersionName = normalize(OccurrentCloudEventExtension.STREAM_VERSION);
+
+        if (Objects.equals(normalizedName, streamIdName) || Objects.equals(normalizedName, streamVersionName)) {
+            throw new IllegalArgumentException(
+                    "StreamReadFilter must not constrain " + kind + " '" + normalizedName + "'. " +
+                            "streamId is provided by the stream read API, and streamVersion is derived from stream history."
+            );
+        }
+    }
+
+    private static String normalize(String name) {
+        requireNonNull(name, "name cannot be null");
+        return name.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/StreamReadFilterTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/StreamReadFilterTest.java
@@ -1,0 +1,200 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.condition.Condition;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.condition.Condition.eq;
+
+@DisplayName("StreamReadFilter")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StreamReadFilterTest {
+
+    @Nested
+    @DisplayName("when creating attribute filters")
+    class When_creating_attribute_filters {
+
+        @ParameterizedTest
+        @MethodSource("org.occurrent.eventstore.api.StreamReadFilterTest#forbidden_name_variants")
+        @DisplayName("rejects reserved stream fields")
+        void rejects_reserved_stream_fields(String reservedName) {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.attribute(reservedName, eq("x")));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain attribute");
+        }
+
+        @Test
+        void rejects_null_attribute_name() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.attribute(null, eq("x")));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("attribute name cannot be null");
+        }
+
+        @Test
+        void rejects_null_condition() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.attribute("type", null));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("Condition cannot be null");
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.occurrent.eventstore.api.StreamReadFilterTest#allowed_attribute_names")
+        @DisplayName("accepts non reserved names")
+        void accepts_non_reserved_names(String name) {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.attribute(name, eq("x")));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+
+        @Test
+        void rejects_reserved_name_independent_of_default_locale() {
+            // Given
+            var previousDefaultLocale = Locale.getDefault();
+            Locale.setDefault(new Locale("tr", "TR"));
+
+            try {
+                // When
+                var thrown = catchThrowable(() -> StreamReadFilter.attribute("  " + OccurrentCloudEventExtension.STREAM_ID.toUpperCase(Locale.ROOT) + "  ", eq("x")));
+
+                // Then
+                assertThat(thrown)
+                        .isExactlyInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("StreamReadFilter must not constrain attribute");
+            } finally {
+                Locale.setDefault(previousDefaultLocale);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("when creating extension filters")
+    class When_creating_extension_filters {
+
+        @ParameterizedTest
+        @MethodSource("org.occurrent.eventstore.api.StreamReadFilterTest#forbidden_name_variants")
+        @DisplayName("rejects reserved stream fields")
+        void rejects_reserved_stream_fields(String reservedName) {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.extension(reservedName, eq("x")));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
+
+        @Test
+        void rejects_null_extension_name() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.extension(null, eq("x")));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("extension name cannot be null");
+        }
+
+        @Test
+        void rejects_null_condition() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.extension("x-correlation-id", (Condition<String>) null));
+
+            // Then
+            assertThat(thrown)
+                    .isExactlyInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("Condition cannot be null");
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.occurrent.eventstore.api.StreamReadFilterTest#allowed_extension_names")
+        @DisplayName("accepts non reserved names")
+        void accepts_non_reserved_names(String name) {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilter.extension(name, eq("x")));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+    }
+
+    private static Stream<String> forbidden_name_variants() {
+        var streamId = OccurrentCloudEventExtension.STREAM_ID;
+        var streamVersion = OccurrentCloudEventExtension.STREAM_VERSION;
+        return Stream.of(
+                streamId,
+                streamId.toUpperCase(Locale.ROOT),
+                "  " + streamId + "  ",
+                "  " + streamId.toUpperCase(Locale.ROOT) + "  ",
+                streamVersion,
+                streamVersion.toUpperCase(Locale.ROOT),
+                "  " + streamVersion + "  ",
+                "  " + streamVersion.toUpperCase(Locale.ROOT) + "  "
+        );
+    }
+
+    private static Stream<String> allowed_attribute_names() {
+        return Stream.of("type", "source", "subject", "x-trace-id", " ");
+    }
+
+    private static Stream<String> allowed_extension_names() {
+        return Stream.of("x-correlation-id", "stream-id", "stream_version", " ");
+    }
+}

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
@@ -1,0 +1,201 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.internal;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import org.occurrent.filter.Filter;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.condition.Condition.eq;
+
+@DisplayName("StreamReadFilterToFilterMapper")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StreamReadFilterToFilterMapperTest {
+
+    @Nested
+    @DisplayName("when filter is null")
+    class When_filter_is_null {
+
+        @Test
+        void rejects_null_filter() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterToFilterMapper.map(null));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("StreamReadFilter cannot be null");
+        }
+    }
+
+    @Nested
+    @DisplayName("when filter is a single predicate")
+    class When_filter_is_a_single_predicate {
+
+        @Test
+        void maps_attribute_filter_to_filter_single_condition() {
+            // Given
+            var input = StreamReadFilter.attribute(StreamReadFilter.TYPE, eq("MyType"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.type("MyType"));
+        }
+
+        @Test
+        void maps_extension_filter_to_filter_single_condition() {
+            // Given
+            var input = StreamReadFilter.extension("x-trace-id", eq("t1"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.filter("x-trace-id", eq("t1")));
+        }
+
+        @Test
+        void maps_data_filter_to_filter_data_predicate() {
+            // Given
+            var input = StreamReadFilter.data("order.id", eq("123"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.data("order.id", eq("123")));
+        }
+
+        @Test
+        void preserves_time_condition_values_without_using_system_defaults() {
+            // Given
+            var boundaryInstant = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            var input = StreamReadFilter.time(eq(boundaryInstant));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.time(eq(boundaryInstant)));
+        }
+
+        @Test
+        void maps_source_convenience_to_equivalent_filter_source() {
+            // Given
+            var uri = URI.create("urn:test");
+            var input = StreamReadFilter.source(uri);
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.source(uri));
+        }
+    }
+
+    @Nested
+    @DisplayName("when filter is composite")
+    class When_filter_is_composite {
+
+        @Test
+        void maps_and_composition_to_filter_and_composition() {
+            // Given
+            var input = StreamReadFilter.type("A").and(StreamReadFilter.subject("S"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.type("A").and(Filter.subject("S")));
+        }
+
+        @Test
+        void maps_or_composition_to_filter_or_composition() {
+            // Given
+            var input = StreamReadFilter.type("A").or(StreamReadFilter.type("B"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped).isEqualTo(Filter.type("A").or(Filter.type("B")));
+        }
+
+        @Test
+        void preserves_filter_order_in_composition() {
+            // Given
+            var first = StreamReadFilter.type("A");
+            var second = StreamReadFilter.subject("S");
+            var input = first.and(second);
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped)
+                    .isEqualTo(new Filter.CompositionFilter(
+                            Filter.CompositionOperator.AND,
+                            List.of(Filter.type("A"), Filter.subject("S"))
+                    ));
+        }
+
+        @Test
+        void preserves_duplicates_in_composition() {
+            // Given
+            var input = StreamReadFilter.type("A").and(StreamReadFilter.type("A"));
+
+            // When
+            var mapped = StreamReadFilterToFilterMapper.map(input);
+
+            // Then
+            assertThat(mapped)
+                    .isEqualTo(new Filter.CompositionFilter(
+                            Filter.CompositionOperator.AND,
+                            List.of(Filter.type("A"), Filter.type("A"))
+                    ));
+        }
+
+        @Test
+        void mapping_is_deterministic_for_same_input() throws Throwable {
+            // Given
+            var input = StreamReadFilter.type("A")
+                    .and(StreamReadFilter.subject("S"))
+                    .or(StreamReadFilter.data("x", eq("1")));
+
+            // When
+            ThrowingSupplier<Filter> map = () -> StreamReadFilterToFilterMapper.map(input);
+            var first = map.get();
+            var second = map.get();
+
+            // Then
+            assertThat(first).isEqualTo(second);
+        }
+    }
+}

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
@@ -53,13 +53,13 @@ class StreamReadFilterToFilterMapperTest {
         @Test
         void returns_only__stream_id_filter_when_stream_read_filter_is_null() {
             // Given
-            var input = StreamReadFilter.type("MyType");
+            StreamReadFilter input = null;
 
             // When
             var mapped = StreamReadFilterToFilterMapper.mapWithStreamId("myStreamId", input);
 
             // Then
-            assertThat(mapped).isEqualTo(Filter.streamId("myStreamId").and(Filter.type("MyType")));
+            assertThat(mapped).isEqualTo(Filter.streamId("myStreamId"));
         }
     }
 

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapperTest.java
@@ -44,7 +44,7 @@ class StreamReadFilterToFilterMapperTest {
             var input = StreamReadFilter.type("MyType");
 
             // When
-            var mapped = StreamReadFilterToFilterMapper.map("myStreamId", input);
+            var mapped = StreamReadFilterToFilterMapper.mapWithStreamId("myStreamId", input);
 
             // Then
             assertThat(mapped).isEqualTo(Filter.streamId("myStreamId").and(Filter.type("MyType")));
@@ -56,7 +56,7 @@ class StreamReadFilterToFilterMapperTest {
             var input = StreamReadFilter.type("MyType");
 
             // When
-            var mapped = StreamReadFilterToFilterMapper.map("myStreamId", input);
+            var mapped = StreamReadFilterToFilterMapper.mapWithStreamId("myStreamId", input);
 
             // Then
             assertThat(mapped).isEqualTo(Filter.streamId("myStreamId").and(Filter.type("MyType")));
@@ -77,7 +77,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.attribute(StreamReadFilter.TYPE, eq("MyType"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.type("MyType"));
@@ -89,7 +89,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.extension("x-trace-id", eq("t1"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.filter("x-trace-id", eq("t1")));
@@ -101,7 +101,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.data("order.id", eq("123"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.data("order.id", eq("123")));
@@ -114,7 +114,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.time(eq(boundaryInstant));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.time(eq(boundaryInstant)));
@@ -127,7 +127,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.source(uri);
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.source(uri));
@@ -144,7 +144,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.type("A").and(StreamReadFilter.subject("S"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.type("A").and(Filter.subject("S")));
@@ -156,7 +156,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.type("A").or(StreamReadFilter.type("B"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped).isEqualTo(Filter.type("A").or(Filter.type("B")));
@@ -170,7 +170,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = first.and(second);
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped)
@@ -186,7 +186,7 @@ class StreamReadFilterToFilterMapperTest {
                 var input = StreamReadFilter.type("A").and(StreamReadFilter.type("A"));
 
                 // When
-                var mapped = StreamReadFilterToFilterMapper.mapInternal(input);
+                var mapped = StreamReadFilterToFilterMapper.map(input);
 
                 // Then
                 assertThat(mapped)
@@ -204,7 +204,7 @@ class StreamReadFilterToFilterMapperTest {
                         .or(StreamReadFilter.data("x", eq("1")));
 
                 // When
-                ThrowingSupplier<Filter> map = () -> StreamReadFilterToFilterMapper.mapInternal(input);
+                ThrowingSupplier<Filter> map = () -> StreamReadFilterToFilterMapper.map(input);
                 var first = map.get();
                 var second = map.get();
 

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidatorTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidatorTest.java
@@ -36,6 +36,25 @@ import static org.occurrent.condition.Condition.eq;
 class StreamReadFilterValidatorTest {
 
     @Nested
+    @DisplayName("when creating StreamReadFilter using factory methods")
+    class FactoryValidation {
+
+        @Test
+        void rejects_forbidden_attribute_name_when_creating_filter() {
+            Throwable thrown = catchThrowable(() -> StreamReadFilter.attribute(OccurrentCloudEventExtension.STREAM_ID, eq("x")));
+            assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain attribute");
+        }
+
+        @Test
+        void rejects_forbidden_extension_name_when_creating_filter() {
+            Throwable thrown = catchThrowable(() -> StreamReadFilter.extension(OccurrentCloudEventExtension.STREAM_VERSION, eq("1")));
+            assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
+    }
+
+    @Nested
     @DisplayName("when filter is null")
     class When_filter_is_null {
 
@@ -118,7 +137,7 @@ class StreamReadFilterValidatorTest {
         @DisplayName("rejects forbidden names supplied via attribute")
         void rejects_forbidden_names_supplied_via_attribute(String forbiddenName) {
             // Given
-            var filter = StreamReadFilter.attribute(forbiddenName, eq("x"));
+            var filter = new StreamReadFilter.AttributeFilter<>(forbiddenName, eq("x"));
 
             // When
             var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
@@ -134,7 +153,7 @@ class StreamReadFilterValidatorTest {
         @DisplayName("rejects forbidden names supplied via extension")
         void rejects_forbidden_names_supplied_via_extension(String forbiddenName) {
             // Given
-            var filter = StreamReadFilter.extension(forbiddenName, eq("x"));
+            var filter = new StreamReadFilter.ExtensionFilter<>(forbiddenName, eq("x"));
 
             // When
             var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
@@ -151,7 +170,7 @@ class StreamReadFilterValidatorTest {
             var previous = Locale.getDefault();
             Locale.setDefault(new Locale("tr", "TR"));
             try {
-                var filter = StreamReadFilter.extension("  " + OccurrentCloudEventExtension.STREAM_ID.toUpperCase(Locale.ROOT) + "  ", eq("x"));
+                var filter = new StreamReadFilter.ExtensionFilter<>("  " + OccurrentCloudEventExtension.STREAM_ID.toUpperCase(Locale.ROOT) + "  ", eq("x"));
 
                 // When
                 var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
@@ -198,7 +217,7 @@ class StreamReadFilterValidatorTest {
         void rejects_forbidden_name_nested_in_composition() {
             // Given
             var filter = StreamReadFilter.type("MyEventType")
-                    .and(StreamReadFilter.extension(OccurrentCloudEventExtension.STREAM_VERSION, eq("1")));
+                    .and(new StreamReadFilter.ExtensionFilter<>(OccurrentCloudEventExtension.STREAM_VERSION, eq("1")));
 
             // When
             var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));

--- a/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidatorTest.java
+++ b/eventstore/api/common/src/test/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidatorTest.java
@@ -1,0 +1,226 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.internal;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.eventstore.api.StreamReadFilter;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.condition.Condition.eq;
+
+@DisplayName("StreamReadFilterValidator")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StreamReadFilterValidatorTest {
+
+    @Nested
+    @DisplayName("when filter is null")
+    class When_filter_is_null {
+
+        @Test
+        void rejects_null_filter() {
+            // Given
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(null));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("StreamReadFilter cannot be null");
+        }
+    }
+
+    @Nested
+    @DisplayName("when filter is allowed")
+    class When_filter_is_allowed {
+
+        @Test
+        void accepts_data_filter() {
+            // Given
+            var filter = StreamReadFilter.data("orderId", eq("123"));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+
+        @Test
+        void accepts_non_reserved_extension_filter() {
+            // Given
+            var filter = StreamReadFilter.extension("myExtension", eq("value"));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+
+        @Test
+        void accepts_attribute_filter_for_regular_cloudevent_attribute() {
+            // Given
+            var filter = StreamReadFilter.attribute(StreamReadFilter.TYPE, eq("MyEventType"));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+
+        @Test
+        void is_deterministic_for_same_input() throws Throwable {
+            // Given
+            var filter = StreamReadFilter.type("MyEventType").and(StreamReadFilter.subject("subject-1"));
+
+            // When
+            ThrowingSupplier<Throwable> validate = () -> catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+            var first = validate.get();
+            var second = validate.get();
+
+            // Then
+            assertThat(first).isNull();
+            assertThat(second).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("when filter attempts to constrain stream identity or stream concurrency")
+    class When_filter_attempts_to_constrain_stream_identity_or_stream_concurrency {
+
+        @ParameterizedTest
+        @MethodSource("forbidden_names_as_attribute_variants")
+        @DisplayName("rejects forbidden names supplied via attribute")
+        void rejects_forbidden_names_supplied_via_attribute(String forbiddenName) {
+            // Given
+            var filter = StreamReadFilter.attribute(forbiddenName, eq("x"));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain attribute");
+        }
+
+        @ParameterizedTest
+        @MethodSource("forbidden_names_as_extension_variants")
+        @DisplayName("rejects forbidden names supplied via extension")
+        void rejects_forbidden_names_supplied_via_extension(String forbiddenName) {
+            // Given
+            var filter = StreamReadFilter.extension(forbiddenName, eq("x"));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
+
+        @Test
+        void rejects_forbidden_names_independent_of_default_locale() {
+            // Given
+            var previous = Locale.getDefault();
+            Locale.setDefault(new Locale("tr", "TR"));
+            try {
+                var filter = StreamReadFilter.extension("  " + OccurrentCloudEventExtension.STREAM_ID.toUpperCase(Locale.ROOT) + "  ", eq("x"));
+
+                // When
+                var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+                // Then
+                assertThat(thrown)
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("StreamReadFilter must not constrain extension");
+            } finally {
+                Locale.setDefault(previous);
+            }
+        }
+
+        static Stream<String> forbidden_names_as_attribute_variants() {
+            return forbiddenNameVariants();
+        }
+
+        static Stream<String> forbidden_names_as_extension_variants() {
+            return forbiddenNameVariants();
+        }
+
+        private static Stream<String> forbiddenNameVariants() {
+            var streamId = OccurrentCloudEventExtension.STREAM_ID;
+            var streamVersion = OccurrentCloudEventExtension.STREAM_VERSION;
+
+            return Stream.of(
+                    streamId,
+                    streamId.toUpperCase(Locale.ROOT),
+                    "  " + streamId + "  ",
+                    "  " + streamId.toUpperCase(Locale.ROOT) + "  ",
+                    streamVersion,
+                    streamVersion.toUpperCase(Locale.ROOT),
+                    "  " + streamVersion + "  ",
+                    "  " + streamVersion.toUpperCase(Locale.ROOT) + "  "
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("when filter is composite")
+    class When_filter_is_composite {
+
+        @Test
+        void rejects_forbidden_name_nested_in_composition() {
+            // Given
+            var filter = StreamReadFilter.type("MyEventType")
+                    .and(StreamReadFilter.extension(OccurrentCloudEventExtension.STREAM_VERSION, eq("1")));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
+
+        @Test
+        void accepts_deeply_nested_valid_composition() {
+            // Given
+            var filter = StreamReadFilter.type("A")
+                    .or(StreamReadFilter.subject("s1").and(StreamReadFilter.data("orderId", eq("1"))))
+                    .and(StreamReadFilter.extension("x-trace-id", eq("t1")));
+
+            // When
+            var thrown = catchThrowable(() -> StreamReadFilterValidator.validate(filter));
+
+            // Then
+            assertThat(thrown).isNull();
+        }
+    }
+}

--- a/eventstore/api/reactor/src/main/java/org/occurrent/eventstore/api/reactor/ReadEventStreamWithFilter.java
+++ b/eventstore/api/reactor/src/main/java/org/occurrent/eventstore/api/reactor/ReadEventStreamWithFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import reactor.core.publisher.Mono;
+
+/**
+ * An interface that should be implemented by event stores that supports reading an {@link EventStream} with a filter.
+ */
+public interface ReadEventStreamWithFilter {
+
+    /**
+     * Read events from a particular event stream that matches the supplied filter.
+     *
+     * @param streamId The id of the stream to read.
+     * @param filter   The filter to apply when reading events
+     * @return An {@link EventStream} containing the events of the stream. Will return an {@link EventStream} with version {@code 0} if event stream doesn't exists.
+     */
+    default Mono<EventStream<CloudEvent>> read(String streamId, StreamReadFilter filter) {
+        return read(streamId, filter, 0, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Read events from a particular event stream that matches the supplied filter from a particular position.
+     *
+     * @param streamId The id of the stream to read.
+     * @param filter   The filter to apply when reading events
+     * @return An {@link EventStream} containing the events of the stream. Will return an {@link EventStream} with version {@code 0} if event stream doesn't exists.
+     */
+    Mono<EventStream<CloudEvent>> read(String streamId, StreamReadFilter filter, int skip, int limit);
+}

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -29,10 +29,8 @@ import org.occurrent.eventstore.api.SortBy.NaturalImpl;
 import org.occurrent.eventstore.api.SortBy.SingleFieldImpl;
 import org.occurrent.eventstore.api.SortBy.SortDirection;
 import org.occurrent.eventstore.api.WriteCondition.StreamVersionWriteCondition;
-import org.occurrent.eventstore.api.blocking.EventStore;
-import org.occurrent.eventstore.api.blocking.EventStoreOperations;
-import org.occurrent.eventstore.api.blocking.EventStoreQueries;
-import org.occurrent.eventstore.api.blocking.EventStream;
+import org.occurrent.eventstore.api.blocking.*;
+import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
 import org.occurrent.filter.Filter;
 import org.occurrent.functionalsupport.internal.FunctionalSupport.Pair;
 
@@ -70,7 +68,7 @@ import static org.occurrent.inmemory.filtermatching.FilterMatcher.matchesFilter;
  * and/or demo purposes. It also supports the {@link EventStoreOperations} contract.
  */
 @NullMarked
-public class InMemoryEventStore implements EventStore, EventStoreOperations, EventStoreQueries {
+public class InMemoryEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter {
 
     // We cannot use ConcurrentMap since it doesn't maintain insertion order
     private final Map<String, CopyOnWriteArrayList<CloudEvent>> state = Collections.synchronizedMap(new LinkedHashMap<>());
@@ -104,13 +102,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     @Override
     public EventStream<CloudEvent> read(String streamId, int skip, int limit) {
-        List<CloudEvent> events = state.get(streamId);
-        if (events == null) {
-            return new EventStreamImpl(streamId, 0, Collections.emptyList());
-        } else if (skip == 0 && limit == Integer.MAX_VALUE) {
-            return new EventStreamImpl(streamId, calculateStreamVersion(events), events);
-        }
-        return new EventStreamImpl(streamId, calculateStreamVersion(events), events.subList(skip, limit));
+        return read(streamId, null, skip, limit);
     }
 
     @Override
@@ -312,6 +304,35 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     @Override
     public boolean exists(Filter filter) {
         return count(filter) > 0;
+    }
+
+    @Override
+    public EventStream<CloudEvent> read(String streamId, @Nullable StreamReadFilter filter, int skip, int limit) {
+        List<CloudEvent> events = state.get(streamId);
+        record StreamVersionAndEvents(long version, List<CloudEvent> events) {
+        }
+
+        final StreamVersionAndEvents streamVersionAndEvents;
+        if (events == null) {
+            return new EventStreamImpl(streamId, 0, Collections.emptyList());
+        }
+
+        var streamVersion = calculateStreamVersion(events);
+        List<CloudEvent> eventsAfterFilter;
+        if (filter == null) {
+            eventsAfterFilter = events;
+        } else {
+            Filter readFilter = StreamReadFilterToFilterMapper.map(filter);
+            eventsAfterFilter = events.stream().filter(cloudEvent -> matchesFilter(cloudEvent, readFilter)).toList();
+        }
+        
+        if (skip == 0 && limit == Integer.MAX_VALUE) {
+            streamVersionAndEvents = new StreamVersionAndEvents(streamVersion, eventsAfterFilter);
+        } else {
+            streamVersionAndEvents = new StreamVersionAndEvents(streamVersion, events.subList(skip, limit));
+        }
+        
+        return new EventStreamImpl(streamId, streamVersionAndEvents.version, streamVersionAndEvents.events);
     }
 
     private static class EventStreamImpl implements EventStream<CloudEvent> {

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
@@ -330,6 +330,17 @@ public class InMemoryEventStoreTest {
                     () -> assertThat(writeResult.newStreamVersion()).isEqualTo(4L)
             );
         }
+
+        @Test
+        void rejects_stream_version_in_stream_read_filter() {
+            InMemoryEventStore inMemoryEventStore = new InMemoryEventStore();
+            unconditionallyPersist(inMemoryEventStore, "name", new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "name"));
+
+            Throwable throwable = catchThrowable(() -> inMemoryEventStore.read("name", StreamReadFilter.extension(STREAM_VERSION, eq(1L))));
+
+            assertThat(throwable).isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
     }
 
 

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -352,7 +352,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         Query query = Query.query(streamIdEqualToCriteria(streamId).and(STREAM_VERSION).lte(currentStreamVersion));
 
         if (streamReadFilter != null) {
-            Filter filter = StreamReadFilterToFilterMapper.mapInternal(streamReadFilter);
+            Filter filter = StreamReadFilterToFilterMapper.map(streamReadFilter);
             var criteria = FilterConverter.convertFilterToCriteria(null, timeRepresentation, filter);
             query.addCriteria(criteria);
         }

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -32,6 +32,7 @@ import org.occurrent.eventstore.api.*;
 import org.occurrent.eventstore.api.WriteCondition.StreamVersionWriteCondition;
 import org.occurrent.eventstore.api.blocking.*;
 import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
+import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
 import org.occurrent.eventstore.mongodb.internal.StreamVersionDiff;
 import org.occurrent.filter.Filter;
@@ -352,6 +353,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         Query query = Query.query(streamIdEqualToCriteria(streamId).and(STREAM_VERSION).lte(currentStreamVersion));
 
         if (streamReadFilter != null) {
+            StreamReadFilterValidator.validate(streamReadFilter);
             Filter filter = StreamReadFilterToFilterMapper.map(streamReadFilter);
             var criteria = FilterConverter.convertFilterToCriteria(null, timeRepresentation, filter);
             query.addCriteria(criteria);

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
@@ -437,6 +437,16 @@ public class SpringMongoEventStoreTest {
                     () -> assertThat(writeResult.newStreamVersion()).isEqualTo(4L)
             );
         }
+
+        @Test
+        void rejects_stream_version_in_stream_read_filter() {
+            persist("name", WriteCondition.streamVersionEq(0), new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "name"));
+
+            Throwable throwable = catchThrowable(() -> eventStore.read("name", StreamReadFilter.extension(OccurrentCloudEventExtension.STREAM_VERSION, eq(1L))));
+
+            assertThat(throwable).isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("StreamReadFilter must not constrain extension");
+        }
     }
 
     @Nested
@@ -1983,4 +1993,3 @@ public class SpringMongoEventStoreTest {
         }
     }
 }
-

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
@@ -167,7 +167,7 @@ public class SpringMongoEventStoreTest {
     @Test
     void can_read_and_write_multiple_events_at_once_to_mongo_spring_blocking_event_store() {
         LocalDateTime now = LocalDateTime.now();
-        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(),now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
+        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(), now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
 
         // When
         persist("name", WriteCondition.streamVersionEq(0), events);
@@ -243,7 +243,7 @@ public class SpringMongoEventStoreTest {
     @Test
     void stream_version_is_not_updated_when_event_insertion_fails() {
         LocalDateTime now = LocalDateTime.now();
-        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(),now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
+        List<DomainEvent> events = Composition.chain(Name.defineTheName(UUID.randomUUID().toString(), now, "name", "Hello World"), es -> Name.changeName(es, UUID.randomUUID().toString(), now, "name", "John Doe"));
 
         persist("name", WriteCondition.streamVersionEq(0), events);
 
@@ -356,6 +356,85 @@ public class SpringMongoEventStoreTest {
                     () -> assertThat(writeResult.streamId()).isEqualTo("name"),
                     () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(2L),
                     () -> assertThat(writeResult.newStreamVersion()).isEqualTo(2L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("stream read filter")
+    class StreamReadFilterTest {
+
+        @Test
+        void can_read_and_write_multiple_events_at_different_occasions() {
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name", WriteCondition.streamVersionEq(0), nameDefined);
+            persist("name", WriteCondition.streamVersionEq(1), nameWasChanged1);
+            persist("name", WriteCondition.streamVersionEq(2), nameWasChanged2);
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name", StreamReadFilter.type(in(NameDefined.class.getSimpleName(), NameWasChanged.class.getSimpleName())));
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+            assertAll(
+                    () -> assertThat(eventStream.version()).isEqualTo(3),
+                    () -> assertThat(readEvents).hasSize(3),
+                    () -> assertThat(readEvents).containsExactly(nameDefined, nameWasChanged1, nameWasChanged2)
+            );
+        }
+
+        @Test
+        void can_read_only_events_of_a_certain_type() {
+            LocalDateTime now = LocalDateTime.now();
+            NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(1), "name", "name2");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusHours(2), "name", "name3");
+
+            // When
+            persist("name", WriteCondition.streamVersionEq(0), nameDefined);
+            persist("name", WriteCondition.streamVersionEq(1), nameWasChanged1);
+            persist("name", WriteCondition.streamVersionEq(2), nameWasChanged2);
+
+            // Then
+            EventStream<CloudEvent> eventStream = eventStore.read("name", StreamReadFilter.type(in(NameWasChanged.class.getSimpleName())));
+            List<DomainEvent> readEvents = deserialize(eventStream.events());
+
+            assertAll(
+                    () -> assertThat(eventStream.version()).isEqualTo(3),
+                    () -> assertThat(readEvents).hasSize(2),
+                    () -> assertThat(readEvents).containsExactly(nameWasChanged1, nameWasChanged2)
+            );
+        }
+
+        @Test
+        void can_write_new_events_to_stream_read_using_stream_read_filter() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+
+            // When
+            DomainEvent event1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "John Doe");
+            DomainEvent event2 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe");
+            DomainEvent event3 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe2");
+            DomainEvent event4 = new NameWasChanged(UUID.randomUUID().toString(), now, "name", "Jan Doe3");
+
+            persist("name", WriteCondition.streamVersionEq(0), event1);
+            persist("name", WriteCondition.streamVersionEq(1), event2);
+            persist("name", WriteCondition.streamVersionEq(2), event3);
+            
+
+            EventStream<CloudEvent> eventStream = eventStore.read("name", StreamReadFilter.type(in(NameWasChanged.class.getSimpleName())));
+            
+            WriteResult writeResult = persist("name", WriteCondition.streamVersionEq(eventStream.version()), event4);
+
+            // Then
+            assertAll(
+                    () -> assertThat(writeResult.streamId()).isEqualTo("name"),
+                    () -> assertThat(writeResult.oldStreamVersion()).isEqualTo(3L),
+                    () -> assertThat(writeResult.newStreamVersion()).isEqualTo(4L)
             );
         }
     }
@@ -755,7 +834,7 @@ public class SpringMongoEventStoreTest {
             }
 
             @EnabledOnOs(MAC)
-            @RepeatedIfExceptionsTest(repeats = 5, suspend = 200,  minSuccess = 5)
+            @RepeatedIfExceptionsTest(repeats = 5, suspend = 200, minSuccess = 5)
             void parallel_writes_to_event_store_does_not_throw_WriteConditionNotFulfilledException_when_write_condition_is_any() {
                 // Given
                 CyclicBarrier cyclicBarrier = new CyclicBarrier(3);
@@ -1840,34 +1919,34 @@ public class SpringMongoEventStoreTest {
         return (T) deserialize(Stream.of(cloudEvent)).get(0);
     }
 
-    private void persist(String eventStreamId, CloudEvent event) {
-        eventStore.write(eventStreamId, Stream.of(event));
+    private WriteResult persist(String eventStreamId, CloudEvent event) {
+        return eventStore.write(eventStreamId, Stream.of(event));
     }
 
-    private void persist(String eventStreamId, DomainEvent event) {
-        eventStore.write(eventStreamId, Stream.of(convertDomainEventCloudEvent(event)));
+    private WriteResult persist(String eventStreamId, DomainEvent event) {
+        return eventStore.write(eventStreamId, Stream.of(convertDomainEventCloudEvent(event)));
     }
 
-    private void persist(String eventStreamId, List<DomainEvent> events) {
-        persist(eventStreamId, events.stream());
+    private WriteResult persist(String eventStreamId, List<DomainEvent> events) {
+        return persist(eventStreamId, events.stream());
     }
 
     private WriteResult persist(String eventStreamId, Stream<DomainEvent> events) {
         return eventStore.write(eventStreamId, events.map(this::convertDomainEventCloudEvent));
     }
 
-    private void persist(String eventStreamId, WriteCondition writeCondition, DomainEvent event) {
+    private WriteResult persist(String eventStreamId, WriteCondition writeCondition, DomainEvent event) {
         List<DomainEvent> events = new ArrayList<>();
         events.add(event);
-        persist(eventStreamId, writeCondition, events);
+        return persist(eventStreamId, writeCondition, events);
     }
 
-    private void persist(String eventStreamId, WriteCondition writeCondition, List<DomainEvent> events) {
-        persist(eventStreamId, writeCondition, events.stream());
+    private WriteResult persist(String eventStreamId, WriteCondition writeCondition, List<DomainEvent> events) {
+        return persist(eventStreamId, writeCondition, events.stream());
     }
 
-    private void persist(String eventStreamId, WriteCondition writeCondition, Stream<DomainEvent> events) {
-        eventStore.write(eventStreamId, writeCondition, events.map(this::convertDomainEventCloudEvent));
+    private WriteResult persist(String eventStreamId, WriteCondition writeCondition, Stream<DomainEvent> events) {
+        return eventStore.write(eventStreamId, writeCondition, events.map(this::convertDomainEventCloudEvent));
     }
 
     private CloudEvent convertDomainEventCloudEvent(DomainEvent domainEvent) {

--- a/test-support/src/main/java/org/occurrent/domain/Name.java
+++ b/test-support/src/main/java/org/occurrent/domain/Name.java
@@ -52,7 +52,7 @@ public class Name {
         if (Objects.equals(currentName, "John Doe")) {
             throw new IllegalArgumentException("Cannot change name from John Doe since this is the ultimate name");
         } else if (currentName.isEmpty()) {
-            throw new IllegalArgumentException("Cannot change name this it is currently undefined");
+            throw new IllegalArgumentException("Cannot change name because it is currently undefined");
         }
         return Collections.singletonList(new NameWasChanged(eventId, TimeConversion.toDate(time), userId, newName));
     }


### PR DESCRIPTION
## Summary
This PR completes StreamReadFilter support end-to-end and introduces a cleaner ApplicationService API migration path based on ExecuteOptions.

## What changed
- Added StreamReadFilter support in EventStore implementations:
  - SpringMongoEventStore
  - MongoEventStore
  - InMemoryEventStore
  - ReactorMongoEventStore
- Added optional capability interfaces for filtered stream reads:
  - blocking API: `ReadEventStreamWithFilter`
  - reactor API: reactor-tailored filtered-read capability
- Updated GenericApplicationService to support StreamReadFilter and ExecuteOptions-based execution.
- Added validation guards in StreamReadFilter to reject reserved keys (`streamid`, `streamversion`) through attribute/extension builders.
- Added focused tests for StreamReadFilter and implementation-level filtered stream reads (including Mongo and Reactor Mongo tests).
- Updated changelog under `### Changelog next version` with:
  - migration notes
  - examples
  - deprecation overview
  - human-readable guidance for when StreamReadFilter is useful

## API ergonomics and migration
- Introduced `ExecuteOptions<T>` with static entry points so users can write:

```java
as.execute(streamId, filter(myFilter).sideEffect(events -> { ... }), fn);
```

- Deprecated legacy overloads that mixed nullable `filter` and nullable `sideEffect` parameters in method signatures, to guide consumers toward ExecuteOptions.

## Why
- Makes filtered stream reads explicit and reusable across implementations.
- Keeps ApplicationService method surface manageable while still supporting optional filter + side effects.
- Strengthens validation early and consistently.

## Validation
- Added/updated tests for StreamReadFilter rules and filtered-read behavior in affected stores.
- Ensured compatibility-preserving behavior where deprecations were introduced (no immediate breaking removal).
