### PR TITLE
Add DCB catch-up subscription: replay and resume by dcbposition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,12 @@
   * `DcbEventMetadata` gives Java callers access to the DCB sequence position and DCB tags of a subscription event, the same metadata Kotlin reads through the `dcbPosition` and `dcbTags` extension properties.
   * `DcbSubscriptions` is an instance wrapper over a `Subscribable` and a `CloudEventConverter`, so DCB subscriptions can be created without passing the converter on every call, mirroring `DcbDomainEventQueries`.
   * Kotlin `queryForListWithPosition` and `queryForSequenceWithPosition` extensions return the matching events together with the observed DCB sequence position.
+* Added DCB catch-up subscription support to `CatchupSubscriptionModel`.
+  * A new DCB-mode constructor takes a `DcbEventStore` and a `DcbQuery`. In this mode the catch-up phase replays historic DCB events ordered by `dcbposition` and the subscription resumes by `dcbposition`, so a DCB application can rebuild a read model from history rather than only subscribing live.
+  * The replay pages through the DCB sequence in position windows, so a large rebuild does not load the whole matched set at once. The window size is configurable through `CatchupSubscriptionModelConfig.dcbCatchupPositionWindowSize`.
+  * Reconciliation of events written during the replay is by `dcbposition` rather than by a count, so the DCB catch-up is immune to the clock-skew loss and the `estimatedDocumentCount` undercount the stream catch-up has to defend against.
+  * The stream catch-up behavior and its constructors are unchanged. A `CatchupSubscriptionModel` is in either stream mode or DCB mode, selected by constructor.
+  * New `DcbSubscriptionPosition` carries a `dcbposition` resume point.
 * Added two DCB word-guessing MongoDB Spring examples.
   * `example-domain-word-guessing-game-es-mongodb-spring-dcb` shows manual DCB wiring with explicit DCB queries, tags, application-service usage, and live durable subscriptions.
   * `example-domain-word-guessing-game-es-mongodb-spring-dcb-autoconfig` shows Spring Boot auto-configuration, `@EnableOccurrent`, DCB-only event-store capabilities, annotation subscriptions, and DCB decider command handling.
@@ -57,6 +63,7 @@
   * [ADR 17](doc/architecture/decisions/0017-introduce-dcb-as-shared-cloudevent-capability.md)
   * [ADR 18](doc/architecture/decisions/0018-spring-mongo-event-store-capabilities.md)
   * [ADR 19](doc/architecture/decisions/0019-dcb-dsl-module.md)
+  * [ADR 20](doc/architecture/decisions/0020-dcb-catch-up-subscription-by-dcbposition.md)
 
 #### Notes
 

--- a/doc/architecture/decisions/0020-dcb-catch-up-subscription-by-dcbposition.md
+++ b/doc/architecture/decisions/0020-dcb-catch-up-subscription-by-dcbposition.md
@@ -1,0 +1,48 @@
+# 20. DCB catch-up subscription by dcbposition
+
+Date: 2026-06-21
+
+## Status
+
+Accepted
+
+## Context
+
+`CatchupSubscriptionModel` replays historic events before handing over to a live, position-aware subscription. Its replay reads stream events from `EventStoreQueries` ordered by `(time, streamversion)`, and the live subscription resumes by a database change-stream token. The catch-up phase is gated on a time-based subscription position (ADR 0014).
+
+DCB events are normal CloudEvents stored in the same collection (ADR 0017). They carry a server-assigned, monotonic `dcbposition` and `dcbtags` as CloudEvent extensions. The live change-stream subscription therefore already observes them. What a pure-DCB application cannot do today is rebuild a read model from DCB history: the `subscribeDcb` DSL is live only. It subscribes to all CloudEvents, post-filters by `DcbQuery`, and resumes by the change-stream token. There is no replay ordered by `dcbposition`, so a projection that starts from the beginning of the DCB sequence never sees the events written before it subscribed.
+
+The clean catch-up key for DCB is `dcbposition`. It is monotonic with insertion and server-assigned, so ordering and reconciliation by it are immune to the clock skew that forced ADR 0014 to reconcile the stream delta by insertion order rather than by `time`. It is also immune to the `estimatedDocumentCount` undercount recorded as a negative in ADR 0014, because a position-ranged read never needs a collection count to decide how much to read.
+
+## Decision
+
+Extend `CatchupSubscriptionModel` with a DCB mode, additively. A new constructor takes a `DcbEventStore`, a `DcbQuery`, and the existing `CatchupSubscriptionModelConfig`. The stream constructors and every stream code path are unchanged and remain the default. DCB behavior is reachable only through the new constructor, and a given instance is in exactly one mode.
+
+In DCB mode the catch-up phase replays by `dcbposition` instead of by time:
+
+1. Page through the DCB sequence with position-windowed reads. Starting from the resume position (`0` for a beginning-of-sequence rebuild, or the stored `dcbposition`), read `dcbEventStore.read(query, DcbReadOptions.between(cursor, min(cursor + window, head)))`, deliver the matching events, advance the cursor, and refresh `head` from the returned `lastSequencePosition`. `lastSequencePosition` is the store head at read time, not the maximum matched position, so each read both returns a bounded slice and reports how far the sequence now extends. Memory stays bounded by the position window, which matters because `read` returns a materialized list.
+2. Capture the live change-stream position after the bulk replay, exactly as in stream mode, so the resume token stays fresh on a long replay.
+3. Reconcile events written during the replay by continuing to page until the head stops advancing. Because `dcbposition` is monotonic, this is a plain range read with no count and no time sort, so it has neither the clock-skew loss nor the count-to-read window that the stream delta has to defend against.
+4. Hand over to the live change-stream subscription, deduplicating the seam through the same fixed-size cache the stream path uses.
+
+The position model adds a `DcbSubscriptionPosition` that encodes the `dcbposition` as a self-describing string, so it round-trips through the existing `SubscriptionPositionStorage` and is distinguishable from both a time-based position and a change-stream token. During catch-up the model persists a `DcbSubscriptionPosition`. After handover the live phase persists the change-stream token, as in stream mode. On restart the stored position selects the path: a `DcbSubscriptionPosition` resumes DCB catch-up from `afterSequencePosition`, a change-stream token resumes the live subscription directly, and the existing time-based and default cases are untouched.
+
+In DCB mode the model owns the `DcbQuery` end to end. The replay reads only matching events. On the live path the model post-filters the wrapped subscription's CloudEvents by `DcbCloudEvents.getPosition(event) > 0` and `DcbCloudEvents.matches(event, query)` before delivering, so the consumer sees only matching DCB events in both phases. The `DcbSubscriptions` DSL becomes a thin converter when it is backed by a catch-up-capable model.
+
+The shared handover machinery (capture the live position, start the delegated subscription, deduplicate the seam) is reused by both modes rather than forked.
+
+## Consequences
+
+Positive:
+
+- A pure-DCB application can rebuild a read model from history and resume by `dcbposition`. The Spring Boot starter can wire catch-up in DCB-only mode.
+- The DCB delta is reconciled by a monotonic, server-assigned position, so it is immune to the two losses that constrain the stream delta: the clock-skew miss closed in ADR 0014, and the `estimatedDocumentCount` undercount left open as a negative there. This is the robust reconciliation ADR 0014 pointed at (the global position from ADR 0008), realized here as `dcbposition`.
+- Position-windowed reads keep replay memory bounded even though `DcbEventStore.read` returns a materialized list, so a large rebuild does not load the whole matched set at once.
+- One subscription model serves both stream and DCB, so the durable and competing-consumer wrappers and the position storage are shared.
+
+Negative:
+
+- A DCB-mode instance is bound to a single `DcbQuery` set at construction. Several read models over different queries need several instances. This matches the one-projection-one-query norm and keeps the resume semantics unambiguous, since the stored position belongs to one query.
+- The model now has two replay sources, `EventStoreQueries` for stream and `DcbEventStore` for DCB, selected by constructor. The surface grows, but the stream path is untouched and an instance is only ever in one mode.
+- The live phase still reads all CloudEvents and post-filters by query, because the change-stream subscription cannot filter by `dcbtags` selectively today. This is the same tradeoff `subscribeDcb` already carries.
+- Resume by `dcbposition` assumes the store assigns it monotonically, which it does, with gaps allowed. Gaps are harmless because the range read returns whatever positions exist in the window.

--- a/subscription/util/blocking/catchup-subscription/pom.xml
+++ b/subscription/util/blocking/catchup-subscription/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>time</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -74,6 +79,24 @@
         <!-- Test -->
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-inmemory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-inmemory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-native</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -87,6 +110,24 @@
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>subscription-mongodb-native-blocking-position-storage</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-spring-blocking</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-mongodb-spring-blocking</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-mongodb-spring-blocking-position-storage</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -22,6 +22,11 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.StartAt.StartAtSubscriptionPosition;
@@ -93,7 +98,9 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     private static final int DEFAULT_CACHE_SIZE = 100;
 
     private final PositionAwareSubscriptionModel subscriptionModel;
-    private final EventStoreQueries eventStoreQueries;
+    private final @Nullable EventStoreQueries eventStoreQueries;
+    private final @Nullable DcbEventStore dcbEventStore;
+    private final @Nullable DcbQuery dcbQuery;
     private final CatchupSubscriptionModelConfig config;
     private final ConcurrentMap<String, Boolean> runningCatchupSubscriptions = new ConcurrentHashMap<>();
     private volatile boolean shuttingDown = false;
@@ -120,9 +127,48 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
      * @param config            The configuration to use
      */
     public CatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config) {
-        this.subscriptionModel = subscriptionModel;
-        this.eventStoreQueries = eventStoreQueries;
-        this.config = config;
+        this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
+        this.eventStoreQueries = Objects.requireNonNull(eventStoreQueries, "eventStoreQueries cannot be null");
+        this.dcbEventStore = null;
+        this.dcbQuery = null;
+        this.config = Objects.requireNonNull(config, "config cannot be null");
+    }
+
+    /**
+     * Create a new instance of {@link CatchupSubscriptionModel} in DCB mode using a default {@link CatchupSubscriptionModelConfig}.
+     * In DCB mode the catch-up phase replays historic DCB events ordered by their {@code dcbposition} (rather than stream
+     * events ordered by time), and the subscription resumes by {@code dcbposition}. Only events matching {@code dcbQuery}
+     * are delivered, in both the replay and the live phase. See ADR 20.
+     *
+     * @param subscriptionModel The subscription that'll be used to subscribe to new events <i>after</i> catch-up is completed.
+     * @param dcbEventStore     The DCB event store that will be used for the DCB catch-up replay.
+     * @param dcbQuery          The DCB query that selects the events this subscription delivers.
+     */
+    public CatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, DcbQuery dcbQuery) {
+        this(subscriptionModel, dcbEventStore, dcbQuery, new CatchupSubscriptionModelConfig(DEFAULT_CACHE_SIZE));
+    }
+
+    /**
+     * Create a new instance of {@link CatchupSubscriptionModel} in DCB mode using the supplied {@link CatchupSubscriptionModelConfig}.
+     * In DCB mode the catch-up phase replays historic DCB events ordered by their {@code dcbposition} (rather than stream
+     * events ordered by time), and the subscription resumes by {@code dcbposition}. Only events matching {@code dcbQuery}
+     * are delivered, in both the replay and the live phase. See ADR 20.
+     *
+     * @param subscriptionModel The subscription that'll be used to subscribe to new events <i>after</i> catch-up is completed.
+     * @param dcbEventStore     The DCB event store that will be used for the DCB catch-up replay.
+     * @param dcbQuery          The DCB query that selects the events this subscription delivers.
+     * @param config            The configuration to use.
+     */
+    public CatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, DcbQuery dcbQuery, CatchupSubscriptionModelConfig config) {
+        this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
+        this.eventStoreQueries = null;
+        this.dcbEventStore = Objects.requireNonNull(dcbEventStore, "dcbEventStore cannot be null");
+        this.dcbQuery = Objects.requireNonNull(dcbQuery, "dcbQuery cannot be null");
+        this.config = Objects.requireNonNull(config, "config cannot be null");
+    }
+
+    private boolean isDcbMode() {
+        return dcbEventStore != null;
     }
 
     /**
@@ -153,8 +199,12 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         if (filter != null && !(filter instanceof OccurrentSubscriptionFilter)) {
             throw new IllegalArgumentException("Only OccurrentSubscriptionFilter is supported!");
         }
+        return isDcbMode()
+                ? subscribeDcb(subscriptionId, filter, startAt, action)
+                : subscribeStream(subscriptionId, filter, startAt, action);
+    }
 
-
+    private Subscription subscribeStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         final StartAt firstStartAt;
         if (startAt.isDefault()) {
             // By default, we check if there's a subscription position stored for this subscription, if so we resume from there, otherwise,
@@ -194,6 +244,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
 
         Filter catchupFilter = deriveFilterToUseDuringCatchupPhase(filter, subscriptionPosition);
 
+        EventStoreQueries eventStoreQueries = Objects.requireNonNull(this.eventStoreQueries, "eventStoreQueries");
         long numberOfEventsBeforeStartingCatchupSubscription = eventStoreQueries.count(catchupFilter);
 
         // Perform the catchup
@@ -309,10 +360,15 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
                     }
                 }));
 
-        return startDelegatedSubscription(subscriptionId, filter, action, subscriptionsWasCancelledOrShutdown, startAtToUse, catchupPhaseCache);
+        Consumer<CloudEvent> liveConsumer = cloudEvent -> {
+            if (!catchupPhaseCache.isCached(cloudEvent.getId())) {
+                action.accept(cloudEvent);
+            }
+        };
+        return startDelegatedSubscription(subscriptionId, filter, subscriptionsWasCancelledOrShutdown, startAtToUse, liveConsumer);
     }
 
-    private Subscription startDelegatedSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, Consumer<CloudEvent> action, boolean subscriptionsWasCancelledOrShutdown, StartAt startAtToUse, FixedSizeCache catchupPhaseEventCache) {
+    private Subscription startDelegatedSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, boolean subscriptionsWasCancelledOrShutdown, StartAt startAtToUse, Consumer<CloudEvent> liveConsumer) {
         final Subscription subscription;
         if (subscriptionsWasCancelledOrShutdown) {
             doIfSubscriptionPositionStorageConfigIs(UseSubscriptionPositionInStorage.class, cfg -> {
@@ -323,13 +379,158 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
             });
             subscription = new CancelledSubscription(subscriptionId);
         } else {
-            subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, filter, startAtToUse, cloudEvent -> {
-                if (!catchupPhaseEventCache.isCached(cloudEvent.getId())) {
-                    action.accept(cloudEvent);
-                }
-            });
+            subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, filter, startAtToUse, liveConsumer);
         }
         return subscription;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // DCB mode: replay historic DCB events ordered by dcbposition and resume by dcbposition (see ADR 20). Additive to
+    // the stream path above; an instance is in exactly one mode (selected by constructor).
+    // ---------------------------------------------------------------------------------------------------------------
+
+    private Subscription subscribeDcb(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        final StartAt firstStartAt;
+        if (startAt.isDefault()) {
+            // Resume from the stored position if there is one, otherwise subscribe live (with the DCB query post-filter).
+            SubscriptionPosition subscriptionPosition = returnIfSubscriptionPositionStorageConfigIs(UseSubscriptionPositionInStorage.class, cfg -> cfg.storage().read(subscriptionId)).orElse(null);
+            if (subscriptionPosition == null) {
+                return startLiveDcbSubscription(subscriptionId, filter, startAt, action, null);
+            } else {
+                firstStartAt = StartAt.subscriptionPosition(subscriptionPosition);
+            }
+        } else if (startAt.isDynamic()) {
+            StartAt startAtGeneratedByDynamic = startAt.get(generateSubscriptionModelContext());
+            if (startAtGeneratedByDynamic == null) {
+                return startLiveDcbSubscription(subscriptionId, filter, startAt, action, null);
+            } else {
+                firstStartAt = startAtGeneratedByDynamic;
+            }
+        } else {
+            firstStartAt = startAt;
+        }
+
+        // A non-DCB position means the catch-up already handed over and the live subscription stored a change-stream
+        // token (or the caller asked to start live directly). Subscribe live, still applying the DCB query post-filter.
+        if (!isDcbCatchupPosition(firstStartAt)) {
+            return startLiveDcbSubscription(subscriptionId, filter, firstStartAt, action, null);
+        }
+
+        Future<Subscription> subscriptionCompletableFuture = CompletableFuture.supplyAsync(() -> startDcbCatchupSubscription(subscriptionId, filter, startAt, action, firstStartAt));
+        return new CatchupSubscription(subscriptionId, subscriptionCompletableFuture);
+    }
+
+    private Subscription startLiveDcbSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAtToUse, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
+        return subscriptionModel.subscribe(subscriptionId, filter, startAtToUse, dcbLiveConsumer(action, cache));
+    }
+
+    private Consumer<CloudEvent> dcbLiveConsumer(Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
+        DcbQuery query = Objects.requireNonNull(this.dcbQuery);
+        return cloudEvent -> {
+            // The live change stream sees every CloudEvent, so post-filter to the DCB events matching the query and
+            // skip those already delivered during the catch-up phase (the handover seam).
+            if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)
+                    && (cache == null || !cache.isCached(cloudEvent.getId()))) {
+                action.accept(cloudEvent);
+            }
+        };
+    }
+
+    private Subscription startDcbCatchupSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
+        runningCatchupSubscriptions.put(subscriptionId, true);
+        DcbEventStore dcbEventStore = Objects.requireNonNull(this.dcbEventStore, "dcbEventStore");
+        DcbQuery query = Objects.requireNonNull(this.dcbQuery, "dcbQuery");
+        long windowSize = config.dcbCatchupPositionWindowSize;
+
+        StartAt nextStartAt = firstStartAt.get(generateSubscriptionModelContext());
+        SubscriptionPosition subscriptionPosition = ((StartAtSubscriptionPosition) Objects.requireNonNull(nextStartAt)).subscriptionPosition;
+        long startPosition = DcbSubscriptionPosition.dcbPositionOf(subscriptionPosition);
+
+        // Bulk replay: page through the DCB sequence from the resume position up to the head observed at the start, in
+        // position windows so a large rebuild does not materialize the whole matched set at once. dcbposition is
+        // monotonic and server-assigned, so this needs no count and no time sort, sidestepping both the clock-skew loss
+        // and the estimatedDocumentCount undercount that the stream delta has to defend against (see ADR 20).
+        long bulkHead = dcbEventStore.read(query, DcbReadOptions.between(startPosition, startPosition)).lastSequencePosition();
+        long cursor = deliverDcbWindows(dcbEventStore, query, startPosition, bulkHead, windowSize, subscriptionId, action, null);
+
+        // Capture the live resume position *after* the bulk replay so the change-stream token stays fresh, the same
+        // reason as the stream path: a token captured before a long replay could age out of the change stream before
+        // the handover.
+        Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
+        StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
+        final SubscriptionPosition globalSubscriptionPosition = delegatedStartAt == null ? null : subscriptionModel.globalSubscriptionPosition();
+
+        FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
+
+        // Reconcile events written during the bulk replay (positions beyond bulkHead) by continuing to page until the
+        // head stops advancing. Re-reads of overlapping windows are deduped by the cache (delivery is at-least-once).
+        // Any event written after the loop is newer than globalSubscriptionPosition and is covered by the live
+        // subscription regardless.
+        long head = dcbEventStore.read(query, DcbReadOptions.between(cursor, cursor)).lastSequencePosition();
+        while (head > cursor && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+            cursor = deliverDcbWindows(dcbEventStore, query, cursor, head, windowSize, subscriptionId, action, catchupPhaseCache);
+            head = dcbEventStore.read(query, DcbReadOptions.between(cursor, cursor)).lastSequencePosition();
+        }
+
+        if (delegatedStartAt == null) {
+            returnIfSubscriptionPositionStorageConfigIs(UseSubscriptionPositionInStorage.class, cfg -> {
+                cfg.storage().delete(subscriptionId);
+                return null;
+            });
+        }
+
+        final boolean subscriptionsWasCancelledOrShutdown;
+        if (!shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+            subscriptionsWasCancelledOrShutdown = false;
+            runningCatchupSubscriptions.remove(subscriptionId);
+        } else {
+            subscriptionsWasCancelledOrShutdown = true;
+        }
+
+        StartAt startAtToUse = StartAt.dynamic(this.<Supplier<StartAt>, UseSubscriptionPositionInStorage>returnIfSubscriptionPositionStorageConfigIs(UseSubscriptionPositionInStorage.class,
+                        cfg -> () -> {
+                            SubscriptionPosition position = cfg.storage().read(subscriptionId);
+                            // If nothing is stored, or the stored position is a DCB position (written by this catch-up),
+                            // save the live change-stream position so the wrapped subscription resumes from there.
+                            if ((position == null || DcbSubscriptionPosition.isDcbSubscriptionPosition(position)) && globalSubscriptionPosition != null) {
+                                position = cfg.storage().save(subscriptionId, globalSubscriptionPosition);
+                            } else if (position == null) {
+                                return delegatedStartAt == null ? startAt : StartAt.subscriptionModelDefault();
+                            }
+                            return StartAt.subscriptionPosition(position);
+                        })
+                .orElse(() -> {
+                    if (globalSubscriptionPosition == null) {
+                        return delegatedStartAt == null ? startAt : StartAt.subscriptionModelDefault();
+                    } else {
+                        return StartAt.subscriptionPosition(globalSubscriptionPosition);
+                    }
+                }));
+
+        return startDelegatedSubscription(subscriptionId, filter, subscriptionsWasCancelledOrShutdown, startAtToUse, dcbLiveConsumer(action, catchupPhaseCache));
+    }
+
+    /**
+     * Delivers DCB events in {@code (fromExclusive, toInclusive]} by paging through position windows, and returns the
+     * position the cursor reached. Stops early on shutdown or cancellation.
+     */
+    private long deliverDcbWindows(DcbEventStore dcbEventStore, DcbQuery query, long fromExclusive, long toInclusive, long windowSize, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
+        long cursor = fromExclusive;
+        while (cursor < toInclusive && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+            long upTo = Math.min(cursor + windowSize, toInclusive);
+            DcbEventStream slice = dcbEventStore.read(query, DcbReadOptions.between(cursor, upTo));
+            deliverCatchupEvents(slice.stream(), subscriptionId, action, cache, e -> DcbSubscriptionPosition.of(DcbCloudEvents.getPosition(e)));
+            cursor = upTo;
+        }
+        return cursor;
+    }
+
+    private static boolean isDcbCatchupPosition(StartAt startAt) {
+        StartAt start = startAt.get(generateSubscriptionModelContext());
+        if (!(start instanceof StartAtSubscriptionPosition)) {
+            return false;
+        }
+        return DcbSubscriptionPosition.isDcbSubscriptionPosition(((StartAtSubscriptionPosition) start).subscriptionPosition);
     }
 
     private static Filter deriveFilterToUseDuringCatchupPhase(@Nullable SubscriptionFilter filter, SubscriptionPosition subscriptionPosition) {
@@ -352,20 +553,29 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     }
 
     private void runCatchupForStream(Stream<CloudEvent> cloudEvents, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
+        deliverCatchupEvents(cloudEvents, subscriptionId, action, cache, e -> TimeBasedSubscriptionPosition.from(e.getTime()));
+    }
+
+    /**
+     * Delivers catch-up events to {@code action}, optionally deduping against {@code cache}, and persists the
+     * subscription position for events matching the catch-up persist predicate. The position to persist is derived per
+     * event by {@code positionToPersist}, which differs between stream mode (time based) and DCB mode (dcbposition).
+     */
+    private void deliverCatchupEvents(Stream<CloudEvent> cloudEvents, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache, Function<CloudEvent, SubscriptionPosition> positionToPersist) {
         // try-with-resources closes the source stream even when takeWhile short-circuits on shutdown, so a
         // resource-backed read (the Spring Mongo bulk replay wraps a server cursor) does not leak its cursor.
         try (cloudEvents) {
             Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId));
             if (cache != null) {
-                // Skip events already delivered in an earlier reconciliation pass (the during-catch-up delta is re-read
-                // until the matching count stabilises, so passes overlap) and record the rest so the live subscription can
-                // skip them at the handover seam. Without the filter the overlapping re-reads would deliver duplicates.
+                // Skip events already delivered in an earlier reconciliation pass (the delta is re-read until it
+                // stabilises, so passes overlap) and record the rest so the live subscription can skip them at the
+                // handover seam. Without the filter the overlapping re-reads would deliver duplicates.
                 takeWhile = takeWhile.filter(e -> !cache.isCached(e.getId())).peek(e -> cache.put(e.getId()));
             }
             takeWhile
                     .peek(action)
                     .filter(returnIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, PersistSubscriptionPositionDuringCatchupPhase::persistCloudEventPositionPredicate).orElse(__ -> false))
-                    .forEach(e -> doIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, cfg -> cfg.storage().save(subscriptionId, TimeBasedSubscriptionPosition.from(e.getTime()))));
+                    .forEach(e -> doIfSubscriptionPositionStorageConfigIs(PersistSubscriptionPositionDuringCatchupPhase.class, cfg -> cfg.storage().save(subscriptionId, positionToPersist.apply(e))));
         }
     }
 
@@ -508,6 +718,8 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         return new StringJoiner(", ", CatchupSubscriptionModel.class.getSimpleName() + "[", "]")
                 .add("subscriptionModel=" + subscriptionModel)
                 .add("eventStoreQueries=" + eventStoreQueries)
+                .add("dcbEventStore=" + dcbEventStore)
+                .add("dcbQuery=" + dcbQuery)
                 .add("config=" + config)
                 .add("runningCatchupSubscriptions=" + runningCatchupSubscriptions)
                 .add("shuttingDown=" + shuttingDown)

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -32,9 +32,17 @@ import static org.occurrent.filter.Filter.TIME;
 @NullMarked
 public class CatchupSubscriptionModelConfig {
 
+    static final long DEFAULT_DCB_CATCHUP_POSITION_WINDOW_SIZE = 1000;
+
     public final int cacheSize;
     public final SubscriptionPositionStorageConfig subscriptionStorageConfig;
     public final SortBy catchupPhaseSortBy;
+    /**
+     * The DCB sequence-position window size used when {@link CatchupSubscriptionModel} replays in DCB mode. The replay
+     * pages through the DCB sequence in windows of this many positions so a large rebuild does not materialize the
+     * whole matched set at once. Ignored in stream mode.
+     */
+    public final long dcbCatchupPositionWindowSize;
 
     /**
      * Create a new {@code CatchupSubscriptionModelConfig} will the given cache size. Will default to sort by time and then stream version (if time is the same for two events)
@@ -77,14 +85,22 @@ public class CatchupSubscriptionModelConfig {
     }
 
     private CatchupSubscriptionModelConfig(int cacheSize, SubscriptionPositionStorageConfig subscriptionStorageConfig, SortBy sortBy) {
+        this(cacheSize, subscriptionStorageConfig, sortBy, DEFAULT_DCB_CATCHUP_POSITION_WINDOW_SIZE);
+    }
+
+    private CatchupSubscriptionModelConfig(int cacheSize, SubscriptionPositionStorageConfig subscriptionStorageConfig, SortBy sortBy, long dcbCatchupPositionWindowSize) {
         if (cacheSize < 1) {
             throw new IllegalArgumentException("Cache size must be greater than or equal to 1");
         }
         Objects.requireNonNull(subscriptionStorageConfig, SubscriptionPositionStorageConfig.class.getSimpleName() + " cannot be null");
         Objects.requireNonNull(sortBy, SortBy.class + " cannot be null");
+        if (dcbCatchupPositionWindowSize < 1) {
+            throw new IllegalArgumentException("DCB catch-up position window size must be greater than or equal to 1");
+        }
         this.cacheSize = cacheSize;
         this.subscriptionStorageConfig = subscriptionStorageConfig;
         this.catchupPhaseSortBy = sortBy;
+        this.dcbCatchupPositionWindowSize = dcbCatchupPositionWindowSize;
     }
 
     /**
@@ -105,7 +121,19 @@ public class CatchupSubscriptionModelConfig {
      * @return A new instance of {@link CatchupSubscriptionModel}.
      */
     public CatchupSubscriptionModelConfig catchupPhaseSortBy(SortBy sortBy) {
-        return new CatchupSubscriptionModelConfig(cacheSize, subscriptionStorageConfig, sortBy);
+        return new CatchupSubscriptionModelConfig(cacheSize, subscriptionStorageConfig, sortBy, dcbCatchupPositionWindowSize);
+    }
+
+    /**
+     * Specify the DCB sequence-position window size used when {@link CatchupSubscriptionModel} replays in DCB mode.
+     * The replay pages through the DCB sequence in windows of this many positions, bounding how many matched events
+     * are held in memory at once. Ignored in stream mode. Default is {@value #DEFAULT_DCB_CATCHUP_POSITION_WINDOW_SIZE}.
+     *
+     * @param dcbCatchupPositionWindowSize The number of DCB sequence positions to read per window. Must be at least 1.
+     * @return A new instance of {@link CatchupSubscriptionModelConfig}.
+     */
+    public CatchupSubscriptionModelConfig dcbCatchupPositionWindowSize(long dcbCatchupPositionWindowSize) {
+        return new CatchupSubscriptionModelConfig(cacheSize, subscriptionStorageConfig, catchupPhaseSortBy, dcbCatchupPositionWindowSize);
     }
 
     @Override

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbSubscriptionPosition.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbSubscriptionPosition.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.subscription.StringBasedSubscriptionPosition;
+import org.occurrent.subscription.SubscriptionPosition;
+
+import java.util.Objects;
+
+/**
+ * A {@link SubscriptionPosition} that points at a DCB sequence position ({@code dcbposition}). It is used by
+ * {@link CatchupSubscriptionModel} in DCB mode to resume a catch-up replay from where it left off.
+ * <p>
+ * The string form is self-describing ({@code "dcbposition:<n>"}) so that it round-trips through a
+ * {@code SubscriptionPositionStorage} (which reads positions back as a {@link StringBasedSubscriptionPosition}) and
+ * stays unambiguously distinguishable from an RFC3339 time position and from a database change-stream resume token.
+ */
+@NullMarked
+public class DcbSubscriptionPosition implements SubscriptionPosition {
+
+    static final String PREFIX = "dcbposition:";
+
+    private final long dcbPosition;
+
+    public DcbSubscriptionPosition(long dcbPosition) {
+        if (dcbPosition < 0) {
+            throw new IllegalArgumentException("DCB position cannot be negative");
+        }
+        this.dcbPosition = dcbPosition;
+    }
+
+    /**
+     * Create a {@code DcbSubscriptionPosition} at the given DCB sequence position. Use {@code 0} to replay from the
+     * beginning of the DCB sequence (positions are assigned from {@code 1}).
+     */
+    public static DcbSubscriptionPosition of(long dcbPosition) {
+        return new DcbSubscriptionPosition(dcbPosition);
+    }
+
+    /**
+     * The DCB sequence position this subscription position points at.
+     */
+    public long dcbPosition() {
+        return dcbPosition;
+    }
+
+    @Override
+    public String asString() {
+        return PREFIX + dcbPosition;
+    }
+
+    /**
+     * Returns whether the supplied subscription position is a DCB sequence position, either a
+     * {@link DcbSubscriptionPosition} or a {@link StringBasedSubscriptionPosition} whose string form was written by one
+     * (the form a {@code SubscriptionPositionStorage} reads back).
+     */
+    public static boolean isDcbSubscriptionPosition(SubscriptionPosition subscriptionPosition) {
+        return subscriptionPosition instanceof DcbSubscriptionPosition ||
+                (subscriptionPosition instanceof StringBasedSubscriptionPosition && subscriptionPosition.asString().startsWith(PREFIX));
+    }
+
+    /**
+     * Reads the DCB sequence position out of a subscription position previously produced by a
+     * {@link DcbSubscriptionPosition}, whether it is still a {@code DcbSubscriptionPosition} or has been read back from
+     * storage as a {@link StringBasedSubscriptionPosition}.
+     */
+    public static long dcbPositionOf(SubscriptionPosition subscriptionPosition) {
+        if (subscriptionPosition instanceof DcbSubscriptionPosition dcb) {
+            return dcb.dcbPosition();
+        }
+        String value = subscriptionPosition.asString();
+        if (!value.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("Not a DCB subscription position: " + value);
+        }
+        return Long.parseLong(value.substring(PREFIX.length()));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DcbSubscriptionPosition that)) return false;
+        return dcbPosition == that.dcbPosition;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(dcbPosition);
+    }
+
+    @Override
+    public String toString() {
+        return asString();
+    }
+}

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionPositionStorage;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPositionStorageConfig.useSubscriptionPositionStorage;
+
+/**
+ * Real MongoDB integration test for {@link CatchupSubscriptionModel} in DCB mode (ADR 20). The in-memory
+ * {@code DcbCatchupSubscriptionModelTest} exercises the DCB-specific replay, resume and filtering logic deterministically
+ * but stubs position-awareness. This test covers the part that only a real database can: the catch-up to live handover
+ * across the change stream, where DCB events written during and after the bulk replay must be delivered exactly once.
+ */
+@Testcontainers
+@Timeout(60)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbCatchupSubscriptionModelMongoTest {
+
+    private static final URI SOURCE = URI.create("urn:test");
+    private static final Duration AT_MOST = Duration.ofSeconds(30);
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                    .withReplicaSet()
+                    .withReuse(true);
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events"));
+
+    private SpringMongoEventStore eventStore;
+    private SpringMongoSubscriptionModel subscriptionModel;
+    private SpringMongoSubscriptionPositionStorage storage;
+    private CatchupSubscriptionModel subscription;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private MongoClient mongoClient;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void create_instances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events");
+        mongoClient = MongoClients.create(connectionString);
+        MongoTemplate mongoTemplate = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        MongoTransactionManager mongoTransactionManager = new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        TimeRepresentation timeRepresentation = TimeRepresentation.RFC_3339_STRING;
+        EventStoreConfig eventStoreConfig = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(connectionString.getCollection())
+                .transactionConfig(mongoTransactionManager)
+                .timeRepresentation(timeRepresentation)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new SpringMongoEventStore(mongoTemplate, eventStoreConfig);
+        subscriptionModel = new SpringMongoSubscriptionModel(mongoTemplate, requireNonNull(connectionString.getCollection()), timeRepresentation);
+        storage = new SpringMongoSubscriptionPositionStorage(mongoTemplate, "storage");
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), SOURCE).idMapper(DomainEvent::eventId).build();
+        time = LocalDateTime.now();
+    }
+
+    @AfterEach
+    void shutdown() {
+        if (subscription != null) {
+            subscription.shutdown();
+        }
+        subscriptionModel.shutdown();
+        mongoClient.close();
+    }
+
+    @Test
+    void replays_dcb_history_then_delivers_live_events_across_the_handover_without_duplicates() {
+        // Given a DCB history written before the subscription starts
+        NameDefined historic1 = nameDefined("historic1");
+        NameDefined historic2 = nameDefined("historic2");
+        appendTagged("name:1", historic1);
+        appendTagged("other:1", nameDefined("ignoredHistoric"));
+        appendTagged("name:1", historic2);
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"),
+                new CatchupSubscriptionModelConfig(100, useSubscriptionPositionStorage(storage).andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1)));
+
+        // When the DCB-mode catch-up subscription replays from the beginning of the DCB sequence and hands over to the live change stream
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)), toDomainEvents(received)).waitUntilStarted();
+
+        // Then the matching history is delivered (non-matching events filtered out)
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+                assertThat(received).containsExactly(historic1, historic2));
+
+        // And when matching and non-matching events are written after the handover
+        NameDefined live1 = nameDefined("live1");
+        NameDefined live2 = nameDefined("live2");
+        appendTagged("name:1", live1);
+        appendTagged("other:1", nameDefined("ignoredLive"));
+        appendTagged("name:1", live2);
+
+        // Then the matching live events arrive through the change stream, in order, with no duplicates at the seam
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() -> {
+            assertThat(received).containsExactly(historic1, historic2, live1, live2);
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    private NameDefined nameDefined(String name) {
+        return new NameDefined(UUID.randomUUID().toString(), time, "name", name);
+    }
+
+    private Consumer<CloudEvent> toDomainEvents(List<DomainEvent> target) {
+        return cloudEvent -> target.add(cloudEventConverter.toDomainEvent(cloudEvent));
+    }
+
+    private void appendTagged(String tag, DomainEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(event -> DcbCloudEvents.withTags(event, List.of(tag)))
+                .toList();
+        eventStore.append(cloudEvents);
+    }
+}

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.SubscriptionPosition;
+import org.occurrent.subscription.StringBasedSubscriptionPosition;
+import org.occurrent.subscription.api.blocking.PositionAwareSubscriptionModel;
+import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionPositionStorage;
+import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPositionStorageConfig.useSubscriptionPositionStorage;
+
+/**
+ * Tests for {@link CatchupSubscriptionModel} in DCB mode (replay and resume by {@code dcbposition}, see ADR 20).
+ * <p>
+ * These use the in-memory event store and subscription model so the DCB-specific logic (position-windowed replay,
+ * dcbposition resume, the query post-filter and the multi-window paging) is exercised deterministically without a
+ * database. The in-memory subscription model is not position aware, so a small {@link PositionAwareInMemorySubscriptionModel}
+ * test double adapts it: it translates the concrete resume position the catch-up hands over into {@code StartAt.now()}
+ * (the in-memory model only supports now and default) and reports a stub global position. The faithful change-stream
+ * resume across the catch-up to live seam is exercised against a real MongoDB change stream by
+ * {@code DcbCatchupSubscriptionModelMongoTest}.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbCatchupSubscriptionModelTest {
+
+    private InMemorySubscriptionModel inMemorySubscriptionModel;
+    private PositionAwareInMemorySubscriptionModel subscriptionModel;
+    private InMemoryEventStore eventStore;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void create_instances() {
+        inMemorySubscriptionModel = new InMemorySubscriptionModel();
+        subscriptionModel = new PositionAwareInMemorySubscriptionModel(inMemorySubscriptionModel);
+        eventStore = new InMemoryEventStore(inMemorySubscriptionModel);
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        time = LocalDateTime.now();
+    }
+
+    @AfterEach
+    void shutdown() {
+        inMemorySubscriptionModel.shutdown();
+    }
+
+    @Test
+    void replays_matching_dcb_events_from_the_beginning_of_the_sequence_in_position_order() {
+        NameDefined name1 = nameDefined("name1");
+        NameDefined name2 = nameDefined("name2");
+        NameDefined name3 = nameDefined("name3");
+        appendTagged("name:1", name1);
+        appendTagged("other:1", nameDefined("ignored"));
+        appendTagged("name:1", name2);
+        appendTagged("name:1", name3);
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"));
+
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)), toDomainEvents(received)).waitUntilStarted();
+
+        await().untilAsserted(() -> assertThat(received).containsExactly(name1, name2, name3));
+    }
+
+    @Test
+    void delivers_events_written_during_and_after_catchup_through_the_live_handover_without_duplicates() {
+        NameDefined historic1 = nameDefined("historic1");
+        NameDefined historic2 = nameDefined("historic2");
+        appendTagged("name:1", historic1);
+        appendTagged("name:1", historic2);
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"));
+
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)), toDomainEvents(received)).waitUntilStarted();
+        await().untilAsserted(() -> assertThat(received).containsExactly(historic1, historic2));
+
+        NameDefined live1 = nameDefined("live1");
+        NameDefined live2 = nameDefined("live2");
+        appendTagged("name:1", live1);
+        appendTagged("other:1", nameDefined("ignoredLive"));
+        appendTagged("name:1", live2);
+
+        await().untilAsserted(() -> {
+            assertThat(received).containsExactly(historic1, historic2, live1, live2);
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    @Test
+    void resumes_replay_after_a_supplied_dcb_position_and_skips_earlier_events() {
+        NameDefined position1 = nameDefined("position1");
+        NameDefined position2 = nameDefined("position2");
+        NameDefined position3 = nameDefined("position3");
+        appendTagged("name:1", position1); // dcbposition 1
+        appendTagged("name:1", position2); // dcbposition 2
+        appendTagged("name:1", position3); // dcbposition 3
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"));
+
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(2)), toDomainEvents(received)).waitUntilStarted();
+
+        await().untilAsserted(() -> assertThat(received).containsExactly(position3));
+    }
+
+    @Test
+    void resumes_replay_from_a_dcb_position_read_back_from_storage() {
+        appendTagged("name:1", nameDefined("position1")); // dcbposition 1
+        NameDefined position2 = nameDefined("position2");
+        appendTagged("name:1", position2);                // dcbposition 2
+
+        SubscriptionPositionStorage storage = new InMemorySubscriptionPositionStorage();
+        storage.save("subscription", DcbSubscriptionPosition.of(1));
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"),
+                new CatchupSubscriptionModelConfig(useSubscriptionPositionStorage(storage).andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1)));
+
+        subscription.subscribe("subscription", StartAt.subscriptionModelDefault(), toDomainEvents(received)).waitUntilStarted();
+
+        await().untilAsserted(() -> assertThat(received).containsExactly(position2));
+    }
+
+    @Test
+    void live_only_subscription_applies_the_dcb_query_post_filter() {
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"));
+
+        // Default start with nothing stored subscribes live (no replay), mirroring the stream path.
+        subscription.subscribe("subscription", StartAt.subscriptionModelDefault(), toDomainEvents(received)).waitUntilStarted();
+
+        NameDefined matching = nameDefined("matching");
+        appendTagged("name:1", matching);
+        appendTagged("other:1", nameDefined("nonMatching"));
+
+        await().untilAsserted(() -> assertThat(received).containsExactly(matching));
+    }
+
+    @Test
+    void replays_across_multiple_position_windows() {
+        List<NameDefined> events = List.of(nameDefined("e1"), nameDefined("e2"), nameDefined("e3"), nameDefined("e4"), nameDefined("e5"));
+        events.forEach(event -> appendTagged("name:1", event));
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        // A window of 2 positions forces the replay to page across several windows to cover all five events.
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tagsAllOf("name:1"),
+                new CatchupSubscriptionModelConfig(100).dcbCatchupPositionWindowSize(2));
+
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)), toDomainEvents(received)).waitUntilStarted();
+
+        await().untilAsserted(() -> assertThat(received).containsExactlyElementsOf(events));
+    }
+
+    private NameDefined nameDefined(String name) {
+        return new NameDefined(UUID.randomUUID().toString(), time, "name", name);
+    }
+
+    private Consumer<CloudEvent> toDomainEvents(List<DomainEvent> target) {
+        return cloudEvent -> target.add(cloudEventConverter.toDomainEvent(cloudEvent));
+    }
+
+    private void appendTagged(String tag, DomainEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(event -> DcbCloudEvents.withTags(event, List.of(tag)))
+                .toList();
+        eventStore.append(cloudEvents);
+    }
+
+    /**
+     * Adapts the (non position aware) {@link InMemorySubscriptionModel} to {@link PositionAwareSubscriptionModel} for
+     * these tests. The catch-up hands over to the live phase with a concrete subscription position, but the in-memory
+     * model only supports {@code now}/{@code default}, so any position start is translated to {@code now}. The stub
+     * global position is enough for the catch-up to take its normal handover path.
+     */
+    private static final class PositionAwareInMemorySubscriptionModel implements PositionAwareSubscriptionModel {
+        private final InMemorySubscriptionModel delegate;
+
+        private PositionAwareInMemorySubscriptionModel(InMemorySubscriptionModel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+            StartAt resolved = startAt.get(new StartAt.SubscriptionModelContext(InMemorySubscriptionModel.class));
+            StartAt startAtToUse = resolved != null && resolved.isDefault() ? StartAt.subscriptionModelDefault() : StartAt.now();
+            return delegate.subscribe(subscriptionId, filter, startAtToUse, action);
+        }
+
+        @Override
+        public @Nullable SubscriptionPosition globalSubscriptionPosition() {
+            return new StringBasedSubscriptionPosition("in-memory-global-position");
+        }
+
+        @Override
+        public void stop() {
+            delegate.stop();
+        }
+
+        @Override
+        public void start(boolean resumeSubscriptionsAutomatically) {
+            delegate.start(resumeSubscriptionsAutomatically);
+        }
+
+        @Override
+        public boolean isRunning() {
+            return delegate.isRunning();
+        }
+
+        @Override
+        public boolean isRunning(String subscriptionId) {
+            return delegate.isRunning(subscriptionId);
+        }
+
+        @Override
+        public boolean isPaused(String subscriptionId) {
+            return delegate.isPaused(subscriptionId);
+        }
+
+        @Override
+        public Subscription resumeSubscription(String subscriptionId) {
+            return delegate.resumeSubscription(subscriptionId);
+        }
+
+        @Override
+        public void pauseSubscription(String subscriptionId) {
+            delegate.pauseSubscription(subscriptionId);
+        }
+
+        @Override
+        public void cancelSubscription(String subscriptionId) {
+            delegate.cancelSubscription(subscriptionId);
+        }
+    }
+
+    private static final class InMemorySubscriptionPositionStorage implements SubscriptionPositionStorage {
+        private final ConcurrentMap<String, SubscriptionPosition> positions = new ConcurrentHashMap<>();
+
+        @Override
+        public SubscriptionPosition read(String subscriptionId) {
+            return positions.get(subscriptionId);
+        }
+
+        @Override
+        public SubscriptionPosition save(String subscriptionId, SubscriptionPosition subscriptionPosition) {
+            positions.put(subscriptionId, subscriptionPosition);
+            return subscriptionPosition;
+        }
+
+        @Override
+        public void delete(String subscriptionId) {
+            positions.remove(subscriptionId);
+        }
+
+        @Override
+        public boolean exists(String subscriptionId) {
+            return positions.containsKey(subscriptionId);
+        }
+    }
+}


### PR DESCRIPTION
## What

Extends `CatchupSubscriptionModel` with a DCB mode so a pure-DCB application can rebuild a read model from history, not just subscribe live. Today the catch-up phase replays stream events ordered by time and the `subscribeDcb` DSL is live only, so a projection that starts from the beginning of the DCB sequence never sees the events written before it subscribed.

This is PR4 in the DCB stack and implements [ADR 20](doc/architecture/decisions/0020-dcb-catch-up-subscription-by-dcbposition.md).

## How

A new constructor takes a `DcbEventStore` and a `DcbQuery`. The stream constructors and every stream code path are unchanged, and an instance is in exactly one mode, selected by constructor.

In DCB mode the catch-up phase replays by `dcbposition`:

* It pages through the DCB sequence with position-windowed reads (`read(query, DcbReadOptions.between(after, upTo))`), starting from the resume position (`0` for a beginning-of-sequence rebuild, or the stored `dcbposition`). It learns the head from the returned `DcbEventStream.lastSequencePosition`, so memory stays bounded even though `read` returns a materialized list. The window size is configurable through `CatchupSubscriptionModelConfig.dcbCatchupPositionWindowSize`.
* The live change-stream position is captured after the bulk replay, exactly as in stream mode, then events written during the replay are reconciled by continuing to page until the head stops advancing.
* On the live path the model post-filters the wrapped subscription's CloudEvents by `DcbCloudEvents.getPosition > 0` and `matches(query)`, and dedups the handover seam through the same fixed-size cache, so the consumer sees only matching DCB events, exactly once, in both phases.

`DcbSubscriptionPosition` encodes the `dcbposition` as `"dcbposition:<n>"` so it round-trips through `SubscriptionPositionStorage` and stays distinguishable from a time position and a change-stream token. During catch-up the model persists a `DcbSubscriptionPosition`. After handover the live phase persists the change-stream token, as in stream mode. On restart the stored position selects the path.

## Why this matters

Because `dcbposition` is monotonic and server-assigned, the DCB reconciliation is a plain position-range read with no `count()` call. That makes the DCB catch-up immune to both losses that constrain the stream delta: the clock-skew miss closed in [ADR 14](doc/architecture/decisions/0014-reconcile-catchup-events-by-insertion-order-to-avoid-loss-under-clock-skew.md), and the `estimatedDocumentCount` undercount left open as a negative there. This is the robust reconciliation ADR 14 pointed at, realized here as `dcbposition`.

## Compatibility

The shared handover machinery (capture-position, delegated subscription, seam dedupe) is reused by both modes via extracted private helpers, not forked. The existing `CatchupSubscriptionModelTest` passes unchanged (16/16). No stream API or behavior changes.

## Tests

* `DcbCatchupSubscriptionModelTest` (in-memory, deterministic): replay from beginning of sequence in position order, during-catch-up handover with no loss and no duplicates, resume from a supplied `dcbposition` and from one read back from storage, live-only query post-filter, and multi-window paging.
* `DcbCatchupSubscriptionModelMongoTest`: the real change-stream handover on the shipping path (`SpringMongoEventStore` as the `DcbEventStore`, `SpringMongoSubscriptionModel` as the live model). DCB history replays, non-matching events are filtered, post-handover live events arrive through the change stream, with `containsExactly` and `doesNotHaveDuplicates` across the seam. This is the part the in-memory test cannot exercise, since the in-memory subscription is not position aware.

Both new suites are green and reran deterministically. The full module suite (16 + 6 + 1) passes.

## Known limitation

A DCB-mode instance is bound to a single `DcbQuery` set at construction, so several read models over different queries need several instances. This matches the one-projection-one-query norm and keeps the resume semantics unambiguous, since the stored position belongs to one query.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-append-placement","parentHead":"d859129a860576ed79edb2ee580f96eb3153a6c3","parentPull":207,"trunk":"main"}
```
-->
