### PR TITLE
Auto-configure the DCB DSL beans in the Spring Boot starter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,8 @@
   * The Spring Boot starter now auto-configures application services from the same capability set: stream `ApplicationService` for `STREAM`, `DcbApplicationService` for `DCB`, and both for `stream,dcb`.
   * DCB-only Spring Boot auto-configuration also exposes `DomainEventQueries` so DCB query DSL extensions can reuse the starter-provided converter while stream application services remain disabled.
   * DCB application-service auto-configuration requires a user-provided `TagGenerator` bean, since DCB tags are domain-specific.
+  * The Spring Boot starter now also auto-configures the DCB DSL when the `DCB` capability is enabled: a `DcbDomainEventQueries` wrapping the auto-configured `DomainEventQueries`, and a `DcbSubscriptions` over the subscription model. Both back off to a user-provided bean of the same type.
+  * In DCB-only mode the auto-configured subscriptions are currently live only, because the catch-up model is not wired in DCB-only mode. Replay by `dcbposition` for auto-configured subscriptions is a follow-up.
   * Occurrent creates missing indexes/collections only. It never removes indexes or collections automatically.
 * Added DCB query excluded-type support.
   * `DcbQueryItem` now has `excludedTypes`.

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/Bootstrap.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/Bootstrap.kt
@@ -21,9 +21,7 @@ import org.occurrent.application.converter.jackson3.jacksonCloudEventConverter
 import org.occurrent.application.converter.typemapper.CloudEventTypeMapper
 import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper
 import org.occurrent.application.service.blocking.dcb.TagGenerator
-import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
 import org.occurrent.dsl.decider.Decider
-import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.example.domain.wordguessinggame.event.GameEvent
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.dcb.GameEventTagGenerator
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.gameplay.decider.WordGuessingGameCommand
@@ -72,9 +70,7 @@ class Bootstrap {
     @Bean
     fun gameEventTagGenerator(): TagGenerator<GameEvent> = GameEventTagGenerator()
 
-    @Bean
-    fun dcbQueryDsl(domainEventQueries: DomainEventQueries<GameEvent>) =
-        DcbDomainEventQueries(domainEventQueries)
+    // DcbDomainEventQueries is auto-configured by the starter when the DCB capability is enabled.
 
     @Bean
     fun wordGuessingGameDecider(): Decider<WordGuessingGameCommand, WordGuessingGameState, GameEvent> =

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/BootstrapContextTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/BootstrapContextTest.kt
@@ -21,6 +21,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.occurrent.application.service.blocking.ApplicationService
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
+import org.occurrent.dsl.dcb.blocking.DcbSubscriptions
 import org.occurrent.dsl.decider.Decider
 import org.occurrent.dsl.query.blocking.DomainEventQueries
 import org.occurrent.dsl.subscription.blocking.Subscriptions
@@ -48,6 +50,10 @@ class BootstrapContextTest {
         assertThat(applicationContext.getBeansOfType(DomainEventQueries::class.java)).containsOnlyKeys("occurrentDomainEventQueries")
         assertThat(applicationContext.getBeansOfType(DcbApplicationService::class.java))
             .containsOnlyKeys("occurrentDcbApplicationService")
+        assertThat(applicationContext.getBeansOfType(DcbDomainEventQueries::class.java))
+            .containsOnlyKeys("occurrentDcbDomainEventQueries")
+        assertThat(applicationContext.getBeansOfType(DcbSubscriptions::class.java))
+            .containsOnlyKeys("occurrentDcbSubscriptions")
         assertThat(applicationContext.getBeansOfType(Decider::class.java)).hasSize(1)
     }
 

--- a/framework/spring-boot-starter-mongodb/pom.xml
+++ b/framework/spring-boot-starter-mongodb/pom.xml
@@ -119,6 +119,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>dcb-dsl-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>annotations</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -29,6 +29,8 @@ import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
 import org.occurrent.application.service.blocking.dcb.GenericDcbApplicationService;
 import org.occurrent.application.service.blocking.dcb.TagGenerator;
 import org.occurrent.application.service.blocking.generic.GenericApplicationService;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
 import org.occurrent.dsl.subscription.blocking.Subscriptions;
 import org.occurrent.eventstore.api.blocking.EventStore;
@@ -170,12 +172,37 @@ public class OccurrentMongoAutoConfiguration<E> {
         return new Subscriptions<>(subscribable, cloudEventConverter);
     }
 
+    /**
+     * DCB subscription DSL, auto-configured when the DCB event-store capability is enabled. In DCB-only mode the
+     * subscription is currently live only, because the catch-up model is not wired in DCB-only mode, so replay by
+     * dcbposition for auto-configured subscriptions is a follow-up.
+     */
+    @Bean
+    @ConditionalOnMissingBean(DcbSubscriptions.class)
+    @Conditional(OnDcbEventStoreCapabilityCondition.class)
+    @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
+    public DcbSubscriptions<E> occurrentDcbSubscriptions(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
+        return new DcbSubscriptions<>(subscribable, cloudEventConverter);
+    }
+
     @Bean
     @ConditionalOnMissingBean(DomainEventQueries.class)
     @Conditional(OnDomainEventQueriesCapabilityCondition.class)
     @ConditionalOnProperty(name = "occurrent.event-store.enabled", havingValue = "true", matchIfMissing = true)
     public DomainEventQueries<E> occurrentDomainEventQueries(EventStoreQueries eventStoreQueries, CloudEventConverter<E> cloudEventConverter) {
         return new DomainEventQueries<>(eventStoreQueries, cloudEventConverter);
+    }
+
+    /**
+     * DCB query DSL, auto-configured when the DCB event-store capability is enabled. It wraps the
+     * {@link DomainEventQueries} bean so a DCB application gets one object for both DCB and stream queries.
+     */
+    @Bean
+    @ConditionalOnMissingBean(DcbDomainEventQueries.class)
+    @Conditional(OnDcbEventStoreCapabilityCondition.class)
+    @ConditionalOnProperty(name = "occurrent.event-store.enabled", havingValue = "true", matchIfMissing = true)
+    public DcbDomainEventQueries<E> occurrentDcbDomainEventQueries(DomainEventQueries<E> domainEventQueries) {
+        return new DcbDomainEventQueries<>(domainEventQueries);
     }
 
     @Bean

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
@@ -25,6 +25,8 @@ import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMa
 import org.occurrent.application.service.blocking.ApplicationService;
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
 import org.occurrent.application.service.blocking.dcb.TagGenerator;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
@@ -231,6 +233,47 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
                 .withBean(TagGenerator.class, () -> tagsForTestEvent())
                 .withBean(DcbApplicationService.class, () -> customApplicationService)
                 .run(context -> assertThat(context.getBean(DcbApplicationService.class)).isSameAs(customApplicationService));
+    }
+
+    @Test
+    void dcb_capability_auto_configures_dcb_query_and_subscription_dsl() {
+        eventStoreConfigContextRunner()
+                .withPropertyValues(
+                        "occurrent.subscription.enabled=true",
+                        "occurrent.event-store.capabilities=dcb"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(DcbDomainEventQueries.class);
+                    assertThat(context).hasSingleBean(DcbSubscriptions.class);
+                });
+    }
+
+    @Test
+    void stream_only_does_not_auto_configure_dcb_query_or_subscription_dsl() {
+        eventStoreConfigContextRunner()
+                .withPropertyValues("occurrent.subscription.enabled=true")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(DcbDomainEventQueries.class);
+                    assertThat(context).doesNotHaveBean(DcbSubscriptions.class);
+                });
+    }
+
+    @Test
+    void custom_dcb_query_and_subscription_dsl_beans_are_not_replaced() {
+        DcbDomainEventQueries<?> customQueries = mock(DcbDomainEventQueries.class);
+        DcbSubscriptions<?> customSubscriptions = mock(DcbSubscriptions.class);
+
+        eventStoreConfigContextRunner()
+                .withPropertyValues(
+                        "occurrent.subscription.enabled=true",
+                        "occurrent.event-store.capabilities=dcb"
+                )
+                .withBean(DcbDomainEventQueries.class, () -> customQueries)
+                .withBean(DcbSubscriptions.class, () -> customSubscriptions)
+                .run(context -> {
+                    assertThat(context.getBean(DcbDomainEventQueries.class)).isSameAs(customQueries);
+                    assertThat(context.getBean(DcbSubscriptions.class)).isSameAs(customSubscriptions);
+                });
     }
 
     @Test


### PR DESCRIPTION
## What

Auto-configures the DCB query and subscription DSL beans in the Spring Boot starter. The starter already auto-configures the DCB application service and the stream `DomainEventQueries` (which serves DCB reads too), but a DCB application still had to hand-define the DCB DSL beans. This closes that gap.

This is PR6 in the DCB stack, scoped to the convenience beans plus docs (the DCB-only subscription catch-up wiring is a deliberate follow-up, see below).

## How

When the DCB event-store capability is enabled the starter now auto-configures:

* `DcbDomainEventQueries`, wrapping the auto-configured `DomainEventQueries`, so a DCB application gets one object for both DCB and stream queries.
* `DcbSubscriptions`, over the subscription model.

Both are gated on the DCB capability and back off to a user-provided bean of the same type (`@ConditionalOnMissingBean`). Neither is created in STREAM-only mode.

The `dcb-autoconfig` example drops its hand-defined `DcbDomainEventQueries` bean and relies on the auto-configured one, which demonstrates the convenience.

## What was already there

Most of the planned DCB starter wiring already existed: capability-conditional beans (`DcbApplicationService` auto-registered when DCB and a `TagGenerator` are present, stream `ApplicationService` gated on STREAM, `DomainEventQueries` for both), `@Subscription` already works with DCB subscriptions, and a characterization test suite across STREAM-only, DCB-only, and STREAM+DCB modes. PR6 only adds the two DSL convenience beans on top.

## Deferred (follow-up)

In DCB-only mode the auto-configured subscriptions are currently live only, because the catch-up model is not wired in DCB-only mode. Replay by `dcbposition` for auto-configured subscriptions is a follow-up: the DCB catch-up added to `CatchupSubscriptionModel` is per-query, which does not compose with the starter's single shared subscription-model stack without per-subscription wiring. This is documented in the changelog and the bean Javadoc.

## Tests

Characterization tests assert both DCB DSL beans are created in DCB mode, neither is created in STREAM-only mode, and a user-provided bean of either type is not replaced. The existing characterization tests and the `dcb-autoconfig` example test pass unchanged.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-appservice-sideeffects","parentHead":"bcc192d47bcc9809be4c65fb14f55ade7d132476","parentPull":210,"trunk":"main"}
```
-->
