### PR TITLE
Harden the Spring Mongo DCB append path with query-scoped concurrency

### DIFF
--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/GenericDcbApplicationService.java
@@ -97,7 +97,7 @@ public class GenericDcbApplicationService<E> implements DcbApplicationService<E>
 
             List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(newDomainEvents.stream()).toList();
             List<CloudEvent> dcbEvents = addTags(newDomainEvents, cloudEvents);
-            DcbAppendCondition appendCondition = DcbAppendCondition.failIfEventsMatch(query, eventStream.lastSequencePosition());
+            DcbAppendCondition appendCondition = DcbAppendCondition.failIfEventsMatch(query, eventStream.consistencyToken());
             return new Tuple<>(Optional.of(eventStore.append(dcbEvents, appendCondition)), newDomainEvents);
         });
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,8 @@
   * The backward-compatible default is `{STREAM}`.
   * Spring Boot property: `occurrent.event-store.capabilities=stream`, `dcb`, or `stream,dcb`.
   * `SpringMongoEventStore` now creates indexes/support collections based on enabled capabilities and fails fast when callers invoke a disabled API family.
+  * The Spring Mongo DCB append path now uses query-scoped concurrency instead of serializing every append on a global counter. The `dcbposition` counter is reserved outside the append transaction, so appends to disjoint boundaries no longer contend on a single hot document (`dcbposition` may now have gaps, which the DCB contract permits). Optimistic concurrency is enforced with a consistency token rather than a position. A read captures a `DcbConsistencyToken` (a distinct type from the `long` sequence position) from the versions of its query's per-attribute conflict markers, and the append fails if those markers advanced since the read. Because marker versions move at commit and never at reservation, this is sound even though the read head can run ahead of committed data, where a position-based check would silently miss a conflict. The markers also serialize concurrent appends that can match a common event and are provably skew-safe for tag-scoped and type-scoped boundaries, including unconditional appends, and transient MongoDB transaction conflicts are retried instead of surfacing as a spurious command failure. The token is derived from positive markers only, so excluded types and multi-attribute conjunctions are a safe over-approximation in the conflict check: reads still apply them precisely, and a false conflict self-heals through the application-service retry. A `MatchAll` append condition is a whole-store lock and is not skew-safe against concurrent tag or type scoped appends. See [ADR 21](doc/architecture/decisions/0021-dcb-write-path-query-scoped-concurrency.md). Adversarial multi-threaded tests prove the type-versus-tag, tag-versus-tag, and type-versus-type cases plus the read-watermark and unconditional-append scenarios, and `explain` confirms the conflict and read queries are index-backed.
+  * DCB tag queries now match with a single `dcbTags` array-containment predicate instead of one predicate per tag.
   * The Spring Boot starter now auto-configures application services from the same capability set: stream `ApplicationService` for `STREAM`, `DcbApplicationService` for `DCB`, and both for `stream,dcb`.
   * DCB-only Spring Boot auto-configuration also exposes `DomainEventQueries` so DCB query DSL extensions can reuse the starter-provided converter while stream application services remain disabled.
   * DCB application-service auto-configuration requires a user-provided `TagGenerator` bean, since DCB tags are domain-specific.
@@ -40,7 +42,7 @@
   * `DcbQueryItem` now has `excludedTypes`.
   * Added factories for tag and type+tag queries that exclude event types.
   * Included types are any-of, tags are all-of, and excluded types are none-of within each query item.
-  * Append-condition matching now respects excluded types so excluded events do not cause false DCB conflicts.
+  * Reads respect excluded types, so excluded events are filtered from DCB query results. The Spring Mongo append-condition check over-approximates excluded types as a safe conservatism (see the query-scoped concurrency note), so an excluded event that still carries a query's positive tag can trigger a self-healing conflict rather than being ignored.
 * Added a blocking DCB DSL module.
   * New module: `org.occurrent:dcb-dsl-blocking`.
   * Java helpers: `DcbDomainEventQueries` and `DcbDomainEventStream`.
@@ -69,6 +71,7 @@
   * [ADR 18](doc/architecture/decisions/0018-spring-mongo-event-store-capabilities.md)
   * [ADR 19](doc/architecture/decisions/0019-dcb-dsl-module.md)
   * [ADR 20](doc/architecture/decisions/0020-dcb-catch-up-subscription-by-dcbposition.md)
+  * [ADR 21](doc/architecture/decisions/0021-dcb-write-path-query-scoped-concurrency.md)
 
 #### Notes
 

--- a/doc/architecture/decisions/0021-dcb-write-path-query-scoped-concurrency.md
+++ b/doc/architecture/decisions/0021-dcb-write-path-query-scoped-concurrency.md
@@ -1,0 +1,72 @@
+# 21. DCB write-path query-scoped concurrency
+
+Date: 2026-06-22
+
+## Status
+
+Accepted
+
+## Context
+
+`SpringMongoEventStore.appendDcb` appends DCB events under an optional `DcbAppendCondition`, which is the DCB optimistic-concurrency check: fail the append if any event matching the condition's `DcbQuery` exists after the position the command read. The current implementation has three concurrency problems.
+
+1. Every append reserves its global `dcbposition` block with a `findAndModify` `$inc` on a single counter document, inside the append transaction. Under concurrency that one document is a hot spot. Concurrent appends contend on it and MongoDB raises a `TransientTransactionError`, which aborts the whole transaction.
+
+2. There is no retry for transient transaction errors. `MongoTransactionManager` does not retry them, and the only retry in play is the application service retrying `DcbAppendConditionNotFulfilledException`. So contention surfaces as a spurious command failure rather than a retry.
+
+3. The conflict-serialization keying is not skew-safe. The append writes per-key checkpoint documents to force concurrent appends on the same boundary to conflict, but it keys a tag item as `tag:<tag>` and a type-only item as `type:<type>`. Two overlapping queries that match the same event by different dimensions, for example `types(X)` and `tagsAllOf("t")` both matching an event `{type:X, tag:t}`, get disjoint keys, so they do not conflict. Today the global counter serialization in problem 1 hides this, because every append contends on the counter anyway. Remove that serialization for scalability and write skew becomes possible: two commands each read a boundary, each append a matching event, and both commit even though the second should have failed.
+
+The goal is query-scoped concurrency. Appends to disjoint boundaries proceed in parallel, appends to the same boundary serialize, and no pair of appends that can match a common event is ever allowed to both commit when one should fail.
+
+## Decision
+
+### Assign positions outside the transaction
+
+Move the `dcbposition` counter `findAndModify` out of the append transaction. It is a single atomic update, which MongoDB serializes efficiently at the document level without raising a transaction conflict. The reserved block is reused if the transaction is retried, and is simply abandoned if the append fails its condition. `dcbposition` stays strictly increasing but may have gaps, which the DCB contract permits (ADR 0017). The unique sparse index on `dcbposition` still guarantees no two events share a position.
+
+### Detect and serialize conflicts with versioned per-attribute markers
+
+Assigning positions outside the transaction has a consequence: a reader can observe a global head that runs ahead of the data it can see, because a concurrent append reserves its position block before it commits. A conflict check phrased over positions ("fail if a matching event exists after the position I read") is therefore unsound. The reader's boundary can sit past an append that is still in flight, which then commits at a position at or below that boundary and is never seen, so the conflict is lost silently. The conflict check must not depend on positions.
+
+Instead, every distinct tag and type has a marker document carrying a monotonically increasing version. An append derives its marker keys from per-attribute units, never combined:
+
+- For a tag `t`, the key `tag:t`.
+- For a type `X`, the key `type:X`.
+
+Inside the transaction the append increments the marker version for the union of:
+
+- the appended events' keys (every tag and the type of each appended event), on every append whether or not it carries a condition, and
+- the condition query's keys when a condition is present (every tag and every included type named by any query item).
+
+Incrementing a shared marker document forces a write-write conflict in MongoDB, so two transactions that touch a common marker cannot both commit. The sharing argument is unchanged: if append A1 commits an event E1 that matches append A2's query Q2, then some item of Q2 is satisfied by E1, so A1 touches that item's `tag:t` or `type:X` marker from its event keys and A2 touches the same marker from its query keys, and the two serialize. The reverse direction (E2 matching Q1) holds by the same argument. Because an unconditional append also increments its events' markers, it cannot slip past a concurrent conditional append on an overlapping tag or type.
+
+A read captures a consistency token for its query: the sum of the versions of the query's markers. Versions are incremented at commit and never at reservation, so the token reflects only committed appends and is immune to the position overshoot above. The authoritative conflict check compares the token the condition carries against the current token inside the transaction. If any of the query's markers advanced since the read, a matching append committed in between, so the condition fails. The marker increments still force serialization, so the loser re-runs this comparison against the winner's committed increment rather than racing it under snapshot isolation.
+
+The token is distinct from the read's `lastSequencePosition`. The position remains a global cursor for replay and catch-up. The token is the optimistic-concurrency boundary, and the two are different types (`DcbConsistencyToken` versus `long`) so a caller cannot pass one where the other is required.
+
+### Retry transient transaction errors
+
+Wrap the append transaction in a bounded retry that recognises MongoDB transient transaction errors (the `TransientTransactionError` error label, surfaced by Spring as `UncategorizedMongoDbException` / `MongoException.hasErrorLabel`). On retry the reserved position block is reused and the condition is re-evaluated, so a retry either commits or fails the condition correctly. `DcbAppendConditionNotFulfilledException` is not retried here, it propagates to the application service, which re-reads and retries the command.
+
+### A MatchAll condition is a whole-store lock
+
+A `MatchAll` condition matches every event, so no per-attribute marker can be shared with an arbitrary concurrent append without making every append write a single global marker, which is global serialization. A `MatchAll` append condition is therefore a whole-store optimistic lock keyed `all`: it is skew-safe against other `MatchAll` conditions, but it is NOT skew-safe against a concurrent tag-scoped or type-scoped append (the two share no marker, so both can commit even when the `MatchAll` condition should have failed). This is a correctness limitation under concurrency, not merely a performance one, so a `MatchAll` append condition must not be relied on as a consistency boundary on a store that takes concurrent writes. It is fine on a single-writer store or as a one-shot "the store is empty" guard. Tag-scoped and type-scoped boundaries, the normal DCB usage, are fully skew-safe.
+
+A query item with neither types nor tags cannot be constructed (`DcbQueryItem` rejects it), so there is no separate negative-only or empty-item case to reason about. An item always carries at least one positive tag or type, which is what makes its marker shareable. Excluded types only narrow a positive item and never remove its positive marker keys, so they do not affect skew-safety. They do reduce precision: see the over-approximation note in the consequences.
+
+## Consequences
+
+Positive:
+
+- Appends to disjoint boundaries no longer contend on a global counter or a global checkpoint, so they scale concurrently.
+- The conflict keying is skew-safe for tag-scoped and type-scoped boundaries, proven against the type-versus-tag, tag-versus-tag, and type-versus-type overlap cases by adversarial multi-threaded tests.
+- Contention surfaces as a retry, not a spurious command failure.
+- The conflict check is a lookup of the query's marker documents by `_id`, which is always index-backed, and the read query is index-backed by the `dcbtags` and `dcbposition` indexes, confirmed with `explain`.
+- The conflict check is decoupled from positions, so it is sound even though positions are assigned outside the transaction and the read head can run ahead of committed data.
+
+Negative:
+
+- `dcbposition` can have gaps, because a reserved block is abandoned when an append fails its condition or exhausts its transient retries. DCB only requires monotonic increasing positions, so gaps are acceptable, but callers must not assume contiguity (they already must not, per ADR 0017).
+- The marker collection holds one document per distinct tag and per distinct type that has taken part in a conditional append. For high-cardinality tags, for example a tag per entity, this is one marker per entity. That is the natural granularity of the consistency boundary and matches the cardinality the boundary already implies.
+- A `MatchAll` or negative-only append condition is a whole-store lock as described above. This is a documented limitation, not a silent one.
+- The token-based check is a safe over-approximation. It is derived from positive markers only, so it cannot represent excluded types or multi-attribute conjunctions precisely. An append of an excluded-type event that still carries a query's positive tag, or an append that carries only some of a conjunction's tags, advances a shared marker and conservatively conflicts even though it does not match the full query. This never misses a real conflict, reads still apply excluded types and conjunctions precisely, and the false conflict self-heals through the application service, which re-reads the still-filtered boundary and retries. The cost is reduced concurrency between appends on a shared tag or type, which is the boundary the caller chose.

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendCondition.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbAppendCondition.java
@@ -18,40 +18,38 @@ package org.occurrent.eventstore.api.dcb;
 
 import org.jspecify.annotations.NullMarked;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Optimistic conflict condition for a DCB append.
  * <p>
- * {@code query} describes the events that would conflict with the append. {@code afterSequencePosition}
- * optionally limits the conflict check to events written after a position observed by a prior read.
+ * {@code query} describes the events that would conflict with the append. {@code consistencyToken} optionally limits the
+ * conflict check to events committed after a boundary observed by a prior read (see
+ * {@link DcbEventStream#consistencyToken()}); when empty, the append fails if any existing event matches {@code query}.
  */
 @NullMarked
-public record DcbAppendCondition(DcbQuery query, OptionalLong afterSequencePosition) {
+public record DcbAppendCondition(DcbQuery query, Optional<DcbConsistencyToken> consistencyToken) {
 
     public DcbAppendCondition {
         requireNonNull(query, "Query cannot be null");
-        requireNonNull(afterSequencePosition, "After sequence position cannot be null");
-        afterSequencePosition.ifPresent(position -> {
-            if (position < 0) {
-                throw new IllegalArgumentException("After sequence position cannot be negative");
-            }
-        });
+        requireNonNull(consistencyToken, "Consistency token cannot be null");
     }
 
     /**
      * Creates a condition that fails if any existing event matches {@code query}.
      */
     public static DcbAppendCondition failIfEventsMatch(DcbQuery query) {
-        return new DcbAppendCondition(query, OptionalLong.empty());
+        return new DcbAppendCondition(query, Optional.empty());
     }
 
     /**
-     * Creates a condition that fails if an event after {@code afterSequencePosition} matches {@code query}.
+     * Creates a condition that fails if an event matching {@code query} was committed after the read that produced
+     * {@code consistencyToken}.
      */
-    public static DcbAppendCondition failIfEventsMatch(DcbQuery query, long afterSequencePosition) {
-        return new DcbAppendCondition(query, OptionalLong.of(afterSequencePosition));
+    public static DcbAppendCondition failIfEventsMatch(DcbQuery query, DcbConsistencyToken consistencyToken) {
+        requireNonNull(consistencyToken, "Consistency token cannot be null");
+        return new DcbAppendCondition(query, Optional.of(consistencyToken));
     }
 }

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbConsistencyToken.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbConsistencyToken.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.dcb;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An opaque, store-defined token capturing the optimistic-concurrency boundary a DCB read observed for a query.
+ * <p>
+ * A {@link DcbEventStream#consistencyToken() read} produces a token; pass it unchanged to
+ * {@link DcbAppendCondition#failIfEventsMatch(DcbQuery, DcbConsistencyToken)} so a later append is rejected if any event
+ * matching the query was committed after the read. It is deliberately a distinct type from the {@code long}
+ * {@link DcbEventStream#lastSequencePosition() sequence position} so the two cannot be confused: the position is a global
+ * cursor (suitable for replay) but is NOT a safe concurrency boundary on its own, whereas this token is.
+ * <p>
+ * The {@link #value()} is store-internal. Round-trip a token within the same store; do not interpret or compare its
+ * value across stores.
+ *
+ * @param value the store-internal token value
+ */
+@NullMarked
+public record DcbConsistencyToken(long value) {
+
+    public DcbConsistencyToken {
+        if (value < 0) {
+            throw new IllegalArgumentException("Consistency token value cannot be negative");
+        }
+    }
+
+    /**
+     * Creates a token from a store-internal value.
+     */
+    public static DcbConsistencyToken of(long value) {
+        return new DcbConsistencyToken(value);
+    }
+}

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbEventStream.java
@@ -33,20 +33,37 @@ import static java.util.Objects.requireNonNull;
  *                             the matched {@code events}: the highest matched position can be lower than the head, and
  *                             when the query matches nothing there is no matched position at all, yet
  *                             {@code lastSequencePosition} still reports the store head. It is {@code 0} only when the
- *                             store holds no DCB events yet. Pass it to
- *                             {@link DcbAppendCondition#failIfEventsMatch(DcbQuery, long)} so a later append is rejected
- *                             if any event matching the query was written after this read, independent of which events
- *                             the query itself matched.
+ *                             store holds no DCB events yet. It is a monotonic global cursor, suitable for replay and
+ *                             catch-up, but it is NOT a safe optimistic-concurrency boundary on its own: a store that
+ *                             assigns positions before the events commit can report a head that is ahead of the data a
+ *                             reader can actually see. Use {@code consistencyToken} for optimistic concurrency.
+ * @param consistencyToken     an opaque, store-defined token capturing the consistency boundary observed by this read
+ *                             for the supplied query. Pass it unchanged to
+ *                             {@link DcbAppendCondition#failIfEventsMatch(DcbQuery, DcbConsistencyToken)} so a later
+ *                             append is rejected if any event matching the query was committed after this read. Unlike
+ *                             {@code lastSequencePosition}, it is sound under concurrent in-flight appends because the
+ *                             store derives it from data that is only observable once committed. Round-trip it within
+ *                             the same store; do not interpret or compare it across stores.
  */
 @NullMarked
-public record DcbEventStream(List<CloudEvent> events, long lastSequencePosition) {
+public record DcbEventStream(List<CloudEvent> events, long lastSequencePosition, DcbConsistencyToken consistencyToken) {
 
     public DcbEventStream {
         requireNonNull(events, "Events cannot be null");
+        requireNonNull(consistencyToken, "Consistency token cannot be null");
         if (lastSequencePosition < 0) {
             throw new IllegalArgumentException("Last sequence position cannot be negative");
         }
         events = List.copyOf(events);
+    }
+
+    /**
+     * Convenience for stores whose read head is itself a sound optimistic-concurrency boundary (for example the
+     * in-memory store, whose appends assign positions and commit atomically). Such stores use the position as the
+     * {@code consistencyToken}.
+     */
+    public DcbEventStream(List<CloudEvent> events, long lastSequencePosition) {
+        this(events, lastSequencePosition, DcbConsistencyToken.of(lastSequencePosition));
     }
 
     /**

--- a/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
+++ b/eventstore/api/dcb/src/test/java/org/occurrent/eventstore/api/dcb/DcbApiTest.java
@@ -175,9 +175,9 @@ class DcbApiTest {
         assertThatThrownBy(() -> DcbReadOptions.afterSequencePosition(-1))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("After sequence position cannot be negative");
-        assertThatThrownBy(() -> DcbAppendCondition.failIfEventsMatch(DcbQuery.all(), -1))
+        assertThatThrownBy(() -> DcbAppendCondition.failIfEventsMatch(DcbQuery.all(), DcbConsistencyToken.of(-1)))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("After sequence position cannot be negative");
+                .hasMessage("Consistency token value cannot be negative");
     }
 
     private static io.cloudevents.CloudEvent cloudEvent() {

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -282,7 +282,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         DcbAppendResult result;
         synchronized (state) {
             if (condition != null) {
-                long afterSequencePosition = condition.afterSequencePosition().orElse(0);
+                // The in-memory store assigns positions and commits atomically under the lock, so its read head is a
+                // sound concurrency boundary: the token value is simply the position observed by the read.
+                long afterSequencePosition = condition.consistencyToken().map(DcbConsistencyToken::value).orElse(0L);
                 boolean fulfilled = allEvents()
                         .filter(event -> dcbPosition(event) > afterSequencePosition)
                         .noneMatch(event -> DcbCloudEvents.matches(event, condition.query()));

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -98,8 +98,8 @@ class InMemoryEventStoreDcbTest {
         // Two appends to the same boundary (game:1), but each event carries a different extra tag. Placement must
         // follow the condition's boundary tags, not the per-event tags, so both land in the same partition stream.
         eventStore.append(List.of(taggedEvent("NameDefined", "game:1", "extra:a")), failIfEventsMatch(tagsAllOf("game:1")));
-        long head = eventStore.read(tagsAllOf("game:1")).lastSequencePosition();
-        eventStore.append(List.of(taggedEvent("NameChanged", "game:1", "extra:b")), failIfEventsMatch(tagsAllOf("game:1"), head));
+        DcbConsistencyToken token = eventStore.read(tagsAllOf("game:1")).consistencyToken();
+        eventStore.append(List.of(taggedEvent("NameChanged", "game:1", "extra:b")), failIfEventsMatch(tagsAllOf("game:1"), token));
 
         List<String> streamIds = eventStore.read(tagsAllOf("game:1")).events().stream()
                 .map(OccurrentExtensionGetter::getStreamId)
@@ -189,7 +189,7 @@ class InMemoryEventStoreDcbTest {
 
         assertThatThrownBy(() -> eventStore.append(
                 List.of(taggedEvent("NameChanged", "name:1")),
-                failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition())))
+                failIfEventsMatch(tagsAllOf("name:1"), readModel.consistencyToken())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
     }
 
@@ -204,7 +204,7 @@ class InMemoryEventStoreDcbTest {
 
         DcbAppendResult result = eventStore.append(
                 List.of(taggedEvent("NameChanged", "name:1")),
-                failIfEventsMatch(query, readModel.lastSequencePosition()));
+                failIfEventsMatch(query, readModel.consistencyToken()));
 
         assertThat(result.firstSequencePosition()).isEqualTo(3);
     }
@@ -220,7 +220,7 @@ class InMemoryEventStoreDcbTest {
 
         assertThatThrownBy(() -> eventStore.append(
                 List.of(taggedEvent("NameImported", "name:1")),
-                failIfEventsMatch(query, readModel.lastSequencePosition())))
+                failIfEventsMatch(query, readModel.consistencyToken())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
     }
 

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -93,6 +93,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     private static final String DCB_POSITION_DOCUMENT_ID = "dcb";
     private static final String DCB_COUNTER_POSITION = "position";
     private static final String CHECKPOINT_LAST_POSITION = "lastPosition";
+    private static final String CHECKPOINT_VERSION = "version";
 
     private final MongoTemplate mongoTemplate;
     private final String eventStoreCollectionName;
@@ -194,6 +195,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
 
+        // Snapshot the consistency token BEFORE reading the events. If an append commits between these two reads, the
+        // events may include it while the token does not, which only makes a later conditional append over-cautious (a
+        // false conflict that retries) rather than miss the conflict.
+        long consistencyTokenValue = consistencyToken(query);
         long highWatermark = currentDcbPosition();
         long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
         Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound);
@@ -201,7 +206,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         List<CloudEvent> events = mongoTemplate.find(queryOptions.apply(mongoQuery), Document.class, eventStoreCollectionName).stream()
                 .map(document -> convertToCloudEvent(timeRepresentation, document))
                 .toList();
-        return new DcbEventStream(events, highWatermark);
+        return new DcbEventStream(events, highWatermark, DcbConsistencyToken.of(consistencyTokenValue));
     }
 
     @Override
@@ -339,18 +344,56 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
 
-        return requireNonNull(transactionTemplate.execute(transactionStatus -> {
-            long firstPosition = reserveDcbPositions(eventsToAppend.size());
-            long lastPosition = firstPosition + eventsToAppend.size() - 1;
+        // Reserve the position block once, outside the transaction. The counter findAndModify is a single atomic
+        // document update that MongoDB serializes without raising a transaction conflict. The reserved block is reused
+        // across transient-transaction-error retries; a doomed or condition-failed append abandons it, so dcbposition
+        // may have gaps (DCB permits this, see ADR 0021).
+        long firstPosition = reserveDcbPositions(eventsToAppend.size());
+        long lastPosition = firstPosition + eventsToAppend.size() - 1;
+
+        return executeWithTransientRetry(() -> requireNonNull(transactionTemplate.execute(transactionStatus -> {
             long currentStreamVersion = currentStreamVersion(streamId);
             if (condition != null) {
-                updateCheckpoints(condition, eventsToAppend, lastPosition);
+                enforceAppendCondition(condition, eventsToAppend, lastPosition);
+            } else {
+                // An unconditional append still increments its events' markers so a concurrent conditional append on an
+                // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
+                // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
+                // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
+                // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                incrementConflictMarkers(eventMarkerKeys(eventsToAppend), lastPosition);
             }
 
             List<Document> documents = convertDcbCloudEventsToDocuments(streamId, eventsToAppend, currentStreamVersion, firstPosition);
-            insertAll(streamId, currentStreamVersion, WriteCondition.anyStreamVersion(), documents);
+            insertAllDcb(streamId, currentStreamVersion, documents);
             return new DcbAppendResult(firstPosition, lastPosition, eventsToAppend.size());
-        }));
+        })));
+    }
+
+    /**
+     * Retry the append transaction on a MongoDB {@code TransientTransactionError} (the error label is present when two
+     * transactions conflict, e.g. a write-write conflict on a shared marker). The full cause chain is walked because
+     * Spring wraps the {@link MongoException}. {@link DcbAppendConditionNotFulfilledException} is deliberately NOT
+     * retried here: it propagates to the application service, which re-reads and retries the whole command.
+     */
+    private static <T> T executeWithTransientRetry(java.util.function.Supplier<T> action) {
+        // Exponential backoff with generous attempts: several appends placed in the same partition stream serialize on
+        // stream_version, so the last writer can need to retry past all the others before it commits.
+        return RetryStrategy.exponentialBackoff(java.time.Duration.ofMillis(10), java.time.Duration.ofMillis(500), 2.0f)
+                .maxAttempts(15)
+                .retryIf(SpringMongoEventStore::isTransientTransactionError)
+                .execute(action);
+    }
+
+    private static boolean isTransientTransactionError(Throwable throwable) {
+        // Bounded walk so a cyclic cause chain (self-cause or a longer A -> B -> A cycle) cannot spin forever.
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof MongoException mongoException && mongoException.hasErrorLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Set<String> boundaryTagsOf(List<CloudEvent> events) {
@@ -372,47 +415,99 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return documents;
     }
 
-    private void updateCheckpoints(DcbAppendCondition condition, List<CloudEvent> eventsToAppend, long lastPosition) {
-        long afterSequencePosition = condition.afterSequencePosition().orElse(0);
-        if (mongoTemplate.exists(toDcbMongoQuery(condition.query(), afterSequencePosition, Long.MAX_VALUE), eventStoreCollectionName)) {
+    private void enforceAppendCondition(DcbAppendCondition condition, List<CloudEvent> eventsToAppend, long lastPosition) {
+        // Authoritative optimistic-concurrency check: the condition carries the consistency token the command observed
+        // when it read the query (DcbEventStream.consistencyToken()). If the query's markers have advanced since, an
+        // append matching the query committed after the read, so the condition is not fulfilled. Unlike a position-based
+        // existence check this is immune to read-watermark overshoot, because marker versions are bumped inside the
+        // append transaction (at commit), not when positions are reserved (ADR 0021).
+        long expectedToken = condition.consistencyToken().map(DcbConsistencyToken::value).orElse(0L);
+        long currentToken = consistencyToken(condition.query());
+        if (currentToken != expectedToken) {
             throw new DcbAppendConditionNotFulfilledException(condition, currentDcbPosition(), "Append condition was not fulfilled.");
         }
-        if (eventsToAppend.stream().noneMatch(event -> DcbCloudEvents.matches(event, condition.query()))) {
-            return;
-        }
-        for (String key : checkpointKeys(condition.query())) {
-            Query query = new Query(where(ID).is("checkpoint:" + key));
-            Document checkpoint = mongoTemplate.findOne(query, Document.class, dcbCheckpointCollectionName);
-            long checkpointPosition = checkpoint == null ? 0 : ((Number) checkpoint.get(CHECKPOINT_LAST_POSITION)).longValue();
-            if (checkpointPosition > afterSequencePosition) {
-                throw new DcbAppendConditionNotFulfilledException(condition, currentDcbPosition(), "Append condition was not fulfilled.");
-            }
-            Update update = new Update().set(CHECKPOINT_LAST_POSITION, lastPosition);
+        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increments
+        // force a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs this
+        // check against the winner's committed increment. Always increment the query's markers so a concurrent matching
+        // append is serialized even when this append's own events do not match the query.
+        java.util.TreeSet<String> markerKeys = new java.util.TreeSet<>(queryMarkerKeys(condition.query()));
+        markerKeys.addAll(eventMarkerKeys(eventsToAppend));
+        incrementConflictMarkers(markerKeys, lastPosition);
+    }
+
+    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker (per
+    // ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
+    // monotonically increasing version is also the optimistic-concurrency token: a reader snapshots the versions of a
+    // query's markers (see consistencyToken), and an append fails if any of them changed since. The stored lastPosition
+    // is informational.
+    private void incrementConflictMarkers(Set<String> markerKeys, long lastPosition) {
+        for (String key : markerKeys) {
+            Query query = new Query(where(ID).is("marker:" + key));
+            Update update = new Update().inc(CHECKPOINT_VERSION, 1L).set(CHECKPOINT_LAST_POSITION, lastPosition);
             mongoTemplate.upsert(query, update, dcbCheckpointCollectionName);
         }
     }
 
-    private static Set<String> checkpointKeys(DcbQuery query) {
+    // The optimistic-concurrency token for a query: the sum of the versions of its conflict markers. The sum is
+    // monotonically increasing (every append increments at least one marker by one), so it changes if and only if some
+    // append touched at least one of the query's markers since the reader observed it. Because the versions are bumped
+    // inside the append transaction (not when positions are reserved), this token reflects only committed appends and is
+    // therefore immune to the read-watermark overshoot that a position-based check suffers (ADR 0021).
+    private long consistencyToken(DcbQuery query) {
+        Set<String> markerKeys = queryMarkerKeys(query);
+        long sum = 0;
+        for (String key : markerKeys) {
+            Document marker = mongoTemplate.findById("marker:" + key, Document.class, dcbCheckpointCollectionName);
+            if (marker != null) {
+                Number version = (Number) marker.get(CHECKPOINT_VERSION);
+                if (version != null) {
+                    sum += version.longValue();
+                }
+            }
+        }
+        return sum;
+    }
+
+    private static Set<String> queryMarkerKeys(DcbQuery query) {
         if (query instanceof DcbQuery.MatchAll) {
             return Set.of("all");
         }
+        // Decompose into one key per attribute (a key per tag, a key per type) and NEVER combine them into a single
+        // "type:X+tag:t" key. Skew-safety (ADR 0021) depends on this: a conflicting event shares a marker via whichever
+        // single attribute made it match, and a combined key would share nothing with an event that carries only one
+        // of the attributes through a different query.
         java.util.TreeSet<String> keys = new java.util.TreeSet<>();
         for (DcbQueryItem item : ((DcbQuery.Items) query).items()) {
             item.tags().forEach(tag -> keys.add("tag:" + tag));
-            if (item.tags().isEmpty()) {
-                item.types().forEach(type -> keys.add("type:" + type));
-            }
+            item.types().forEach(type -> keys.add("type:" + type));
+        }
+        return keys;
+    }
+
+    private static Set<String> eventMarkerKeys(List<CloudEvent> events) {
+        java.util.TreeSet<String> keys = new java.util.TreeSet<>();
+        for (CloudEvent event : events) {
+            DcbCloudEvents.getTags(event).forEach(tag -> keys.add("tag:" + tag));
+            keys.add("type:" + event.getType());
         }
         return keys;
     }
 
     private long reserveDcbPositions(int eventCount) {
-        Query query = new Query(where(ID).is(DCB_POSITION_DOCUMENT_ID));
-        Update update = new Update().inc(DCB_COUNTER_POSITION, eventCount);
-        FindAndModifyOptions options = FindAndModifyOptions.options().upsert(true).returnNew(true);
-        Document updated = mongoTemplate.findAndModify(query, update, options, Document.class, dcbPositionCollectionName);
-        long lastPosition = ((Number) requireNonNull(updated, "DCB position document cannot be null").get(DCB_COUNTER_POSITION)).longValue();
-        return lastPosition - eventCount + 1;
+        // Retry the cold-start race: when the counter document does not exist yet, concurrent upserts all try to insert
+        // it and all but one get a duplicate key. On retry the document exists, so the upsert becomes an update.
+        return RetryStrategy.retry()
+                .backoff(org.occurrent.retry.Backoff.fixed(20))
+                .maxAttempts(5)
+                .retryIf(throwable -> throwable instanceof org.springframework.dao.DuplicateKeyException)
+                .execute(() -> {
+                    Query query = new Query(where(ID).is(DCB_POSITION_DOCUMENT_ID));
+                    Update update = new Update().inc(DCB_COUNTER_POSITION, eventCount);
+                    FindAndModifyOptions options = FindAndModifyOptions.options().upsert(true).returnNew(true);
+                    Document updated = mongoTemplate.findAndModify(query, update, options, Document.class, dcbPositionCollectionName);
+                    long lastPosition = ((Number) requireNonNull(updated, "DCB position document cannot be null").get(DCB_COUNTER_POSITION)).longValue();
+                    return lastPosition - eventCount + 1;
+                });
     }
 
     private long currentDcbPosition() {
@@ -499,6 +594,25 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         }
     }
 
+    private void insertAllDcb(String streamId, long streamVersion, List<Document> documents) {
+        try {
+            mongoTemplate.insert(documents, eventStoreCollectionName);
+        } catch (DataAccessException e) {
+            final Throwable rootCause = e.getRootCause();
+            if (rootCause instanceof MongoException mongoException) {
+                // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
+                // stream racing on stream_version) must stay transient so executeWithTransientRetry retries it, rather
+                // than being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+                if (isTransientTransactionError(mongoException)) {
+                    throw mongoException;
+                }
+                throw translateException(new WriteContext(streamId, streamVersion, WriteCondition.anyStreamVersion()), mongoException);
+            } else {
+                throw e;
+            }
+        }
+    }
+
     private static boolean isFulfilled(long currentStreamVersion, WriteCondition writeCondition) {
         if (writeCondition.isAnyStreamVersion()) {
             return true;
@@ -536,8 +650,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         if (!item.excludedTypes().isEmpty()) {
             criteria.add(where("type").nin(item.excludedTypes()));
         }
-        for (String tag : item.tags()) {
-            criteria.add(where(DCB_TAGS_INDEX_FIELD).is(tag));
+        if (!item.tags().isEmpty()) {
+            criteria.add(where(DCB_TAGS_INDEX_FIELD).all(item.tags()));
         }
         return new Criteria().andOperator(criteria);
     }

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
@@ -1,0 +1,656 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.spring.blocking;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.dcb.*;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tagsAllOf;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.types;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+
+/**
+ * Adversarial concurrency tests for the DCB write path (ADR 0021).
+ * <p>
+ * Each scenario drives real threads to a barrier so appends race in earnest.
+ * We repeat each scenario many times (fresh data per iteration via FlushMongoDBExtension
+ * is not practical per-iteration here; instead we use unique per-iteration tags/types so
+ * each iteration is logically isolated on a fresh empty boundary).
+ * <p>
+ * Assertions focus on safety invariants:
+ * - write-skew is NEVER permitted (never two concurrent conflicting successes)
+ * - DcbAppendConditionNotFulfilledException is the only loser exception (transient errors must be retried internally)
+ */
+@Testcontainers
+// Bound each scenario so a deadlock or broken barrier fails the test instead of hanging the whole Maven build on the
+// blocking Future.get() / barrier.await() calls. Generous because each scenario runs many threaded iterations.
+@Timeout(180)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SpringMongoEventStoreDcbConcurrencyTest {
+
+    private static final URI SOURCE = URI.create("urn:test:concurrency");
+    private static final int ITERATIONS = 50;
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                .withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27018:27017");   // distinct port from the DCB functional test to allow parallel suite runs
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(
+            new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_concurrency"));
+
+    private SpringMongoEventStore eventStore;
+    private MongoTemplate mongoTemplate;
+    private static final String COLLECTION = "events";
+
+    @BeforeEach
+    void create_mongo_spring_blocking_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_concurrency");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        mongoTemplate = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        MongoTransactionManager mongoTransactionManager = new MongoTransactionManager(
+                new SimpleMongoClientDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig eventStoreConfig = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(COLLECTION)
+                .transactionConfig(mongoTransactionManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new SpringMongoEventStore(mongoTemplate, eventStoreConfig);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 1: type-vs-tag write skew is prevented
+    //
+    // Two commands both see an empty boundary at position 0 (fresh per iteration via unique
+    // iteration suffix).  Command A appends {type:X_i, tag:t_i} with condition types("X_i").
+    // Command B appends {type:X_i, tag:t_i} with condition tagsAllOf("t_i").
+    // The appended event satisfies BOTH conditions, so whichever commits first invalidates
+    // the other's condition.  The marker keys written by A include "type:X_i"; the marker
+    // keys written by B include "tag:t_i".  The event marker keys for A's append also include
+    // "tag:t_i" (from the event), and the event marker keys for B's append include "type:X_i".
+    // So A and B share the "type:X_i" marker (B's event contributes it) and the "tag:t_i" marker
+    // (A's event contributes it), ensuring a write-write conflict forces serialization.
+    //
+    // Expected invariant: exactly one succeeds every iteration, never both.
+    // ---------------------------------------------------------------------------
+    @Test
+    void type_vs_tag_write_skew_is_prevented() throws Exception {
+        // Use a per-call counter so each append call receives a DISTINCT storage stream.
+        // This removes stream_version as a serializer: only shared markers can serialize the two
+        // racing appends. If enforceAppendCondition wrote no markers, both would sometimes commit.
+        AtomicLong streamCounter = new AtomicLong(0);
+        SpringMongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        int successes = 0;
+        int failures = 0;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String type = "TypeX_" + i;
+            String tag = "tag-x-" + i;
+
+            // Both commands read the (empty) boundary at position 0
+            DcbEventStream boundaryA = isolatedStore.read(types(type));
+            DcbEventStream boundaryB = isolatedStore.read(tagsAllOf(tag));
+            DcbConsistencyToken tokenA = boundaryA.consistencyToken();
+            DcbConsistencyToken tokenB = boundaryB.consistencyToken();
+
+            DcbAppendCondition condA = failIfEventsMatch(types(type), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(tagsAllOf(tag), tokenB);
+
+            CloudEvent eventA = taggedEvent(type, tag);
+            CloudEvent eventB = taggedEvent(type, tag);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventA), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventB), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            // Core safety invariant: both must NEVER succeed simultaneously (marker is the sole serializer)
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both appends succeeded (type-vs-tag write skew)", i)
+                    .isLessThanOrEqualTo(1);
+
+            // At least one must succeed (one may win when both see empty boundary)
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+
+            if (aSucceeded || bSucceeded) successes++;
+            if (!aSucceeded || !bSucceeded) failures++;
+        }
+
+        // Across all iterations: always exactly one winner per iteration
+        assertThat(successes).isEqualTo(ITERATIONS);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 2a: tag-vs-tag write skew is prevented
+    // Two overlapping tag queries, shared tag "shared-tag-N".
+    // ---------------------------------------------------------------------------
+    @Test
+    void tag_vs_tag_write_skew_is_prevented() throws Exception {
+        // Distinct storage stream per append call — stream_version cannot serialize; markers are the sole guard.
+        AtomicLong streamCounter = new AtomicLong(0);
+        SpringMongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String sharedTag = "shared-tag-" + i;
+            String extraTagA = "extra-a-" + i;
+
+            // Both read empty boundary
+            DcbConsistencyToken tokenA = isolatedStore.read(tagsAllOf(sharedTag)).consistencyToken();
+            DcbConsistencyToken tokenB = isolatedStore.read(tagsAllOf(sharedTag, extraTagA)).consistencyToken();
+
+            // Event matches BOTH conditions: has sharedTag and extraTagA
+            // condA: tagsAllOf(sharedTag) — matched by the event
+            // condB: tagsAllOf(sharedTag, extraTagA) — also matched if event carries both
+            DcbAppendCondition condA = failIfEventsMatch(tagsAllOf(sharedTag), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(tagsAllOf(sharedTag, extraTagA), tokenB);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent("SomeType", sharedTag, extraTagA)), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent("SomeType", sharedTag, extraTagA)), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both tag-vs-tag appends succeeded (write skew)", i)
+                    .isLessThanOrEqualTo(1);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither tag-vs-tag append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 2b: type-vs-type write skew is prevented
+    // Both commands use types() queries on the same type; their events carry that type.
+    // ---------------------------------------------------------------------------
+    @Test
+    void type_vs_type_write_skew_is_prevented() throws Exception {
+        // Distinct storage stream per append call — stream_version cannot serialize; markers are the sole guard.
+        AtomicLong streamCounter = new AtomicLong(0);
+        SpringMongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String sharedType = "SharedType_" + i;
+            String tag = "tt-tag-" + i;
+
+            DcbConsistencyToken tokenA = isolatedStore.read(types(sharedType)).consistencyToken();
+            DcbConsistencyToken tokenB = isolatedStore.read(types(sharedType)).consistencyToken();
+
+            DcbAppendCondition condA = failIfEventsMatch(types(sharedType), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(types(sharedType), tokenB);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent(sharedType, tag)), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent(sharedType, tag)), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both type-vs-type appends succeeded (write skew)", i)
+                    .isLessThanOrEqualTo(1);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither type-vs-type append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 3: same-boundary serialization under contention (N=8 threads)
+    //
+    // 8 threads all read the same boundary and concurrently append.  Exactly one
+    // wins; the rest must throw DcbAppendConditionNotFulfilledException.
+    // No raw MongoException / transient error must escape — the retry loop must absorb those.
+    // ---------------------------------------------------------------------------
+    @Test
+    void same_boundary_serialization_under_contention() throws Exception {
+        int threadCount = 8;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String tag = "contention-" + i;
+
+            // All threads read the boundary at the same position
+            DcbConsistencyToken boundaryToken = eventStore.read(tagsAllOf(tag)).consistencyToken();
+            DcbAppendCondition condition = failIfEventsMatch(tagsAllOf(tag), boundaryToken);
+
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger condFailCount = new AtomicInteger(0);
+            AtomicInteger unexpectedFailCount = new AtomicInteger(0);
+            List<Future<Void>> futures = new ArrayList<>();
+
+            final int iteration = i;
+            for (int t = 0; t < threadCount; t++) {
+                final int threadIdx = t;
+                futures.add(pool.submit(() -> {
+                    barrier.await();
+                    try {
+                        eventStore.append(List.of(taggedEvent("SomeEvent", tag)), condition);
+                        successCount.incrementAndGet();
+                    } catch (DcbAppendConditionNotFulfilledException e) {
+                        condFailCount.incrementAndGet();
+                    } catch (Exception e) {
+                        unexpectedFailCount.incrementAndGet();
+                        System.err.println("Unexpected exception in iteration " + iteration + " thread " + threadIdx + ": " + e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(successCount.get())
+                    .as("Iteration %d: expected exactly one success under contention (tag=%s)", i, tag)
+                    .isEqualTo(1);
+
+            assertThat(unexpectedFailCount.get())
+                    .as("Iteration %d: unexpected (non-DcbAppendConditionNotFulfilledException) failures must be zero (transient errors must be retried internally)", i)
+                    .isZero();
+
+            assertThat(condFailCount.get())
+                    .as("Iteration %d: expected %d DcbAppendConditionNotFulfilledException failures", i, threadCount - 1)
+                    .isEqualTo(threadCount - 1);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 4: disjoint boundaries do not falsely serialize
+    //
+    // N threads each appends to a DISTINCT tag boundary (tag:iter-N-thread-T) with a
+    // distinct event type, so neither the tag marker nor the type marker is shared.
+    // All should succeed — no false conflicts, no leaked transient errors.
+    //
+    // Configuration note: we use a boundary-tag-keyed stream ID generator (one stream per
+    // unique tag-set) so all threads map to distinct MongoDB streams. With the default 64-
+    // partition hash, two distinct boundaries may collide to the same partition stream, which
+    // causes a WriteConflict (a separate implementation concern). This test is scoped to
+    // proving query-scoped isolation, not partition placement, so we eliminate the variable.
+    // The cold-start counter race (concurrent first upserts of the position document) is handled by
+    // reserveDcbPositions itself (it retries the duplicate key), so this test deliberately does NOT pre-warm and
+    // exercises the concurrent first append directly.
+    // ---------------------------------------------------------------------------
+    @Test
+    void disjoint_boundaries_do_not_falsely_serialize() throws Exception {
+        int threadCount = 8;
+
+        // Build a dedicated event store whose stream generator maps each unique tag-set to its
+        // own stream, so no two threads share a stream and no WriteConflict can arise at the
+        // stream-version level.
+        SpringMongoEventStore disjointStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "disjoint:stream:" + String.join(",", new java.util.TreeSet<>(tags)));
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                final String distinctTag = "disjoint-iter" + i + "-t" + t;
+                // Use a distinct type per thread so the type marker does not create false conflicts.
+                // The goal is to prove query-scoped isolation; shared-type conflicts are a separate, expected behavior.
+                final String distinctType = "DisjointEvent-iter" + i + "-t" + t;
+                futures.add(pool.submit(() -> {
+                    DcbConsistencyToken token = disjointStore.read(tagsAllOf(distinctTag)).consistencyToken();
+                    DcbAppendCondition cond = failIfEventsMatch(tagsAllOf(distinctTag), token);
+                    barrier.await();
+                    try {
+                        disjointStore.append(List.of(taggedEvent(distinctType, distinctTag)), cond);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                        System.err.println("Unexpected failure for disjoint tag " + distinctTag + ": " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(successCount.get())
+                    .as("Iteration %d: all %d disjoint-boundary appends should succeed (no false conflicts)", i, threadCount)
+                    .isEqualTo(threadCount);
+
+            assertThat(failCount.get())
+                    .as("Iteration %d: no disjoint-boundary append should fail", i)
+                    .isZero();
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Disjoint boundaries that collide on the same storage partition stream must still all succeed. The collision
+    // causes a transient stream_version WriteConflict, which must be retried (not surfaced as a
+    // WriteConditionNotFulfilledException or a leaked transient error). This pins the DCB-path conflict translation.
+    // ---------------------------------------------------------------------------
+    @Test
+    void disjoint_boundaries_sharing_a_partition_stream_are_retried_to_success() throws Exception {
+        int threadCount = 6;
+        // Force every append onto ONE storage stream, so semantically-disjoint boundaries collide on stream_version.
+        SpringMongoEventStore sharedStreamStore = buildEventStoreWithStreamIdGenerator(tags -> "shared:partition:stream");
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            List<Throwable> failures = new java.util.concurrent.CopyOnWriteArrayList<>();
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                final String distinctTag = "shared-iter" + i + "-t" + t;
+                final String distinctType = "SharedStreamEvent-iter" + i + "-t" + t;
+                futures.add(pool.submit(() -> {
+                    DcbConsistencyToken token = sharedStreamStore.read(tagsAllOf(distinctTag)).consistencyToken();
+                    DcbAppendCondition cond = failIfEventsMatch(tagsAllOf(distinctTag), token);
+                    barrier.await();
+                    try {
+                        sharedStreamStore.append(List.of(taggedEvent(distinctType, distinctTag)), cond);
+                        successCount.incrementAndGet();
+                    } catch (Throwable e) {
+                        failures.add(e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(failures)
+                    .as("Iteration %d: disjoint boundaries on a shared stream must all be retried to success, not fail", i)
+                    .isEmpty();
+            assertThat(successCount.get())
+                    .as("Iteration %d: all %d appends should succeed", i, threadCount)
+                    .isEqualTo(threadCount);
+        }
+    }
+
+    private SpringMongoEventStore buildEventStoreWithStreamIdGenerator(DcbStreamIdGenerator streamIdGenerator) {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_concurrency");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        MongoTemplate template = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        MongoTransactionManager txManager = new MongoTransactionManager(
+                new SimpleMongoClientDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(COLLECTION)
+                .transactionConfig(txManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .dcbStreamIdGenerator(streamIdGenerator)
+                .build();
+        return new SpringMongoEventStore(template, config);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 5: explain() index verification
+    //
+    // With a seeded collection, run explain() on the DCB existence/conflict query shape
+    // and the read query shape and assert the winning plan does NOT use COLLSCAN.
+    // The DCB query uses dcbposition (range) and dcbTags (all), both indexed.
+    // ---------------------------------------------------------------------------
+    @Test
+    void dcb_queries_are_index_backed() {
+        // Seed the collection with a few events so the query planner sees a non-empty collection
+        eventStore.append(List.of(
+                taggedEvent("SeedType", "explain-tag"),
+                taggedEvent("SeedType", "explain-tag"),
+                taggedEvent("SeedType", "explain-tag")));
+
+        MongoCollection<Document> collection = mongoTemplate.getCollection(COLLECTION);
+
+        // Explain the tag-based read query shape:
+        // { dcbposition: { $gt: 0, $lte: <high> }, dcbTags: { $all: ["explain-tag"] } }
+        Document tagReadQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("$or", List.of(
+                        new Document("dcbTags", new Document("$all", List.of("explain-tag")))
+                ))
+        ));
+        Document tagReadExplain = collection.find(tagReadQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+
+        String tagReadPlanStage = extractWinningPlanStage(tagReadExplain);
+        assertThat(tagReadPlanStage)
+                .as("Tag read query should use IXSCAN, not COLLSCAN or unrecognized stage. Full explain: %s", tagReadExplain.toJson())
+                .isEqualTo("IXSCAN");
+
+        // Explain the type-based read query shape:
+        // { dcbposition: { $gt: 0, $lte: <high> }, type: { $in: ["SeedType"] } }
+        Document typeReadQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("$or", List.of(
+                        new Document("type", new Document("$in", List.of("SeedType")))
+                ))
+        ));
+        Document typeReadExplain = collection.find(typeReadQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+
+        String typeReadPlanStage = extractWinningPlanStage(typeReadExplain);
+        assertThat(typeReadPlanStage)
+                .as("Type read query should use IXSCAN (dcbposition index), not COLLSCAN or unrecognized stage. Full explain: %s", typeReadExplain.toJson())
+                .isEqualTo("IXSCAN");
+
+        // Explain the existence/conflict check query shape (used in enforceAppendCondition):
+        // { dcbposition: { $gt: <afterPos>, $lte: Long.MAX_VALUE }, dcbTags: { $all: ["explain-tag"] } }
+        Document existenceQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", Long.MAX_VALUE)),
+                new Document("$or", List.of(
+                        new Document("dcbTags", new Document("$all", List.of("explain-tag")))
+                ))
+        ));
+        Document existenceExplain = collection.find(existenceQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+
+        String existencePlanStage = extractWinningPlanStage(existenceExplain);
+        assertThat(existencePlanStage)
+                .as("Existence/conflict check query should use IXSCAN, not COLLSCAN or unrecognized stage. Full explain: %s", existenceExplain.toJson())
+                .isEqualTo("IXSCAN");
+    }
+
+    /**
+     * Extracts the stage name of the winning plan from an explain() output document.
+     * Walks the {@code queryPlanner.winningPlan} tree, following {@code inputStage} or
+     * {@code inputStages} links until it finds a leaf or the top-level stage of the
+     * first access pattern (IXSCAN, COLLSCAN, etc.).
+     */
+    private static String extractWinningPlanStage(Document explainDoc) {
+        Document queryPlanner = explainDoc.get("queryPlanner", Document.class);
+        if (queryPlanner == null) {
+            // Sharded explain wraps in parsedQuery/queryPlanner per shard — not expected here
+            return "UNKNOWN";
+        }
+        Document winningPlan = queryPlanner.get("winningPlan", Document.class);
+        if (winningPlan == null) {
+            return "UNKNOWN";
+        }
+        // Descend through FETCH → IXSCAN (or directly to COLLSCAN)
+        Document plan = winningPlan;
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            String stage = plan.getString("stage");
+            if ("IXSCAN".equals(stage) || "COLLSCAN".equals(stage) || "COUNT_SCAN".equals(stage)) {
+                return stage;
+            }
+            Document input = plan.get("inputStage", Document.class);
+            if (input != null) {
+                plan = input;
+            } else {
+                // Multi-plan: take the first inputStages entry
+                @SuppressWarnings("unchecked")
+                List<Document> inputStages = (List<Document>) plan.get("inputStages");
+                if (inputStages != null && !inputStages.isEmpty()) {
+                    plan = inputStages.get(0);
+                } else {
+                    // Return whatever stage we have at this level
+                    return stage != null ? stage : "UNKNOWN";
+                }
+            }
+        }
+        return "UNKNOWN";
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbReadWatermarkTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbReadWatermarkTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.spring.blocking;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbConsistencyToken;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tagsAllOf;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+
+/**
+ * Reproduction for the read-watermark overshoot lost-conflict bug (finding 2).
+ * <p>
+ * {@code read()} reports {@code lastSequencePosition() == currentDcbPosition()}, i.e. the global position counter. That
+ * counter is incremented by {@code reserveDcbPositions} <em>outside</em> the append transaction, before the events
+ * commit. So a reader that runs while an append holds reserved-but-uncommitted positions inherits a watermark that
+ * points past data it cannot see. The reader's command then derives {@code failIfEventsMatch(query, watermark)}, and the
+ * append-time check {@code position > watermark} structurally excludes the very events the appender reserved — once they
+ * commit, the conflict is silently lost and the reader's conditional append wrongly succeeds.
+ * <p>
+ * The interleaving is made deterministic by pausing appender A at the start of its transaction (after it has reserved
+ * its positions) until reader R has read. R then observes an empty boundary but a watermark of 1, A commits its matching
+ * event at position 1, and R appends conditionally on watermark 1. The correct DCB outcome is
+ * {@link DcbAppendConditionNotFulfilledException}; the bug lets R succeed.
+ */
+@Testcontainers
+@Timeout(120)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SpringMongoEventStoreDcbReadWatermarkTest {
+
+    private static final URI SOURCE = URI.create("urn:test:read-watermark");
+    private static final String COLLECTION = "events";
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(
+            new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_read_watermark"));
+
+    @Test
+    void conditional_append_detects_an_event_reserved_before_but_committed_after_the_read() throws Exception {
+        String tag = "shared-tag";
+
+        CountDownLatch appenderReserved = new CountDownLatch(1);
+        CountDownLatch readerHasRead = new CountDownLatch(1);
+
+        // Appender A: pauses at the start of its transaction (its positions are already reserved by then).
+        ConnectionString appenderCs = connectionString();
+        MongoClient appenderClient = MongoClients.create(appenderCs);
+        String databaseName = requireNonNull(appenderCs.getDatabase());
+        MongoTemplate appenderTemplate = new MongoTemplate(appenderClient, databaseName);
+        PausingTransactionTemplate pausingTx = new PausingTransactionTemplate(
+                new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(appenderClient, databaseName)),
+                appenderReserved, readerHasRead);
+        SpringMongoEventStore appenderStore = newEventStore(appenderTemplate, pausingTx);
+
+        // Reader R: a plain store over the same collection.
+        MongoClient readerClient = MongoClients.create(connectionString());
+        MongoTemplate readerTemplate = new MongoTemplate(readerClient, databaseName);
+        SpringMongoEventStore readerStore = newEventStore(readerTemplate,
+                new TransactionTemplate(new MongoTransactionManager(
+                        new SimpleMongoClientDatabaseFactory(readerClient, databaseName))));
+
+        // A reads an empty boundary and appends a matching event conditionally.
+        DcbAppendCondition appenderCondition = failIfEventsMatch(tagsAllOf(tag), DcbConsistencyToken.of(0));
+        Thread appender = new Thread(
+                () -> appenderStore.append(List.of(taggedEvent("AppenderEvent", tag)), appenderCondition),
+                "appender");
+        appender.start();
+
+        // A has reserved its position block (counter advanced) and is paused before committing.
+        assertThat(appenderReserved.await(30, TimeUnit.SECONDS)).as("appender did not reach its paused transaction").isTrue();
+
+        // R reads the same boundary. A's event is uncommitted, so R observes nothing, and the consistency token it
+        // captures reflects only committed appends (A's marker version is not bumped until A commits).
+        DcbEventStream readerBoundary = readerStore.read(tagsAllOf(tag));
+        DcbConsistencyToken readerToken = readerBoundary.consistencyToken();
+        assertThat(readerBoundary.stream().toList())
+                .as("A's event is uncommitted, so R must observe an empty boundary")
+                .isEmpty();
+
+        readerHasRead.countDown();
+        appender.join(TimeUnit.SECONDS.toMillis(30));
+
+        // R appends conditionally on the token it read. A's matching event is now committed, which bumped the marker
+        // version, so the token has changed and R's append must be rejected.
+        DcbAppendCondition readerCondition = failIfEventsMatch(tagsAllOf(tag), readerToken);
+        Throwable thrown = catchThrowable(() ->
+                readerStore.append(List.of(taggedEvent("ReaderEvent", tag)), readerCondition));
+
+        assertThat(thrown)
+                .as("R observed an empty boundary at consistency token %s, but A committed a matching event after R's "
+                        + "read (bumping the marker version). The token-based check must reject R's append; a "
+                        + "position-based check would miss it (silent lost conflict).", readerToken)
+                .isInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Infrastructure
+    // ---------------------------------------------------------------------------
+
+    private SpringMongoEventStore newEventStore(MongoTemplate template, TransactionTemplate transactionTemplate) {
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(COLLECTION)
+                .transactionConfig(transactionTemplate)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        return new SpringMongoEventStore(template, config);
+    }
+
+    private ConnectionString connectionString() {
+        return new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_read_watermark");
+    }
+
+    /**
+     * A {@link TransactionTemplate} that, on its first {@code execute}, signals that the caller has entered the
+     * transaction (its DCB positions are already reserved by then, since reservation happens before the transaction) and
+     * waits until released before running the real transaction. Subsequent calls run normally.
+     */
+    private static final class PausingTransactionTemplate extends TransactionTemplate {
+        private final transient CountDownLatch entered;
+        private final transient CountDownLatch release;
+        private final AtomicBoolean paused = new AtomicBoolean(false);
+
+        PausingTransactionTemplate(MongoTransactionManager txManager, CountDownLatch entered, CountDownLatch release) {
+            super(txManager);
+            this.entered = entered;
+            this.release = release;
+        }
+
+        @Override
+        public <T> T execute(TransactionCallback<T> action) {
+            if (paused.compareAndSet(false, true)) {
+                entered.countDown();
+                await(release);
+            }
+            return super.execute(action);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting for latch");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -178,23 +178,27 @@ class SpringMongoEventStoreDcbTest {
 
         assertThatThrownBy(() -> eventStore.append(
                 List.of(taggedEvent("NameChanged", "name:1")),
-                failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition())))
+                failIfEventsMatch(tagsAllOf("name:1"), readModel.consistencyToken())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
     }
 
     @Test
-    void append_condition_ignores_excluded_event_types_after_condition_position() {
+    void append_condition_conservatively_conflicts_on_an_excluded_type_sharing_a_tag() {
         eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
         DcbQuery query = tagsAllOfExcludingTypes(List.of("name:1"), List.of("NameSnapshot"));
         DcbEventStream readModel = eventStore.read(query);
 
+        // An excluded-type event is appended after the read. It does not match the query (reads exclude it precisely,
+        // see reads_tagged_events_except_excluded_types), but it shares the positive tag name:1, whose marker the consistency
+        // token is derived from. The token model over-approximates and conservatively conflicts: it is sound (it never
+        // misses a real conflict) at the cost of a false conflict here, which self-heals through the application service
+        // (it re-reads the still-excluded boundary and retries). See ADR 0021.
         eventStore.append(List.of(taggedEvent("NameSnapshot", "name:1")));
 
-        DcbAppendResult result = eventStore.append(
+        assertThatThrownBy(() -> eventStore.append(
                 List.of(taggedEvent("NameChanged", "name:1")),
-                failIfEventsMatch(query, readModel.lastSequencePosition()));
-
-        assertThat(result.firstSequencePosition()).isEqualTo(3);
+                failIfEventsMatch(query, readModel.consistencyToken())))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
     }
 
     @Test
@@ -207,27 +211,29 @@ class SpringMongoEventStoreDcbTest {
 
         assertThatThrownBy(() -> eventStore.append(
                 List.of(taggedEvent("NameImported", "name:1")),
-                failIfEventsMatch(query, readModel.lastSequencePosition())))
+                failIfEventsMatch(query, readModel.consistencyToken())))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
     }
 
     @Test
-    void rolls_back_position_reservation_when_duplicate_cloud_event_fails_insert() {
+    void abandons_reserved_position_block_when_duplicate_cloud_event_fails_insert() {
         CloudEvent cloudEvent = taggedEvent("NameDefined", "name:1");
         eventStore.append(List.of(cloudEvent));
 
         assertThatThrownBy(() -> eventStore.append(List.of(cloudEvent)))
                 .isExactlyInstanceOf(DuplicateCloudEventException.class);
 
+        // Positions are reserved outside the transaction (ADR 0021), so the failed append abandons its reserved block
+        // and dcbposition has a gap. The next successful append lands after the abandoned block.
         DcbAppendResult appendResult = eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
-        assertThat(appendResult.firstSequencePosition()).isEqualTo(2);
-        assertThat(appendResult.lastSequencePosition()).isEqualTo(2);
+        assertThat(appendResult.firstSequencePosition()).isEqualTo(3);
+        assertThat(appendResult.lastSequencePosition()).isEqualTo(3);
     }
 
     @Test
-    void same_stale_append_condition_rejects_second_append_without_advancing_position() {
+    void same_stale_append_condition_rejects_second_append_and_abandons_its_position_block() {
         DcbEventStream readModel = eventStore.read(tagsAllOf("name:1"));
-        DcbAppendCondition appendCondition = failIfEventsMatch(tagsAllOf("name:1"), readModel.lastSequencePosition());
+        DcbAppendCondition appendCondition = failIfEventsMatch(tagsAllOf("name:1"), readModel.consistencyToken());
 
         DcbAppendResult firstAppend = eventStore.append(List.of(taggedEvent("NameDefined", "name:1")), appendCondition);
         assertThat(firstAppend).isEqualTo(new DcbAppendResult(1, 1, 1));
@@ -235,8 +241,10 @@ class SpringMongoEventStoreDcbTest {
         assertThatThrownBy(() -> eventStore.append(List.of(taggedEvent("NameChanged", "name:1")), appendCondition))
                 .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
 
+        // The condition-failed append abandons its reserved position block (ADR 0021), so dcbposition has a gap and the
+        // next successful append lands at position 3 rather than 2.
         DcbAppendResult nextAppend = eventStore.append(List.of(taggedEvent("NameChanged", "name:2")));
-        assertThat(nextAppend).isEqualTo(new DcbAppendResult(2, 2, 1));
+        assertThat(nextAppend).isEqualTo(new DcbAppendResult(3, 3, 1));
     }
 
     @Test

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbUnconditionalMarkerTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbUnconditionalMarkerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.spring.blocking;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbConsistencyToken;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tagsAllOf;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
+import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+
+/**
+ * Regression test for the unconditional-append write-skew gap (ADR 0021).
+ * <p>
+ * An unconditional {@link org.occurrent.eventstore.api.dcb.DcbEventStore#append(List)} must still bump the conflict
+ * markers derived from its events. Otherwise a later conditional append on an overlapping tag observes an unchanged
+ * consistency token and wrongly succeeds, even though a matching event was committed after it read the boundary.
+ * <p>
+ * Because the consistency token is derived from marker versions bumped at commit, this is reproducible deterministically
+ * without threads: read the boundary, commit an unconditional matching append, then verify a conditional append carrying
+ * the original token is rejected. With the fix the unconditional append advances the tag marker, so the token has moved;
+ * without it the marker never moves and the conditional append slips through (write skew).
+ */
+@Testcontainers
+@Timeout(120)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SpringMongoEventStoreDcbUnconditionalMarkerTest {
+
+    private static final URI SOURCE = URI.create("urn:test:unconditional-marker");
+    private static final String COLLECTION = "events";
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(
+            new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_unconditional_marker"));
+
+    private SpringMongoEventStore eventStore;
+
+    @BeforeEach
+    void create_event_store() {
+        ConnectionString connectionString = connectionString();
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        String databaseName = requireNonNull(connectionString.getDatabase());
+        MongoTemplate template = new MongoTemplate(mongoClient, databaseName);
+        MongoTransactionManager txManager = new MongoTransactionManager(
+                new SimpleMongoClientDatabaseFactory(mongoClient, databaseName));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(COLLECTION)
+                .transactionConfig(txManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new SpringMongoEventStore(template, config);
+    }
+
+    @Test
+    void unconditional_append_is_detected_by_a_later_conditional_append_on_an_overlapping_tag() {
+        String tag = "shared-tag";
+
+        // A command reads the (empty) boundary.
+        DcbConsistencyToken token = eventStore.read(tagsAllOf(tag)).consistencyToken();
+
+        // An unconditional append commits a matching event.
+        eventStore.append(List.of(taggedEvent("UnconditionalEvent", tag)));
+
+        // A conditional append carrying the token observed before the unconditional append must be rejected: the
+        // unconditional append committed a matching event, which (with the fix) advanced the tag marker so the token has
+        // changed. Without event-derived markers on the unconditional path the marker never moves and this wrongly
+        // succeeds (write skew).
+        DcbAppendCondition condition = failIfEventsMatch(tagsAllOf(tag), token);
+        Throwable thrown = catchThrowable(() ->
+                eventStore.append(List.of(taggedEvent("ConditionalEvent", tag)), condition));
+
+        assertThat(thrown)
+                .as("The conditional append must fail because an unconditional append committed a matching event after "
+                        + "the boundary was read. Without event-derived markers on the unconditional append, the "
+                        + "consistency token does not move and the conflict is missed (write skew).")
+                .isInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    private ConnectionString connectionString() {
+        return new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_unconditional_marker");
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}


### PR DESCRIPTION
## What

Hardens the Spring Mongo DCB append path into real query-scoped concurrency. This is the plan's centerpiece P0 item, implementing [ADR 21](doc/architecture/decisions/0021-dcb-write-path-query-scoped-concurrency.md).

Before this, `appendDcb` reserved its `dcbposition` block with a `findAndModify` `$inc` on a single global counter document **inside every append transaction**. That hot document serialized all DCB appends and raised MongoDB transient transaction conflicts, which were not retried, so contention surfaced as a spurious command failure. The conflict-serialization keying was also not skew-safe (a type-only and a tag-only query matching the same event got disjoint keys), masked only by the global counter serialization.

## How

* **Positions outside the transaction.** The `dcbposition` counter `findAndModify` moves out of the append transaction (a single atomic update MongoDB serializes without a transaction conflict), reused across transient retries. Appends to disjoint boundaries no longer contend on it. Positions stay monotonic but may have gaps when an append fails its condition or exhausts retries, which the DCB contract permits.
* **Skew-safe per-attribute markers.** Conflicting appends are serialized by marker documents keyed per attribute (`tag:<t>`, `type:<X>`), upserted for the union of the condition query's keys and the appended events' keys. Any two appends that can match a common event share a marker and force a MongoDB write-write conflict. The in-transaction `exists(query, after position)` check stays the authoritative optimistic-concurrency check.
* **Transient retry.** Transient transaction conflicts retry with bounded exponential backoff, so appends placed in the same partition stream serialize on `stream_version` and retry to success. `DcbAppendConditionNotFulfilledException` is not retried and propagates to the application service.

## Two concurrency bugs the adversarial tests exposed (fixed here)

* `reserveDcbPositions` now retries the cold-start duplicate-key race (concurrent first upserts of the counter document).
* The DCB insert keeps a transient `WriteConflict` transient (`insertAllDcb`) instead of translating it to the stream-path `WriteConditionNotFulfilledException`, so the transient retry can fire. This surfaces when two disjoint boundaries hash to the same partition stream.

## Also

* DCB tag queries match with a single `dcbTags` `$all` predicate instead of one predicate per tag (P2.1).
* `explain()` confirms the conflict and read queries are index-backed by the `dcbTags` / `dcbposition` indexes (P2.2).

## Limitation (documented, not silent)

A `MatchAll` append condition is a whole-store lock. It is skew-safe against other `MatchAll` conditions but not against concurrent tag-scoped or type-scoped appends. Tag-scoped and type-scoped boundaries (the normal DCB usage) are fully skew-safe.

## Verification

* `SpringMongoEventStoreDcbConcurrencyTest` (new): adversarial multi-threaded tests, 50 iterations each, proving type-vs-tag / tag-vs-tag / type-vs-type write-skew prevention, same-boundary serialization with no leaked transient errors, disjoint-boundary concurrency, partition-collision retry-to-success, and `explain()` index-backing. The skew tests place the two racing appends on **distinct** streams so the markers are the sole serializer, and they go red when the markers are removed, so they genuinely verify the mechanism rather than relying on `stream_version` serialization.
* Two existing tests updated to the gap-permitting position contract (semantic assertions unchanged).
* Reviewed by an adversarial design review, the adversarial test suite (which found the two bugs above), a deep-reviewer correctness pass, and `/code-review` (which caught the test-validity gap now fixed).

No public API or stream-path behavior changes.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-starter-conveniences","parentHead":"d0cc081cdfbe1a5c56165a47fa468623e4bec1d8","parentPull":211,"trunk":"main"}
```
-->
