### PR TITLE
Fix DCB DSL compilation and renumber DCB ADRs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,8 +35,8 @@
 * Added a blocking DCB DSL module.
   * New module: `org.occurrent:dcb-dsl-blocking`.
   * Java helpers: `DcbDomainEventQueries` and `DcbDomainEventStream`.
-  * Java and Kotlin DCB query helpers compose with `DomainEventQueries`, reusing its configured `CloudEventConverter` and wrapped query implementation instead of requiring callers to pass a `DcbEventStore` directly.
-  * Kotlin query extensions on `DomainEventQueries`: `queryForSequence`, `queryForList`, and `queryWithPosition`.
+  * `DcbDomainEventQueries` wraps a `DomainEventQueries`, reusing its configured `CloudEventConverter` and delegating the regular stream query API, so a DCB application uses one object for both DCB queries and stream queries instead of passing a `DcbEventStore` directly.
+  * Kotlin query extensions on `DcbDomainEventQueries`: `queryForSequence` and `queryForList`. The `queryWithPosition` overloads are member functions on `DcbDomainEventQueries`.
   * Kotlin live subscription extension on `Subscribable`: `subscribeDcb`.
   * DCB subscription helpers subscribe to CloudEvents and post-filter DCB-tagged events by `DcbQuery`; they are live subscription conveniences, not DCB-consistent reads.
   * DCB subscription metadata callbacks reuse the existing `EventMetadata` type and expose DCB metadata through Kotlin extension properties: `dcbPosition` and `dcbTags`.

--- a/changelog.md
+++ b/changelog.md
@@ -47,9 +47,9 @@
   * The DCB autoconfig example uses the starter-provided Jackson 3 `CloudEventConverter` with a domain-specific `ReflectionCloudEventTypeMapper`, instead of a custom converter.
   * Both examples assert DCB-only stream API rejection while keeping DCB-written events observable as normal CloudEvents with DCB and Occurrent storage metadata.
 * Added ADRs for the DCB design:
-  * [ADR 14](doc/architecture/decisions/0014-introduce-dcb-as-shared-cloudevent-capability.md)
-  * [ADR 15](doc/architecture/decisions/0015-spring-mongo-event-store-capabilities.md)
-  * [ADR 16](doc/architecture/decisions/0016-dcb-dsl-module.md)
+  * [ADR 17](doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md)
+  * [ADR 18](doc/architecture/decisions/0018-spring-mongo-event-store-capabilities.md)
+  * [ADR 19](doc/architecture/decisions/0019-dcb-dsl-module.md)
 
 #### Notes
 

--- a/doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md
+++ b/doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md
@@ -1,4 +1,4 @@
-# 14. Introduce DCB as shared CloudEvent capability
+# 17. Introduce DCB as shared CloudEvent capability
 
 Date: 2026-05-22
 

--- a/doc/architecture/decisions/0018-spring-mongo-event-store-capabilities.md
+++ b/doc/architecture/decisions/0018-spring-mongo-event-store-capabilities.md
@@ -1,4 +1,4 @@
-# 15. Spring Mongo Event Store Capabilities
+# 18. Spring Mongo Event Store Capabilities
 
 Date: 2026-05-23
 

--- a/doc/architecture/decisions/0019-dcb-dsl-module.md
+++ b/doc/architecture/decisions/0019-dcb-dsl-module.md
@@ -1,4 +1,4 @@
-# 16. DCB DSL Module
+# 19. DCB DSL Module
 
 Date: 2026-05-23
 

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
@@ -17,246 +17,73 @@
 package org.occurrent.dsl.dcb.blocking;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
-import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbEventStream;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
-import org.occurrent.filter.Filter;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Helpers for querying DCB event stores to domain events.
+ * Helpers for querying a DCB-capable event store through a {@link DomainEventQueries}, converting the
+ * matched CloudEvents into your domain event type.
+ *
+ * <p>The supplied {@link DomainEventQueries} must be backed by an event store that also implements
+ * {@link DcbEventStore} (for example the in-memory event store, or the Spring MongoDB event store with the
+ * DCB capability enabled). Stream-based usage of {@link DomainEventQueries} is unaffected.</p>
  */
 @NullMarked
-public class DcbDomainEventQueries<E> {
+public final class DcbDomainEventQueries {
 
-    private final DomainEventQueries<E> domainEventQueries;
-    private final DcbEventStore dcbEventStore;
-
-    public DcbDomainEventQueries(DomainEventQueries<E> domainEventQueries, DcbEventStore dcbEventStore) {
-        this.domainEventQueries = domainEventQueries;
-        this.dcbEventStore = dcbEventStore;
+    private DcbDomainEventQueries() {
     }
 
     /**
      * Queries matching DCB events from the beginning of the DCB sequence.
      */
-    public Stream<E> query(DcbQuery query) {
-        return queryWithPosition(query).stream();
+    public static <E> Stream<E> query(DomainEventQueries<E> domainEventQueries, DcbQuery query) {
+        return queryWithPosition(domainEventQueries, query).stream();
     }
 
     /**
      * Queries matching DCB events using the supplied read options.
      */
-    public Stream<E> query(DomainEventQueries<E> domainEventQueries, DcbQuery query, DcbReadOptions options) {
-        return queryWithPosition(query, options).stream();
+    public static <E> Stream<E> query(DomainEventQueries<E> domainEventQueries, DcbQuery query, DcbReadOptions options) {
+        return queryWithPosition(domainEventQueries, query, options).stream();
     }
 
     /**
-     * Queries matching DCB events and returns both domain events and the observed DCB sequence position.
+     * Queries matching DCB events and returns both the domain events and the observed DCB sequence position.
      */
-    public DcbDomainEventStream<E> queryWithPosition(DcbQuery query) {
-        return queryWithPosition(query, DcbReadOptions.fromBeginning());
+    public static <E> DcbDomainEventStream<E> queryWithPosition(DomainEventQueries<E> domainEventQueries, DcbQuery query) {
+        return queryWithPosition(domainEventQueries, query, DcbReadOptions.fromBeginning());
     }
 
     /**
-     * Queries matching DCB events using the supplied read options and returns both domain events and the observed DCB sequence position.
+     * Queries matching DCB events using the supplied read options and returns both the domain events and the
+     * observed DCB sequence position.
      */
-    public DcbDomainEventStream<E> queryWithPosition(DcbQuery query, DcbReadOptions options) {
+    public static <E> DcbDomainEventStream<E> queryWithPosition(DomainEventQueries<E> domainEventQueries, DcbQuery query, DcbReadOptions options) {
         requireNonNull(domainEventQueries, DomainEventQueries.class.getSimpleName() + " cannot be null");
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
+        DcbEventStore dcbEventStore = requireDcbEventStore(domainEventQueries);
         DcbEventStream eventStream = dcbEventStore.read(query, options);
-        return new DcbDomainEventStream<>(domainEventQueries, eventStream.lastSequencePosition());
+        List<E> events = domainEventQueries.<E>toDomainEvents(eventStream.stream()).toList();
+        return new DcbDomainEventStream<>(events, eventStream.lastSequencePosition());
     }
 
-
-    // Delegate all other query methods to the wrapped DomainEventQueries
-
-    /**
-     * @see DomainEventQueries#queryOne(Filter)
-     */
-    @Nullable
-    public <E1 extends E> E1 queryOne(Filter filter) {
-        return domainEventQueries.queryOne(filter);
-    }
-
-    /**
-     * @see DomainEventQueries#queryOne(Class)
-     */
-    @Nullable
-    public <E1 extends E> E1 queryOne(Class<E1> type) {
-        return domainEventQueries.queryOne(type);
-    }
-
-    /**
-     * @see DomainEventQueries#queryOne(Class, SortBy)
-     */
-    @Nullable
-    public <E1 extends E> E1 queryOne(Class<E1> type, SortBy sortBy) {
-        return domainEventQueries.queryOne(type, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#queryOne(Class, int, int)
-     */
-    @Nullable
-    public <E1 extends E> E1 queryOne(Class<E1> type, int skip, int limit) {
-        return domainEventQueries.queryOne(type, skip, limit);
-    }
-
-    /**
-     * @see DomainEventQueries#queryOne(Class, int, int, SortBy)
-     */
-    @Nullable
-    public <E1 extends E> E1 queryOne(Class<E1> type, int skip, int limit, SortBy sortBy) {
-        return domainEventQueries.queryOne(type, skip, limit, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Class)
-     */
-    public <E1 extends E> Stream<E1> query(Class<E1> type) {
-        return domainEventQueries.query(type);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Class, int, int)
-     */
-    public <E1 extends E> Stream<E1> query(Class<E1> type, int skip, int limit) {
-        return domainEventQueries.query(type, skip, limit);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Class, int, int, SortBy)
-     */
-    public <E1 extends E> Stream<E1> query(Class<E1> type, int skip, int limit, SortBy sortBy) {
-        return domainEventQueries.query(type, skip, limit, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Class, SortBy)
-     */
-    public <E1 extends E> Stream<E1> query(Class<E1> type, SortBy sortBy) {
-        return domainEventQueries.query(type, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Filter, int, int, SortBy)
-     */
-    public <E1 extends E> Stream<E1> query(Filter filter, int skip, int limit, SortBy sortBy) {
-        return domainEventQueries.query(filter, skip, limit, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Collection, int, int, SortBy)
-     */
-    public Stream<E> query(Collection<Class<? extends E>> types, int skip, int limit, SortBy sortBy) {
-        return domainEventQueries.query(types, skip, limit, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Collection, int, int)
-     */
-    public Stream<E> query(Collection<Class<? extends E>> types, int skip, int limit) {
-        return domainEventQueries.query(types, skip, limit);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Collection, SortBy)
-     */
-    public Stream<E> query(Collection<Class<? extends E>> types, SortBy sortBy) {
-        return domainEventQueries.query(types, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Collection)
-     */
-    public Stream<E> query(Collection<Class<? extends E>> types) {
-        return domainEventQueries.query(types);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Class, Class[])
-     */
-    public Stream<E> query(Class<? extends E> type, @Nullable Class<? extends E>... types) {
-        return domainEventQueries.query(type, types);
-    }
-
-    /**
-     * @see DomainEventQueries#count(Filter)
-     */
-    public long count(Filter filter) {
-        return domainEventQueries.count(filter);
-    }
-
-    /**
-     * @see DomainEventQueries#count()
-     */
-    public long count() {
-        return domainEventQueries.count();
-    }
-
-    /**
-     * @see DomainEventQueries#exists(Filter)
-     */
-    public boolean exists(Filter filter) {
-        return domainEventQueries.exists(filter);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Filter, SortBy)
-     */
-    public <E1 extends E> Stream<E1> query(Filter filter, SortBy sortBy) {
-        return domainEventQueries.query(filter, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#query(Filter, int, int)
-     */
-    public <E1 extends E> Stream<E1> query(Filter filter, int skip, int limit) {
-        return domainEventQueries.query(filter, skip, limit);
-    }
-
-    /**
-     * @see DomainEventQueries#all(int, int, SortBy)
-     */
-    public Stream<E> all(int skip, int limit, SortBy sortBy) {
-        return domainEventQueries.all(skip, limit, sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#all(SortBy)
-     */
-    public Stream<E> all(SortBy sortBy) {
-        return domainEventQueries.all(sortBy);
-    }
-
-    /**
-     * @see DomainEventQueries#all(int, int)
-     */
-    public Stream<E> all(int skip, int limit) {
-        return domainEventQueries.all(skip, limit);
-    }
-
-    /**
-     * @see DomainEventQueries#all()
-     */
-    public Stream<E> all() {
-        return domainEventQueries.all();
-    }
-
-    /**
-     * @see DomainEventQueries#query(Filter)
-     */
-    public <E1 extends E> Stream<E1> query(Filter filter) {
-        return domainEventQueries.query(filter);
+    private static DcbEventStore requireDcbEventStore(DomainEventQueries<?> domainEventQueries) {
+        EventStoreQueries eventStoreQueries = domainEventQueries.eventStoreQueries();
+        if (!(eventStoreQueries instanceof DcbEventStore dcbEventStore)) {
+            throw new IllegalArgumentException("DCB queries require the " + DomainEventQueries.class.getSimpleName() + " to be backed by a "
+                    + DcbEventStore.class.getSimpleName() + ", but was " + (eventStoreQueries == null ? "null" : eventStoreQueries.getClass().getName()));
+        }
+        return dcbEventStore;
     }
 }

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
@@ -17,72 +17,205 @@
 package org.occurrent.dsl.dcb.blocking;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbEventStream;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.filter.Filter;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Helpers for querying a DCB-capable event store through a {@link DomainEventQueries}, converting the
- * matched CloudEvents into your domain event type.
+ * Queries a DCB-capable event store and converts the matched CloudEvents into your domain event type.
  *
- * <p>The supplied {@link DomainEventQueries} must be backed by an event store that also implements
- * {@link DcbEventStore} (for example the in-memory event store, or the Spring MongoDB event store with the
- * DCB capability enabled). Stream-based usage of {@link DomainEventQueries} is unaffected.</p>
+ * <p>This wraps a {@link DomainEventQueries} so a DCB application can use a single object for both DCB queries
+ * (the {@link #query(DcbQuery)} family) and the regular stream-oriented queries (which are delegated to the
+ * wrapped {@link DomainEventQueries} unchanged). The wrapped instance must be backed by an event store that
+ * also implements {@link DcbEventStore} (for example the in-memory event store, or the Spring MongoDB event
+ * store with the DCB capability enabled); otherwise the constructor throws.</p>
+ *
+ * @param <E> the domain event type
  */
 @NullMarked
-public final class DcbDomainEventQueries {
+public class DcbDomainEventQueries<E> {
 
-    private DcbDomainEventQueries() {
+    private final DomainEventQueries<E> domainEventQueries;
+    private final DcbEventStore dcbEventStore;
+
+    /**
+     * Wraps a {@link DomainEventQueries} backed by a DCB-capable event store.
+     *
+     * @throws IllegalArgumentException if the wrapped {@link DomainEventQueries} is not backed by a {@link DcbEventStore}
+     */
+    public DcbDomainEventQueries(DomainEventQueries<E> domainEventQueries) {
+        this.domainEventQueries = requireNonNull(domainEventQueries, DomainEventQueries.class.getSimpleName() + " cannot be null");
+        this.dcbEventStore = requireDcbEventStore(domainEventQueries);
     }
+
+    // ------------------------------------------------------------------------------------------------------
+    // DCB queries
+    // ------------------------------------------------------------------------------------------------------
 
     /**
      * Queries matching DCB events from the beginning of the DCB sequence.
      */
-    public static <E> Stream<E> query(DomainEventQueries<E> domainEventQueries, DcbQuery query) {
-        return queryWithPosition(domainEventQueries, query).stream();
+    public Stream<E> query(DcbQuery query) {
+        return query(query, DcbReadOptions.fromBeginning());
     }
 
     /**
-     * Queries matching DCB events using the supplied read options.
+     * Queries matching DCB events using the supplied read options. The CloudEvents are converted to domain
+     * events lazily, so terminal short-circuiting operations such as {@code findFirst} or {@code limit} avoid
+     * converting events that are never consumed.
      */
-    public static <E> Stream<E> query(DomainEventQueries<E> domainEventQueries, DcbQuery query, DcbReadOptions options) {
-        return queryWithPosition(domainEventQueries, query, options).stream();
+    public Stream<E> query(DcbQuery query, DcbReadOptions options) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return domainEventQueries.toDomainEvents(dcbEventStore.read(query, options).stream());
     }
 
     /**
      * Queries matching DCB events and returns both the domain events and the observed DCB sequence position.
      */
-    public static <E> DcbDomainEventStream<E> queryWithPosition(DomainEventQueries<E> domainEventQueries, DcbQuery query) {
-        return queryWithPosition(domainEventQueries, query, DcbReadOptions.fromBeginning());
+    public DcbDomainEventStream<E> queryWithPosition(DcbQuery query) {
+        return queryWithPosition(query, DcbReadOptions.fromBeginning());
     }
 
     /**
      * Queries matching DCB events using the supplied read options and returns both the domain events and the
      * observed DCB sequence position.
      */
-    public static <E> DcbDomainEventStream<E> queryWithPosition(DomainEventQueries<E> domainEventQueries, DcbQuery query, DcbReadOptions options) {
-        requireNonNull(domainEventQueries, DomainEventQueries.class.getSimpleName() + " cannot be null");
+    public DcbDomainEventStream<E> queryWithPosition(DcbQuery query, DcbReadOptions options) {
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
-        DcbEventStore dcbEventStore = requireDcbEventStore(domainEventQueries);
         DcbEventStream eventStream = dcbEventStore.read(query, options);
-        List<E> events = domainEventQueries.<E>toDomainEvents(eventStream.stream()).toList();
+        List<E> events = domainEventQueries.toDomainEvents(eventStream.stream()).toList();
         return new DcbDomainEventStream<>(events, eventStream.lastSequencePosition());
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Stream queries delegated to the wrapped DomainEventQueries
+    // ------------------------------------------------------------------------------------------------------
+
+    @Nullable
+    public <E1 extends E> E1 queryOne(Filter filter) {
+        return domainEventQueries.queryOne(filter);
+    }
+
+    @Nullable
+    public <E1 extends E> E1 queryOne(Class<E1> type) {
+        return domainEventQueries.queryOne(type);
+    }
+
+    @Nullable
+    public <E1 extends E> E1 queryOne(Class<E1> type, SortBy sortBy) {
+        return domainEventQueries.queryOne(type, sortBy);
+    }
+
+    @Nullable
+    public <E1 extends E> E1 queryOne(Class<E1> type, int skip, int limit) {
+        return domainEventQueries.queryOne(type, skip, limit);
+    }
+
+    @Nullable
+    public <E1 extends E> E1 queryOne(Class<E1> type, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.queryOne(type, skip, limit, sortBy);
+    }
+
+    public <E1 extends E> Stream<E1> query(Class<E1> type) {
+        return domainEventQueries.query(type);
+    }
+
+    public <E1 extends E> Stream<E1> query(Class<E1> type, int skip, int limit) {
+        return domainEventQueries.query(type, skip, limit);
+    }
+
+    public <E1 extends E> Stream<E1> query(Class<E1> type, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(type, skip, limit, sortBy);
+    }
+
+    public <E1 extends E> Stream<E1> query(Class<E1> type, SortBy sortBy) {
+        return domainEventQueries.query(type, sortBy);
+    }
+
+    public <E1 extends E> Stream<E1> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(filter, skip, limit, sortBy);
+    }
+
+    public Stream<E> query(Collection<Class<? extends E>> types, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(types, skip, limit, sortBy);
+    }
+
+    public Stream<E> query(Collection<Class<? extends E>> types, int skip, int limit) {
+        return domainEventQueries.query(types, skip, limit);
+    }
+
+    public Stream<E> query(Collection<Class<? extends E>> types, SortBy sortBy) {
+        return domainEventQueries.query(types, sortBy);
+    }
+
+    public Stream<E> query(Collection<Class<? extends E>> types) {
+        return domainEventQueries.query(types);
+    }
+
+    @SafeVarargs
+    public final Stream<E> query(Class<? extends E> type, @Nullable Class<? extends E>... types) {
+        return domainEventQueries.query(type, types);
+    }
+
+    public long count(Filter filter) {
+        return domainEventQueries.count(filter);
+    }
+
+    public long count() {
+        return domainEventQueries.count();
+    }
+
+    public boolean exists(Filter filter) {
+        return domainEventQueries.exists(filter);
+    }
+
+    public <E1 extends E> Stream<E1> query(Filter filter, SortBy sortBy) {
+        return domainEventQueries.query(filter, sortBy);
+    }
+
+    public <E1 extends E> Stream<E1> query(Filter filter, int skip, int limit) {
+        return domainEventQueries.query(filter, skip, limit);
+    }
+
+    public Stream<E> all(int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.all(skip, limit, sortBy);
+    }
+
+    public Stream<E> all(SortBy sortBy) {
+        return domainEventQueries.all(sortBy);
+    }
+
+    public Stream<E> all(int skip, int limit) {
+        return domainEventQueries.all(skip, limit);
+    }
+
+    public Stream<E> all() {
+        return domainEventQueries.all();
+    }
+
+    public <E1 extends E> Stream<E1> query(Filter filter) {
+        return domainEventQueries.query(filter);
     }
 
     private static DcbEventStore requireDcbEventStore(DomainEventQueries<?> domainEventQueries) {
         EventStoreQueries eventStoreQueries = domainEventQueries.eventStoreQueries();
         if (!(eventStoreQueries instanceof DcbEventStore dcbEventStore)) {
             throw new IllegalArgumentException("DCB queries require the " + DomainEventQueries.class.getSimpleName() + " to be backed by a "
-                    + DcbEventStore.class.getSimpleName() + ", but was " + (eventStoreQueries == null ? "null" : eventStoreQueries.getClass().getName()));
+                    + DcbEventStore.class.getSimpleName() + ", but was " + eventStoreQueries.getClass().getName());
         }
         return dcbEventStore;
     }

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
@@ -16,7 +16,6 @@
 
 package org.occurrent.dsl.dcb.blocking
 
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.eventstore.api.dcb.DcbQuery
 import org.occurrent.eventstore.api.dcb.DcbReadOptions
 import kotlin.streams.asSequence
@@ -26,30 +25,19 @@ import kotlin.streams.asSequence
  *
  * @see DcbDomainEventQueries.query
  */
-fun <T : Any> DomainEventQueries<T>.queryForSequence(
+fun <T : Any> DcbDomainEventQueries<T>.queryForSequence(
     query: DcbQuery,
     options: DcbReadOptions = DcbReadOptions.fromBeginning()
 ): Sequence<T> =
-    DcbDomainEventQueries.query(this, query, options).asSequence()
+    this.query(query, options).asSequence()
 
 /**
  * Query that returns a [List] instead of a [java.util.stream.Stream].
  *
  * @see DcbDomainEventQueries.query
  */
-fun <T : Any> DomainEventQueries<T>.queryForList(
+fun <T : Any> DcbDomainEventQueries<T>.queryForList(
     query: DcbQuery,
     options: DcbReadOptions = DcbReadOptions.fromBeginning()
 ): List<T> =
-    DcbDomainEventQueries.query(this, query, options).toList()
-
-/**
- * Query and keep the DCB sequence position returned by the read.
- *
- * @see DcbDomainEventQueries.queryWithPosition
- */
-fun <T : Any> DomainEventQueries<T>.queryWithPosition(
-    query: DcbQuery,
-    options: DcbReadOptions = DcbReadOptions.fromBeginning()
-): DcbDomainEventStream<T> =
-    DcbDomainEventQueries.queryWithPosition(this, query, options)
+    this.query(query, options).toList()

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
@@ -43,8 +43,6 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries.query;
-import static org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries.queryWithPosition;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class DcbDomainEventQueriesTest {
@@ -52,6 +50,7 @@ class DcbDomainEventQueriesTest {
     private InMemoryEventStore eventStore;
     private CloudEventConverter<DomainEvent> cloudEventConverter;
     private DomainEventQueries<DomainEvent> domainEventQueries;
+    private DcbDomainEventQueries<DomainEvent> dcbQueries;
     private LocalDateTime time;
 
     @BeforeEach
@@ -59,6 +58,7 @@ class DcbDomainEventQueriesTest {
         eventStore = new InMemoryEventStore();
         cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
         domainEventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+        dcbQueries = new DcbDomainEventQueries<>(domainEventQueries);
         time = LocalDateTime.now();
     }
 
@@ -68,7 +68,7 @@ class DcbDomainEventQueriesTest {
         NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
         append("name:1", nameDefined, nameWasChanged);
 
-        List<DomainEvent> events = query(domainEventQueries, DcbQuery.tagsAllOf("name:1")).toList();
+        List<DomainEvent> events = dcbQueries.query(DcbQuery.tagsAllOf("name:1")).toList();
 
         assertThat(events).containsExactly(nameDefined, nameWasChanged);
     }
@@ -80,7 +80,7 @@ class DcbDomainEventQueriesTest {
         append("name:1", nameDefined);
         append("name:1", nameWasChanged);
 
-        List<DomainEvent> events = query(domainEventQueries, DcbQuery.tagsAllOf("name:1"), DcbReadOptions.afterSequencePosition(1)).toList();
+        List<DomainEvent> events = dcbQueries.query(DcbQuery.tagsAllOf("name:1"), DcbReadOptions.afterSequencePosition(1)).toList();
 
         assertThat(events).containsExactly(nameWasChanged);
     }
@@ -91,7 +91,7 @@ class DcbDomainEventQueriesTest {
         append("name:1", nameDefined);
         append("other:1", new NameWasChanged("eventId2", time, "name", "Jane Doe"));
 
-        DcbDomainEventStream<DomainEvent> eventStream = queryWithPosition(domainEventQueries, DcbQuery.tagsAllOf("name:1"));
+        DcbDomainEventStream<DomainEvent> eventStream = dcbQueries.queryWithPosition(DcbQuery.tagsAllOf("name:1"));
 
         assertThat(eventStream.events()).containsExactly(nameDefined);
         assertThat(eventStream.stream()).containsExactly(nameDefined);

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries.query;
 import static org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries.queryWithPosition;
 
@@ -113,9 +114,12 @@ class DcbDomainEventQueriesTest {
                 .toList();
         eventStoreWithSubscriptions.append("dcb:partition:0", cloudEvents);
 
-        assertThat(metadata).hasSize(1);
-        assertThat(metadata.get(0).getStreamId()).isEqualTo("dcb:partition:0");
-        assertThat(metadata.get(0).getStreamVersion()).isEqualTo(1);
+        // The in-memory subscription model dispatches asynchronously, so wait for the callback like the sibling tests do.
+        await().untilAsserted(() -> {
+            assertThat(metadata).hasSize(1);
+            assertThat(metadata.get(0).getStreamId()).isEqualTo("dcb:partition:0");
+            assertThat(metadata.get(0).getStreamVersion()).isEqualTo(1);
+        });
     }
 
     private void append(String tag, DomainEvent... events) {

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -50,6 +50,7 @@ class DcbDslKotlinTest {
     private lateinit var subscriptionModel: InMemorySubscriptionModel
     private lateinit var cloudEventConverter: CloudEventConverter<DomainEvent>
     private lateinit var domainEventQueries: DomainEventQueries<DomainEvent>
+    private lateinit var dcbQueries: DcbDomainEventQueries<DomainEvent>
     private lateinit var time: LocalDateTime
 
     @BeforeEach
@@ -58,6 +59,7 @@ class DcbDslKotlinTest {
         eventStore = InMemoryEventStore(subscriptionModel)
         cloudEventConverter = JacksonCloudEventConverter.Builder<DomainEvent>(ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build()
         domainEventQueries = DomainEventQueries(eventStore, cloudEventConverter)
+        dcbQueries = DcbDomainEventQueries(domainEventQueries)
         time = LocalDateTime.now()
     }
 
@@ -72,9 +74,9 @@ class DcbDslKotlinTest {
         val nameWasChanged = NameWasChanged("eventId2", time, "name", "Jane Doe")
         append("name:1", nameDefined, nameWasChanged)
 
-        assertThat(domainEventQueries.queryForSequence(DcbQuery.tagsAllOf("name:1")).toList()).containsExactly(nameDefined, nameWasChanged)
-        assertThat(domainEventQueries.queryForList(DcbQuery.type(NameDefined::class.qualifiedName!!))).containsExactly(nameDefined)
-        assertThat(domainEventQueries.queryForList(DcbQuery.tagsAllOf("name:1"), DcbReadOptions.afterSequencePosition(1))).containsExactly(nameWasChanged)
+        assertThat(dcbQueries.queryForSequence(DcbQuery.tagsAllOf("name:1")).toList()).containsExactly(nameDefined, nameWasChanged)
+        assertThat(dcbQueries.queryForList(DcbQuery.type(NameDefined::class.qualifiedName!!))).containsExactly(nameDefined)
+        assertThat(dcbQueries.queryForList(DcbQuery.tagsAllOf("name:1"), DcbReadOptions.afterSequencePosition(1))).containsExactly(nameWasChanged)
     }
 
     @Test
@@ -83,7 +85,7 @@ class DcbDslKotlinTest {
         append("other:1", NameWasChanged("eventId2", time, "name", "Jane Doe"))
         append("name:1", nameDefined)
 
-        val eventStream = domainEventQueries.queryWithPosition(DcbQuery.type(NameDefined::class.qualifiedName!!))
+        val eventStream = dcbQueries.queryWithPosition(DcbQuery.type(NameDefined::class.qualifiedName!!))
 
         assertThat(eventStream.events()).containsExactly(nameDefined)
         assertThat(eventStream.lastSequencePosition()).isEqualTo(2)

--- a/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/DomainEventQueries.java
+++ b/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/DomainEventQueries.java
@@ -326,6 +326,7 @@ public class DomainEventQueries<T> {
      */
     @SuppressWarnings("unchecked")
     public <E extends T> Stream<E> toDomainEvents(Stream<CloudEvent> stream) {
+        Objects.requireNonNull(stream, "Stream cannot be null");
         return stream.map(cloudEventConverter::toDomainEvent).map(t -> (E) t);
     }
 

--- a/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/DomainEventQueries.java
+++ b/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/DomainEventQueries.java
@@ -50,6 +50,14 @@ public class DomainEventQueries<T> {
     }
 
     /**
+     * The underlying {@link EventStoreQueries} this instance reads from. Useful for capabilities layered on top of
+     * the event store, such as DCB queries when the store also implements {@code DcbEventStore}.
+     */
+    public EventStoreQueries eventStoreQueries() {
+        return eventStoreQueries;
+    }
+
+    /**
      * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
      *
      * @return All cloud events matching the specified filter, skip, limit and sort by <code>sortBy</code>.
@@ -312,8 +320,12 @@ public class DomainEventQueries<T> {
         return toDomainEvents(eventStoreQueries.query(filter));
     }
 
+    /**
+     * Convert a stream of {@link CloudEvent}s into domain events using the configured {@link CloudEventConverter}.
+     * Useful when you already have CloudEvents (for example from a DCB read) and want them as domain events.
+     */
     @SuppressWarnings("unchecked")
-    private <E extends T> Stream<E> toDomainEvents(Stream<CloudEvent> stream) {
+    public <E extends T> Stream<E> toDomainEvents(Stream<CloudEvent> stream) {
         return stream.map(cloudEventConverter::toDomainEvent).map(t -> (E) t);
     }
 

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/Bootstrap.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/Bootstrap.kt
@@ -21,7 +21,9 @@ import org.occurrent.application.converter.jackson3.jacksonCloudEventConverter
 import org.occurrent.application.converter.typemapper.CloudEventTypeMapper
 import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper
 import org.occurrent.application.service.blocking.dcb.TagGenerator
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.decider.Decider
+import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.dcb.GameEventTagGenerator
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.gameplay.decider.WordGuessingGameCommand
@@ -69,6 +71,10 @@ class Bootstrap {
 
     @Bean
     fun gameEventTagGenerator(): TagGenerator<GameEvent> = GameEventTagGenerator()
+
+    @Bean
+    fun dcbQueryDsl(domainEventQueries: DomainEventQueries<GameEvent>) =
+        DcbDomainEventQueries(domainEventQueries)
 
     @Bean
     fun wordGuessingGameDecider(): Decider<WordGuessingGameCommand, WordGuessingGameState, GameEvent> =

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
@@ -19,8 +19,8 @@ package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autocon
 import org.occurrent.annotation.Subscription
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForSequence
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.EventMetadata
 import org.occurrent.example.domain.wordguessinggame.event.*
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.dcb.GameDcbQueries
@@ -35,7 +35,7 @@ import java.util.UUID
 @Component
 class WhenGameIsEndedThenAddGameToEndedGamesOverview(
     private val mongo: MongoOperations,
-    private val domainEventQueries: DomainEventQueries<GameEvent>
+    private val domainEventQueries: DcbDomainEventQueries<GameEvent>
 ) {
     private val log = loggerFor<WhenGameIsEndedThenAddGameToEndedGamesOverview>()
 

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/game/FindGameByIdQuery.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/game/FindGameByIdQuery.kt
@@ -16,8 +16,8 @@
 
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.gameplay.views.game
 
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForSequence
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.dcb.GameDcbQueries
 import org.occurrent.example.domain.wordguessinggame.readmodel.GameReadModel
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class FindGameByIdQuery(private val domainEventQueries: DomainEventQueries<GameEvent>) {
+class FindGameByIdQuery(private val domainEventQueries: DcbDomainEventQueries<GameEvent>) {
 
     fun execute(gameId: UUID): GameReadModel? =
         domainEventQueries.queryForSequence(GameDcbQueries.allGameEvents(gameId)).assembleGameReadModelFromDomainEvents()

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
@@ -19,8 +19,8 @@ import org.occurrent.annotation.Subscription
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForList
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.EventMetadata
 import org.occurrent.example.domain.wordguessinggame.event.CharacterInWordHintWasRevealed
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
@@ -42,7 +42,7 @@ import kotlin.streams.asStream
 @Component
 class RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord(
     private val applicationService: DcbApplicationService<GameEvent>,
-    private val domainEventQueries: DomainEventQueries<GameEvent>
+    private val domainEventQueries: DcbDomainEventQueries<GameEvent>
 ) {
 
     @Subscription(id = "WhenPlayerGuessedTheWrongWordThenRevealCharacterInWordHintPolicy")

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/AnnotationPoliciesAndDcbReadPathsTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/AnnotationPoliciesAndDcbReadPathsTest.kt
@@ -20,8 +20,8 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.cloudevents.OccurrentExtensionGetter
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForList
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
 import org.occurrent.eventstore.api.dcb.DcbEventStore
 import org.occurrent.eventstore.api.dcb.DcbQuery
@@ -71,7 +71,7 @@ class AnnotationPoliciesAndDcbReadPathsTest {
     private lateinit var cloudEventConverter: CloudEventConverter<GameEvent>
 
     @Autowired
-    private lateinit var domainEventQueries: DomainEventQueries<GameEvent>
+    private lateinit var domainEventQueries: DcbDomainEventQueries<GameEvent>
 
     @Autowired
     private lateinit var findGameById: FindGameByIdQuery

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/DeciderCommandHandlersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/DeciderCommandHandlersTest.kt
@@ -20,8 +20,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.occurrent.application.converter.CloudEventConverter
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForList
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
 import org.occurrent.eventstore.api.dcb.DcbEventStore
 import org.occurrent.eventstore.api.dcb.DcbQuery
@@ -63,7 +63,7 @@ class DeciderCommandHandlersTest {
     private lateinit var cloudEventConverter: CloudEventConverter<GameEvent>
 
     @Autowired
-    private lateinit var domainEventQueries: DomainEventQueries<GameEvent>
+    private lateinit var domainEventQueries: DcbDomainEventQueries<GameEvent>
 
     @Test
     fun `starts game through decider command path`() {

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/Bootstrap.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/Bootstrap.kt
@@ -19,6 +19,7 @@ import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
 import org.occurrent.application.service.blocking.dcb.GenericDcbApplicationService
 import org.occurrent.application.service.blocking.dcb.TagGenerator
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.Subscriptions
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig
@@ -90,6 +91,10 @@ class Bootstrap : WebMvcConfigurer {
     @Bean
     fun queryDsl(eventStore: SpringMongoEventStore, converter: CloudEventConverter<GameEvent>) =
         DomainEventQueries(eventStore, converter)
+
+    @Bean
+    fun dcbQueryDsl(domainEventQueries: DomainEventQueries<GameEvent>) =
+        DcbDomainEventQueries(domainEventQueries)
 
     @Bean
     fun objectMapper(): ObjectMapper = jacksonObjectMapper()

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
@@ -16,8 +16,8 @@
 
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.features.gameplay.views.endedgamesoverview
 
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForSequence
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.Subscriptions
 import org.occurrent.example.domain.wordguessinggame.event.*
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.features.dcb.GameDcbQueries
@@ -40,7 +40,7 @@ class WhenGameIsEndedThenAddGameToEndedGamesOverview {
     private lateinit var mongo: MongoOperations
 
     @Autowired
-    private lateinit var domainEventQueries: DomainEventQueries<GameEvent>
+    private lateinit var domainEventQueries: DcbDomainEventQueries<GameEvent>
 
     @Bean
     fun whenGameIsEndedThenAddGameToEndedGamesOverviewPolicy() =

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/views/game/FindGameByIdQuery.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/views/game/FindGameByIdQuery.kt
@@ -16,8 +16,8 @@
 
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.features.gameplay.views.game
 
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForSequence
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.features.dcb.GameDcbQueries
 import org.occurrent.example.domain.wordguessinggame.readmodel.GameReadModel
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class FindGameByIdQuery(private val domainEventQueries: DomainEventQueries<GameEvent>) {
+class FindGameByIdQuery(private val domainEventQueries: DcbDomainEventQueries<GameEvent>) {
 
     fun execute(gameId: UUID): GameReadModel? =
         domainEventQueries.queryForSequence(GameDcbQueries.allGameEvents(gameId)).assembleGameReadModelFromDomainEvents()

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
@@ -16,8 +16,8 @@
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.features.wordhint
 
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForList
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.Subscriptions
 import org.occurrent.example.domain.wordguessinggame.event.CharacterInWordHintWasRevealed
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
@@ -38,7 +38,7 @@ import kotlin.streams.asStream
 @Configuration
 class RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord(
     private val applicationService: DcbApplicationService<GameEvent>,
-    private val domainEventQueries: DomainEventQueries<GameEvent>,
+    private val domainEventQueries: DcbDomainEventQueries<GameEvent>,
     private val subscriptions: Subscriptions<GameEvent>
 ) {
 

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/usecases/GameplayUsecasesAndPoliciesTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/usecases/GameplayUsecasesAndPoliciesTest.kt
@@ -20,8 +20,8 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.cloudevents.OccurrentExtensionGetter
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.dcb.blocking.queryForList
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
 import org.occurrent.eventstore.api.dcb.DcbEventStore
 import org.occurrent.example.domain.wordguessinggame.event.CharacterInWordHintWasRevealed
@@ -63,7 +63,7 @@ class GameplayUsecasesAndPoliciesTest {
     private lateinit var cloudEventConverter: CloudEventConverter<GameEvent>
 
     @Autowired
-    private lateinit var domainEventQueries: DomainEventQueries<GameEvent>
+    private lateinit var domainEventQueries: DcbDomainEventQueries<GameEvent>
 
     @Autowired
     private lateinit var revealInitialCharacters: RevealInitialCharactersInWordHintAfterGameIsStarted


### PR DESCRIPTION
Two things to unblock the DCB work.

First, the `dcb-dsl-blocking` module didn't compile. `DcbDomainEventQueries` was stuck half-way between an instance class and static helpers, and the Kotlin extensions called a form that didn't exist. I made it an instance wrapper: you construct `DcbDomainEventQueries` from a `DomainEventQueries`, and it delegates the full stream query API while adding the DCB `query(DcbQuery)` and `queryWithPosition(DcbQuery, DcbReadOptions)` methods. So a DCB app can use a single object for both the DCB queries and the regular stream queries. The `DcbEventStore` is derived from the underlying event store, and the constructor throws a clear error when the store isn't DCB-backed. `query(..)` maps the matched events to domain events lazily, so `findFirst` and `limit` short-circuit. `DomainEventQueries` gains a public `toDomainEvents(..)` and an `eventStoreQueries()` accessor, both additive.

Second, the DCB ADRs collided with the released `0014` catch-up ADR, so I renumbered them to `0017`, `0018`, and `0019` and updated the headings and the changelog links.

The changes are backward compatible, stream-based usage of `DomainEventQueries` is unaffected.

Verification: `mvn test-compile` is green again (it failed before), and the `query-dsl` and `dcb-dsl` suites pass.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-support","parentHead":"aaa599de0cbada947bbb4f12a720df7ddac372f4","parentPull":201,"trunk":"main"}
```
-->
