### PR TITLE
Document the DCB position contract and add tests

### DIFF
--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendResult.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendResult.java
@@ -21,6 +21,11 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Sequence-position result from a successful DCB append.
  *
+ * <p>DCB sequence positions are global to the event store, start at 1, and are strictly increasing (monotonic). A
+ * successful append is assigned a contiguous block of positions ({@code firstSequencePosition}..{@code lastSequencePosition}).
+ * Positions across separate appends may contain gaps (for example a failed or concurrently-retried append may leave a
+ * reserved position unused), so callers must rely only on the relative ordering of positions, never on contiguity.</p>
+ *
  * @param firstSequencePosition the first global DCB sequence position assigned to the appended events
  * @param lastSequencePosition the last global DCB sequence position assigned to the appended events
  * @param eventCount the number of events appended

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendResult.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendResult.java
@@ -22,9 +22,9 @@ import org.jspecify.annotations.NullMarked;
  * Sequence-position result from a successful DCB append.
  *
  * <p>DCB sequence positions are global to the event store, start at 1, and are strictly increasing (monotonic). A
- * successful append is assigned a contiguous block of positions ({@code firstSequencePosition}..{@code lastSequencePosition}).
- * Positions across separate appends may contain gaps (for example a failed or concurrently-retried append may leave a
- * reserved position unused), so callers must rely only on the relative ordering of positions, never on contiguity.</p>
+ * single successful append is assigned a contiguous block of positions ({@code firstSequencePosition}..{@code
+ * lastSequencePosition}). Across separate appends only the relative ordering of positions is guaranteed, so callers
+ * must compare positions for ordering and must not assume the positions of different appends are contiguous.</p>
  *
  * @param firstSequencePosition the first global DCB sequence position assigned to the appended events
  * @param lastSequencePosition the last global DCB sequence position assigned to the appended events

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
@@ -28,7 +28,13 @@ import static java.util.Objects.requireNonNull;
  * Immutable result of a DCB read.
  *
  * @param events the CloudEvents matched by the DCB query and read options
- * @param lastSequencePosition the latest DCB sequence position observed by the read, or {@code 0} when none has been observed
+ * @param lastSequencePosition the event store's global DCB head at the time of the read, that is the highest DCB
+ *                             sequence position assigned anywhere in the store, NOT the highest position among the
+ *                             matched {@code events} (which may be lower, or {@code 0} when the query matched nothing).
+ *                             It is {@code 0} only when the store holds no DCB events yet. Pass it to
+ *                             {@link DcbAppendCondition#failIfEventsMatch(DcbQuery, long)} so a later append is rejected
+ *                             if any event matching the query was written after this read, independent of which events
+ *                             the query itself matched.
  */
 @NullMarked
 public record DcbEventStream(List<CloudEvent> events, long lastSequencePosition) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
@@ -29,9 +29,11 @@ import static java.util.Objects.requireNonNull;
  *
  * @param events the CloudEvents matched by the DCB query and read options
  * @param lastSequencePosition the event store's global DCB head at the time of the read, that is the highest DCB
- *                             sequence position assigned anywhere in the store, NOT the highest position among the
- *                             matched {@code events} (which may be lower, or {@code 0} when the query matched nothing).
- *                             It is {@code 0} only when the store holds no DCB events yet. Pass it to
+ *                             sequence position assigned anywhere in the store. This is NOT the highest position among
+ *                             the matched {@code events}: the highest matched position can be lower than the head, and
+ *                             when the query matches nothing there is no matched position at all, yet
+ *                             {@code lastSequencePosition} still reports the store head. It is {@code 0} only when the
+ *                             store holds no DCB events yet. Pass it to
  *                             {@link DcbAppendCondition#failIfEventsMatch(DcbQuery, long)} so a later append is rejected
  *                             if any event matching the query was written after this read, independent of which events
  *                             the query itself matched.

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -244,6 +244,41 @@ class InMemoryEventStoreDcbTest {
         assertThat(eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1"))).firstSequencePosition()).isEqualTo(1);
     }
 
+    @Test
+    void last_sequence_position_is_the_store_head_not_the_max_matched_position() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        eventStore.append("dcb:partition:0", List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:2")));
+
+        // The query matches only the two "name:1" events (positions 1 and 2), but the store head is 3.
+        DcbEventStream matchesSome = eventStore.read(tagsAllOf("name:1"));
+        assertThat(matchesSome.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(matchesSome.lastSequencePosition()).isEqualTo(3);
+
+        // A query that matches nothing still observes the store head.
+        DcbEventStream matchesNone = eventStore.read(tagsAllOf("name:absent"));
+        assertThat(matchesNone.events()).isEmpty();
+        assertThat(matchesNone.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void failed_append_does_not_break_position_monotonicity() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        CloudEvent duplicate = taggedEvent("NameDefined", "name:1");
+        DcbAppendResult first = eventStore.append("dcb:partition:0", List.of(duplicate));
+
+        assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(duplicate)))
+                .isExactlyInstanceOf(DuplicateCloudEventException.class);
+
+        // A rejected append must not corrupt the sequence. The next position is strictly greater than the last
+        // committed one. Positions are monotonic, gaps are allowed (see DcbAppendResult).
+        DcbAppendResult next = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:2")));
+        assertThat(next.firstSequencePosition()).isGreaterThan(first.lastSequencePosition());
+        assertThat(next.lastSequencePosition()).isGreaterThanOrEqualTo(next.firstSequencePosition());
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), Set.of(tags));
     }

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -264,7 +264,7 @@ class InMemoryEventStoreDcbTest {
     }
 
     @Test
-    void failed_append_does_not_break_position_monotonicity() {
+    void failed_append_does_not_consume_a_dcb_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
         CloudEvent duplicate = taggedEvent("NameDefined", "name:1");
         DcbAppendResult first = eventStore.append("dcb:partition:0", List.of(duplicate));
@@ -272,11 +272,12 @@ class InMemoryEventStoreDcbTest {
         assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(duplicate)))
                 .isExactlyInstanceOf(DuplicateCloudEventException.class);
 
-        // A rejected append must not corrupt the sequence. The next position is strictly greater than the last
-        // committed one. Positions are monotonic, gaps are allowed (see DcbAppendResult).
+        // The shared DcbAppendResult contract only guarantees ordering across appends, but the in-memory store
+        // advances its position counter only after an append commits, so a rejected append consumes no position
+        // and the next successful append gets exactly the following position.
         DcbAppendResult next = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:2")));
-        assertThat(next.firstSequencePosition()).isGreaterThan(first.lastSequencePosition());
-        assertThat(next.lastSequencePosition()).isGreaterThanOrEqualTo(next.firstSequencePosition());
+        assertThat(next.firstSequencePosition()).isEqualTo(first.lastSequencePosition() + 1);
+        assertThat(next.lastSequencePosition()).isEqualTo(next.firstSequencePosition());
     }
 
     private static CloudEvent taggedEvent(String type, String... tags) {

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -255,6 +255,24 @@ class SpringMongoEventStoreDcbTest {
         assertThat(eventStore.read(tagsAllOf("name:2")).events()).hasSize(1);
     }
 
+    @Test
+    void last_sequence_position_is_the_store_head_not_the_max_matched_position() {
+        eventStore.append("dcb:partition:0", List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:2")));
+
+        // The query matches only the two "name:1" events (positions 1 and 2), but the store head is 3.
+        DcbEventStream matchesSome = eventStore.read(tagsAllOf("name:1"));
+        assertThat(matchesSome.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(matchesSome.lastSequencePosition()).isEqualTo(3);
+
+        // A query that matches nothing still observes the store head.
+        DcbEventStream matchesNone = eventStore.read(tagsAllOf("name:absent"));
+        assertThat(matchesNone.events()).isEmpty();
+        assertThat(matchesNone.lastSequencePosition()).isEqualTo(3);
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), Set.of(tags));
     }


### PR DESCRIPTION
Locks down the DCB position contract so the write-path concurrency work can build on a documented base.

`DcbEventStream.lastSequencePosition` is now documented as the store's global DCB head at read time, not the highest position among the events the query matched. That distinction matters because the application service passes it to `failIfEventsMatch`, so it has to reflect everything the reader has seen, not just the matched subset.

`DcbAppendResult` documents that positions are global, start at 1, and are strictly increasing, that a single append is one contiguous block, and that across separate appends only the relative ordering is guaranteed. The contract deliberately stops short of promising contiguity (gap-free positions). Both stores happen to be gap-free today, but the query-scoped concurrency write path in the next PR allocates the global position without guaranteeing contiguity on Mongo, so callers must compare positions for ordering and never assume there are no gaps.

Tests: on both the in-memory and Spring Mongo stores, a read whose query matches only some, then none, of the events still reports the store head. On the in-memory store, a rejected append assigns no position, so the next successful append gets exactly the following position.

Documentation and tests only. No production behavior changes.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
