### PR TITLE
Make the DCB append API own its storage placement

### DIFF
--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
@@ -26,62 +26,48 @@ import org.occurrent.retry.RetryStrategy.Retry;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toCollection;
 
 /**
  * Default blocking {@link DcbApplicationService} implementation.
  * <p>
- * It coordinates a {@link DcbEventStore}, a {@link CloudEventConverter}, a
- * {@link TagGenerator}, and a {@link DcbStreamIdGenerator} so application code can keep
- * domain decisions expressed in domain events while DCB metadata is applied at the
- * CloudEvent boundary.
+ * It coordinates a {@link DcbEventStore}, a {@link CloudEventConverter}, and a
+ * {@link TagGenerator} so application code can keep domain decisions expressed in domain
+ * events while DCB metadata is applied at the CloudEvent boundary. Storage stream
+ * placement is configured on the {@link DcbEventStore}.
  */
 @NullMarked
 public class GenericDcbApplicationService<E> implements DcbApplicationService<E> {
     private final DcbEventStore eventStore;
     private final CloudEventConverter<E> cloudEventConverter;
     private final TagGenerator<E> tagGenerator;
-    private final DcbStreamIdGenerator streamIdGenerator;
     private final RetryStrategy retryStrategy;
 
     /**
-     * Creates a service with the default partitioned storage stream id generator and retry strategy.
+     * Creates a service with the default retry strategy.
      */
     public GenericDcbApplicationService(DcbEventStore eventStore, CloudEventConverter<E> cloudEventConverter, TagGenerator<E> tagGenerator) {
-        this(eventStore, cloudEventConverter, tagGenerator, new PartitionedDcbStreamIdGenerator(), defaultRetryStrategy());
+        this(eventStore, cloudEventConverter, tagGenerator, defaultRetryStrategy());
     }
 
     /**
-     * Creates a service with the default partitioned storage stream id generator and a custom retry strategy.
+     * Creates a service with explicit collaborators for event conversion, DCB tagging, and retries after DCB
+     * append conflicts. Storage stream placement is configured on the {@link DcbEventStore}, not here.
      */
     public GenericDcbApplicationService(DcbEventStore eventStore, CloudEventConverter<E> cloudEventConverter, TagGenerator<E> tagGenerator, RetryStrategy retryStrategy) {
-        this(eventStore, cloudEventConverter, tagGenerator, new PartitionedDcbStreamIdGenerator(), retryStrategy);
-    }
-
-    /**
-     * Creates a service with explicit collaborators for event conversion, DCB tagging,
-     * storage stream placement, and retries after DCB append conflicts.
-     */
-    public GenericDcbApplicationService(DcbEventStore eventStore, CloudEventConverter<E> cloudEventConverter, TagGenerator<E> tagGenerator, DcbStreamIdGenerator streamIdGenerator, RetryStrategy retryStrategy) {
         if (eventStore == null) throw new IllegalArgumentException(DcbEventStore.class.getSimpleName() + " cannot be null");
         if (cloudEventConverter == null) throw new IllegalArgumentException(CloudEventConverter.class.getSimpleName() + " cannot be null");
         if (tagGenerator == null) throw new IllegalArgumentException(TagGenerator.class.getSimpleName() + " cannot be null");
-        if (streamIdGenerator == null) throw new IllegalArgumentException(DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
         if (retryStrategy == null) throw new IllegalArgumentException(RetryStrategy.class.getSimpleName() + " cannot be null");
 
         this.eventStore = eventStore;
         this.cloudEventConverter = cloudEventConverter;
         this.tagGenerator = tagGenerator;
-        this.streamIdGenerator = streamIdGenerator;
         this.retryStrategy = retryStrategy;
     }
 
@@ -104,8 +90,7 @@ public class GenericDcbApplicationService<E> implements DcbApplicationService<E>
             List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(newDomainEvents.stream()).toList();
             List<CloudEvent> dcbEvents = addTags(newDomainEvents, cloudEvents);
             DcbAppendCondition appendCondition = DcbAppendCondition.failIfEventsMatch(query, eventStream.lastSequencePosition());
-            String streamId = streamIdGenerator.generateStreamId(tagsFromQuery(query));
-            return Optional.of(eventStore.append(streamId, dcbEvents, appendCondition));
+            return Optional.of(eventStore.append(dcbEvents, appendCondition));
         });
     }
 
@@ -118,16 +103,6 @@ public class GenericDcbApplicationService<E> implements DcbApplicationService<E>
             dcbEvents.add(DcbCloudEvents.withTags(cloudEvents.get(i), tagGenerator.tags(domainEvents.get(i))));
         }
         return dcbEvents;
-    }
-
-    private static Set<String> tagsFromQuery(DcbQuery query) {
-        if (query instanceof DcbQuery.Items items) {
-            return items.items().stream()
-                    .map(DcbQueryItem::tags)
-                    .flatMap(Collection::stream)
-                    .collect(toCollection(TreeSet::new));
-        }
-        return new TreeSet<>();
     }
 
     private static <T> Stream<T> emptyStreamIfNull(@Nullable Stream<T> stream) {

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationServiceTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationServiceTest.java
@@ -50,12 +50,11 @@ class GenericDcbApplicationServiceTest {
     @Test
     void reads_by_dcb_query_and_appends_with_tags_from_domain_events() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1"))));
+        eventStore.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1"))));
         GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(
                 eventStore,
                 converter(),
                 event -> Set.of(event.name()),
-                __ -> "dcb:partition:0",
                 GenericDcbApplicationService.defaultRetryStrategy());
 
         Optional<DcbAppendResult> result = applicationService.execute(tagsAllOf("name:1"), events -> {
@@ -89,14 +88,13 @@ class GenericDcbApplicationServiceTest {
     @Test
     void retries_from_a_fresh_dcb_read_when_append_condition_detects_a_conflict() {
         InMemoryEventStore delegate = new InMemoryEventStore();
-        delegate.append("dcb:partition:0", List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1"))));
+        delegate.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1"))));
         ConflictingOnceDcbEventStore eventStore = new ConflictingOnceDcbEventStore(delegate, converter().toCloudEvent(new DomainEvent("NameChangedByOther", "name:1")));
         AtomicInteger attempts = new AtomicInteger();
         GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(
                 eventStore,
                 converter(),
                 event -> Set.of(event.name()),
-                __ -> "dcb:partition:0",
                 GenericDcbApplicationService.defaultRetryStrategy());
 
         Optional<DcbAppendResult> result = applicationService.execute(tagsAllOf("name:1"), events -> {
@@ -160,16 +158,16 @@ class GenericDcbApplicationServiceTest {
         }
 
         @Override
-        public DcbAppendResult append(String streamId, List<CloudEvent> events) {
-            return delegate.append(streamId, events);
+        public DcbAppendResult append(List<CloudEvent> events) {
+            return delegate.append(events);
         }
 
         @Override
-        public DcbAppendResult append(String streamId, List<CloudEvent> events, DcbAppendCondition condition) {
+        public DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition) {
             if (conflictInserted.compareAndSet(false, true)) {
-                delegate.append(streamId, List.of(conflictingEvent));
+                delegate.append(List.of(conflictingEvent));
             }
-            return delegate.append(streamId, events, condition);
+            return delegate.append(events, condition);
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 #### Highlights
 
+* `DcbEventStore.append` no longer takes a storage stream id. The store now derives the Occurrent storage stream from the appended events' DCB tags, so callers reason in DCB terms (tags and append conditions) instead of storage stream ids. Placement is configured on the store through a `DcbStreamIdGenerator` (moved to the `eventstore-api-dcb` module, defaulting to `PartitionedDcbStreamIdGenerator`), set on `InMemoryEventStore` via a constructor and on the Spring Mongo store via `EventStoreConfig.Builder.dcbStreamIdGenerator(..)`. The application service no longer takes a `DcbStreamIdGenerator`.
 * Added initial Dynamic Consistency Boundary (DCB) support.
   * New module: `org.occurrent:eventstore-api-dcb`.
   * New core API types include `DcbEventStore`, `DcbQuery`, `DcbQueryItem`, `DcbReadOptions`, `DcbEventStream`, `DcbAppendCondition`, `DcbAppendResult`, `DcbAppendConditionNotFulfilledException`, and `DcbCloudEvents`.

--- a/doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md
+++ b/doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md
@@ -48,7 +48,9 @@ The first implementation provides:
 - blocking DCB API,
 - in-memory DCB support in the existing `InMemoryEventStore`,
 - Spring Mongo blocking DCB support in the existing `SpringMongoEventStore`,
-- blocking DCB application service using `CloudEventConverter`, `TagGenerator`, and partitioned stream id generation.
+- blocking DCB application service using `CloudEventConverter` and `TagGenerator`.
+
+The DCB append API does not expose a storage stream id. The event store derives the storage stream that DCB-written events are placed in from their DCB tags, using a partitioned stream id generator (configurable per store). DCB-written events still keep `streamid` and `streamversion` metadata, so they remain readable through the stream APIs by those partition stream ids.
 
 Existing stream APIs remain backward compatible:
 

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
@@ -112,13 +112,13 @@ class DcbDomainEventQueriesTest {
         List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(new NameDefined("eventId1", time, "name", "Some Doe")))
                 .map(event -> DcbCloudEvents.withTags(event, List.of("name:1")))
                 .toList();
-        eventStoreWithSubscriptions.append("dcb:partition:0", cloudEvents);
+        eventStoreWithSubscriptions.append(cloudEvents);
 
         // The in-memory subscription model dispatches asynchronously, so wait for the callback like the sibling tests do.
         await().untilAsserted(() -> {
             assertThat(metadata).hasSize(1);
-            assertThat(metadata.get(0).getStreamId()).isEqualTo("dcb:partition:0");
-            assertThat(metadata.get(0).getStreamVersion()).isEqualTo(1);
+            assertThat(metadata.get(0).getStreamId()).startsWith("dcb:partition:");
+            assertThat(metadata.get(0).getStreamVersion()).isPositive();
         });
     }
 
@@ -126,6 +126,6 @@ class DcbDomainEventQueriesTest {
         List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
                 .map(event -> DcbCloudEvents.withTags(event, List.of(tag)))
                 .toList();
-        eventStore.append("dcb:partition:0", cloudEvents);
+        eventStore.append(cloudEvents);
     }
 }

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
@@ -109,6 +109,6 @@ class DcbSubscriptionsTest {
         List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
                 .map(event -> DcbCloudEvents.withTags(event, tags))
                 .toList();
-        eventStore.append("dcb:partition:0", cloudEvents);
+        eventStore.append(cloudEvents);
     }
 }

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbApplicationServiceDeciderExtensionsTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbApplicationServiceDeciderExtensionsTest.kt
@@ -54,7 +54,6 @@ class DcbApplicationServiceDeciderExtensionsTest {
             eventStore,
             cloudEventConverter,
             { event: DomainEvent -> setOf(tagFor(event)) },
-            { "dcb:partition:0" },
             GenericDcbApplicationService.defaultRetryStrategy()
         )
         time = LocalDateTime.now()
@@ -127,7 +126,7 @@ class DcbApplicationServiceDeciderExtensionsTest {
         val cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(*events))
             .map { event -> DcbCloudEvents.withTags(event, setOf("name:name")) }
             .toList()
-        eventStore.append("dcb:partition:0", cloudEvents)
+        eventStore.append(cloudEvents)
     }
 
     private fun readNameEvents(nameId: String): List<DomainEvent> =

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -156,8 +156,8 @@ class DcbDslKotlinTest {
 
         await().untilAsserted {
             assertThat(metadata).hasSize(1)
-            assertThat(metadata[0].streamId).isEqualTo("dcb:partition:0")
-            assertThat(metadata[0].streamVersion).isEqualTo(1)
+            assertThat(metadata[0].streamId).startsWith("dcb:partition:")
+            assertThat(metadata[0].streamVersion).isPositive()
             assertThat(metadata[0].dcbPosition).isEqualTo(1)
             assertThat(metadata[0].dcbTags).containsExactlyInAnyOrder("name:1", "tenant:1")
         }
@@ -177,8 +177,8 @@ class DcbDslKotlinTest {
 
         await().untilAsserted {
             assertThat(metadata).hasSize(1)
-            assertThat(metadata[0].streamId).isEqualTo("dcb:partition:0")
-            assertThat(metadata[0].streamVersion).isEqualTo(1)
+            assertThat(metadata[0].streamId).startsWith("dcb:partition:")
+            assertThat(metadata[0].streamVersion).isPositive()
             assertThat(metadata[0].dcbPosition).isEqualTo(1)
             assertThat(metadata[0].dcbTags).containsExactly("name:1")
         }
@@ -213,7 +213,7 @@ class DcbDslKotlinTest {
         val cloudEvents: List<CloudEvent> = cloudEventConverter.toCloudEvents(Stream.of(*events))
             .map { event -> DcbCloudEvents.withTags(event, tags) }
             .toList()
-        eventStore.append("dcb:partition:0", cloudEvents)
+        eventStore.append(cloudEvents)
     }
 
     private fun writeStreamEvent(event: DomainEvent) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
@@ -134,6 +134,22 @@ public final class DcbCloudEvents {
     }
 
     /**
+     * Returns the union of the tags the query constrains on, that is the consistency boundary it defines. A
+     * {@link DcbQuery.MatchAll} query and a query that only constrains on types both yield an empty set. This is the
+     * stable per-boundary tag set a store can use to place DCB-written events, rather than the per-event tags which
+     * a {@code TagGenerator} may extend differently per event.
+     */
+    public static Set<String> boundaryTags(DcbQuery query) {
+        requireNonNull(query, "Query cannot be null");
+        if (query instanceof DcbQuery.Items items) {
+            return items.items().stream()
+                    .flatMap(item -> item.tags().stream())
+                    .collect(toCollection(TreeSet::new));
+        }
+        return Set.of();
+    }
+
+    /**
      * Strips, validates, de-duplicates, and sorts DCB tags into their canonical set form.
      */
     public static Set<String> canonicalizeTags(Collection<String> tags) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
@@ -142,9 +142,9 @@ public final class DcbCloudEvents {
     public static Set<String> boundaryTags(DcbQuery query) {
         requireNonNull(query, "Query cannot be null");
         if (query instanceof DcbQuery.Items items) {
-            return items.items().stream()
+            return Set.copyOf(items.items().stream()
                     .flatMap(item -> item.tags().stream())
-                    .collect(toCollection(TreeSet::new));
+                    .collect(toCollection(TreeSet::new)));
         }
         return Set.of();
     }

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStore.java
@@ -68,12 +68,17 @@ public interface DcbEventStore {
     }
 
     /**
-     * Appends DCB-tagged CloudEvents to the given Occurrent storage stream without an additional DCB condition.
+     * Appends DCB-tagged CloudEvents without an additional DCB condition.
+     * <p>
+     * The Occurrent storage stream the events are placed in is derived by the store from the events' DCB tags, so
+     * callers reason in DCB terms (tags and append conditions) rather than in storage stream ids.
      */
-    DcbAppendResult append(String streamId, List<CloudEvent> events);
+    DcbAppendResult append(List<CloudEvent> events);
 
     /**
-     * Appends DCB-tagged CloudEvents to the given Occurrent storage stream if {@code condition} is fulfilled.
+     * Appends DCB-tagged CloudEvents if {@code condition} is fulfilled.
+     * <p>
+     * The Occurrent storage stream the events are placed in is derived by the store from the events' DCB tags.
      */
-    DcbAppendResult append(String streamId, List<CloudEvent> events, DcbAppendCondition condition);
+    DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition);
 }

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbStreamIdGenerator.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbStreamIdGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.application.service.blocking.dcb;
+package org.occurrent.eventstore.api.dcb;
 
 import java.util.Set;
 

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/PartitionedDcbStreamIdGenerator.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/PartitionedDcbStreamIdGenerator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.application.service.blocking.dcb;
+package org.occurrent.eventstore.api.dcb;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;

--- a/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/PartitionedDcbStreamIdGeneratorTest.java
+++ b/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/PartitionedDcbStreamIdGeneratorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.application.service.blocking.dcb;
+package org.occurrent.eventstore.api.dcb;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -276,7 +276,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
         Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
         Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
-        String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
+        String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
 
         List<CloudEvent> addedEvents;
         DcbAppendResult result;

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -84,6 +84,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     private final Map<String, Long> insertionOrderByEventKey = new ConcurrentHashMap<>();
 
     private final Consumer<Stream<CloudEvent>> listener;
+    private final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create an instance of {@link InMemoryEventStore}
@@ -104,10 +105,22 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
      * @param listener A listener that will be invoked after events have been written to the datastore (synchronously!)
      */
     public InMemoryEventStore(@Nullable Consumer<Stream<CloudEvent>> listener) {
+        this(listener, new PartitionedDcbStreamIdGenerator());
+    }
+
+    /**
+     * Create an instance of {@link InMemoryEventStore} with a <code>listener</code> and a custom
+     * {@link DcbStreamIdGenerator} that decides which Occurrent storage stream DCB-written events are placed in.
+     *
+     * @param listener            A listener that will be invoked after events have been written to the datastore (synchronously!)
+     * @param dcbStreamIdGenerator Derives the storage stream id for DCB appends from the events' DCB tags
+     */
+    public InMemoryEventStore(@Nullable Consumer<Stream<CloudEvent>> listener, DcbStreamIdGenerator dcbStreamIdGenerator) {
         if (listener == null) {
             throw new IllegalArgumentException("listener cannot be null");
         }
         this.listener = listener;
+        this.dcbStreamIdGenerator = requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
     }
 
     @Override
@@ -249,19 +262,19 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     }
 
     @Override
-    public DcbAppendResult append(String streamId, List<CloudEvent> events) {
-        return appendDcb(streamId, events, null);
+    public DcbAppendResult append(List<CloudEvent> events) {
+        return appendDcb(events, null);
     }
 
     @Override
-    public DcbAppendResult append(String streamId, List<CloudEvent> events, DcbAppendCondition condition) {
+    public DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition) {
         requireNonNull(condition, "Append condition cannot be null");
-        return appendDcb(streamId, events, condition);
+        return appendDcb(events, condition);
     }
 
-    private DcbAppendResult appendDcb(String streamId, List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
-        requireNonNull(streamId, "Stream id cannot be null");
+    private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
+        String streamId = dcbStreamIdGenerator.generateStreamId(boundaryTagsOf(eventsToAppend));
 
         List<CloudEvent> addedEvents;
         DcbAppendResult result;
@@ -300,6 +313,10 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     private Stream<CloudEvent> allEvents() {
         return state.values().stream().flatMap(List::stream);
+    }
+
+    private static Set<String> boundaryTagsOf(List<CloudEvent> events) {
+        return events.stream().flatMap(event -> DcbCloudEvents.getTags(event).stream()).collect(Collectors.toCollection(TreeSet::new));
     }
 
     private static List<CloudEvent> validateDcbEvents(List<CloudEvent> events) {

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -104,7 +104,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
      *
      * @param listener A listener that will be invoked after events have been written to the datastore (synchronously!)
      */
-    public InMemoryEventStore(@Nullable Consumer<Stream<CloudEvent>> listener) {
+    public InMemoryEventStore(Consumer<Stream<CloudEvent>> listener) {
         this(listener, new PartitionedDcbStreamIdGenerator());
     }
 
@@ -115,11 +115,8 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
      * @param listener            A listener that will be invoked after events have been written to the datastore (synchronously!)
      * @param dcbStreamIdGenerator Derives the storage stream id for DCB appends from the events' DCB tags
      */
-    public InMemoryEventStore(@Nullable Consumer<Stream<CloudEvent>> listener, DcbStreamIdGenerator dcbStreamIdGenerator) {
-        if (listener == null) {
-            throw new IllegalArgumentException("listener cannot be null");
-        }
-        this.listener = listener;
+    public InMemoryEventStore(Consumer<Stream<CloudEvent>> listener, DcbStreamIdGenerator dcbStreamIdGenerator) {
+        this.listener = requireNonNull(listener, "listener cannot be null");
         this.dcbStreamIdGenerator = requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
     }
 

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -274,9 +274,11 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
-        // Place by the condition's boundary tags when there is one, so the same boundary always lands in the same
-        // partition regardless of per-event tags. Fall back to the events' tags when there is no condition.
-        Set<String> placementTags = condition != null ? DcbCloudEvents.boundaryTags(condition.query()) : boundaryTagsOf(eventsToAppend);
+        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
+        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
+        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
+        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
         String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
 
         List<CloudEvent> addedEvents;

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -274,7 +274,10 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
-        String streamId = dcbStreamIdGenerator.generateStreamId(boundaryTagsOf(eventsToAppend));
+        // Place by the condition's boundary tags when there is one, so the same boundary always lands in the same
+        // partition regardless of per-event tags. Fall back to the events' tags when there is no condition.
+        Set<String> placementTags = condition != null ? DcbCloudEvents.boundaryTags(condition.query()) : boundaryTagsOf(eventsToAppend);
+        String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
 
         List<CloudEvent> addedEvents;
         DcbAppendResult result;

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -48,7 +48,7 @@ class InMemoryEventStoreDcbTest {
     @Test
     void dcb_writes_are_visible_as_normal_cloud_events() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
 
         assertThat(eventStore.all())
                 .extracting(CloudEvent::getType)
@@ -64,9 +64,9 @@ class InMemoryEventStoreDcbTest {
 
         // Interleave DCB appends with a regular stream write. Natural order must follow the order things were
         // written, regardless of which write path produced them.
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         eventStore.write("stream:1", WriteCondition.streamVersionEq(0), Stream.of(event("OrderPlaced")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThat(eventStore.all(SortBy.natural(ASCENDING)))
                 .extracting(CloudEvent::getType)
@@ -79,9 +79,9 @@ class InMemoryEventStoreDcbTest {
 
         // Positions 1 and 3 land in one partition stream, position 2 in another. A DCB read must return them in
         // global dcbposition order, not grouped by the stream they happen to be stored in.
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
-        eventStore.append("dcb:partition:1", List.of(taggedEvent("NameChanged", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("OrderPlaced", "name:1")));
 
         DcbEventStream eventStream = eventStore.read(tagsAllOf("name:1"));
 
@@ -93,7 +93,7 @@ class InMemoryEventStoreDcbTest {
     @Test
     void reads_events_matching_type_or_all_tags_after_sequence_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1", "tenant:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -113,7 +113,7 @@ class InMemoryEventStoreDcbTest {
     @Test
     void reads_tagged_events_except_excluded_types() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameSnapshot", "name:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -128,7 +128,7 @@ class InMemoryEventStoreDcbTest {
     @Test
     void reads_type_and_tagged_events_except_excluded_types() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "name:1")));
@@ -146,7 +146,7 @@ class InMemoryEventStoreDcbTest {
     @Test
     void applies_excluded_types_per_query_item() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameSnapshot", "name:1"),
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -163,13 +163,12 @@ class InMemoryEventStoreDcbTest {
     @Test
     void rejects_append_when_matching_event_exists_after_condition_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbEventStream readModel = eventStore.read(tagsAllOf("name:1"));
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThatThrownBy(() -> eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameChanged", "name:1")),
                 failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
@@ -178,14 +177,13 @@ class InMemoryEventStoreDcbTest {
     @Test
     void append_condition_ignores_excluded_event_types_after_condition_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbQuery query = tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"));
         DcbEventStream readModel = eventStore.read(query);
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameSnapshot", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameSnapshot", "name:1")));
 
         DcbAppendResult result = eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameChanged", "name:1")),
                 failIfEventsMatch(query, readModel.lastSequencePosition()));
 
@@ -195,14 +193,13 @@ class InMemoryEventStoreDcbTest {
     @Test
     void append_condition_rejects_non_excluded_event_types_after_condition_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbQuery query = tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"));
         DcbEventStream readModel = eventStore.read(query);
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThatThrownBy(() -> eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameImported", "name:1")),
                 failIfEventsMatch(query, readModel.lastSequencePosition())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
@@ -213,9 +210,9 @@ class InMemoryEventStoreDcbTest {
         InMemoryEventStore eventStore = new InMemoryEventStore();
         CloudEvent cloudEvent = taggedEvent("NameDefined", "name:1");
 
-        eventStore.append("dcb:partition:0", List.of(cloudEvent));
+        eventStore.append(List.of(cloudEvent));
 
-        assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(cloudEvent)))
+        assertThatThrownBy(() -> eventStore.append(List.of(cloudEvent)))
                 .isExactlyInstanceOf(DuplicateCloudEventException.class);
     }
 
@@ -227,7 +224,7 @@ class InMemoryEventStoreDcbTest {
                 .withData("{\"tags\":[\"name:1\"]}".getBytes(UTF_8))
                 .build(), Set.of("name:2"));
 
-        eventStore.append("dcb:partition:0", List.of(cloudEvent));
+        eventStore.append(List.of(cloudEvent));
 
         assertThat(eventStore.read(tagsAllOf("name:1")).events()).isEmpty();
         assertThat(eventStore.read(tagsAllOf("name:2")).events()).hasSize(1);
@@ -236,18 +233,18 @@ class InMemoryEventStoreDcbTest {
     @Test
     void delete_all_resets_dcb_sequence() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
 
         eventStore.deleteAll();
 
         assertThat(eventStore.read(all()).lastSequencePosition()).isZero();
-        assertThat(eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1"))).firstSequencePosition()).isEqualTo(1);
+        assertThat(eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).firstSequencePosition()).isEqualTo(1);
     }
 
     @Test
     void last_sequence_position_is_the_store_head_not_the_max_matched_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "name:2")));
@@ -267,15 +264,15 @@ class InMemoryEventStoreDcbTest {
     void failed_append_does_not_consume_a_dcb_position() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
         CloudEvent duplicate = taggedEvent("NameDefined", "name:1");
-        DcbAppendResult first = eventStore.append("dcb:partition:0", List.of(duplicate));
+        DcbAppendResult first = eventStore.append(List.of(duplicate));
 
-        assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(duplicate)))
+        assertThatThrownBy(() -> eventStore.append(List.of(duplicate)))
                 .isExactlyInstanceOf(DuplicateCloudEventException.class);
 
         // The shared DcbAppendResult contract only guarantees ordering across appends, but the in-memory store
         // advances its position counter only after an append commits, so a rejected append consumes no position
         // and the next successful append gets exactly the following position.
-        DcbAppendResult next = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:2")));
+        DcbAppendResult next = eventStore.append(List.of(taggedEvent("NameChanged", "name:2")));
         assertThat(next.firstSequencePosition()).isEqualTo(first.lastSequencePosition() + 1);
         assertThat(next.lastSequencePosition()).isEqualTo(next.firstSequencePosition());
     }
@@ -283,9 +280,9 @@ class InMemoryEventStoreDcbTest {
     @Test
     void exists_and_count_report_matching_dcb_events() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "order:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("OrderPlaced", "order:1")));
 
         assertThat(eventStore.exists(tagsAllOf("name:1"))).isTrue();
         assertThat(eventStore.exists(tagsAllOf("absent:1"))).isFalse();
@@ -297,9 +294,9 @@ class InMemoryEventStoreDcbTest {
     @Test
     void read_honors_up_to_sequence_position_upper_bound() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("OrderPlaced", "name:1")));
 
         DcbEventStream upToTwo = eventStore.read(tagsAllOf("name:1"), DcbReadOptions.upToSequencePosition(2));
 
@@ -311,9 +308,9 @@ class InMemoryEventStoreDcbTest {
     @Test
     void any_of_matches_the_union_of_its_items() {
         InMemoryEventStore eventStore = new InMemoryEventStore();
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("OrderPlaced", "order:1")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("Unrelated", "other:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("OrderPlaced", "order:1")));
+        eventStore.append(List.of(taggedEvent("Unrelated", "other:1")));
 
         DcbQuery query = anyOf(
                 DcbQueryItem.types(List.of("NameDefined")),

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -21,6 +21,7 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 import org.occurrent.eventstore.api.DuplicateCloudEventException;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.WriteCondition;
@@ -88,6 +89,23 @@ class InMemoryEventStoreDcbTest {
         assertThat(eventStream.events())
                 .extracting(CloudEvent::getType)
                 .containsExactly("NameDefined", "NameChanged", "OrderPlaced");
+    }
+
+    @Test
+    void dcb_append_with_condition_places_the_same_boundary_in_the_same_stream_regardless_of_per_event_tags() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+
+        // Two appends to the same boundary (game:1), but each event carries a different extra tag. Placement must
+        // follow the condition's boundary tags, not the per-event tags, so both land in the same partition stream.
+        eventStore.append(List.of(taggedEvent("NameDefined", "game:1", "extra:a")), failIfEventsMatch(tagsAllOf("game:1")));
+        long head = eventStore.read(tagsAllOf("game:1")).lastSequencePosition();
+        eventStore.append(List.of(taggedEvent("NameChanged", "game:1", "extra:b")), failIfEventsMatch(tagsAllOf("game:1"), head));
+
+        List<String> streamIds = eventStore.read(tagsAllOf("game:1")).events().stream()
+                .map(event -> (String) event.getExtension(OccurrentCloudEventExtension.STREAM_ID))
+                .distinct()
+                .toList();
+        assertThat(streamIds).hasSize(1);
     }
 
     @Test

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -21,7 +21,7 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.cloudevents.OccurrentExtensionGetter;
 import org.occurrent.eventstore.api.DuplicateCloudEventException;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.WriteCondition;
@@ -102,10 +102,11 @@ class InMemoryEventStoreDcbTest {
         eventStore.append(List.of(taggedEvent("NameChanged", "game:1", "extra:b")), failIfEventsMatch(tagsAllOf("game:1"), head));
 
         List<String> streamIds = eventStore.read(tagsAllOf("game:1")).events().stream()
-                .map(event -> (String) event.getExtension(OccurrentCloudEventExtension.STREAM_ID))
+                .map(OccurrentExtensionGetter::getStreamId)
                 .distinct()
                 .toList();
         assertThat(streamIds).hasSize(1);
+        assertThat(streamIds.get(0)).startsWith("dcb:partition:");
     }
 
     @Test

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
@@ -19,6 +19,8 @@ package org.occurrent.eventstore.mongodb.spring.blocking;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
+import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
+import org.occurrent.eventstore.api.dcb.PartitionedDcbStreamIdGenerator;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.MongoTransactionManager;
@@ -50,6 +52,7 @@ public class EventStoreConfig {
     public final Function<Query, Query> queryOptions;
     public final Function<Query, Query> readOptions;
     public final Set<SpringMongoEventStoreCapability> eventStoreCapabilities;
+    public final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create a new instance of {@code EventStoreConfig}.
@@ -59,10 +62,10 @@ public class EventStoreConfig {
      * @param timeRepresentation       How time should be represented in the database
      */
     public EventStoreConfig(String eventStoreCollectionName, TransactionTemplate transactionTemplate, TimeRepresentation timeRepresentation) {
-        this(eventStoreCollectionName, transactionTemplate, timeRepresentation, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_READ_OPTIONS_FUNCTION, DEFAULT_EVENT_STORE_CAPABILITIES);
+        this(eventStoreCollectionName, transactionTemplate, timeRepresentation, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_READ_OPTIONS_FUNCTION, DEFAULT_EVENT_STORE_CAPABILITIES, new PartitionedDcbStreamIdGenerator());
     }
 
-    private EventStoreConfig(String eventStoreCollectionName, TransactionTemplate transactionTemplate, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions, Set<SpringMongoEventStoreCapability> eventStoreCapabilities) {
+    private EventStoreConfig(String eventStoreCollectionName, TransactionTemplate transactionTemplate, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions, Set<SpringMongoEventStoreCapability> eventStoreCapabilities, DcbStreamIdGenerator dcbStreamIdGenerator) {
         requireNonNull(eventStoreCollectionName, "Event store collection name cannot be null");
         requireNonNull(transactionTemplate, TransactionTemplate.class.getSimpleName() + " cannot be null");
         requireNonNull(timeRepresentation, TimeRepresentation.class.getSimpleName() + " cannot be null");
@@ -70,6 +73,7 @@ public class EventStoreConfig {
         if (eventStoreCapabilities.isEmpty()) {
             throw new IllegalArgumentException("Event store capabilities cannot be empty");
         }
+        requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
         // Note that we deliberately allow the WriteConcern to be null in order to be able to use the default MongoTemplate settings
         this.eventStoreCollectionName = eventStoreCollectionName;
         this.transactionTemplate = transactionTemplate;
@@ -77,6 +81,7 @@ public class EventStoreConfig {
         this.queryOptions = queryOptions;
         this.readOptions = readOptions;
         this.eventStoreCapabilities = Set.copyOf(eventStoreCapabilities);
+        this.dcbStreamIdGenerator = dcbStreamIdGenerator;
     }
 
     @Override
@@ -84,12 +89,12 @@ public class EventStoreConfig {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig)) return false;
         EventStoreConfig that = (EventStoreConfig) o;
-        return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionTemplate, that.transactionTemplate) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities);
+        return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionTemplate, that.transactionTemplate) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventStoreCollectionName, transactionTemplate, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities);
+        return Objects.hash(eventStoreCollectionName, transactionTemplate, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities, dcbStreamIdGenerator);
     }
 
     @Override
@@ -101,6 +106,7 @@ public class EventStoreConfig {
                 .add("queryOptions=" + queryOptions)
                 .add("readOptions=" + readOptions)
                 .add("eventStoreCapabilities=" + eventStoreCapabilities)
+                .add("dcbStreamIdGenerator=" + dcbStreamIdGenerator)
                 .toString();
     }
 
@@ -112,6 +118,7 @@ public class EventStoreConfig {
         private Function<Query, Query> queryOptions = DEFAULT_QUERY_OPTIONS_FUNCTION;
         private Function<Query, Query> readOptions = DEFAULT_READ_OPTIONS_FUNCTION;
         private Set<SpringMongoEventStoreCapability> eventStoreCapabilities = DEFAULT_EVENT_STORE_CAPABILITIES;
+        private DcbStreamIdGenerator dcbStreamIdGenerator = new PartitionedDcbStreamIdGenerator();
 
         /**
          * @param eventStoreCollectionName The collection in which the events are persisted
@@ -227,8 +234,22 @@ public class EventStoreConfig {
             return eventStoreCapabilities(capabilities);
         }
 
+        /**
+         * Choose how DCB-written events are placed into Occurrent storage streams. The default partitions them
+         * across a fixed number of streams keyed by the events' DCB tags. The placement does not affect DCB read or
+         * append-condition semantics, which are global by sequence position and tags.
+         *
+         * @param dcbStreamIdGenerator The generator that derives the storage stream id from the events' DCB tags.
+         * @return The same {@code Builder} instance.
+         */
+        @NullMarked
+        public Builder dcbStreamIdGenerator(DcbStreamIdGenerator dcbStreamIdGenerator) {
+            this.dcbStreamIdGenerator = requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
+            return this;
+        }
+
         public EventStoreConfig build() {
-            return new EventStoreConfig(eventStoreCollectionName, transactionTemplate, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities);
+            return new EventStoreConfig(eventStoreCollectionName, transactionTemplate, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities, dcbStreamIdGenerator);
         }
     }
 }

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -332,7 +332,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
-        String streamId = dcbStreamIdGenerator.generateStreamId(boundaryTagsOf(eventsToAppend));
+        // Place by the condition's boundary tags when there is one, so the same boundary always lands in the same
+        // partition regardless of per-event tags. Fall back to the events' tags when there is no condition.
+        Set<String> placementTags = condition != null ? DcbCloudEvents.boundaryTags(condition.query()) : boundaryTagsOf(eventsToAppend);
+        String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
 
         return requireNonNull(transactionTemplate.execute(transactionStatus -> {
             long firstPosition = reserveDcbPositions(eventsToAppend.size());

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -332,9 +332,11 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
-        // Place by the condition's boundary tags when there is one, so the same boundary always lands in the same
-        // partition regardless of per-event tags. Fall back to the events' tags when there is no condition.
-        Set<String> placementTags = condition != null ? DcbCloudEvents.boundaryTags(condition.query()) : boundaryTagsOf(eventsToAppend);
+        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
+        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
+        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
+        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
         String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
 
         return requireNonNull(transactionTemplate.execute(transactionStatus -> {

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -103,6 +103,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     private final Function<Query, Query> queryOptions;
     private final Function<Query, Query> readOptions;
     private final Set<SpringMongoEventStoreCapability> eventStoreCapabilities;
+    private final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create a new instance of {@code SpringBlockingMongoEventStore}
@@ -122,6 +123,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         this.queryOptions = config.queryOptions;
         this.readOptions = config.readOptions;
         this.eventStoreCapabilities = config.eventStoreCapabilities;
+        this.dcbStreamIdGenerator = config.dcbStreamIdGenerator;
         initializeEventStore(eventStoreCollectionName, dcbPositionCollectionName, dcbCheckpointCollectionName, eventStoreCapabilities, mongoTemplate);
     }
 
@@ -203,16 +205,16 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     @Override
-    public DcbAppendResult append(String streamId, List<CloudEvent> events) {
+    public DcbAppendResult append(List<CloudEvent> events) {
         requireDcbCapability();
-        return appendDcb(streamId, events, null);
+        return appendDcb(events, null);
     }
 
     @Override
-    public DcbAppendResult append(String streamId, List<CloudEvent> events, DcbAppendCondition condition) {
+    public DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition) {
         requireDcbCapability();
         requireNonNull(condition, "Append condition cannot be null");
-        return appendDcb(streamId, events, condition);
+        return appendDcb(events, condition);
     }
 
     @Override
@@ -328,9 +330,9 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return mapWithIndex(cloudEvents, currentStreamVersion, pair -> convertToDocument(timeRepresentation, streamId, pair.t1, pair.t2)).toList();
     }
 
-    private DcbAppendResult appendDcb(String streamId, List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
-        requireNonNull(streamId, "Stream id cannot be null");
+    private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
+        String streamId = dcbStreamIdGenerator.generateStreamId(boundaryTagsOf(eventsToAppend));
 
         return requireNonNull(transactionTemplate.execute(transactionStatus -> {
             long firstPosition = reserveDcbPositions(eventsToAppend.size());
@@ -344,6 +346,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             insertAll(streamId, currentStreamVersion, WriteCondition.anyStreamVersion(), documents);
             return new DcbAppendResult(firstPosition, lastPosition, eventsToAppend.size());
         }));
+    }
+
+    private static Set<String> boundaryTagsOf(List<CloudEvent> events) {
+        return events.stream().flatMap(event -> DcbCloudEvents.getTags(event).stream()).collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
     }
 
     private List<Document> convertDcbCloudEventsToDocuments(String streamId, List<CloudEvent> cloudEvents, long currentStreamVersion, long firstPosition) {

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -337,7 +337,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
         Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
         Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
-        String streamId = dcbStreamIdGenerator.generateStreamId(placementTags);
+        String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
 
         return requireNonNull(transactionTemplate.execute(transactionStatus -> {
             long firstPosition = reserveDcbPositions(eventsToAppend.size());

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreCapabilityTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreCapabilityTest.java
@@ -175,8 +175,8 @@ class SpringMongoEventStoreCapabilityTest {
         SpringMongoEventStore eventStore = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM).build());
 
         assertUnsupportedDcbOperation(() -> eventStore.read(tagsAllOf("name:1")));
-        assertUnsupportedDcbOperation(() -> eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1"))));
-        assertUnsupportedDcbOperation(() -> eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")), DcbAppendCondition.failIfEventsMatch(tagsAllOf("name:1"))));
+        assertUnsupportedDcbOperation(() -> eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))));
+        assertUnsupportedDcbOperation(() -> eventStore.append(List.of(taggedEvent("NameDefined", "name:1")), DcbAppendCondition.failIfEventsMatch(tagsAllOf("name:1"))));
     }
 
     @Test
@@ -202,7 +202,7 @@ class SpringMongoEventStoreCapabilityTest {
         SpringMongoEventStore eventStore = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM, DCB).build());
 
         eventStore.write("name:1", WriteCondition.anyStreamVersion(), java.util.stream.Stream.of(event("NameDefined")));
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThat(eventStore.read("name:1").events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
         assertThat(eventStore.read(tagsAllOf("name:1")).events()).extracting(CloudEvent::getType).containsExactly("NameChanged");
@@ -214,7 +214,7 @@ class SpringMongoEventStoreCapabilityTest {
         streamOnly.write("name:1", WriteCondition.anyStreamVersion(), java.util.stream.Stream.of(event("NameDefined")));
 
         SpringMongoEventStore both = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM, DCB).build());
-        both.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        both.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThat(both.read("name:1").events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
         assertThat(both.read(tagsAllOf("name:1")).events()).extracting(CloudEvent::getType).containsExactly("NameChanged");
@@ -223,27 +223,35 @@ class SpringMongoEventStoreCapabilityTest {
     @Test
     void dcb_to_stream_and_dcb_preserves_dcb_reads_and_enables_stream_reads_of_dcb_events() {
         SpringMongoEventStore dcbOnly = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(DCB).build());
-        dcbOnly.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
-        dcbOnly.append("dcb:partition:1", List.of(taggedEvent("OrderPlaced", "order:1")));
+        dcbOnly.append(List.of(taggedEvent("NameDefined", "name:1")));
+        dcbOnly.append(List.of(taggedEvent("OrderPlaced", "order:1")));
 
         SpringMongoEventStore both = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM, DCB).build());
 
         assertThat(both.read(tagsAllOf("name:1")).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
-        assertThat(both.read("dcb:partition:0").events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
-        assertThat(both.read("dcb:partition:0").version()).isEqualTo(1);
-        assertThat(both.read("dcb:partition:1").events()).extracting(CloudEvent::getType).containsExactly("OrderPlaced");
-        assertThat(both.read("dcb:partition:1").version()).isEqualTo(1);
+        assertThat(both.read(tagsAllOf("order:1")).events()).extracting(CloudEvent::getType).containsExactly("OrderPlaced");
+
+        // DCB-written events are still stored as normal Occurrent stream events, readable via the stream API by the
+        // storage stream id the store derived for them from the events' DCB tags.
+        String nameStreamId = OccurrentExtensionGetter.getStreamId(both.read(tagsAllOf("name:1")).events().get(0));
+        String orderStreamId = OccurrentExtensionGetter.getStreamId(both.read(tagsAllOf("order:1")).events().get(0));
+        assertThat(nameStreamId).startsWith("dcb:partition:");
+        assertThat(orderStreamId).startsWith("dcb:partition:");
+        assertThat(both.read(nameStreamId).events()).extracting(CloudEvent::getType).contains("NameDefined");
+        assertThat(both.read(orderStreamId).events()).extracting(CloudEvent::getType).contains("OrderPlaced");
     }
 
     @Test
     void dcb_only_events_still_have_occurrent_stream_metadata() {
         SpringMongoEventStore dcbOnly = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(DCB).build());
-        dcbOnly.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1"), taggedEvent("NameChanged", "name:1")));
+        dcbOnly.append(List.of(taggedEvent("NameDefined", "name:1"), taggedEvent("NameChanged", "name:1")));
 
         List<CloudEvent> events = dcbOnly.read(tagsAllOf("name:1")).events();
 
         assertThat(events).hasSize(2);
-        assertThat(events).extracting(OccurrentExtensionGetter::getStreamId).containsExactly("dcb:partition:0", "dcb:partition:0");
+        // Appended together, so both events share the same derived partition stream, in order.
+        assertThat(events).extracting(OccurrentExtensionGetter::getStreamId).allSatisfy(streamId -> assertThat(streamId).startsWith("dcb:partition:"));
+        assertThat(OccurrentExtensionGetter.getStreamId(events.get(0))).isEqualTo(OccurrentExtensionGetter.getStreamId(events.get(1)));
         assertThat(events).extracting(OccurrentExtensionGetter::getStreamVersion).containsExactly(1L, 2L);
     }
 
@@ -251,12 +259,14 @@ class SpringMongoEventStoreCapabilityTest {
     void stream_and_dcb_to_stream_preserves_stream_reads_for_stream_and_dcb_written_events() {
         SpringMongoEventStore both = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM, DCB).build());
         both.write("name:1", WriteCondition.anyStreamVersion(), java.util.stream.Stream.of(event("NameDefined")));
-        both.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        both.append(List.of(taggedEvent("NameChanged", "name:1")));
+        String dcbStreamId = OccurrentExtensionGetter.getStreamId(both.read(tagsAllOf("name:1")).events().get(0));
 
         SpringMongoEventStore streamOnly = new SpringMongoEventStore(mongoTemplate, eventStoreConfig(STREAM).build());
 
         assertThat(streamOnly.read("name:1").events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
-        assertThat(streamOnly.read("dcb:partition:0").events()).extracting(CloudEvent::getType).containsExactly("NameChanged");
+        assertThat(dcbStreamId).startsWith("dcb:partition:");
+        assertThat(streamOnly.read(dcbStreamId).events()).extracting(CloudEvent::getType).contains("NameChanged");
         assertThatThrownBy(() -> streamOnly.read(tagsAllOf("name:1")))
                 .isExactlyInstanceOf(UnsupportedOperationException.class);
     }

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -93,7 +93,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void dcb_writes_are_visible_to_normal_event_store_queries() {
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
 
         assertThat(eventStore.all(SortBy.natural(SortBy.SortDirection.ASCENDING)))
                 .extracting(CloudEvent::getType)
@@ -105,7 +105,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void reads_events_matching_type_or_all_tags_after_sequence_position() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1", "tenant:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -124,7 +124,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void reads_tagged_events_except_excluded_types() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameSnapshot", "name:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -138,7 +138,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void reads_type_and_tagged_events_except_excluded_types() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "name:1")));
@@ -155,7 +155,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void applies_excluded_types_per_query_item() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameSnapshot", "name:1"),
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -171,13 +171,12 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void rejects_append_when_matching_event_exists_after_condition_position() {
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbEventStream readModel = eventStore.read(tagsAllOf("name:1"));
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThatThrownBy(() -> eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameChanged", "name:1")),
                 failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
@@ -185,14 +184,13 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void append_condition_ignores_excluded_event_types_after_condition_position() {
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbQuery query = tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"));
         DcbEventStream readModel = eventStore.read(query);
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameSnapshot", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameSnapshot", "name:1")));
 
         DcbAppendResult result = eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameChanged", "name:1")),
                 failIfEventsMatch(query, readModel.lastSequencePosition()));
 
@@ -201,14 +199,13 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void append_condition_rejects_non_excluded_event_types_after_condition_position() {
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbQuery query = tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"));
         DcbEventStream readModel = eventStore.read(query);
 
-        eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
 
         assertThatThrownBy(() -> eventStore.append(
-                "dcb:partition:0",
                 List.of(taggedEvent("NameImported", "name:1")),
                 failIfEventsMatch(query, readModel.lastSequencePosition())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
@@ -217,12 +214,12 @@ class SpringMongoEventStoreDcbTest {
     @Test
     void rolls_back_position_reservation_when_duplicate_cloud_event_fails_insert() {
         CloudEvent cloudEvent = taggedEvent("NameDefined", "name:1");
-        eventStore.append("dcb:partition:0", List.of(cloudEvent));
+        eventStore.append(List.of(cloudEvent));
 
-        assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(cloudEvent)))
+        assertThatThrownBy(() -> eventStore.append(List.of(cloudEvent)))
                 .isExactlyInstanceOf(DuplicateCloudEventException.class);
 
-        DcbAppendResult appendResult = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")));
+        DcbAppendResult appendResult = eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
         assertThat(appendResult.firstSequencePosition()).isEqualTo(2);
         assertThat(appendResult.lastSequencePosition()).isEqualTo(2);
     }
@@ -232,13 +229,13 @@ class SpringMongoEventStoreDcbTest {
         DcbEventStream readModel = eventStore.read(tagsAllOf("name:1"));
         DcbAppendCondition appendCondition = failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition());
 
-        DcbAppendResult firstAppend = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameDefined", "name:1")), appendCondition);
+        DcbAppendResult firstAppend = eventStore.append(List.of(taggedEvent("NameDefined", "name:1")), appendCondition);
         assertThat(firstAppend).isEqualTo(new DcbAppendResult(1, 1, 1));
 
-        assertThatThrownBy(() -> eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:1")), appendCondition))
+        assertThatThrownBy(() -> eventStore.append(List.of(taggedEvent("NameChanged", "name:1")), appendCondition))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
 
-        DcbAppendResult nextAppend = eventStore.append("dcb:partition:0", List.of(taggedEvent("NameChanged", "name:2")));
+        DcbAppendResult nextAppend = eventStore.append(List.of(taggedEvent("NameChanged", "name:2")));
         assertThat(nextAppend).isEqualTo(new DcbAppendResult(2, 2, 1));
     }
 
@@ -249,7 +246,7 @@ class SpringMongoEventStoreDcbTest {
                 .withData("{\"tags\":[\"name:1\"]}".getBytes(UTF_8))
                 .build(), Set.of("name:2"));
 
-        eventStore.append("dcb:partition:0", List.of(cloudEvent));
+        eventStore.append(List.of(cloudEvent));
 
         assertThat(eventStore.read(tagsAllOf("name:1")).events()).isEmpty();
         assertThat(eventStore.read(tagsAllOf("name:2")).events()).hasSize(1);
@@ -257,7 +254,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void last_sequence_position_is_the_store_head_not_the_max_matched_position() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "name:2")));
@@ -275,7 +272,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void exists_and_count_report_matching_dcb_events() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "order:1")));
@@ -288,7 +285,7 @@ class SpringMongoEventStoreDcbTest {
 
     @Test
     void read_honors_up_to_sequence_position_upper_bound() {
-        eventStore.append("dcb:partition:0", List.of(
+        eventStore.append(List.of(
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("NameChanged", "name:1"),
                 taggedEvent("OrderPlaced", "name:1")));

--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
@@ -153,7 +153,7 @@ public class SpringMongoSubscriptionModelTest {
         NameDefined nameDefined = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
 
         // When
-        mongoEventStore.append("dcb:partition:0", serialize(nameDefined)
+        mongoEventStore.append(serialize(nameDefined)
                 .map(event -> DcbCloudEvents.withTags(event, List.of("name:1")))
                 .toList());
 


### PR DESCRIPTION
Stops the DCB model from leaking Occurrent storage placement. `DcbEventStore.append` no longer takes a storage stream id:

```java
DcbAppendResult append(List<CloudEvent> events);
DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition);
```

Callers now reason purely in DCB terms (tags and append conditions). The event store derives the storage stream from the appended events' DCB tags using a `DcbStreamIdGenerator` it owns. `DcbStreamIdGenerator` and `PartitionedDcbStreamIdGenerator` moved from the application-service module into `eventstore/api/dcb` so the store can use them. `InMemoryEventStore` takes the generator through a constructor (defaulting to partitioned), `SpringMongoEventStore` through `EventStoreConfig`. `GenericDcbApplicationService` no longer derives or passes a stream id, and placement is now configured on the store.

This is unreleased API, so it is a breaking change made now while it is free.

Important: this keeps the prior decision intact. DCB-written events still keep `streamid` and `streamversion` metadata and still land in partition streams, so the DCB-to-stream switch described in ADR 0018 and 0019 still works (you can read them through the stream APIs by their partition stream ids). Only the public API stops exposing the storage stream id, the placement itself stays internal. ADR 0017 is updated to reflect that the store, not the application service, derives placement.

Safe because in both stores the stream id was only physical placement. DCB reads and conflict detection are global (by `dcbposition`, tags, and checkpoints), and the Mongo append uses `anyStreamVersion()`, so changing how the stream id is derived does not affect read or conflict semantics.

Tests that asserted a DCB event lived in a specific `dcb:partition:0` stream were relaxed to read the actual derived partition id (placement is derived now). Assertions about `dcbposition`, tags, ordering, and counts are unchanged.

Verification: `mvn test-compile` green across the project, the api/inmemory/app-service/dcb-dsl suites pass, `SpringMongoEventStoreDcbTest` + `SpringMongoEventStoreCapabilityTest` are 27/27, and `SpringMongoSubscriptionModelTest` is 28/28.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-dsl-ergonomics","parentHead":"a2fc81141e047f02ec30a028abaea912cfaa3770","parentPull":206,"trunk":"main"}
```
-->
