### PR TITLE
Add STREAM+DCB combined-mode @SpringBootTest and a missing-TagGenerator warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,7 @@
   * DCB tag queries now match with a single `dcbTags` array-containment predicate instead of one predicate per tag.
   * The Spring Boot starter now auto-configures application services from the same capability set: stream `ApplicationService` for `STREAM`, `DcbApplicationService` for `DCB`, and both for `stream,dcb`.
   * DCB-only Spring Boot auto-configuration also exposes `DomainEventQueries` so DCB query DSL extensions can reuse the starter-provided converter while stream application services remain disabled.
-  * DCB application-service auto-configuration requires a user-provided `TagGenerator` bean, since DCB tags are domain-specific.
+  * DCB application-service auto-configuration requires a user-provided `TagGenerator` bean, since DCB tags are domain-specific. When the DCB capability is enabled but no `TagGenerator` bean is found, the starter now logs a warning explaining that `DcbApplicationService` is not auto-configured, instead of skipping silently.
   * The Spring Boot starter now also auto-configures the DCB DSL when the `DCB` capability is enabled: a `DcbDomainEventQueries` wrapping the auto-configured `DomainEventQueries`, and a `DcbSubscriptions` over the subscription model. Both back off to a user-provided bean of the same type.
   * In DCB-only mode the auto-configured subscriptions are currently live only, because the catch-up model is not wired in DCB-only mode. Replay by `dcbposition` for auto-configured subscriptions is a follow-up.
   * Occurrent creates missing indexes/collections only. It never removes indexes or collections automatically.

--- a/framework/spring-boot-starter-mongodb/pom.xml
+++ b/framework/spring-boot-starter-mongodb/pom.xml
@@ -134,5 +134,20 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -21,6 +21,8 @@ import com.mongodb.ReadConcern;
 import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
 import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
@@ -84,6 +86,8 @@ import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubs
 @EnableConfigurationProperties(OccurrentProperties.class)
 @Import(Jackson3CloudEventConverterConfiguration.class)
 public class OccurrentMongoAutoConfiguration<E> {
+
+    private static final Logger log = LoggerFactory.getLogger(OccurrentMongoAutoConfiguration.class);
 
     @Bean
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
@@ -224,7 +228,13 @@ public class OccurrentMongoAutoConfiguration<E> {
             }
             boolean hasDcbApplicationService = beanFactory.getBeanNamesForType(DcbApplicationService.class, false, false).length > 0;
             boolean hasTagGenerator = beanFactory.getBeanNamesForType(TagGenerator.class, false, false).length > 0;
-            if (hasDcbApplicationService || !hasTagGenerator) {
+            if (hasDcbApplicationService) {
+                return;
+            }
+            if (!hasTagGenerator) {
+                log.warn("Occurrent DCB event-store capability is enabled but no {} bean was found, so a {} is not auto-configured. " +
+                                "Define a {} bean (it derives the DCB tags written with each event) to enable auto-configuration, or provide your own {} bean.",
+                        TagGenerator.class.getName(), DcbApplicationService.class.getName(), TagGenerator.class.getSimpleName(), DcbApplicationService.class.getSimpleName());
                 return;
             }
             RootBeanDefinition beanDefinition = new RootBeanDefinition(DcbApplicationService.class);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCombinedModeTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCombinedModeTest.java
@@ -1,0 +1,150 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.blocking.dcb.TagGenerator;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Boots the real {@link OccurrentMongoAutoConfiguration} against a MongoDB replica-set testcontainer
+ * with both STREAM and DCB capabilities enabled, and exercises a real append + read on each path.
+ */
+@SpringBootTest(
+        classes = OccurrentMongoAutoConfigurationCombinedModeTest.CombinedModeApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=stream,dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:combined-mode-test"
+        }
+)
+@Import(OccurrentMongoAutoConfigurationCombinedModeTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+class OccurrentMongoAutoConfigurationCombinedModeTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private ApplicationService<TestEvent> applicationService;
+
+    @Autowired
+    private DcbApplicationService<TestEvent> dcbApplicationService;
+
+    @Autowired
+    private DomainEventQueries<TestEvent> domainEventQueries;
+
+    @Autowired
+    private DcbDomainEventQueries<TestEvent> dcbDomainEventQueries;
+
+    @Test
+    void combined_mode_auto_configures_both_the_stream_and_dcb_application_services() {
+        assertThat(applicationContext.getBeansOfType(ApplicationService.class)).isNotEmpty();
+        assertThat(applicationContext.getBeansOfType(DcbApplicationService.class)).isNotEmpty();
+    }
+
+    @Test
+    void stream_application_service_appends_an_event_that_the_stream_query_reads_back() {
+        String streamId = UUID.randomUUID().toString();
+        TestEvent event = new TestEvent(UUID.randomUUID().toString(), new Date(), "stream-name", "stream-subject");
+
+        applicationService.execute(streamId, __ -> Stream.of(event));
+
+        try (Stream<TestEvent> read = domainEventQueries.query(TestEvent.class)) {
+            assertThat(read).contains(event);
+        }
+    }
+
+    @Test
+    void dcb_application_service_appends_a_tagged_event_that_the_dcb_query_reads_back() {
+        String tag = "tenant:" + UUID.randomUUID();
+        TestEvent event = new TestEvent(UUID.randomUUID().toString(), new Date(), "dcb-name", tag);
+
+        dcbApplicationService.execute(DcbQuery.tagsAllOf(tag), __ -> Stream.of(event));
+
+        try (Stream<TestEvent> read = dcbDomainEventQueries.query(DcbQuery.tagsAllOf(tag))) {
+            assertThat(read).containsExactly(event);
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class CombinedModeApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        // The default TimeRepresentation is DATE, which rejects sub-millisecond precision, so map the event
+        // timestamp (millisecond precision) instead of relying on the fallback converter's OffsetDateTime.now().
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:combined-mode-test"))
+                    .typeMapper(typeMapper)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        TagGenerator<TestEvent> testEventTagGenerator() {
+            return event -> Set.of(event.subject());
+        }
+    }
+
+    record TestEvent(String eventId, Date timestamp, String name, String subject) {
+    }
+}


### PR DESCRIPTION
## What

Closes the last two plan items for DCB starter coverage: a STREAM+DCB combined-mode `@SpringBootTest`, and a startup warning when DCB is enabled without a `TagGenerator`.

The starter already had `ApplicationContextRunner` characterization tests across all capability modes, and the example covers DCB-only with a real MongoDB. What was missing was a full-context test exercising both capabilities together, and a diagnostic when a common misconfiguration silently produced no `DcbApplicationService`.

## How

* **Combined-mode `@SpringBootTest`** (`OccurrentMongoAutoConfigurationCombinedModeTest`): boots the real `OccurrentMongoAutoConfiguration` against a MongoDB replica set (`@ServiceConnection`) with `occurrent.event-store.capabilities=stream,dcb` and a user-provided `TagGenerator` + `CloudEventConverter`. It asserts both the stream `ApplicationService` and the `DcbApplicationService` are wired, then exercises a real append plus read on each path: stream via `ApplicationService.execute` + `DomainEventQueries`, DCB via `DcbApplicationService.execute` + `DcbDomainEventQueries`.
* **Missing-`TagGenerator` warning**: when the DCB capability is enabled but no `TagGenerator` bean is found, the DCB registrar now logs a warning explaining that `DcbApplicationService` is not auto-configured and how to fix it, instead of skipping silently. The warning fires only when there is no `TagGenerator` and the user has not supplied their own `DcbApplicationService`, so a user who provides their own service is never warned.

## Verification

The starter module's tests are green (the new 3 combined-mode tests plus the existing characterization tests unchanged). The missing-`TagGenerator` skip is already covered by the existing characterization test.

No public API changes. STREAM-only and DCB-only behavior are unchanged.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-write-path-concurrency","parentHead":"0e792b04cc9eddc6f64acef347e45ffd118e50c2","parentPull":213,"trunk":"main"}
```
-->
