### PR TITLE
Add DCB DSL and metadata ergonomics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,9 @@
   * DCB subscription helpers subscribe to CloudEvents and post-filter DCB-tagged events by `DcbQuery`; they are live subscription conveniences, not DCB-consistent reads.
   * DCB subscription metadata callbacks reuse the existing `EventMetadata` type and expose DCB metadata through Kotlin extension properties: `dcbPosition` and `dcbTags`.
   * Kotlin decider extensions on `DcbApplicationService` mirror the stream decider helpers while using `DcbQuery` as the decision boundary.
+  * `DcbEventMetadata` gives Java callers access to the DCB sequence position and DCB tags of a subscription event, the same metadata Kotlin reads through the `dcbPosition` and `dcbTags` extension properties.
+  * `DcbSubscriptions` is an instance wrapper over a `Subscribable` and a `CloudEventConverter`, so DCB subscriptions can be created without passing the converter on every call, mirroring `DcbDomainEventQueries`.
+  * Kotlin `queryForListWithPosition` and `queryForSequenceWithPosition` extensions return the matching events together with the observed DCB sequence position.
 * Added two DCB word-guessing MongoDB Spring examples.
   * `example-domain-word-guessing-game-es-mongodb-spring-dcb` shows manual DCB wiring with explicit DCB queries, tags, application-service usage, and live durable subscriptions.
   * `example-domain-word-guessing-game-es-mongodb-spring-dcb-autoconfig` shows Spring Boot auto-configuration, `@EnableOccurrent`, DCB-only event-store capabilities, annotation subscriptions, and DCB decider command handling.

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadata.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadata.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.dsl.subscription.blocking.EventMetadata;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Java-friendly view over an {@link EventMetadata} that exposes DCB-specific metadata, namely the DCB sequence
+ * position and the DCB tags.
+ * <p>
+ * The generic {@link EventMetadata} lives in the subscription DSL and intentionally does not depend on the DCB API,
+ * so these accessors live here in the DCB DSL module. Kotlin callers can use the {@code EventMetadata.dcbPosition}
+ * and {@code EventMetadata.dcbTags} extension properties instead.
+ */
+@NullMarked
+public final class DcbEventMetadata {
+
+    private final EventMetadata metadata;
+
+    public DcbEventMetadata(EventMetadata metadata) {
+        this.metadata = requireNonNull(metadata, EventMetadata.class.getSimpleName() + " cannot be null");
+    }
+
+    /**
+     * Wraps an {@link EventMetadata} so its DCB metadata can be read.
+     */
+    public static DcbEventMetadata from(EventMetadata metadata) {
+        return new DcbEventMetadata(metadata);
+    }
+
+    /**
+     * The DCB sequence position of the event, or empty when the event has no DCB position (for example a
+     * regular stream-written event).
+     */
+    public OptionalLong dcbPosition() {
+        return decodePosition(metadata.getData().get(DcbCloudEvents.POSITION));
+    }
+
+    /**
+     * The canonical DCB tags of the event, or an empty set when the event has no DCB tags.
+     */
+    public Set<String> dcbTags() {
+        return decodeTags(metadata.getData().get(DcbCloudEvents.TAGS));
+    }
+
+    /**
+     * The id of the Occurrent storage stream the event was written to.
+     */
+    public String streamId() {
+        return metadata.getStreamId();
+    }
+
+    /**
+     * The version of the event within its Occurrent storage stream.
+     */
+    public long streamVersion() {
+        return metadata.getStreamVersion();
+    }
+
+    /**
+     * The wrapped {@link EventMetadata}.
+     */
+    public EventMetadata eventMetadata() {
+        return metadata;
+    }
+
+    static OptionalLong decodePosition(@Nullable Object value) {
+        if (value == null) {
+            return OptionalLong.empty();
+        }
+        if (value instanceof Number number) {
+            return OptionalLong.of(number.longValue());
+        }
+        if (value instanceof String string) {
+            return OptionalLong.of(Long.parseLong(string));
+        }
+        throw new IllegalArgumentException("DCB position extension must be a Number or String");
+    }
+
+    static Set<String> decodeTags(@Nullable Object value) {
+        if (value == null) {
+            return Set.of();
+        }
+        if (value instanceof String string) {
+            return DcbCloudEvents.decodeTags(string);
+        }
+        throw new IllegalArgumentException("DCB tags extension must be a String");
+    }
+}

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadata.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadata.java
@@ -66,21 +66,8 @@ public final class DcbEventMetadata {
     }
 
     /**
-     * The id of the Occurrent storage stream the event was written to.
-     */
-    public String streamId() {
-        return metadata.getStreamId();
-    }
-
-    /**
-     * The version of the event within its Occurrent storage stream.
-     */
-    public long streamVersion() {
-        return metadata.getStreamVersion();
-    }
-
-    /**
-     * The wrapped {@link EventMetadata}.
+     * The wrapped {@link EventMetadata}, for the generic subscription metadata (such as the storage stream id and
+     * version) that is not specific to DCB.
      */
     public EventMetadata eventMetadata() {
         return metadata;

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.subscription.blocking.EventMetadata;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.OccurrentSubscriptionFilter;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.Subscribable;
+import org.occurrent.subscription.api.blocking.Subscription;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Subscribes to live DCB-tagged events without having to pass the {@link CloudEventConverter} on every call.
+ * <p>
+ * This wraps a {@link Subscribable} and a {@link CloudEventConverter}, mirroring how {@link DcbDomainEventQueries}
+ * wraps its dependencies. The subscriptions are live CloudEvent subscriptions that post-filter DCB-tagged events
+ * by a {@link DcbQuery}. They are not DCB reads, so they provide no DCB append-condition or high-watermark
+ * guarantees.
+ *
+ * @param <E> the domain event type
+ */
+@NullMarked
+public final class DcbSubscriptions<E> {
+
+    private final Subscribable subscribable;
+    private final CloudEventConverter<E> cloudEventConverter;
+
+    public DcbSubscriptions(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
+        this.subscribable = requireNonNull(subscribable, Subscribable.class.getSimpleName() + " cannot be null");
+        this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}.
+     */
+    public Subscription subscribe(String subscriptionId, DcbQuery query, Consumer<E> fn) {
+        return subscribe(subscriptionId, query, null, fn);
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt}.
+     */
+    public Subscription subscribe(String subscriptionId, DcbQuery query, @Nullable StartAt startAt, Consumer<E> fn) {
+        requireNonNull(fn, "Subscription function cannot be null");
+        return subscribeWithMetadata(subscriptionId, query, startAt, (metadata, event) -> fn.accept(event));
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, exposing DCB metadata to the callback.
+     * <p>
+     * This is a distinct method rather than an overload of {@link #subscribe} so that a method reference like
+     * {@code list::add} stays unambiguous on the {@link Consumer} overloads.
+     */
+    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, BiConsumer<DcbEventMetadata, E> fn) {
+        return subscribeWithMetadata(subscriptionId, query, null, fn);
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt} and exposing DCB metadata
+     * to the callback.
+     */
+    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, @Nullable StartAt startAt, BiConsumer<DcbEventMetadata, E> fn) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(fn, "Subscription function cannot be null");
+
+        Consumer<CloudEvent> consumer = cloudEvent -> {
+            if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
+                E event = cloudEventConverter.toDomainEvent(cloudEvent);
+                fn.accept(DcbEventMetadata.from(toEventMetadata(cloudEvent)), event);
+            }
+        };
+
+        OccurrentSubscriptionFilter filter = OccurrentSubscriptionFilter.filter(Filter.all());
+        Subscription subscription = startAt == null
+                ? subscribable.subscribe(subscriptionId, filter, consumer)
+                : subscribable.subscribe(subscriptionId, filter, startAt, consumer);
+        subscription.waitUntilStarted();
+        return subscription;
+    }
+
+    private static EventMetadata toEventMetadata(CloudEvent cloudEvent) {
+        Map<String, Object> data = new HashMap<>();
+        for (String extensionName : cloudEvent.getExtensionNames()) {
+            data.put(extensionName, cloudEvent.getExtension(extensionName));
+        }
+        return new EventMetadata(data);
+    }
+}

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -43,6 +43,10 @@ import static java.util.Objects.requireNonNull;
  * wraps its dependencies. The subscriptions are live CloudEvent subscriptions that post-filter DCB-tagged events
  * by a {@link DcbQuery}. They are not DCB reads, so they provide no DCB append-condition or high-watermark
  * guarantees.
+ * <p>
+ * Like {@link Subscribable}, the {@code subscribe} methods return the {@link Subscription} without waiting for it to
+ * start. Call {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before
+ * you continue (for example to avoid missing the first events of a brand new subscription).
  *
  * @param <E> the domain event type
  */
@@ -99,11 +103,9 @@ public final class DcbSubscriptions<E> {
         };
 
         OccurrentSubscriptionFilter filter = OccurrentSubscriptionFilter.filter(Filter.all());
-        Subscription subscription = startAt == null
+        return startAt == null
                 ? subscribable.subscribe(subscriptionId, filter, consumer)
                 : subscribable.subscribe(subscriptionId, filter, startAt, consumer);
-        subscription.waitUntilStarted();
-        return subscription;
     }
 
     private static EventMetadata toEventMetadata(CloudEvent cloudEvent) {

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -31,6 +31,7 @@ import org.occurrent.subscription.api.blocking.Subscription;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -109,9 +110,13 @@ public final class DcbSubscriptions<E> {
     }
 
     private static EventMetadata toEventMetadata(CloudEvent cloudEvent) {
-        Map<String, Object> data = new HashMap<>();
-        for (String extensionName : cloudEvent.getExtensionNames()) {
-            data.put(extensionName, cloudEvent.getExtension(extensionName));
+        Set<String> extensionNames = cloudEvent.getExtensionNames();
+        Map<String, Object> data = new HashMap<>(extensionNames.size());
+        for (String extensionName : extensionNames) {
+            Object value = cloudEvent.getExtension(extensionName);
+            if (value != null) {
+                data.put(extensionName, value);
+            }
         }
         return new EventMetadata(data);
     }

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
@@ -41,3 +41,25 @@ fun <T : Any> DcbDomainEventQueries<T>.queryForList(
     options: DcbReadOptions = DcbReadOptions.fromBeginning()
 ): List<T> =
     this.query(query, options).toList()
+
+/**
+ * Query that returns the matching domain events as a [List] together with the observed DCB sequence position.
+ *
+ * @see DcbDomainEventQueries.queryWithPosition
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForListWithPosition(
+    query: DcbQuery,
+    options: DcbReadOptions = DcbReadOptions.fromBeginning()
+): Pair<List<T>, Long> =
+    this.queryWithPosition(query, options).let { it.events() to it.lastSequencePosition() }
+
+/**
+ * Query that returns the matching domain events as a [Sequence] together with the observed DCB sequence position.
+ *
+ * @see DcbDomainEventQueries.queryWithPosition
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForSequenceWithPosition(
+    query: DcbQuery,
+    options: DcbReadOptions = DcbReadOptions.fromBeginning()
+): Pair<Sequence<T>, Long> =
+    this.queryWithPosition(query, options).let { it.events().asSequence() to it.lastSequencePosition() }

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
@@ -33,12 +33,16 @@ import org.occurrent.subscription.api.blocking.Subscription
  *
  * Events delivered by `subscribeDcb` are DCB-tagged and therefore have a non-null position.
  */
-val EventMetadata.dcbPosition: Long? get() = positionOrNull(data[DcbCloudEvents.POSITION])
+val EventMetadata.dcbPosition: Long?
+    get() {
+        val position = DcbEventMetadata.decodePosition(data[DcbCloudEvents.POSITION])
+        return if (position.isPresent) position.asLong else null
+    }
 
 /**
  * The canonical DCB tags of an event, or an empty set when the event has no DCB tags.
  */
-val EventMetadata.dcbTags: Set<String> get() = tags(data[DcbCloudEvents.TAGS])
+val EventMetadata.dcbTags: Set<String> get() = DcbEventMetadata.decodeTags(data[DcbCloudEvents.TAGS])
 
 /**
  * Subscribes to live DCB-tagged events that match [query].
@@ -93,17 +97,4 @@ fun <E : Any> Subscribable.subscribeDcb(
             waitUntilStarted()
         }
     }
-}
-
-private fun tags(value: Any?): Set<String> = when (value) {
-    null -> emptySet()
-    is String -> DcbCloudEvents.decodeTags(value)
-    else -> throw IllegalArgumentException("DCB tags extension must be a String")
-}
-
-private fun positionOrNull(value: Any?): Long? = when (value) {
-    null -> null
-    is Number -> value.toLong()
-    is String -> value.toLong()
-    else -> throw IllegalArgumentException("DCB position extension must be a Number or String")
 }

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadataTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbEventMetadataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.dsl.subscription.blocking.EventMetadata;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbEventMetadataTest {
+
+    @Test
+    void reads_position_when_stored_as_number() {
+        EventMetadata metadata = new EventMetadata(Map.of(DcbCloudEvents.POSITION, 7L));
+
+        assertThat(DcbEventMetadata.from(metadata).dcbPosition()).hasValue(7L);
+    }
+
+    @Test
+    void reads_position_when_stored_as_string() {
+        EventMetadata metadata = new EventMetadata(Map.of(DcbCloudEvents.POSITION, "7"));
+
+        assertThat(DcbEventMetadata.from(metadata).dcbPosition()).hasValue(7L);
+    }
+
+    @Test
+    void position_is_empty_when_absent() {
+        EventMetadata metadata = new EventMetadata(Map.of());
+
+        assertThat(DcbEventMetadata.from(metadata).dcbPosition()).isEmpty();
+    }
+
+    @Test
+    void reads_and_canonicalizes_tags() {
+        EventMetadata metadata = new EventMetadata(Map.of(DcbCloudEvents.TAGS, DcbCloudEvents.encodeTags(Set.of("name:1", "tenant:2"))));
+
+        assertThat(DcbEventMetadata.from(metadata).dcbTags()).containsExactlyInAnyOrder("name:1", "tenant:2");
+    }
+
+    @Test
+    void tags_are_empty_when_absent() {
+        EventMetadata metadata = new EventMetadata(Map.of());
+
+        assertThat(DcbEventMetadata.from(metadata).dcbTags()).isEmpty();
+    }
+}

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
@@ -70,7 +70,7 @@ class DcbSubscriptionsTest {
     @Test
     void delivers_only_matching_dcb_events() {
         CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
-        dcbSubscriptions.subscribe("subscription", DcbQuery.tagsAllOf("name:1"), (DomainEvent event) -> received.add(event));
+        dcbSubscriptions.subscribe("subscription", DcbQuery.tagsAllOf("name:1"), (DomainEvent event) -> received.add(event)).waitUntilStarted();
 
         NameDefined matching = new NameDefined("eventId1", time, "name", "Some Doe");
         append("name:1", matching);
@@ -89,7 +89,7 @@ class DcbSubscriptionsTest {
             positions.add(metadata.dcbPosition());
             tags.add(metadata.dcbTags());
             events.add(event);
-        });
+        }).waitUntilStarted();
 
         NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
         append(List.of("name:1", "tenant:2"), nameDefined);

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbSubscriptionsTest {
+
+    private InMemorySubscriptionModel subscriptionModel;
+    private InMemoryEventStore eventStore;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private DcbSubscriptions<DomainEvent> dcbSubscriptions;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void createInstances() {
+        subscriptionModel = new InMemorySubscriptionModel();
+        eventStore = new InMemoryEventStore(subscriptionModel);
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        dcbSubscriptions = new DcbSubscriptions<>(subscriptionModel, cloudEventConverter);
+        time = LocalDateTime.now();
+    }
+
+    @AfterEach
+    void shutdown() {
+        subscriptionModel.shutdown();
+    }
+
+    @Test
+    void delivers_only_matching_dcb_events() {
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        dcbSubscriptions.subscribe("subscription", DcbQuery.tagsAllOf("name:1"), (DomainEvent event) -> received.add(event));
+
+        NameDefined matching = new NameDefined("eventId1", time, "name", "Some Doe");
+        append("name:1", matching);
+        append("other:1", new NameWasChanged("eventId2", time, "name", "Jane Doe"));
+
+        await().untilAsserted(() -> assertThat(received).containsExactly(matching));
+    }
+
+    @Test
+    void metadata_overload_exposes_dcb_position_and_tags() {
+        CopyOnWriteArrayList<OptionalLong> positions = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<Set<String>> tags = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<DomainEvent> events = new CopyOnWriteArrayList<>();
+
+        dcbSubscriptions.subscribeWithMetadata("subscription", DcbQuery.tagsAllOf("name:1"), (metadata, event) -> {
+            positions.add(metadata.dcbPosition());
+            tags.add(metadata.dcbTags());
+            events.add(event);
+        });
+
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        append(List.of("name:1", "tenant:2"), nameDefined);
+
+        await().untilAsserted(() -> {
+            assertThat(events).containsExactly(nameDefined);
+            assertThat(positions).containsExactly(OptionalLong.of(1));
+            assertThat(tags.get(0)).containsExactlyInAnyOrder("name:1", "tenant:2");
+        });
+    }
+
+    private void append(String tag, DomainEvent... events) {
+        append(List.of(tag), events);
+    }
+
+    private void append(List<String> tags, DomainEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(event -> DcbCloudEvents.withTags(event, tags))
+                .toList();
+        eventStore.append("dcb:partition:0", cloudEvents);
+    }
+}

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
@@ -80,7 +80,7 @@ class DcbSubscriptionsTest {
     }
 
     @Test
-    void metadata_overload_exposes_dcb_position_and_tags() {
+    void subscribe_with_metadata_exposes_dcb_position_and_tags() {
         CopyOnWriteArrayList<OptionalLong> positions = new CopyOnWriteArrayList<>();
         CopyOnWriteArrayList<Set<String>> tags = new CopyOnWriteArrayList<>();
         CopyOnWriteArrayList<DomainEvent> events = new CopyOnWriteArrayList<>();

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -92,6 +92,21 @@ class DcbDslKotlinTest {
     }
 
     @Test
+    fun queryForListWithPosition_and_queryForSequenceWithPosition_return_events_and_position() {
+        val nameDefined = NameDefined("eventId1", time, "name", "Some Doe")
+        append("name:1", nameDefined)
+        append("other:1", NameWasChanged("eventId2", time, "name", "Jane Doe"))
+
+        val (list, listPosition) = dcbQueries.queryForListWithPosition(DcbQuery.tagsAllOf("name:1"))
+        assertThat(list).containsExactly(nameDefined)
+        assertThat(listPosition).isEqualTo(2)
+
+        val (sequence, sequencePosition) = dcbQueries.queryForSequenceWithPosition(DcbQuery.tagsAllOf("name:1"))
+        assertThat(sequence.toList()).containsExactly(nameDefined)
+        assertThat(sequencePosition).isEqualTo(2)
+    }
+
+    @Test
     fun dcb_subscription_invokes_callback_only_for_matching_dcb_events() {
         val received = CopyOnWriteArrayList<DomainEvent>()
 


### PR DESCRIPTION
Additive DCB DSL conveniences on top of the refined API in the parent PR. No behavior changes to existing code.

`DcbEventMetadata` gives Java callers typed access to `dcbPosition` and `dcbTags` from an `EventMetadata`. Until now those were Kotlin extension properties, so Java couldn't read them cleanly. It lives in the dcb-dsl module on purpose, so the generic `EventMetadata` in subscription-dsl stays decoupled from the DCB API. The Kotlin `dcbPosition`/`dcbTags` extension properties now delegate to it, so the decode logic lives in one place.

`DcbSubscriptions` wraps a `Subscribable` and a `CloudEventConverter`, so you configure the converter once instead of passing it on every subscribe (the same shape as `DcbDomainEventQueries`). The metadata callback is a separate `subscribeWithMetadata` method rather than an overload of `subscribe`, so a method reference like `list::add` stays unambiguous on the plain `subscribe`. Same live post-filter behavior and the same caveat as the Kotlin `subscribeDcb`: it is not a DCB-consistent read.

The Kotlin `queryForListWithPosition` and `queryForSequenceWithPosition` extensions return the events together with the observed DCB position, matching the existing `queryForList`/`queryForSequence` style.

Verification: `mvn test-compile` green across the project, and the dcb-dsl suite passes (run twice for the async subscription tests).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-api-shape","parentHead":"71a0f2aef2d17f6ed8a9a8cdca2ecab8aefa2083","parentPull":205,"trunk":"main"}
```
-->
