### PR TITLE
Close count-to-read window event loss in CatchupSubscriptionModel handover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+### Changelog next version
+
+* Fixed a remaining silent event loss in `CatchupSubscriptionModel` at the handover from the catch-up phase to the live subscription.
+  * The delta reconciliation sized its read from a count of matching events and then read the newest N of them. An event written in the window between that count and the read shifted the newest-N window forward and pushed the oldest during-catch-up event out of the read. That event sat at or before the live subscription's resume position, so the live subscription did not redeliver it either, and it was lost. This is the residual case left open by the 0.20.4 fix, which closed the clock-skew variant but not the count-to-read window.
+  * The reconciliation now re-reads the recent tail until the matching count stops growing, so an event that arrives in the count-to-read window is picked up by a later pass instead of being skipped. Overlapping passes are deduplicated through the handover cache, so at-least-once delivery is preserved without introducing duplicates.
+  * See [ADR 14](doc/architecture/decisions/0014-reconcile-catchup-events-by-insertion-order-to-avoid-loss-under-clock-skew.md).
+
 ### 0.20.4 (2026-06-18)
 
 * Fixed a silent event loss in `CatchupSubscriptionModel` at the handover from the catch-up phase to the live subscription.

--- a/doc/architecture/decisions/0014-reconcile-catchup-events-by-insertion-order-to-avoid-loss-under-clock-skew.md
+++ b/doc/architecture/decisions/0014-reconcile-catchup-events-by-insertion-order-to-avoid-loss-under-clock-skew.md
@@ -38,6 +38,21 @@ eventStoreQueries.query(catchupFilter, 0, numberOfEventsNotConsumed, SortBy.natu
 
 `SortBy.natural` is insertion order. It is monotonic with insertion regardless of the events' `time`, so a clock-skewed event written during the replay is still among the newest events and is no longer skipped. The live resume position stays captured after the bulk replay, so its token stays fresh and the oplog problem above does not arise. The bulk replay keeps `catchupPhaseSortBy` unchanged, so its time-ordered delivery and its index requirements are the same as before.
 
+The delta size comes from a count, and the count and the `$natural` read are not atomic: an event written between them inflates the store and shifts the newest-N window forward, pushing the oldest during-catch-up event out of the read. That event sits at or before the live resume position, so the live subscription would not redeliver it either, and it would be lost. To close that window the delta step re-reads until the matching count stops growing:
+
+```java
+long reconciledThroughCount = numberOfEventsBeforeStartingCatchupSubscription;
+long matchingEventCount = eventStoreQueries.count(catchupFilter);
+while (matchingEventCount > reconciledThroughCount) {
+    long numberOfEventsToReconcile = matchingEventCount - numberOfEventsBeforeStartingCatchupSubscription;
+    // read newest numberOfEventsToReconcile in SortBy.natural(DESCENDING), reverse, deliver through the cache
+    reconciledThroughCount = matchingEventCount;
+    matchingEventCount = eventStoreQueries.count(catchupFilter);
+}
+```
+
+Each pass reads every event after the pre-catch-up boundary, so a pass during which no event is written has necessarily delivered them all; any event written after a pass is, by definition, newer than the live resume position and is covered by the live subscription regardless. Re-reads re-deliver already-seen events, which the existing handover cache dedupes (delivery stays at-least-once).
+
 `SortBy.natural` has to mean the same thing on both event stores for this to be correct. On MongoDB it maps to `$natural`, which is global insertion order. On `InMemoryEventStore` it iterated the per-stream map, so an event appended to an existing stream was grouped with that stream rather than placed at the global end. That is now fixed: `InMemoryEventStore` assigns each event a global insertion sequence at write time and sorts `SortBy.natural` by it, matching MongoDB. The existing test `sort_by_natural_asc_sorts_by_insertion_order` already described this intent, it only passed before because it wrote one event per stream.
 
 ### Performance
@@ -67,5 +82,6 @@ Positive:
 Negative:
 
 - The delta's reverse `$natural` scan is not index-backed. With a selective filter on a busy store it reads recent non-matching writes until it has `delta` matches. For large rebuilds, keep the replay window low-write so this stays small. This is the same operational posture the motivating rebuild already uses.
-- The delta size comes from a count difference (`count(catchupFilter)` after the replay minus the count before it), and the count and the `$natural` query are not atomic. Two narrow cases remain. If matching events are written between the after-replay count and the query, the newest-N window shifts forward and can push the oldest during-replay events out of it (those are below the live resume position, so they would be lost). If matching events are deleted during the replay, the net count understates how many were written and the query reads too few. The write window is tiny in practice because there is no I/O between the count and the query, and append-only stores never hit the delete case, but both are real. Closing them fully needs the global position from ADR 0008, or an ascending `skip = count-before` read that walks the whole backlog (the cost this change set out to avoid).
+- The delta size comes from a count difference (`count(catchupFilter)` after the replay minus the count before it), and the count and the `$natural` query are not atomic. The concurrent-write case, where an event written between the after-replay count and the query shifts the newest-N window and pushes the oldest during-replay events out of it (those are below the live resume position, so they would be lost), is closed by the re-read loop in the Decision: the loop keeps reading until the count stops growing, so a shifted-out event is picked up on a later pass. One narrow case remains: if matching events are deleted during the replay, the net count understates how many were written and the loop terminates having read too few. Append-only stores never hit this. Closing it fully needs the global position from ADR 0008. The loop also assumes the matching-event count eventually stabilises during catch-up. A store under sustained write saturation could keep it iterating, but catch-up is a bounded startup activity and the live subscription handles steady state.
+- The loop's termination depends on `count(catchupFilter)` being exact. The MongoDB store returns `estimatedDocumentCount` for `Filter.All`, which is the count used when a subscription replays from beginning of time with no filter, and that value is approximate. It can undercount after an unclean shutdown, which would terminate the loop early and lose events, and it can overcount under sharding, which only causes extra deduplicated reads. The in-memory store counts exactly. As with the deletion case, closing this fully needs the global position from ADR 0008, tracked for the position-based DCB catch-up. Until then a beginning-of-time rebuild on MongoDB should run against a cleanly shut down collection.
 - The no-live case (an in-memory projection that replays from beginning of time on every restart and never starts the wrapped subscription) relies on the same insertion-order delta and is correct on stores whose natural order is global insertion order.

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -222,26 +222,39 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
             globalSubscriptionPosition = subscriptionModel.globalSubscriptionPosition();
         }
 
-        // Here we check if new events have arrived during catchup phase, if so we stream/catch-up these events as well.
-        long numberOfEventsAfterCatchupSubscriptionCompleted = eventStoreQueries.count(catchupFilter);
-        long numberOfEventsNotConsumed = numberOfEventsAfterCatchupSubscriptionCompleted - numberOfEventsBeforeStartingCatchupSubscription;
-
         // We generate a cache so that events that are streamed at the same time as streaming the events missed
         // during the catch-up phase are not streamed again.
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
-        if (numberOfEventsNotConsumed > 0) {
-            // The events written during the catch-up phase are, by definition, the most-recently-inserted events.
-            // We fetch exactly them by reading the newest "numberOfEventsNotConsumed" events in *insertion order*
-            // (SortBy.natural, descending + limit, no skip) and then reversing them back to insertion order for
-            // delivery. Selecting by insertion order rather than the configurable, time-based catchupPhaseSortBy
-            // is what makes this reconciliation loss-free under clock skew: a during-catch-up event whose "time"
-            // is earlier than the replay cursor's already-passed position would otherwise sort before the
-            // already-processed boundary (missed here) and sit below the live subscription's resume position
-            // (missed there too), and would be silently lost. Reading the newest N in insertion order also reads
-            // only the recent tail instead of skipping the whole backlog, which matters on large event stores.
-            List<CloudEvent> eventsWrittenDuringCatchup = new ArrayList<>(eventStoreQueries.query(catchupFilter, 0, Math.toIntExact(numberOfEventsNotConsumed), SortBy.natural(DESCENDING)).toList());
+
+        // Reconcile events that arrived during the catch-up phase, i.e. those written after the bulk replay started
+        // but at or before the live subscription's resume position (globalSubscriptionPosition). They are, by
+        // definition, the most-recently-inserted matching events, so we read the newest ones in *insertion order*
+        // (SortBy.natural, descending + limit, no skip) and reverse them back to insertion order for delivery.
+        //
+        // Selecting by insertion order rather than the configurable, time-based catchupPhaseSortBy is what makes this
+        // reconciliation loss-free under clock skew: a during-catch-up event whose "time" is earlier than the replay
+        // cursor's already-passed position would otherwise sort before the already-processed boundary (missed here)
+        // and sit below the live subscription's resume position (missed there too), and would be silently lost.
+        // Reading the newest N in insertion order also reads only the recent tail instead of skipping the whole
+        // backlog, which matters on large event stores.
+        //
+        // The number to read is derived from a count, but more events can be written between that count and the read.
+        // Such a write inflates the store and shifts the "newest N" window forward, pushing the oldest during-catch-up
+        // event out of the read; being at or before globalSubscriptionPosition it would not be re-delivered by the live
+        // subscription either, and would be lost. To close that window we re-read until the matching count stops
+        // growing: each pass reads every event after the pre-catch-up boundary, so a pass during which no new event is
+        // written has necessarily delivered them all. Re-reads re-deliver already-seen events, which are deduped by the
+        // cache (delivery is at-least-once). Any event written after a pass is, by definition, newer than
+        // globalSubscriptionPosition and is therefore covered by the live subscription regardless.
+        long reconciledThroughCount = numberOfEventsBeforeStartingCatchupSubscription;
+        long matchingEventCount = eventStoreQueries.count(catchupFilter);
+        while (matchingEventCount > reconciledThroughCount) {
+            long numberOfEventsToReconcile = matchingEventCount - numberOfEventsBeforeStartingCatchupSubscription;
+            List<CloudEvent> eventsWrittenDuringCatchup = new ArrayList<>(eventStoreQueries.query(catchupFilter, 0, Math.toIntExact(numberOfEventsToReconcile), SortBy.natural(DESCENDING)).toList());
             Collections.reverse(eventsWrittenDuringCatchup);
             runCatchupForStream(eventsWrittenDuringCatchup.stream(), subscriptionId, action, catchupPhaseCache);
+            reconciledThroughCount = matchingEventCount;
+            matchingEventCount = eventStoreQueries.count(catchupFilter);
         }
 
         // We check if the delegated subscription model is not allowed to subscribe. If so, we remove any temporary subscription position written during the catchup phase
@@ -339,14 +352,21 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     }
 
     private void runCatchupForStream(Stream<CloudEvent> cloudEvents, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
-        Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId));
-        if (cache != null) {
-            takeWhile = takeWhile.peek(e -> cache.put(e.getId()));
+        // try-with-resources closes the source stream even when takeWhile short-circuits on shutdown, so a
+        // resource-backed read (the Spring Mongo bulk replay wraps a server cursor) does not leak its cursor.
+        try (cloudEvents) {
+            Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId));
+            if (cache != null) {
+                // Skip events already delivered in an earlier reconciliation pass (the during-catch-up delta is re-read
+                // until the matching count stabilises, so passes overlap) and record the rest so the live subscription can
+                // skip them at the handover seam. Without the filter the overlapping re-reads would deliver duplicates.
+                takeWhile = takeWhile.filter(e -> !cache.isCached(e.getId())).peek(e -> cache.put(e.getId()));
+            }
+            takeWhile
+                    .peek(action)
+                    .filter(returnIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, PersistSubscriptionPositionDuringCatchupPhase::persistCloudEventPositionPredicate).orElse(__ -> false))
+                    .forEach(e -> doIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, cfg -> cfg.storage().save(subscriptionId, TimeBasedSubscriptionPosition.from(e.getTime()))));
         }
-        takeWhile
-                .peek(action)
-                .filter(returnIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, PersistSubscriptionPositionDuringCatchupPhase::persistCloudEventPositionPredicate).orElse(__ -> false))
-                .forEach(e -> doIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, cfg -> cfg.storage().save(subscriptionId, TimeBasedSubscriptionPosition.from(e.getTime()))));
     }
 
     private static SubscriptionModelContext generateSubscriptionModelContext() {

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelTest.java
@@ -33,8 +33,10 @@ import org.occurrent.domain.DomainEvent;
 import org.occurrent.domain.NameDefined;
 import org.occurrent.domain.NameWasChanged;
 import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.mongodb.nativedriver.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
+import org.occurrent.filter.Filter;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.StartAt;
@@ -51,10 +53,12 @@ import org.testcontainers.mongodb.MongoDBContainer;
 import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.time.ZoneOffset.UTC;
@@ -375,6 +379,126 @@ public class CatchupSubscriptionModelTest {
                 assertThat(state).hasSize(5).extracting(this::deserialize).containsExactly(nameDefined1, nameDefined2, nameChanged1, nameDefined3, nameDefined4));
 
         thread.join();
+    }
+
+    /**
+     * Deterministic reproduction of the catch-up to live handover loss race. The catch-up phase sizes its
+     * during-catch-up reconciliation from a count and then reads the newest N events; an event written in the window
+     * between that count and the read shifts the "newest N" window forward and pushes the oldest during-catch-up event
+     * out of the read. Since that event sits at or before the live subscription's resume position it is not redelivered
+     * by the live subscription either, and is silently lost.
+     * <p>
+     * We force the race with a spying {@link EventStoreQueries} that injects writes at the exact handover seams instead
+     * of relying on timing: two events written during the bulk replay (so they can only reach the subscriber through
+     * the reconciliation, never the live subscription), and one "intruder" written between the post-replay count and
+     * the reconciliation read. On the unfixed code the first during-catch-up event is lost; the fix re-reads until the
+     * count stabilises and delivers it.
+     */
+    @Test
+    void catchup_subscription_does_not_lose_events_written_in_the_count_to_read_window_during_handover() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        NameDefined historic1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "historic1");
+        NameDefined historic2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(1), "name", "historic2");
+        NameWasChanged historic3 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(2), "name", "historic3");
+
+        mongoEventStore.write("h1", 0, serialize(historic1));
+        mongoEventStore.write("h2", 0, serialize(historic2));
+        mongoEventStore.write("h1", 1, serialize(historic3));
+
+        // Written during the bulk replay (after the replay cursor, at or before the live resume position), so they can
+        // only reach the subscriber through the during-catch-up reconciliation, not through the live subscription.
+        NameDefined duringCatchup1 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "duringCatchup1");
+        NameDefined duringCatchup2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(4), "name", "duringCatchup2");
+        // Written in the window between the post-replay count and the reconciliation read; on the buggy code this
+        // shifts the "newest N" window and pushes duringCatchup1 out of the read.
+        NameDefined windowIntruder = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(5), "name", "windowIntruder");
+
+        Runnable injectDuringBulkReplay = () -> {
+            mongoEventStore.write("d1", 0, serialize(duringCatchup1));
+            mongoEventStore.write("d2", 0, serialize(duringCatchup2));
+        };
+        Runnable injectBetweenCountAndRead = () -> mongoEventStore.write("i1", 0, serialize(windowIntruder));
+
+        EventStoreQueries spyingQueries = new HandoverRaceInducingQueries(mongoEventStore, injectDuringBulkReplay, injectBetweenCountAndRead);
+
+        subscription.shutdown(); // discard the idle subscription created in @BeforeEach (also shuts down its executor)
+        subscriptionExecutor = Executors.newCachedThreadPool();
+        NativeMongoSubscriptionModel wrappedSubscription = new NativeMongoSubscriptionModel(database, eventCollection, TimeRepresentation.DATE, subscriptionExecutor, RetryStrategy.none());
+        subscription = new CatchupSubscriptionModel(wrappedSubscription, spyingQueries,
+                new CatchupSubscriptionModelConfig(100, useSubscriptionPositionStorage(storage).andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1)));
+
+        CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+
+        // When
+        subscription.subscribe(UUID.randomUUID().toString(), StartAt.subscriptionPosition(TimeBasedSubscriptionPosition.beginningOfTime()), state::add).waitUntilStarted();
+
+        // Then -- every event up to and during the catch-up phase must be delivered. On the unfixed handover,
+        // duringCatchup1 is lost (shifted out of the reconciliation read and below the live resume position).
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+                assertThat(state).extracting(this::deserialize)
+                        .contains(historic1, historic2, historic3, duringCatchup1, duringCatchup2));
+
+        // And the reconciliation must not deliver duplicates: the loop re-reads overlapping windows, which the
+        // handover cache must dedupe. (No new events are written after the handover, so the set is stable now.)
+        assertThat(state).extracting(CloudEvent::getId).doesNotHaveDuplicates();
+    }
+
+    /**
+     * Delegating {@link EventStoreQueries} that deterministically injects writes at the catch-up handover seams to
+     * reproduce the count-to-read window race. The two-argument {@code query} represents the bulk replay; the
+     * four-argument {@code query} represents the reconciliation read; the second {@code count} call is the post-replay
+     * count whose result the reconciliation read is sized from.
+     */
+    private static final class HandoverRaceInducingQueries implements EventStoreQueries {
+        private final EventStoreQueries delegate;
+        private final Runnable injectDuringBulkReplay;
+        private final Runnable injectBetweenCountAndRead;
+        private final AtomicInteger countInvocations = new AtomicInteger();
+        private boolean bulkReplayInjectionDone = false;
+
+        private HandoverRaceInducingQueries(EventStoreQueries delegate, Runnable injectDuringBulkReplay, Runnable injectBetweenCountAndRead) {
+            this.delegate = delegate;
+            this.injectDuringBulkReplay = injectDuringBulkReplay;
+            this.injectBetweenCountAndRead = injectBetweenCountAndRead;
+        }
+
+        @Override
+        public Stream<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+            // Reconciliation read (and any later read): always reflects the current store.
+            return delegate.query(filter, skip, limit, sortBy);
+        }
+
+        @Override
+        public Stream<CloudEvent> query(Filter filter, SortBy sortBy) {
+            // Bulk replay: materialise the snapshot the cursor would have returned, then simulate events that are
+            // written after the cursor passed but before the post-replay count, so they fall to the reconciliation.
+            final List<CloudEvent> bulkReplaySnapshot;
+            try (Stream<CloudEvent> bulkReplay = delegate.query(filter, sortBy)) {
+                bulkReplaySnapshot = bulkReplay.collect(Collectors.toList());
+            }
+            if (!bulkReplayInjectionDone) {
+                bulkReplayInjectionDone = true;
+                injectDuringBulkReplay.run();
+            }
+            return bulkReplaySnapshot.stream();
+        }
+
+        @Override
+        public long count(Filter filter) {
+            long count = delegate.count(filter);
+            if (countInvocations.incrementAndGet() == 2) {
+                // The 2nd count is the post-replay count. Inject a concurrent write after it is taken but before the
+                // reconciliation read runs, reproducing the count-to-read window exactly.
+                injectBetweenCountAndRead.run();
+            }
+            return count;
+        }
+
+        @Override
+        public boolean exists(Filter filter) {
+            return delegate.exists(filter);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

Closes a remaining silent event loss in `CatchupSubscriptionModel` at the handover from the catch-up phase to the live subscription.

The catch-up phase reconciles events written during the bulk replay by sizing a read from `count(matchingEvents)` and then reading the newest N of them in natural insertion order. The count and the read are two separate operations. An event written in between shifts the newest-N window forward and pushes the oldest during-catch-up event out of the read. That event sits at or before the live subscription's resume position, so the live subscription does not redeliver it either, and it is lost.

This is the residual case left open by 0.20.4 (the "count to read window" negative documented in ADR 0014). That change fixed the clock-skew variant by switching the delta to insertion order, but the count-to-read window stayed open.

## Fix

Re-read the recent tail until the matching count stops growing, so an event that arrives in the count-to-read window is reconciled by a later pass instead of being skipped. Each pass reads the newest `currentCount - preCatchupCount` events, which always spans from the pre-catch-up boundary forward, so the oldest during-catch-up event can no longer be pushed out.

`runCatchupForStream` now filters already-cached event ids before delivering, so the overlapping re-reads are deduplicated through the handover cache. At-least-once delivery is preserved without introducing duplicates.

The insertion-order delta reconciliation from ADR 0014 (natural descending with a limit) is untouched, so the clock-skew guarantee from 0.20.4 is unchanged.

## Known limitation

The re-read loop terminates when the matching count stops growing between two consecutive counts. Under sustained write saturation during startup the count may keep growing and the loop may keep iterating before it hands off to the live subscription. Each pass still delivers, so this is a bounded delay in handover, not a loss. The case is documented in ADR 0014.

## Verification

* Added `catchup_subscription_does_not_lose_events_written_in_the_count_to_read_window_during_handover`, a deterministic adversarial test that injects writes at the exact handover seams (during the bulk replay, and between the post-replay count and the reconciliation read) through a delegating `EventStoreQueries`. It asserts every event is delivered and there are no duplicates. Red before the fix, green after.
* `CatchupSubscriptionModelTest` is green (16/16), including 20 consecutive reruns of the previously flaky handover test and the new adversarial test.

## Compatibility

The change is limited to the during-catch-up reconciliation in `CatchupSubscriptionModel`. No public API changes, no behavioral change for stream-only callers beyond closing the loss.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
