### PR TITLE
Upgrade Spring Boot from 4.0.4 to 4.1.0

### DIFF
--- a/.context/ORCHESTRATOR.md
+++ b/.context/ORCHESTRATOR.md
@@ -1,6 +1,6 @@
 # Occurrent Orchestrator Memory
 
-Last updated: 2026-06-25
+Last updated: 2026-05-22
 
 ## Current State
 
@@ -125,10 +125,12 @@ Testing:
 Root managed versions include:
 
 - CloudEvents `4.0.1`
-- Kotlin `2.3.21` (pin kept: drives the `kotlin-maven-plugin` version, which no BOM manages)
-- Jackson 2 `2.21.4`, Jackson 3 `3.1.4` (pins kept and aligned to the Spring Boot BOM; referenced across ~20 module POMs for the dual Jackson 2 + Jackson 3 converter support)
-- Spring Boot `4.1.0`
-- Reactor and the MongoDB driver are no longer pinned in the root POM; the Spring Boot dependency BOM now governs them (Reactor `2025.0.6`, MongoDB driver `5.8.0` as of 4.1.0). The explicit `reactor-bom` and `mongodb-driver-bom` imports were removed as redundant.
+- Kotlin `2.3.10`
+- Jackson 2 `2.19.2`
+- Jackson 3 `3.0.4`
+- Reactor BOM `2024.0.10`
+- Spring Boot `4.0.4`
+- MongoDB driver BOM `5.6.1`
 - Testcontainers `2.0.5`
 - JUnit `5.11.3`
 - JobRunr `8.1.0`

--- a/.context/ORCHESTRATOR.md
+++ b/.context/ORCHESTRATOR.md
@@ -1,6 +1,6 @@
 # Occurrent Orchestrator Memory
 
-Last updated: 2026-05-22
+Last updated: 2026-06-25
 
 ## Current State
 
@@ -125,12 +125,10 @@ Testing:
 Root managed versions include:
 
 - CloudEvents `4.0.1`
-- Kotlin `2.3.10`
-- Jackson 2 `2.19.2`
-- Jackson 3 `3.0.4`
-- Reactor BOM `2024.0.10`
-- Spring Boot `4.0.4`
-- MongoDB driver BOM `5.6.1`
+- Kotlin `2.3.21` (pin kept: drives the `kotlin-maven-plugin` version, which no BOM manages)
+- Jackson 2 `2.21.4`, Jackson 3 `3.1.4` (pins kept and aligned to the Spring Boot BOM; referenced across ~20 module POMs for the dual Jackson 2 + Jackson 3 converter support)
+- Spring Boot `4.1.0`
+- Reactor and the MongoDB driver are no longer pinned in the root POM; the Spring Boot dependency BOM now governs them (Reactor `2025.0.6`, MongoDB driver `5.8.0` as of 4.1.0). The explicit `reactor-bom` and `mongodb-driver-bom` imports were removed as redundant.
 - Testcontainers `2.0.5`
 - JUnit `5.11.3`
 - JobRunr `8.1.0`

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
   * The delta reconciliation sized its read from a count of matching events and then read the newest N of them. An event written in the window between that count and the read shifted the newest-N window forward and pushed the oldest during-catch-up event out of the read. That event sat at or before the live subscription's resume position, so the live subscription did not redeliver it either, and it was lost. This is the residual case left open by the 0.20.4 fix, which closed the clock-skew variant but not the count-to-read window.
   * The reconciliation now re-reads the recent tail until the matching count stops growing, so an event that arrives in the count-to-read window is picked up by a later pass instead of being skipped. Overlapping passes are deduplicated through the handover cache, so at-least-once delivery is preserved without introducing duplicates.
   * See [ADR 14](doc/architecture/decisions/0014-reconcile-catchup-events-by-insertion-order-to-avoid-loss-under-clock-skew.md).
+* Upgraded Spring Boot from 4.0.4 to 4.1.0. This pulls in Spring Framework 7.0.8, Spring Data 2026.0.0, Reactor 2025.0.x, the MongoDB driver 5.8.0, Kotlin 2.3.21, and Jackson 2.21.4 / 3.1.4 transitively.
+  * The explicit Reactor and MongoDB driver version overrides were removed from the root build, so their versions are now governed by the Spring Boot dependency BOM.
 
 ### 0.20.4 (2026-06-18)
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,12 @@
         <kotlin.compiler.jvmTarget>${maven.compiler.release}</kotlin.compiler.jvmTarget>
         <junit.version>5.11.3</junit.version>
         <test-containers.version>2.0.5</test-containers.version>
-        <kotlin.version>2.3.10</kotlin.version>
-        <jackson2.version>2.19.2</jackson2.version>
-        <jackson3.version>3.0.4</jackson3.version>
+        <kotlin.version>2.3.21</kotlin.version>
+        <jackson2.version>2.21.4</jackson2.version>
+        <jackson3.version>3.1.4</jackson3.version>
         <cloudevents.version>4.0.1</cloudevents.version>
-        <reactor-bom.version>2024.0.10</reactor-bom.version>
-        <spring-boot.version>4.0.4</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <spring-retry.version>2.0.12</spring-retry.version>
-        <mongo.version>5.6.1</mongo.version>
         <dokka.version>2.0.0</dokka.version>
         <awaitility.version>4.2.2</awaitility.version>
         <jobrunr.version>8.1.0</jobrunr.version>
@@ -119,13 +117,6 @@
                 <groupId>com.j2html</groupId>
                 <artifactId>j2html</artifactId>
                 <version>1.4.0</version>
-            </dependency>
-            <dependency>
-                <groupId>io.projectreactor</groupId>
-                <artifactId>reactor-bom</artifactId>
-                <version>${reactor-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.rabbitmq</groupId>
@@ -177,14 +168,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Mongo -->
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-bom</artifactId>
-                <version>${mongo.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <dependency>
                 <groupId>org.jspecify</groupId>


### PR DESCRIPTION
## What

Upgrades Spring Boot from 4.0.4 to 4.1.0 (the latest 4.1.x, released 2026-06-10). This is a minor in-major bump, so there are no source changes, only the build.

## Changes

In the root `pom.xml`:

- `spring-boot.version` 4.0.4 to 4.1.0.
- `kotlin.version` 2.3.10 to 2.3.21. I kept this pin because it also drives the `kotlin-maven-plugin` version, which no BOM manages.
- `jackson2.version` 2.19.2 to 2.21.4 and `jackson3.version` 3.0.4 to 3.1.4, aligned to what the 4.1.0 BOM manages. I kept these pins too, since they are referenced across the module POMs for the dual Jackson 2 and Jackson 3 converter support.
- Removed the `reactor-bom` and `mongodb-driver-bom` imports. They were pinning versions the Spring Boot BOM already governs, so Reactor (2025.0.6) and the MongoDB driver (5.8.0) now come straight from Spring Boot.

`changelog.md` gets an entry under the next-version heading documenting the upgrade and the transitive bumps so downstream consumers can see what moved.

## Risk

Low. The compile was clean across every module, so nothing in Occurrent was calling an API that 4.1 removed. The Reactor 3.7 to 3.8 and MongoDB driver 5.6 to 5.8 bumps are the parts worth a second look, and both are covered by the test suite below.

## Verification

Full multi-module `mvn -B package`: BUILD SUCCESS, 1336 tests, 0 failures, 0 errors, 0 skipped, 98 modules. The MongoDB and subscription tests ran against real containers, not mocks.

CI already runs on Temurin 17 and 21, both supported by 4.1, so no workflow change was needed.
