### PR TITLE
Refine the DCB API before release

### DIFF
--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
@@ -121,10 +121,13 @@ public class GenericDcbApplicationService<E> implements DcbApplicationService<E>
     }
 
     private static Set<String> tagsFromQuery(DcbQuery query) {
-        return query.items().stream()
-                .map(DcbQueryItem::tags)
-                .flatMap(Collection::stream)
-                .collect(toCollection(TreeSet::new));
+        if (query instanceof DcbQuery.Items items) {
+            return items.items().stream()
+                    .map(DcbQueryItem::tags)
+                    .flatMap(Collection::stream)
+                    .collect(toCollection(TreeSet::new));
+        }
+        return new TreeSet<>();
     }
 
     private static <T> Stream<T> emptyStreamIfNull(@Nullable Stream<T> stream) {

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
 * Added initial Dynamic Consistency Boundary (DCB) support.
   * New module: `org.occurrent:eventstore-api-dcb`.
   * New core API types include `DcbEventStore`, `DcbQuery`, `DcbQueryItem`, `DcbReadOptions`, `DcbEventStream`, `DcbAppendCondition`, `DcbAppendResult`, `DcbAppendConditionNotFulfilledException`, and `DcbCloudEvents`.
+  * `DcbQuery` is a sealed type, either `DcbQuery.MatchAll` or `DcbQuery.Items`, built through factories such as `all()`, `types(..)`, `tagsAllOf(..)`, `typeAndTagsAllOf(..)`, `fromItems(..)`, and `anyOf(..)` for an OR across query items.
+  * `DcbReadOptions` scopes a read with an optional exclusive lower bound (`afterSequencePosition`) and an optional inclusive upper bound (`upToSequencePosition`).
+  * `DcbEventStore` exposes `exists(DcbQuery)` and `count(DcbQuery)` for checking a boundary without materializing the matching events.
   * DCB is implemented as an optional capability over the existing CloudEvent storage model, not as a separate event representation.
   * DCB metadata is stored as CloudEvent extensions:
     * `dcbtags` for canonical DCB tags.

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -75,7 +75,7 @@ class DcbDslKotlinTest {
         append("name:1", nameDefined, nameWasChanged)
 
         assertThat(dcbQueries.queryForSequence(DcbQuery.tagsAllOf("name:1")).toList()).containsExactly(nameDefined, nameWasChanged)
-        assertThat(dcbQueries.queryForList(DcbQuery.type(NameDefined::class.qualifiedName!!))).containsExactly(nameDefined)
+        assertThat(dcbQueries.queryForList(DcbQuery.types(NameDefined::class.qualifiedName!!))).containsExactly(nameDefined)
         assertThat(dcbQueries.queryForList(DcbQuery.tagsAllOf("name:1"), DcbReadOptions.afterSequencePosition(1))).containsExactly(nameWasChanged)
     }
 
@@ -85,7 +85,7 @@ class DcbDslKotlinTest {
         append("other:1", NameWasChanged("eventId2", time, "name", "Jane Doe"))
         append("name:1", nameDefined)
 
-        val eventStream = dcbQueries.queryWithPosition(DcbQuery.type(NameDefined::class.qualifiedName!!))
+        val eventStream = dcbQueries.queryWithPosition(DcbQuery.types(NameDefined::class.qualifiedName!!))
 
         assertThat(eventStream.events()).containsExactly(nameDefined)
         assertThat(eventStream.lastSequencePosition()).isEqualTo(2)

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendCondition.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendCondition.java
@@ -25,15 +25,14 @@ import static java.util.Objects.requireNonNull;
 /**
  * Optimistic conflict condition for a DCB append.
  * <p>
- * {@code failIfEventsMatch} describes the events that would conflict with the append.
- * {@code afterSequencePosition} optionally limits the conflict check to events written
- * after a position observed by a prior read.
+ * {@code query} describes the events that would conflict with the append. {@code afterSequencePosition}
+ * optionally limits the conflict check to events written after a position observed by a prior read.
  */
 @NullMarked
-public record DcbAppendCondition(DcbQuery failIfEventsMatch, OptionalLong afterSequencePosition) {
+public record DcbAppendCondition(DcbQuery query, OptionalLong afterSequencePosition) {
 
     public DcbAppendCondition {
-        requireNonNull(failIfEventsMatch, "Fail-if-events-match query cannot be null");
+        requireNonNull(query, "Query cannot be null");
         requireNonNull(afterSequencePosition, "After sequence position cannot be null");
         afterSequencePosition.ifPresent(position -> {
             if (position < 0) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
@@ -120,10 +120,10 @@ public final class DcbCloudEvents {
     public static boolean matches(CloudEvent cloudEvent, DcbQuery query) {
         requireNonNull(cloudEvent, "CloudEvent cannot be null");
         requireNonNull(query, "Query cannot be null");
-        if (query.matchAll()) {
-            return true;
+        if (query instanceof DcbQuery.Items items) {
+            return items.items().stream().anyMatch(item -> matches(cloudEvent, item));
         }
-        return query.items().stream().anyMatch(item -> matches(cloudEvent, item));
+        return true;
     }
 
     private static boolean matches(CloudEvent cloudEvent, DcbQueryItem item) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
@@ -21,6 +21,8 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Event store operations for Dynamic Consistency Boundary reads and appends.
  * <p>
@@ -50,6 +52,7 @@ public interface DcbEventStore {
      * efficient existence check.
      */
     default boolean exists(DcbQuery query) {
+        requireNonNull(query, "Query cannot be null");
         return !read(query).events().isEmpty();
     }
 
@@ -60,6 +63,7 @@ public interface DcbEventStore {
      * efficient count.
      */
     default long count(DcbQuery query) {
+        requireNonNull(query, "Query cannot be null");
         return read(query).events().size();
     }
 

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
@@ -44,6 +44,26 @@ public interface DcbEventStore {
     DcbEventStream read(DcbQuery query, DcbReadOptions options);
 
     /**
+     * Returns whether any DCB event in the store matches {@code query}.
+     * <p>
+     * The default implementation reads the matching events; implementations should override it with a more
+     * efficient existence check.
+     */
+    default boolean exists(DcbQuery query) {
+        return !read(query).events().isEmpty();
+    }
+
+    /**
+     * Returns the number of DCB events in the store that match {@code query}.
+     * <p>
+     * The default implementation reads the matching events; implementations should override it with a more
+     * efficient count.
+     */
+    default long count(DcbQuery query) {
+        return read(query).events().size();
+    }
+
+    /**
      * Appends DCB-tagged CloudEvents to the given Occurrent storage stream without an additional DCB condition.
      */
     DcbAppendResult append(String streamId, List<CloudEvent> events);

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
@@ -50,6 +50,7 @@ public sealed interface DcbQuery permits DcbQuery.MatchAll, DcbQuery.Items {
     record Items(List<DcbQueryItem> items) implements DcbQuery {
         public Items {
             requireNonNull(items, "Items cannot be null");
+            items.forEach(item -> requireNonNull(item, "Query item cannot be null"));
             items = List.copyOf(items);
             if (items.isEmpty()) {
                 throw new IllegalArgumentException("A query must contain at least one query item");

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
@@ -68,6 +68,7 @@ public sealed interface DcbQuery permits DcbQuery.MatchAll, DcbQuery.Items {
      * Creates a query from explicit query items.
      */
     static DcbQuery fromItems(Collection<DcbQueryItem> items) {
+        requireNonNull(items, "Items cannot be null");
         return new Items(List.copyOf(items));
     }
 

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
@@ -18,6 +18,7 @@ package org.occurrent.eventstore.api.dcb;
 
 import org.jspecify.annotations.NullMarked;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -30,56 +31,78 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 /**
  * Query that selects CloudEvents by DCB metadata.
  * <p>
- * A query either matches all DCB events or consists of one or more query items. Each
- * item contributes an alternative match. Inside an item, types are matched as any-of,
- * tags as all-of, and excluded types as none-of.
+ * A query is either {@link MatchAll} (every DCB event) or {@link Items}, a non-empty list of
+ * {@link DcbQueryItem} alternatives that are OR-ed together. Inside an item, types are matched as
+ * any-of, tags as all-of, and excluded types as none-of.
  */
 @NullMarked
-public record DcbQuery(boolean matchAll, List<DcbQueryItem> items) {
+public sealed interface DcbQuery permits DcbQuery.MatchAll, DcbQuery.Items {
 
-    public DcbQuery {
-        requireNonNull(items, "Items cannot be null");
-        items = List.copyOf(items);
-        if (matchAll && !items.isEmpty()) {
-            throw new IllegalArgumentException("A query that matches all events cannot contain query items");
-        }
-        if (!matchAll && items.isEmpty()) {
-            throw new IllegalArgumentException("A query must contain at least one query item unless it matches all events");
+    /**
+     * A query that matches every DCB event.
+     */
+    record MatchAll() implements DcbQuery {
+    }
+
+    /**
+     * A query that matches an event when the event matches any of the {@code items}.
+     */
+    record Items(List<DcbQueryItem> items) implements DcbQuery {
+        public Items {
+            requireNonNull(items, "Items cannot be null");
+            items = List.copyOf(items);
+            if (items.isEmpty()) {
+                throw new IllegalArgumentException("A query must contain at least one query item");
+            }
         }
     }
 
     /**
      * Creates a query that matches every DCB event.
      */
-    public static DcbQuery all() {
-        return new DcbQuery(true, List.of());
+    static DcbQuery all() {
+        return new MatchAll();
     }
 
     /**
      * Creates a query from explicit query items.
      */
-    public static DcbQuery fromItems(Collection<DcbQueryItem> items) {
-        return new DcbQuery(false, List.copyOf(items));
+    static DcbQuery fromItems(Collection<DcbQueryItem> items) {
+        return new Items(List.copyOf(items));
+    }
+
+    /**
+     * Creates a query that matches an event when it matches any of the supplied query items.
+     */
+    static DcbQuery anyOf(DcbQueryItem first, DcbQueryItem... rest) {
+        requireNonNull(first, "First item cannot be null");
+        requireNonNull(rest, "Additional items cannot be null");
+        List<DcbQueryItem> items = new ArrayList<>();
+        items.add(first);
+        for (DcbQueryItem item : rest) {
+            items.add(requireNonNull(item, "Item cannot be null"));
+        }
+        return new Items(items);
     }
 
     /**
      * Creates a query that matches any event whose CloudEvent type is one of the supplied types.
      */
-    public static DcbQuery type(String type, String... additionalTypes) {
+    static DcbQuery types(String type, String... additionalTypes) {
         return fromItems(List.of(DcbQueryItem.types(combine(type, additionalTypes))));
     }
 
     /**
      * Creates a query that matches events containing all supplied DCB tags.
      */
-    public static DcbQuery tagsAllOf(String tag, String... additionalTags) {
+    static DcbQuery tagsAllOf(String tag, String... additionalTags) {
         return fromItems(List.of(DcbQueryItem.tagsAllOf(combine(tag, additionalTags))));
     }
 
     /**
      * Creates a query that matches any of the supplied CloudEvent types and all supplied DCB tags.
      */
-    public static DcbQuery typeAndTagsAllOf(Collection<String> types, Collection<String> tags) {
+    static DcbQuery typeAndTagsAllOf(Collection<String> types, Collection<String> tags) {
         return fromItems(List.of(DcbQueryItem.typeAndTagsAllOf(types, tags)));
     }
 
@@ -87,7 +110,7 @@ public record DcbQuery(boolean matchAll, List<DcbQueryItem> items) {
      * Creates a query that matches events containing all supplied DCB tags except
      * events whose CloudEvent type is excluded.
      */
-    public static DcbQuery tagsAllOfExcludingTypes(Collection<String> tags, Collection<String> excludedTypes) {
+    static DcbQuery tagsAllOfExcludingTypes(Collection<String> tags, Collection<String> excludedTypes) {
         return fromItems(List.of(DcbQueryItem.tagsAllOfExcludingTypes(tags, excludedTypes)));
     }
 
@@ -95,7 +118,7 @@ public record DcbQuery(boolean matchAll, List<DcbQueryItem> items) {
      * Creates a query that matches any of the supplied CloudEvent types and all supplied
      * DCB tags, except events whose CloudEvent type is excluded.
      */
-    public static DcbQuery typeAndTagsAllOfExcludingTypes(Collection<String> types, Collection<String> tags, Collection<String> excludedTypes) {
+    static DcbQuery typeAndTagsAllOfExcludingTypes(Collection<String> types, Collection<String> tags, Collection<String> excludedTypes) {
         return fromItems(List.of(DcbQueryItem.typeAndTagsAllOfExcludingTypes(types, tags, excludedTypes)));
     }
 

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
@@ -25,31 +25,59 @@ import static java.util.Objects.requireNonNull;
 /**
  * Options that scope a DCB read.
  *
- * @param afterSequencePosition optional lower bound; when present, only events after this DCB sequence position are returned
+ * @param afterSequencePosition optional exclusive lower bound; when present, only events with a DCB sequence position
+ *                              strictly greater than this value are returned
+ * @param upToSequencePosition  optional inclusive upper bound; when present, only events with a DCB sequence position
+ *                              less than or equal to this value are returned. When absent, the read includes everything
+ *                              up to the store's DCB head at read time.
  */
 @NullMarked
-public record DcbReadOptions(OptionalLong afterSequencePosition) {
+public record DcbReadOptions(OptionalLong afterSequencePosition, OptionalLong upToSequencePosition) {
 
     public DcbReadOptions {
         requireNonNull(afterSequencePosition, "After sequence position cannot be null");
+        requireNonNull(upToSequencePosition, "Up to sequence position cannot be null");
         afterSequencePosition.ifPresent(position -> {
             if (position < 0) {
                 throw new IllegalArgumentException("After sequence position cannot be negative");
             }
         });
+        upToSequencePosition.ifPresent(position -> {
+            if (position < 0) {
+                throw new IllegalArgumentException("Up to sequence position cannot be negative");
+            }
+        });
+        if (afterSequencePosition.isPresent() && upToSequencePosition.isPresent()
+                && afterSequencePosition.getAsLong() >= upToSequencePosition.getAsLong()) {
+            throw new IllegalArgumentException("After sequence position must be less than up to sequence position");
+        }
     }
 
     /**
-     * Reads from the beginning of the DCB sequence.
+     * Reads from the beginning of the DCB sequence up to the store head.
      */
     public static DcbReadOptions fromBeginning() {
-        return new DcbReadOptions(OptionalLong.empty());
+        return new DcbReadOptions(OptionalLong.empty(), OptionalLong.empty());
     }
 
     /**
-     * Reads only events after the supplied DCB sequence position.
+     * Reads only events after the supplied DCB sequence position (exclusive).
      */
     public static DcbReadOptions afterSequencePosition(long position) {
-        return new DcbReadOptions(OptionalLong.of(position));
+        return new DcbReadOptions(OptionalLong.of(position), OptionalLong.empty());
+    }
+
+    /**
+     * Reads from the beginning up to and including the supplied DCB sequence position.
+     */
+    public static DcbReadOptions upToSequencePosition(long position) {
+        return new DcbReadOptions(OptionalLong.empty(), OptionalLong.of(position));
+    }
+
+    /**
+     * Reads events after {@code afterExclusive} (exclusive) and up to and including {@code upToInclusive}.
+     */
+    public static DcbReadOptions between(long afterExclusive, long upToInclusive) {
+        return new DcbReadOptions(OptionalLong.of(afterExclusive), OptionalLong.of(upToInclusive));
     }
 }

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
@@ -48,8 +48,10 @@ public record DcbReadOptions(OptionalLong afterSequencePosition, OptionalLong up
             }
         });
         if (afterSequencePosition.isPresent() && upToSequencePosition.isPresent()
-                && afterSequencePosition.getAsLong() >= upToSequencePosition.getAsLong()) {
-            throw new IllegalArgumentException("After sequence position must be less than up to sequence position");
+                && afterSequencePosition.getAsLong() > upToSequencePosition.getAsLong()) {
+            // The lower bound is exclusive and the upper bound is inclusive, so an equal pair is a valid empty range.
+            // Only an inverted range (after greater than upTo) is rejected.
+            throw new IllegalArgumentException("After sequence position cannot be greater than up to sequence position");
         }
     }
 

--- a/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
+++ b/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
@@ -63,8 +63,9 @@ class DcbApiTest {
         assertThat(item.types()).isEmpty();
         assertThat(item.tags()).containsExactly("name:1");
         assertThat(item.excludedTypes()).containsExactlyInAnyOrder("NameImported", "NameSnapshot");
-        assertThat(((DcbQuery.Items) DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"))).items().get(0).excludedTypes())
-                .containsExactly("NameSnapshot");
+        assertThat(DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot")))
+                .isInstanceOfSatisfying(DcbQuery.Items.class, items ->
+                        assertThat(items.items().get(0).excludedTypes()).containsExactly("NameSnapshot"));
     }
 
     @Test

--- a/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
+++ b/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
@@ -37,7 +37,7 @@ class DcbApiTest {
     void query_must_be_all_or_contain_at_least_one_item() {
         assertThatThrownBy(() -> DcbQuery.fromItems(List.of()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("A query must contain at least one query item unless it matches all events");
+                .hasMessage("A query must contain at least one query item");
     }
 
     @Test
@@ -63,7 +63,7 @@ class DcbApiTest {
         assertThat(item.types()).isEmpty();
         assertThat(item.tags()).containsExactly("name:1");
         assertThat(item.excludedTypes()).containsExactlyInAnyOrder("NameImported", "NameSnapshot");
-        assertThat(DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot")).items().get(0).excludedTypes())
+        assertThat(((DcbQuery.Items) DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"))).items().get(0).excludedTypes())
                 .containsExactly("NameSnapshot");
     }
 
@@ -128,11 +128,11 @@ class DcbApiTest {
         io.cloudevents.CloudEvent event = DcbCloudEvents.withTags(cloudEvent("NameDefined"), List.of("name:1", "tenant:1"));
 
         assertThat(DcbCloudEvents.matches(event, DcbQuery.all())).isTrue();
-        assertThat(DcbCloudEvents.matches(event, DcbQuery.type("NameDefined"))).isTrue();
+        assertThat(DcbCloudEvents.matches(event, DcbQuery.types("NameDefined"))).isTrue();
         assertThat(DcbCloudEvents.matches(event, DcbQuery.tagsAllOf("name:1", "tenant:1"))).isTrue();
         assertThat(DcbCloudEvents.matches(event, DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameWasChanged")))).isTrue();
         assertThat(DcbCloudEvents.matches(event, DcbQuery.tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameDefined")))).isFalse();
-        assertThat(DcbCloudEvents.matches(event, DcbQuery.type("NameWasChanged"))).isFalse();
+        assertThat(DcbCloudEvents.matches(event, DcbQuery.types("NameWasChanged"))).isFalse();
         assertThat(DcbCloudEvents.matches(event, DcbQuery.tagsAllOf("name:1", "tenant:2"))).isFalse();
     }
 

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -214,14 +214,38 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         synchronized (state) {
             long highWatermark = nextDcbPosition.get() - 1;
             long afterSequencePosition = options.afterSequencePosition().orElse(0);
+            long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
             List<CloudEvent> matchingEvents = allEvents()
                     .filter(event -> dcbPosition(event) > afterSequencePosition)
-                    .filter(event -> dcbPosition(event) <= highWatermark)
+                    .filter(event -> dcbPosition(event) <= upperBound)
                     .filter(event -> DcbCloudEvents.matches(event, query))
                     .sorted(Comparator.comparingLong(InMemoryEventStore::dcbPosition))
                     .toList();
             return new DcbEventStream(matchingEvents, highWatermark);
         }
+    }
+
+    @Override
+    public boolean exists(DcbQuery query) {
+        requireNonNull(query, "Query cannot be null");
+        synchronized (state) {
+            return matchingDcbEvents(query).findAny().isPresent();
+        }
+    }
+
+    @Override
+    public long count(DcbQuery query) {
+        requireNonNull(query, "Query cannot be null");
+        synchronized (state) {
+            return matchingDcbEvents(query).count();
+        }
+    }
+
+    private Stream<CloudEvent> matchingDcbEvents(DcbQuery query) {
+        long highWatermark = nextDcbPosition.get() - 1;
+        return allEvents()
+                .filter(event -> dcbPosition(event) > 0 && dcbPosition(event) <= highWatermark)
+                .filter(event -> DcbCloudEvents.matches(event, query));
     }
 
     @Override
@@ -246,7 +270,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
                 long afterSequencePosition = condition.afterSequencePosition().orElse(0);
                 boolean fulfilled = allEvents()
                         .filter(event -> dcbPosition(event) > afterSequencePosition)
-                        .noneMatch(event -> DcbCloudEvents.matches(event, condition.failIfEventsMatch()));
+                        .noneMatch(event -> DcbCloudEvents.matches(event, condition.query()));
                 long currentPosition = nextDcbPosition.get() - 1;
                 if (!fulfilled) {
                     throw new DcbAppendConditionNotFulfilledException(condition, currentPosition, "Append condition was not fulfilled.");

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -280,6 +280,50 @@ class InMemoryEventStoreDcbTest {
         assertThat(next.lastSequencePosition()).isEqualTo(next.firstSequencePosition());
     }
 
+    @Test
+    void exists_and_count_report_matching_dcb_events() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "order:1")));
+
+        assertThat(eventStore.exists(tagsAllOf("name:1"))).isTrue();
+        assertThat(eventStore.exists(tagsAllOf("absent:1"))).isFalse();
+        assertThat(eventStore.count(tagsAllOf("name:1"))).isEqualTo(2);
+        assertThat(eventStore.count(tagsAllOf("order:1"))).isEqualTo(1);
+        assertThat(eventStore.count(all())).isEqualTo(3);
+    }
+
+    @Test
+    void read_honors_up_to_sequence_position_upper_bound() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "name:1")));
+
+        DcbEventStream upToTwo = eventStore.read(tagsAllOf("name:1"), DcbReadOptions.upToSequencePosition(2));
+
+        assertThat(upToTwo.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        // lastSequencePosition is always the store head, not the upper bound used for this read.
+        assertThat(upToTwo.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void any_of_matches_the_union_of_its_items() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "order:1")));
+        eventStore.append("dcb:partition:0", List.of(taggedEvent("Unrelated", "other:1")));
+
+        DcbQuery query = anyOf(
+                DcbQueryItem.types(List.of("NameDefined")),
+                DcbQueryItem.tagsAllOf(List.of("order:1")));
+
+        assertThat(eventStore.read(query).events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined", "OrderPlaced");
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), Set.of(tags));
     }

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -196,7 +196,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
         Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound);
         mongoQuery.with(Sort.by(Sort.Direction.ASC, DcbCloudEvents.POSITION));
-        List<CloudEvent> events = mongoTemplate.find(mongoQuery, Document.class, eventStoreCollectionName).stream()
+        List<CloudEvent> events = mongoTemplate.find(queryOptions.apply(mongoQuery), Document.class, eventStoreCollectionName).stream()
                 .map(document -> convertToCloudEvent(timeRepresentation, document))
                 .toList();
         return new DcbEventStream(events, highWatermark);
@@ -219,14 +219,14 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     public boolean exists(DcbQuery query) {
         requireDcbCapability();
         requireNonNull(query, "Query cannot be null");
-        return mongoTemplate.exists(toDcbMongoQuery(query, 0, currentDcbPosition()), eventStoreCollectionName);
+        return mongoTemplate.exists(queryOptions.apply(toDcbMongoQuery(query, 0, currentDcbPosition())), eventStoreCollectionName);
     }
 
     @Override
     public long count(DcbQuery query) {
         requireDcbCapability();
         requireNonNull(query, "Query cannot be null");
-        return mongoTemplate.count(toDcbMongoQuery(query, 0, currentDcbPosition()), eventStoreCollectionName);
+        return mongoTemplate.count(queryOptions.apply(toDcbMongoQuery(query, 0, currentDcbPosition())), eventStoreCollectionName);
     }
 
     @Override

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -193,7 +193,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireNonNull(options, "Read options cannot be null");
 
         long highWatermark = currentDcbPosition();
-        Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), highWatermark);
+        long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+        Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound);
         mongoQuery.with(Sort.by(Sort.Direction.ASC, DcbCloudEvents.POSITION));
         List<CloudEvent> events = mongoTemplate.find(mongoQuery, Document.class, eventStoreCollectionName).stream()
                 .map(document -> convertToCloudEvent(timeRepresentation, document))
@@ -212,6 +213,20 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireDcbCapability();
         requireNonNull(condition, "Append condition cannot be null");
         return appendDcb(streamId, events, condition);
+    }
+
+    @Override
+    public boolean exists(DcbQuery query) {
+        requireDcbCapability();
+        requireNonNull(query, "Query cannot be null");
+        return mongoTemplate.exists(toDcbMongoQuery(query, 0, currentDcbPosition()), eventStoreCollectionName);
+    }
+
+    @Override
+    public long count(DcbQuery query) {
+        requireDcbCapability();
+        requireNonNull(query, "Query cannot be null");
+        return mongoTemplate.count(toDcbMongoQuery(query, 0, currentDcbPosition()), eventStoreCollectionName);
     }
 
     @Override
@@ -348,13 +363,13 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private void updateCheckpoints(DcbAppendCondition condition, List<CloudEvent> eventsToAppend, long lastPosition) {
         long afterSequencePosition = condition.afterSequencePosition().orElse(0);
-        if (mongoTemplate.exists(toDcbMongoQuery(condition.failIfEventsMatch(), afterSequencePosition, Long.MAX_VALUE), eventStoreCollectionName)) {
+        if (mongoTemplate.exists(toDcbMongoQuery(condition.query(), afterSequencePosition, Long.MAX_VALUE), eventStoreCollectionName)) {
             throw new DcbAppendConditionNotFulfilledException(condition, currentDcbPosition(), "Append condition was not fulfilled.");
         }
-        if (eventsToAppend.stream().noneMatch(event -> DcbCloudEvents.matches(event, condition.failIfEventsMatch()))) {
+        if (eventsToAppend.stream().noneMatch(event -> DcbCloudEvents.matches(event, condition.query()))) {
             return;
         }
-        for (String key : checkpointKeys(condition.failIfEventsMatch())) {
+        for (String key : checkpointKeys(condition.query())) {
             Query query = new Query(where(ID).is("checkpoint:" + key));
             Document checkpoint = mongoTemplate.findOne(query, Document.class, dcbCheckpointCollectionName);
             long checkpointPosition = checkpoint == null ? 0 : ((Number) checkpoint.get(CHECKPOINT_LAST_POSITION)).longValue();
@@ -367,11 +382,11 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     private static Set<String> checkpointKeys(DcbQuery query) {
-        if (query.matchAll()) {
+        if (query instanceof DcbQuery.MatchAll) {
             return Set.of("all");
         }
         java.util.TreeSet<String> keys = new java.util.TreeSet<>();
-        for (DcbQueryItem item : query.items()) {
+        for (DcbQueryItem item : ((DcbQuery.Items) query).items()) {
             item.tags().forEach(tag -> keys.add("tag:" + tag));
             if (item.tags().isEmpty()) {
                 item.types().forEach(type -> keys.add("type:" + type));
@@ -493,10 +508,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private static Query toDcbMongoQuery(DcbQuery query, long afterSequencePosition, long upperSequencePosition) {
         Criteria positionCriteria = where(DcbCloudEvents.POSITION).gt(afterSequencePosition).lte(upperSequencePosition);
-        if (query.matchAll()) {
+        if (query instanceof DcbQuery.MatchAll) {
             return new Query(positionCriteria);
         }
-        List<Criteria> itemCriteria = query.items().stream()
+        List<Criteria> itemCriteria = ((DcbQuery.Items) query).items().stream()
                 .map(SpringMongoEventStore::toCriteria)
                 .toList();
         return new Query(new Criteria().andOperator(positionCriteria, new Criteria().orOperator(itemCriteria)));

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -273,6 +273,32 @@ class SpringMongoEventStoreDcbTest {
         assertThat(matchesNone.lastSequencePosition()).isEqualTo(3);
     }
 
+    @Test
+    void exists_and_count_report_matching_dcb_events() {
+        eventStore.append("dcb:partition:0", List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "order:1")));
+
+        assertThat(eventStore.exists(tagsAllOf("name:1"))).isTrue();
+        assertThat(eventStore.exists(tagsAllOf("absent:1"))).isFalse();
+        assertThat(eventStore.count(tagsAllOf("name:1"))).isEqualTo(2);
+        assertThat(eventStore.count(all())).isEqualTo(3);
+    }
+
+    @Test
+    void read_honors_up_to_sequence_position_upper_bound() {
+        eventStore.append("dcb:partition:0", List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:1")));
+
+        DcbEventStream upToTwo = eventStore.read(tagsAllOf("name:1"), DcbReadOptions.upToSequencePosition(2));
+
+        assertThat(upToTwo.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(upToTwo.lastSequencePosition()).isEqualTo(3);
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), Set.of(tags));
     }

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/dcb/GameDcbHelpersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/dcb/GameDcbHelpersTest.kt
@@ -74,12 +74,12 @@ class GameDcbHelpersTest {
                 tags = setOf("game:$gameId")
         )
 
-        assertThat(GameDcbQueries.wordHintDecisionContext(gameId).items()).containsExactlyInAnyOrder(
+        assertThat((GameDcbQueries.wordHintDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(CharacterInWordHintWasRevealed::class.eventType()), tags = setOf("wordhint:$gameId"))
         )
 
-        assertThat(GameDcbQueries.pointsDecisionContext(gameId).items()).containsExactlyInAnyOrder(
+        assertThat((GameDcbQueries.pointsDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(PlayerGuessedTheWrongWord::class.eventType()), tags = setOf("gameplay:$gameId")),
                 queryItem(types = setOf(PlayerWasAwardedPointsForGuessingTheRightWord::class.eventType()), tags = setOf("points:$gameId")),
@@ -88,8 +88,8 @@ class GameDcbHelpersTest {
     }
 
     private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
-        assertThat(query.matchAll()).isFalse()
-        assertThat(query.items()).containsExactly(queryItem(types, tags))
+        assertThat(query).isInstanceOf(DcbQuery.Items::class.java)
+        assertThat((query as DcbQuery.Items).items()).containsExactly(queryItem(types, tags))
     }
 
     private fun queryItem(types: Set<String> = emptySet(), tags: Set<String>) = org.occurrent.eventstore.api.dcb.DcbQueryItem(types, tags)

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/dcb/GameDcbHelpersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/dcb/GameDcbHelpersTest.kt
@@ -19,6 +19,7 @@ package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autocon
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.api.dcb.DcbQueryItem
 import org.occurrent.example.domain.wordguessinggame.event.CharacterInWordHintWasRevealed
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.event.GameWasLost
@@ -74,12 +75,12 @@ class GameDcbHelpersTest {
                 tags = setOf("game:$gameId")
         )
 
-        assertThat((GameDcbQueries.wordHintDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
+        assertThat(itemsOf(GameDcbQueries.wordHintDecisionContext(gameId))).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(CharacterInWordHintWasRevealed::class.eventType()), tags = setOf("wordhint:$gameId"))
         )
 
-        assertThat((GameDcbQueries.pointsDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
+        assertThat(itemsOf(GameDcbQueries.pointsDecisionContext(gameId))).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(PlayerGuessedTheWrongWord::class.eventType()), tags = setOf("gameplay:$gameId")),
                 queryItem(types = setOf(PlayerWasAwardedPointsForGuessingTheRightWord::class.eventType()), tags = setOf("points:$gameId")),
@@ -87,9 +88,13 @@ class GameDcbHelpersTest {
         )
     }
 
-    private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
+    private fun itemsOf(query: DcbQuery): List<DcbQueryItem> {
         assertThat(query).isInstanceOf(DcbQuery.Items::class.java)
-        assertThat((query as DcbQuery.Items).items()).containsExactly(queryItem(types, tags))
+        return (query as DcbQuery.Items).items()
+    }
+
+    private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
+        assertThat(itemsOf(query)).containsExactly(queryItem(types, tags))
     }
 
     private fun queryItem(types: Set<String> = emptySet(), tags: Set<String>) = org.occurrent.eventstore.api.dcb.DcbQueryItem(types, tags)

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/dcb/GameDcbHelpersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/dcb/GameDcbHelpersTest.kt
@@ -19,6 +19,7 @@ package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.feature
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.api.dcb.DcbQueryItem
 import org.occurrent.example.domain.wordguessinggame.event.CharacterInWordHintWasRevealed
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.event.GameWasLost
@@ -74,12 +75,12 @@ class GameDcbHelpersTest {
                 tags = setOf("game:$gameId")
         )
 
-        assertThat((GameDcbQueries.wordHintDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
+        assertThat(itemsOf(GameDcbQueries.wordHintDecisionContext(gameId))).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(CharacterInWordHintWasRevealed::class.eventType()), tags = setOf("wordhint:$gameId"))
         )
 
-        assertThat((GameDcbQueries.pointsDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
+        assertThat(itemsOf(GameDcbQueries.pointsDecisionContext(gameId))).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(PlayerGuessedTheWrongWord::class.eventType()), tags = setOf("gameplay:$gameId")),
                 queryItem(types = setOf(PlayerWasAwardedPointsForGuessingTheRightWord::class.eventType()), tags = setOf("points:$gameId")),
@@ -87,9 +88,13 @@ class GameDcbHelpersTest {
         )
     }
 
-    private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
+    private fun itemsOf(query: DcbQuery): List<DcbQueryItem> {
         assertThat(query).isInstanceOf(DcbQuery.Items::class.java)
-        assertThat((query as DcbQuery.Items).items()).containsExactly(queryItem(types, tags))
+        return (query as DcbQuery.Items).items()
+    }
+
+    private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
+        assertThat(itemsOf(query)).containsExactly(queryItem(types, tags))
     }
 
     private fun queryItem(types: Set<String> = emptySet(), tags: Set<String>) = org.occurrent.eventstore.api.dcb.DcbQueryItem(types, tags)

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/dcb/GameDcbHelpersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/dcb/GameDcbHelpersTest.kt
@@ -74,12 +74,12 @@ class GameDcbHelpersTest {
                 tags = setOf("game:$gameId")
         )
 
-        assertThat(GameDcbQueries.wordHintDecisionContext(gameId).items()).containsExactlyInAnyOrder(
+        assertThat((GameDcbQueries.wordHintDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(CharacterInWordHintWasRevealed::class.eventType()), tags = setOf("wordhint:$gameId"))
         )
 
-        assertThat(GameDcbQueries.pointsDecisionContext(gameId).items()).containsExactlyInAnyOrder(
+        assertThat((GameDcbQueries.pointsDecisionContext(gameId) as DcbQuery.Items).items()).containsExactlyInAnyOrder(
                 queryItem(types = setOf(GameWasStarted::class.eventType()), tags = setOf("game:$gameId")),
                 queryItem(types = setOf(PlayerGuessedTheWrongWord::class.eventType()), tags = setOf("gameplay:$gameId")),
                 queryItem(types = setOf(PlayerWasAwardedPointsForGuessingTheRightWord::class.eventType()), tags = setOf("points:$gameId")),
@@ -88,8 +88,8 @@ class GameDcbHelpersTest {
     }
 
     private fun assertSingleQueryItem(query: DcbQuery, types: Set<String> = emptySet(), tags: Set<String>) {
-        assertThat(query.matchAll()).isFalse()
-        assertThat(query.items()).containsExactly(queryItem(types, tags))
+        assertThat(query).isInstanceOf(DcbQuery.Items::class.java)
+        assertThat((query as DcbQuery.Items).items()).containsExactly(queryItem(types, tags))
     }
 
     private fun queryItem(types: Set<String> = emptySet(), tags: Set<String>) = org.occurrent.eventstore.api.dcb.DcbQueryItem(types, tags)


### PR DESCRIPTION
Refines the DCB API while it's still unreleased, so the breaking changes cost nothing now and save churn later. No production behavior changes, just the API shape plus the consumers that follow from it.

`DcbQuery` is now a sealed interface (`MatchAll` and `Items`) instead of a record carrying a `boolean matchAll` flag next to a list of items. The old shape let you build an illegal value (match-all and items at the same time) that only failed at runtime. The sealed type makes that unrepresentable. I also renamed the `type(..)` factory to `types(..)` (it takes several types, like `tagsAllOf`), and added `anyOf(..)` for building an OR query from multiple items.

`DcbReadOptions` gains an inclusive `upToSequencePosition` upper bound alongside the existing exclusive `afterSequencePosition` lower bound, so you can read a bounded slice of the DCB sequence. Both stores honor it.

`DcbAppendCondition`'s component is renamed from `failIfEventsMatch` to `query`, so the accessor reads `condition.query()`. The `failIfEventsMatch(..)` factories are unchanged.

`DcbEventStore` gains `exists(DcbQuery)` and `count(DcbQuery)` for the common "is this boundary empty" / "how many match" checks without materialising the events. They default to a read for any third-party implementation and are overridden efficiently in the in-memory and Spring Mongo stores.

All consumers (both stores, the application service, the DSL, and the examples) and tests are updated in the same commit so everything compiles, and there are new tests for `exists`/`count`, the `upToSequencePosition` bound, and `anyOf`.

Verification: `mvn test-compile` green across the project, the api/inmemory/app-service/dcb-dsl suites pass, and `SpringMongoEventStoreDcbTest` is 14/14.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
