### PR TITLE
Add cancel to the DCB subscription DSL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ### Changelog next version
 
+* The DCB subscription DSL can now cancel a subscription.
+  * `DcbSubscriptions.cancel(subscriptionId)` stops and removes a subscription, so per-connection teardown no longer has to reach past the DSL into the subscription model. An SSE activity feed, for example, can subscribe when a client connects and cancel when it disconnects, all through `DcbSubscriptions`. The DSL now wraps a `SubscriptionModel` rather than a bare `Subscribable` to make this possible.
+
 * DCB subscriptions now catch up from history in DCB-only mode.
   * In a DCB-only application the Spring Boot starter wraps the subscription model in a DCB-mode `CatchupSubscriptionModel`, so a subscription started at a `DcbSubscriptionPosition` replays past events by `dcbposition` before switching to live delivery. A read model can therefore be rebuilt from history on startup. Started without such a position, a DCB subscription stays live only, as before.
   * Request a replay from the start with `StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0))`. A STREAM-and-DCB application keeps its stream catch-up and does not yet get DCB catch-up.

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -28,6 +28,7 @@ import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.Subscribable;
 import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,25 +41,26 @@ import static java.util.Objects.requireNonNull;
 /**
  * Subscribes to live DCB-tagged events without having to pass the {@link CloudEventConverter} on every call.
  * <p>
- * This wraps a {@link Subscribable} and a {@link CloudEventConverter}, mirroring how {@link DcbDomainEventQueries}
+ * This wraps a {@link SubscriptionModel} and a {@link CloudEventConverter}, mirroring how {@link DcbDomainEventQueries}
  * wraps its dependencies. The subscriptions are live CloudEvent subscriptions that post-filter DCB-tagged events
  * by a {@link DcbQuery}. They are not DCB reads, so they provide no DCB append-condition or high-watermark
  * guarantees.
  * <p>
  * Like {@link Subscribable}, the {@code subscribe} methods return the {@link Subscription} without waiting for it to
  * start. Call {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before
- * you continue (for example to avoid missing the first events of a brand new subscription).
+ * you continue (for example to avoid missing the first events of a brand new subscription). Call {@link #cancel(String)}
+ * to stop and remove a subscription, for example when a per-connection subscription is no longer needed.
  *
  * @param <E> the domain event type
  */
 @NullMarked
 public final class DcbSubscriptions<E> {
 
-    private final Subscribable subscribable;
+    private final SubscriptionModel subscriptionModel;
     private final CloudEventConverter<E> cloudEventConverter;
 
-    public DcbSubscriptions(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
-        this.subscribable = requireNonNull(subscribable, Subscribable.class.getSimpleName() + " cannot be null");
+    public DcbSubscriptions(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+        this.subscriptionModel = requireNonNull(subscriptionModel, SubscriptionModel.class.getSimpleName() + " cannot be null");
         this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
     }
 
@@ -105,8 +107,18 @@ public final class DcbSubscriptions<E> {
 
         OccurrentSubscriptionFilter filter = OccurrentSubscriptionFilter.filter(Filter.all());
         return startAt == null
-                ? subscribable.subscribe(subscriptionId, filter, consumer)
-                : subscribable.subscribe(subscriptionId, filter, startAt, consumer);
+                ? subscriptionModel.subscribe(subscriptionId, filter, consumer)
+                : subscriptionModel.subscribe(subscriptionId, filter, startAt, consumer);
+    }
+
+    /**
+     * Cancels and removes the subscription with the given id, stopping further delivery to its callback. Cancelling an
+     * unknown or already cancelled subscription id is a no-op. This is the natural teardown for a per-connection
+     * subscription, such as an SSE activity feed that subscribes when a client connects and cancels when it disconnects.
+     */
+    public void cancel(String subscriptionId) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        subscriptionModel.cancelSubscription(subscriptionId);
     }
 
     private static EventMetadata toEventMetadata(CloudEvent cloudEvent) {

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptionsTest.java
@@ -101,6 +101,30 @@ class DcbSubscriptionsTest {
         });
     }
 
+    @Test
+    void cancel_stops_further_delivery_to_the_subscription() {
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        dcbSubscriptions.subscribe("subscription", DcbQuery.tagsAllOf("name:1"), (DomainEvent event) -> received.add(event)).waitUntilStarted();
+
+        NameDefined beforeCancel = new NameDefined("eventId1", time, "name", "Some Doe");
+        append("name:1", beforeCancel);
+        await().untilAsserted(() -> assertThat(received).containsExactly(beforeCancel));
+
+        dcbSubscriptions.cancel("subscription");
+
+        // A second, still-live subscription is a positive control. Once it receives the post-cancel event we know the
+        // append was processed and delivered, so the cancelled subscription has had its chance. Asserting against that
+        // is stronger than waiting a fixed window, which only shows the event had not arrived yet.
+        CopyOnWriteArrayList<DomainEvent> witnessReceived = new CopyOnWriteArrayList<>();
+        dcbSubscriptions.subscribe("witness", DcbQuery.tagsAllOf("name:1"), (DomainEvent event) -> witnessReceived.add(event)).waitUntilStarted();
+
+        NameWasChanged afterCancel = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", afterCancel);
+
+        await().untilAsserted(() -> assertThat(witnessReceived).containsExactly(afterCancel));
+        assertThat(received).containsExactly(beforeCancel);
+    }
+
     private void append(String tag, DomainEvent... events) {
         append(List.of(tag), events);
     }

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/enrollment/web/EnrollmentController.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/enrollment/web/EnrollmentController.kt
@@ -26,7 +26,6 @@ import org.occurrent.example.domain.courseenrollment.features.enrollment.readmod
 import org.occurrent.example.domain.courseenrollment.features.enrollment.usecases.enrollStudent
 import org.occurrent.example.domain.courseenrollment.features.enrollment.usecases.unenrollStudent
 import org.occurrent.example.domain.courseenrollment.infrastructure.dcb.CourseEnrollmentDcbQueries
-import org.occurrent.subscription.api.blocking.SubscriptionModel
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
@@ -42,8 +41,7 @@ class EnrollmentController(
     private val applicationService: DcbApplicationService<DomainEvent>,
     private val courseDetail: CourseDetail,
     private val courseDashboard: CourseDashboard,
-    private val dcbSubscriptions: DcbSubscriptions<DomainEvent>,
-    private val subscriptionModel: SubscriptionModel
+    private val dcbSubscriptions: DcbSubscriptions<DomainEvent>
 ) {
 
     @GetMapping("/courses/{id}")
@@ -99,9 +97,9 @@ class EnrollmentController(
                 }
             }
         }
-        emitter.onCompletion { subscriptionModel.cancelSubscription(subscriptionId) }
-        emitter.onTimeout { subscriptionModel.cancelSubscription(subscriptionId) }
-        emitter.onError { subscriptionModel.cancelSubscription(subscriptionId) }
+        emitter.onCompletion { dcbSubscriptions.cancel(subscriptionId) }
+        emitter.onTimeout { dcbSubscriptions.cancel(subscriptionId) }
+        emitter.onError { dcbSubscriptions.cancel(subscriptionId) }
         // Wait until the subscription is running before returning, so the feed does not miss the first action after the
         // page opens.
         subscription.waitUntilStarted()

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -198,8 +198,8 @@ public class OccurrentMongoAutoConfiguration<E> {
     @ConditionalOnMissingBean(DcbSubscriptions.class)
     @Conditional(OnDcbEventStoreCapabilityCondition.class)
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
-    public DcbSubscriptions<E> occurrentDcbSubscriptions(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
-        return new DcbSubscriptions<>(subscribable, cloudEventConverter);
+    public DcbSubscriptions<E> occurrentDcbSubscriptions(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+        return new DcbSubscriptions<>(subscriptionModel, cloudEventConverter);
     }
 
     @Bean

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModelLifeCycle.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModelLifeCycle.java
@@ -76,7 +76,8 @@ public interface SubscriptionModelLifeCycle {
 
     /**
      * Cancel a subscription, this will remove the position from position storage (if used),
-     * and you cannot restart it from its current position again.
+     * and you cannot restart it from its current position again. Cancelling a subscription id that is unknown or
+     * already cancelled is a no-op.
      */
     void cancelSubscription(String subscriptionId);
 


### PR DESCRIPTION
`DcbSubscriptions` had no way to cancel a subscription. Per-connection teardown therefore had to reach past the DSL and call `SubscriptionModel.cancelSubscription(id)` directly, which is what the course-enrollment SSE activity feed did. That leaks subscription-model plumbing into a controller that otherwise only talks to the DSL.

I added `DcbSubscriptions.cancel(subscriptionId)`. To make it possible the DSL now wraps a `SubscriptionModel` instead of a bare `Subscribable`. The auto-configured bean already is a `SubscriptionModel`, so nothing changes at the wiring level. The example SSE feed now subscribes and cancels entirely through `DcbSubscriptions` and no longer injects the subscription model.

This is the first of a set of DCB subscription improvements. The later ones split the stream and DCB subscription models apart, give DCB subscriptions server-side filtering, and add a `@DcbSubscription` annotation. Cancel is the small independent piece, so it lands first.

### Verification

* `rtk mvn -pl dsl/dcb-dsl/blocking -am -Dtest=DcbSubscriptionsTest test`: Tests run: 3, Failures: 0, Errors: 0. Includes the new `cancel_stops_further_delivery_to_the_subscription`.
* `rtk mvn -Pexamples-module -pl example/domain/course-enrollment test`: `CourseEnrollmentTest` 5/5 and `CourseEnrollmentWebTest` 9/9.
* `rtk mvn -pl framework/spring-boot-starter-mongodb -am test-compile`: clean.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-example-course-enrollment","parentHead":"d704c1617d166f7673c90a12a97087bc197db9fd","parentPull":221,"trunk":"main"}
```
-->
