### PR TITLE
Snapshot query results inside the lock in InMemoryEventStore

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+### 0.20.4 (2026-06-18)
+
+* Fixed a `ConcurrentModificationException` that could occur when consuming a stream returned by `InMemoryEventStore.query(..)` while another thread writes to the store.
+  * The returned stream was lazy, so its sort, skip, and limit ran after the query lock was released. A concurrent `write(..)` modifies the backing map at that point, which could throw or expose an in-flight stream.
+  * `query(..)` now snapshots the matching events while holding the lock, like `count(..)` already did, and then sorts, skips, and limits on that snapshot.
+  * This matters more now because `CatchupSubscriptionModel` delta reconciliation queries with `SortBy.natural(DESCENDING)`, so the in-memory store can be read concurrently with writes during a catch-up.
+
 ### 0.20.3 (2026-03-29)
 
 * Completed the Spring Boot starter fallback fix for composed `CloudEventConverter` setups.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 0.20.4 (2026-06-18)
+### Changelog next version
 
 * Fixed a `ConcurrentModificationException` that could occur when consuming a stream returned by `InMemoryEventStore.query(..)` while another thread writes to the store.
   * The returned stream was lazy, so its sort, skip, and limit ran after the query lock was released. A concurrent `write(..)` modifies the backing map at that point, which could throw or expose an in-flight stream.

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -248,15 +248,15 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         Objects.requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
         Objects.requireNonNull(sortBy, SortBy.class.getSimpleName() + " cannot be null");
 
-        // Materialize a snapshot of the matching events while holding the lock. The stream returned to the caller
-        // is consumed lazily (sort/skip/limit happen on terminal operations), so iterating over state.values()
-        // outside the lock could race with a concurrent write() that structurally modifies the backing map and
-        // throw ConcurrentModificationException (or observe an in-flight stream). count() snapshots the same way.
-        final List<CloudEvent> snapshot;
+        // Snapshot the per-stream event lists under the lock, then filter and sort outside it. The stream returned
+        // to the caller is consumed lazily, so iterating state.values() outside the lock could race with a concurrent
+        // write() that structurally modifies the backing map and throw ConcurrentModificationException. Each value is
+        // a CopyOnWriteArrayList that write() replaces atomically, so iterating a snapshotted reference stays safe.
+        final List<CopyOnWriteArrayList<CloudEvent>> snapshot;
         synchronized (state) {
-            snapshot = state.values().stream().flatMap(List::stream).filter(cloudEvent -> matchesFilter(cloudEvent, filter)).collect(Collectors.toList());
+            snapshot = new ArrayList<>(state.values());
         }
-        Stream<CloudEvent> stream = snapshot.stream();
+        Stream<CloudEvent> stream = snapshot.stream().flatMap(List::stream).filter(cloudEvent -> matchesFilter(cloudEvent, filter));
 
         final Stream<CloudEvent> streamToSort;
         final Map<CloudEvent, Integer> cloudEventPositionCache;

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -248,10 +248,15 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         Objects.requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
         Objects.requireNonNull(sortBy, SortBy.class.getSimpleName() + " cannot be null");
 
-        Stream<CloudEvent> stream;
+        // Materialize a snapshot of the matching events while holding the lock. The stream returned to the caller
+        // is consumed lazily (sort/skip/limit happen on terminal operations), so iterating over state.values()
+        // outside the lock could race with a concurrent write() that structurally modifies the backing map and
+        // throw ConcurrentModificationException (or observe an in-flight stream). count() snapshots the same way.
+        final List<CloudEvent> snapshot;
         synchronized (state) {
-            stream = state.values().stream().flatMap(List::stream).filter(cloudEvent -> matchesFilter(cloudEvent, filter));
+            snapshot = state.values().stream().flatMap(List::stream).filter(cloudEvent -> matchesFilter(cloudEvent, filter)).collect(Collectors.toList());
         }
+        Stream<CloudEvent> stream = snapshot.stream();
 
         final Stream<CloudEvent> streamToSort;
         final Map<CloudEvent, Integer> cloudEventPositionCache;

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1042,7 +1043,7 @@ public class InMemoryEventStoreTest {
 
             // Consume the lazily evaluated query stream (sort/skip/limit happen on the terminal operation)
             // while the writer keeps structurally modifying the backing map.
-            writerStarted.await();
+            assertThat(writerStarted.await(10, TimeUnit.SECONDS)).as("Writer thread should start within 10 seconds").isTrue();
             while (!writer.isDone()) {
                 try {
                     List<CloudEvent> result = inMemoryEventStore.query(Filter.all(), 0, Integer.MAX_VALUE, SortBy.natural(DESCENDING)).collect(Collectors.toList());
@@ -1054,7 +1055,7 @@ public class InMemoryEventStoreTest {
                 }
             }
 
-            writer.get();
+            writer.get(60, TimeUnit.SECONDS);
             executor.shutdownNow();
 
             // Then

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreTest.java
@@ -43,6 +43,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1015,6 +1020,47 @@ public class InMemoryEventStoreTest {
         @BeforeEach
         void create_event_store() {
             inMemoryEventStore = new InMemoryEventStore();
+        }
+
+        @Test
+        void query_consumed_concurrently_with_writes_to_new_streams_does_not_throw_and_returns_consistent_result() throws Exception {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            int numberOfWrites = 500;
+            CountDownLatch writerStarted = new CountDownLatch(1);
+            AtomicReference<Throwable> readerFailure = new AtomicReference<>();
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+
+            // When
+            Future<?> writer = executor.submit(() -> {
+                writerStarted.countDown();
+                for (int i = 0; i < numberOfWrites; i++) {
+                    NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(i), "name" + i, "name" + i);
+                    unconditionallyPersist(inMemoryEventStore, "stream" + i, nameDefined);
+                }
+            });
+
+            // Consume the lazily evaluated query stream (sort/skip/limit happen on the terminal operation)
+            // while the writer keeps structurally modifying the backing map.
+            writerStarted.await();
+            while (!writer.isDone()) {
+                try {
+                    List<CloudEvent> result = inMemoryEventStore.query(Filter.all(), 0, Integer.MAX_VALUE, SortBy.natural(DESCENDING)).collect(Collectors.toList());
+                    // The snapshot must be internally consistent: no duplicate events from an in-flight write.
+                    assertThat(result).doesNotHaveDuplicates();
+                } catch (Throwable t) {
+                    readerFailure.set(t);
+                    break;
+                }
+            }
+
+            writer.get();
+            executor.shutdownNow();
+
+            // Then
+            assertThat(readerFailure.get()).as("Concurrent query must not fail while writes happen").isNull();
+            List<CloudEvent> finalResult = inMemoryEventStore.query(Filter.all(), 0, Integer.MAX_VALUE, SortBy.natural(DESCENDING)).collect(Collectors.toList());
+            assertThat(finalResult).hasSize(numberOfWrites);
         }
 
         @Test


### PR DESCRIPTION
## What

`InMemoryEventStore.query(Filter, int, int, SortBy)` built its stream over `state.values()` inside the `synchronized (state)` block, but the stream is lazy. The terminal operation (the sort, skip, and limit that run when the caller consumes the returned `Stream`) happened after the lock was released.

That opens a race. A concurrent `write(...)` structurally modifies the backing `LinkedHashMap` through `state.compute`, so if a caller is still iterating a previously returned query stream, the lazy iteration over `state.values()` can throw `ConcurrentModificationException` or quietly include an in-flight stream. `count(Filter)` in the same class already does the right thing and runs its terminal operation inside the lock.

## Fix

I materialize the filtered events into a snapshot list while holding the lock, mirroring how `count` works, then run the sort, skip, and limit on that snapshot outside the lock. The snapshot is both safer and a more consistent read.

## Why now

This is a pre-existing issue, but it matters more now. `CatchupSubscriptionModel` delta reconciliation queries with `SortBy.natural(DESCENDING)`, so the in-memory store can be read concurrently with writes during a catch-up.

## Risk

Low. The change is limited to `query`, and the rest of the method runs unchanged on the snapshot stream instead of the live one. `InMemoryEventStore` is a test and demo store, so the extra copy is not a concern.

## Verification

I added a test that consumes `query` concurrently with writes to new streams and asserts no `ConcurrentModificationException` and a consistent result. I confirmed it fails without the fix and passes with it. The full `InMemoryEventStoreTest` class (80 tests) passes.
