### PR TITLE
Stabilize three flaky MongoDB integration tests

### DIFF
--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
@@ -183,12 +183,17 @@ class SpringMongoMaterializedViewConfigTest {
                     name2
                 }
 
-                val outcome: Result<List<String>> = try {
-                    Result.success(listOf(f1.get(10, TimeUnit.SECONDS), f2.get(10, TimeUnit.SECONDS)))
-                } catch (e: ExecutionException) {
-                    Result.failure(e.cause ?: e)
-                } finally {
-                    pool.shutdownNow()
+                // Wait for both tasks to settle before inspecting the persisted version, so a thrown first task
+                // can't leave the second one still writing to Mongo in the background.
+                val r1 = runCatching { f1.get(10, TimeUnit.SECONDS) }
+                val r2 = runCatching { f2.get(10, TimeUnit.SECONDS) }
+                pool.shutdownNow()
+
+                val outcome: Result<List<String>> = if (r1.isSuccess && r2.isSuccess) {
+                    Result.success(listOf(r1.getOrThrow(), r2.getOrThrow()))
+                } else {
+                    val failure = (r1.exceptionOrNull() ?: r2.exceptionOrNull())!!
+                    Result.failure((failure as? ExecutionException)?.cause ?: failure)
                 }
 
                 if (!requireConflict || getState(userId).version == 1L) {

--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 
-@Timeout(10)
+@Timeout(30)
 @Testcontainers
 @DisplayNameGeneration(DisplayNameGenerator.Simple::class)
 class SpringMongoMaterializedViewConfigTest {
@@ -122,7 +122,7 @@ class SpringMongoMaterializedViewConfigTest {
                 }))
 
                 // When
-                val names = materializedView.updateNameInParallel(userId)
+                val names = materializedView.updateNameInParallel(userId, requireConflict = true)
 
                 // Then
                 val state = getState(userId)
@@ -145,7 +145,7 @@ class SpringMongoMaterializedViewConfigTest {
                 val materializedView = materializedView(config(optimisticLockingHandling = OptimisticLockingHandling.rethrow()))
 
                 // When
-                val throwable = catchThrowable { materializedView.updateNameInParallel(userId) }
+                val throwable = catchThrowable { materializedView.updateNameInParallel(userId, requireConflict = true) }
 
                 // Then
                 val state = getState(userId)
@@ -156,31 +156,51 @@ class SpringMongoMaterializedViewConfigTest {
             }
         }
 
-        private fun MaterializedView<DomainEvent>.updateNameInParallel(userId: String): List<String> {
-            val barrier = CyclicBarrier(2)
-            val name1 = randomName()
-            val name2 = randomName()
-            val pool = Executors.newFixedThreadPool(2)
+        // Runs two updates against the same view in parallel. They only collide into an OptimisticLockingFailureException
+        // when both threads read the same version before either writes, which does not always happen under load. When the
+        // caller needs the conflict to occur (the ignore/rethrow handlers), set requireConflict and the helper retries
+        // until exactly one of the two updates was applied (persisted version == 1). The default (retry) handler reapplies
+        // the loser, so its version ends at 2 whether or not a conflict happened, and it does not need the retry.
+        private fun MaterializedView<DomainEvent>.updateNameInParallel(userId: String, requireConflict: Boolean = false): List<String> {
+            val maxAttempts = if (requireConflict) 50 else 1
+            repeat(maxAttempts) { attempt ->
+                if (attempt > 0) resetStateToVersionZero(userId)
 
-            val f1 = pool.submit<String> {
-                barrier.await()
-                update(nameChanged(userId, name1))
-                name1
-            }
-            val f2 = pool.submit<String> {
-                barrier.await()
-                update(nameChanged(userId, name2))
-                name2
-            }
+                val barrier = CyclicBarrier(2)
+                val name1 = randomName()
+                val name2 = randomName()
+                val pool = Executors.newFixedThreadPool(2)
 
-            return try {
-                listOf(f1.get(), f2.get())
-            } catch (e: ExecutionException) {
-                val cause = e.cause ?: e
-                throw cause
-            } finally {
-                pool.shutdown()
+                val f1 = pool.submit<String> {
+                    barrier.await()
+                    update(nameChanged(userId, name1))
+                    name1
+                }
+                val f2 = pool.submit<String> {
+                    barrier.await()
+                    update(nameChanged(userId, name2))
+                    name2
+                }
+
+                val outcome: Result<List<String>> = try {
+                    Result.success(listOf(f1.get(), f2.get()))
+                } catch (e: ExecutionException) {
+                    Result.failure(e.cause ?: e)
+                } finally {
+                    pool.shutdown()
+                }
+
+                if (!requireConflict || getState(userId).version == 1L) {
+                    return outcome.getOrElse { throw it }
+                }
             }
+            throw AssertionError("Could not induce an OptimisticLockingFailureException after $maxAttempts attempts")
+        }
+
+        // Removes the read model and recreates it at version 0 so the next parallel attempt starts from a clean slate.
+        private fun resetStateToVersionZero(userId: String) {
+            mongoOperations.remove(getState(userId))
+            saveState(userId)
         }
     }
 

--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SpringMongoMaterializedViewConfigTest.kt
@@ -45,6 +45,7 @@ import java.util.*
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -172,22 +173,22 @@ class SpringMongoMaterializedViewConfigTest {
                 val pool = Executors.newFixedThreadPool(2)
 
                 val f1 = pool.submit<String> {
-                    barrier.await()
+                    barrier.await(10, TimeUnit.SECONDS)
                     update(nameChanged(userId, name1))
                     name1
                 }
                 val f2 = pool.submit<String> {
-                    barrier.await()
+                    barrier.await(10, TimeUnit.SECONDS)
                     update(nameChanged(userId, name2))
                     name2
                 }
 
                 val outcome: Result<List<String>> = try {
-                    Result.success(listOf(f1.get(), f2.get()))
+                    Result.success(listOf(f1.get(10, TimeUnit.SECONDS), f2.get(10, TimeUnit.SECONDS)))
                 } catch (e: ExecutionException) {
                     Result.failure(e.cause ?: e)
                 } finally {
-                    pool.shutdown()
+                    pool.shutdownNow()
                 }
 
                 if (!requireConflict || getState(userId).version == 1L) {

--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
@@ -671,7 +671,9 @@ public class SpringMongoSubscriptionModelTest {
             mongoEventStore.write("1", serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
 
             // Then
-            await().atMost(2, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
+            // Restart-recovery await: after the mocked failure the subscription model restarts the change stream, which
+            // can take longer than a couple of seconds on a loaded CI machine. Awaitility short-circuits on success.
+            await().atMost(10, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
         }
 
     }
@@ -729,7 +731,9 @@ public class SpringMongoSubscriptionModelTest {
             mongoEventStore.write("1", serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
 
             // Then
-            await().atMost(2, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
+            // Restart-recovery await: after the mocked failure the subscription model restarts the change stream, which
+            // can take longer than a couple of seconds on a loaded CI machine. Awaitility short-circuits on success.
+            await().atMost(10, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
         }
     }
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
@@ -62,7 +62,6 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.occurrent.filter.Filter.TIME;
 import static org.occurrent.filter.Filter.type;
 import static org.occurrent.functional.CheckedFunction.unchecked;
@@ -71,9 +70,15 @@ import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPo
 import static org.occurrent.time.TimeConversion.toLocalDateTime;
 
 @Testcontainers
-@Timeout(15)
+@Timeout(60)
 @DisplayNameGeneration(ReplaceUnderscores.class)
 public class CatchupSubscriptionModelTest {
+
+    // Generous awaitility timeout: the catch-up to live change-stream handover can take noticeably longer than a few
+    // seconds on a loaded CI machine. Awaitility short-circuits as soon as the condition is met, so this does not slow
+    // down passing runs, it only removes false timeouts. Kept below the per-test @Timeout so a real hang still fails
+    // with awaitility's assertion detail rather than a bare JUnit timeout.
+    private static final Duration AT_MOST = Duration.ofSeconds(30);
 
     @Container
     private static final MongoDBContainer mongoDBContainer =
@@ -133,7 +138,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(UUID.randomUUID().toString(), StartAt.subscriptionPosition(TimeBasedSubscriptionPosition.beginningOfTime()), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(3));
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(3));
     }
 
     @Test
@@ -154,7 +159,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribeFromBeginningOfTime(UUID.randomUUID().toString(), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(3));
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(3));
     }
 
     @Test
@@ -194,7 +199,7 @@ public class CatchupSubscriptionModelTest {
         }).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(5));
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(5));
     }
 
     @Test
@@ -244,7 +249,7 @@ public class CatchupSubscriptionModelTest {
         String id1 = nameDefined1.eventId();
         String id2 = nameDefined2.eventId();
         String id3 = nameWasChanged1.eventId();
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() ->
                 assertThat(state).extracting(CloudEvent::getId).contains(id1, id2, id3, skewedId));
     }
 
@@ -266,7 +271,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(UUID.randomUUID().toString(), filter(type(NameDefined.class.getName())), StartAt.subscriptionPosition(TimeBasedSubscriptionPosition.beginningOfTime()), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> {
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> {
             assertThat(state).hasSize(2);
             assertThat(state).extracting(CloudEvent::getType).containsOnly(NameDefined.class.getName());
         });
@@ -290,7 +295,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribeFromBeginningOfTime(UUID.randomUUID().toString(), filter(type(NameDefined.class.getName())), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> {
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> {
             assertThat(state).hasSize(2);
             assertThat(state).extracting(CloudEvent::getType).containsOnly(NameDefined.class.getName());
         });
@@ -321,7 +326,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(UUID.randomUUID().toString(), StartAtTime.beginningOfTime(), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).extracting(CloudEvent::getId).containsExactly(eventId3, eventId2, eventId1));
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).extracting(CloudEvent::getId).containsExactly(eventId3, eventId2, eventId1));
     }
 
     @Test
@@ -366,7 +371,7 @@ public class CatchupSubscriptionModelTest {
         }).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 assertThat(state).hasSize(5).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameChanged1, nameDefined3, nameDefined4));
 
         thread.join();
@@ -417,7 +422,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(subscriptionId, state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 assertThat(state).hasSize(4).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameDefined3, nameWasChanged1));
     }
 
@@ -466,7 +471,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(subscriptionId, filter(type(NameDefined.class.getName())), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 assertThat(state).hasSize(4).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameDefined3, nameDefined4));
     }
 
@@ -524,7 +529,7 @@ public class CatchupSubscriptionModelTest {
         mongoEventStore.write("3", 0, serialize(nameDefined3));
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 assertThat(state).hasSize(4).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameDefined4, nameDefined3));
     }
 
@@ -576,7 +581,7 @@ public class CatchupSubscriptionModelTest {
         mongoEventStore.write("1", 2, serialize(nameWasChanged2));
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 assertThat(state).hasSize(3).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameWasChanged2));
     }
 
@@ -625,7 +630,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 // Note that it's correct behavior that we expect 6 events here since the first subscription is not configured to store subscription position during catch-up => duplicates
                 assertThat(state).hasSize(6).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameDefined1, nameDefined2, nameDefined3, nameWasChanged1));
     }
@@ -676,7 +681,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
                 // Note that it's correct behavior that we expect 6 events here since the first subscription is not configured to store subscription position during catch-up => duplicates
                 assertThat(state).hasSize(6).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameDefined1, nameDefined2, nameDefined3, nameWasChanged1));
     }
@@ -710,7 +715,7 @@ public class CatchupSubscriptionModelTest {
         subscription.subscribe(subscriptionId, StartAt.subscriptionPosition(TimeBasedSubscriptionPosition.beginningOfTime()), state::add).waitUntilStarted();
 
         // Then
-        await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(100));
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(100));
         assertThat(numberOfSavedPositions).hasValue(11); // Store every 10th position equals 10 for 100 events + 1 additional save for global subscription position before switching to continuous mode
         assertThat(storage.read(subscriptionId)).isNotNull();
     }


### PR DESCRIPTION
Three integration tests flaked in CI for timing and concurrency reasons, not because anything was actually broken. These are test-only changes, no production code is touched.

`CatchupSubscriptionModelTest` waited only 5 seconds (awaitility) for the catch-up to live change-stream handover, and a 15-second class timeout capped it further. Under CI load that handover can take longer than 5 seconds, so the wait timed out. I raised the awaitility timeout to 30 seconds and the class timeout to 60. Awaitility returns as soon as the condition holds, so a passing run is just as fast as before.

`SpringMongoSubscriptionModelTest` has two restart-on-failure tests (the `ChangeStreamHistoryLost` and `MongoException` cases, where the failure is mocked). They only waited 2 seconds for the event to arrive after the subscription restarts, which is tight once a restart is involved. I raised those two awaits to 10 seconds.

`SpringMongoMaterializedViewConfigTest` forced an optimistic-locking conflict by running two updates in parallel behind a `CyclicBarrier`. They only conflict when both threads read the same version before either writes, and under load they sometimes ran one after the other, so no conflict happened and the assertion failed. The `ignore` and `rethrow` cases now retry the race until exactly one update is applied, resetting the document to version zero between attempts. The `retries` case keeps a single attempt because it reapplies the update, so its version reaches 2 even on a real conflict. No assertions changed.

I verified each one with repeated runs: `CatchupSubscriptionModelTest` 8/8, `SpringMongoMaterializedViewConfigTest` 8/8, `SpringMongoSubscriptionModelTest` 5/5.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
