### PR TITLE
Filter DCB subscriptions server-side

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### Changelog next version
 
+* DCB subscriptions now filter server-side.
+  * A new `DcbSubscriptionFilter`, wrapping a `DcbQuery`, is a first-class `SubscriptionFilter` alongside the stream `OccurrentSubscriptionFilter`. The Spring and native MongoDB subscription models translate it into a change stream `$match`, so a DCB read model that cares about a few event types or a tag boundary no longer receives every DCB event and discards most of them in the consumer. The in-memory model honors it in process. `DcbSubscriptions` now subscribes with it and keeps a small in-process check only as a correctness floor for backends that do not filter.
+  * Tag containment matches the indexed `dcbTags` array the event store already writes, exposed as the public constant `OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD`.
+  * See [ADR 23](doc/architecture/decisions/0023-server-side-filtering-for-dcb-subscriptions.md).
+
 * The DCB subscription DSL can now cancel a subscription.
   * `DcbSubscriptions.cancel(subscriptionId)` stops and removes a subscription, so per-connection teardown no longer has to reach past the DSL into the subscription model. An SSE activity feed, for example, can subscribe when a client connects and cancel when it disconnects, all through `DcbSubscriptions`. The DSL now wraps a `SubscriptionModel` rather than a bare `Subscribable` to make this possible.
 

--- a/doc/architecture/decisions/0023-server-side-filtering-for-dcb-subscriptions.md
+++ b/doc/architecture/decisions/0023-server-side-filtering-for-dcb-subscriptions.md
@@ -1,0 +1,41 @@
+# 23. Server-side filtering for DCB subscriptions
+
+Date: 2026-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0019 introduced the DCB DSL and recorded a v1 simplification: `DcbSubscriptions` subscribed with `OccurrentSubscriptionFilter.filter(Filter.all())` and post-filtered every delivered CloudEvent in process by a `DcbQuery` (`DcbCloudEvents.getPosition(event) > 0` and `DcbCloudEvents.matches(event, query)`). A stream subscription instead accepts a `Filter` that becomes a server-side MongoDB change stream `$match`, so the `@Subscription` annotation can push `Filter.type(...)` down to the database.
+
+That gap matters under load. A DCB read model that cares about a few event types still received every DCB event in the store and discarded most of them in the consumer thread. The course-enrollment dashboard subscriber is the concrete example: it subscribed with `DcbQuery.all()` and did an is-type check per event.
+
+The subscription filter layer already has the seam needed to fix this. `org.occurrent.subscription.SubscriptionFilter` is an empty marker interface. `OccurrentSubscriptionFilter` is its stream implementation, wrapping an Occurrent `Filter`. The Mongo subscription models already dispatch on the concrete `SubscriptionFilter` type: `ApplyFilterToChangeStreamOptionsBuilder` (Spring) and `NativeMongoSubscriptionModel` (native driver) translate `OccurrentSubscriptionFilter` to a change stream `$match` and throw on filter types they do not recognize.
+
+The user asked whether the filter abstraction itself should be split into a common part plus a stream-specific and a DCB-specific part, rather than bending one filter type to serve both, and asked for the choice that holds up long term and under full production load.
+
+The DCB query already translates to MongoDB. `SpringMongoEventStore.toCriteria(DcbQueryItem)` turns a query item into criteria for DCB reads: types to `$in` on `type`, excluded types to `$nin`, tags to `$all` on the stored `dcbTags` indexed array. The event store writes that `dcbTags` array next to the newline-joined `dcbtags` extension precisely so tag containment is queryable.
+
+## Decision
+
+Treat `SubscriptionFilter` as the common abstraction and give DCB its own implementation rather than forking the stream `Filter`.
+
+- Add `org.occurrent.subscription.DcbSubscriptionFilter`, a record wrapping a `DcbQuery`, in `subscription/core`. It is the DCB counterpart to `OccurrentSubscriptionFilter`: the stream filter wraps a `Filter`, the DCB filter wraps a `DcbQuery`. The stream `Filter` class is not changed or forked.
+- Add `DcbSubscriptionFilterConverter` in `subscription/mongodb/common/base`. It converts a `DcbQuery` into one change stream `$match` aggregation stage that reproduces the `DcbCloudEvents.matches` semantics server-side: within an item, types are any-of (`$in`), tags are all-of (`$all` on the `dcbTags` array), excluded types are none-of (`$nin`), and the items are OR-ed. A `dcbposition > 0` condition is always applied so only DCB-tagged events are delivered, matching the in-process guard. All fields are matched under the `fullDocument` prefix the change stream wraps the stored document in.
+- One converter serves both Mongo backends. It returns an `org.bson.Document` `$match` stage, which the Spring model passes to `ChangeStreamOptionsBuilder.filter(Document...)` and the native model adds straight to its pipeline. Both gain a `DcbSubscriptionFilter` dispatch branch.
+- The in-memory subscription model honors `DcbSubscriptionFilter` too, matching in process via `DcbCloudEvents`, so non-Mongo subscribables filter correctly rather than throwing on the new filter type. `InMemorySubscription` now holds a `Predicate<CloudEvent>` instead of a stream `Filter`, which is the general shape both the stream and DCB cases reduce to.
+- `DcbSubscriptions` passes a `DcbSubscriptionFilter(query)` to the backend instead of `Filter.all()`. It keeps its in-process `getPosition > 0 && matches(query)` check as a correctness floor, because the DSL wraps an arbitrary `Subscribable` and cannot assume the backend honors the filter. A capable backend reduces volume server-side, and the floor guarantees correctness everywhere.
+- The `dcbTags` array field name was a private constant duplicated in the event store. Promote it to the public `OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD` so the event store that writes it and the subscription that matches against it share one definition. This is the storage contract between writer and reader.
+
+On the question of splitting the `Filter` class itself: do not. `SubscriptionFilter` is already the common seam, so the clean split is stream `Filter` for stream subscriptions and `DcbQuery` for DCB subscriptions, each an implementation of `SubscriptionFilter` over shared Mongo plumbing. The two query models share no structure today that a common filter base would capture without inventing it. If a genuine shared core emerges later, extract it then rather than speculatively now.
+
+## Consequences
+
+- A DCB subscription against MongoDB now filters server-side. A read model that cares about a few types or a tag boundary no longer pulls every DCB event into the consumer.
+- The change stream `fullDocument` carries the `dcbTags` array, since the event store stores it on the document, so tag all-of works server-side as `$all` on that array rather than as a brittle match on the newline-joined `dcbtags` string.
+- All three blocking subscription backends (Spring Mongo, native Mongo, in-memory) accept `DcbSubscriptionFilter`. Routing `DcbSubscriptions` through it does not break any shipped backend. The reactor model is out of scope, since DCB support is blocking only. The native-driver model gains the filter for parity, but there is no native-driver DCB event store today (DCB append lives in the Spring Mongo and in-memory stores), so the native path is covered by the shared converter's unit tests and the Spring end-to-end test rather than by a synthetic native end-to-end test over a workflow that does not exist yet.
+- `CatchupSubscriptionModel`, the decorator the DCB stack wires above the Mongo model, had a single upfront guard that rejected every filter except `OccurrentSubscriptionFilter`. That guard belongs to the stream catch-up path, which converts the filter into an Occurrent `Filter` for the historical query. It now lives only there, so the DCB path passes a `DcbSubscriptionFilter` straight through to the inner model.
+- This supersedes the ADR 0019 note that DCB subscriptions only post-filter in process. The in-process check remains as a correctness floor, not as the only filter.
+- The DCB query to Mongo translation now exists in two places: `SpringMongoEventStore.toCriteria` for DCB reads (spring-data `Criteria`, bounded position window, no prefix) and `DcbSubscriptionFilterConverter` for change stream matches (`Document`, `fullDocument` prefix, `dcbposition > 0`). They differ in field prefix and position handling, so they are kept separate rather than unified speculatively. Unify them behind one parameterized converter only if a third caller appears or they start drifting.

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -23,8 +23,7 @@ import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.subscription.blocking.EventMetadata;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
-import org.occurrent.filter.Filter;
-import org.occurrent.subscription.OccurrentSubscriptionFilter;
+import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.Subscribable;
 import org.occurrent.subscription.api.blocking.Subscription;
@@ -98,6 +97,8 @@ public final class DcbSubscriptions<E> {
         requireNonNull(query, "Query cannot be null");
         requireNonNull(fn, "Subscription function cannot be null");
 
+        // A capable subscription model filters DCB events server-side from the DcbSubscriptionFilter. The in-process
+        // check stays as a correctness floor for any Subscribable that does not honor the filter.
         Consumer<CloudEvent> consumer = cloudEvent -> {
             if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
                 E event = cloudEventConverter.toDomainEvent(cloudEvent);
@@ -105,7 +106,7 @@ public final class DcbSubscriptions<E> {
             }
         };
 
-        OccurrentSubscriptionFilter filter = OccurrentSubscriptionFilter.filter(Filter.all());
+        DcbSubscriptionFilter filter = DcbSubscriptionFilter.filter(query);
         return startAt == null
                 ? subscriptionModel.subscribe(subscriptionId, filter, consumer)
                 : subscriptionModel.subscribe(subscriptionId, filter, startAt, consumer);

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
@@ -22,8 +22,7 @@ import org.occurrent.application.converter.get
 import org.occurrent.dsl.subscription.blocking.EventMetadata
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
 import org.occurrent.eventstore.api.dcb.DcbQuery
-import org.occurrent.filter.Filter
-import org.occurrent.subscription.OccurrentSubscriptionFilter
+import org.occurrent.subscription.DcbSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.api.blocking.Subscribable
 import org.occurrent.subscription.api.blocking.Subscription
@@ -77,6 +76,8 @@ fun <E : Any> Subscribable.subscribeDcb(
     waitUntilStarted: Boolean = true,
     fn: (EventMetadata, E) -> Unit
 ): Subscription {
+    // A capable subscription model filters DCB events server-side from the DcbSubscriptionFilter. The in-process
+    // check stays as a correctness floor for any Subscribable that does not honor the filter.
     val consumer: (CloudEvent) -> Unit = { cloudEvent ->
         if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
             val event = cloudEventConverter[cloudEvent]
@@ -85,7 +86,7 @@ fun <E : Any> Subscribable.subscribeDcb(
         }
     }
 
-    val filter = OccurrentSubscriptionFilter.filter(Filter.all())
+    val filter = DcbSubscriptionFilter.filter(query)
     val subscription = if (startAt == null) {
         subscribe(subscriptionId, filter, consumer)
     } else {

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
@@ -38,7 +38,13 @@ import static org.occurrent.time.internal.RFC3339.RFC_3339_DATE_TIME_FORMATTER;
  * into a MongoDB {@link Document} and vice versa.
  */
 public class OccurrentCloudEventMongoDocumentMapper {
-    private static final String DCB_TAGS_INDEX_FIELD = "dcbTags";
+    /**
+     * The name of the indexed array field that holds an event's DCB tags in the stored MongoDB document, kept alongside
+     * the newline-joined {@code dcbtags} CloudEvent extension so that tag containment can be queried with {@code $all}.
+     * This is the storage contract shared between the event store, which writes it, and a DCB subscription, which
+     * matches a change stream against it.
+     */
+    public static final String DCB_TAGS_INDEX_FIELD = "dcbTags";
     private static final String DCB_POSITION = "dcbposition";
 
     public static Document convertToDocument(TimeRepresentation timeRepresentation, String streamId, long streamVersion, CloudEvent cloudEvent) {

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -65,6 +65,7 @@ import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
+import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD;
 import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent;
 import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToDocument;
 import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
@@ -89,7 +90,6 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class SpringMongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter, DcbEventStore {
 
     private static final String ID = "_id";
-    private static final String DCB_TAGS_INDEX_FIELD = "dcbTags";
     private static final String DCB_POSITION_DOCUMENT_ID = "dcb";
     private static final String DCB_COUNTER_POSITION = "position";
     private static final String CHECKPOINT_LAST_POSITION = "lastPosition";

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbServerSideSubscriptionFilteringMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbServerSideSubscriptionFilteringMongoTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.SubscriptionModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that server-side change stream filtering via {@link DcbSubscriptionFilter} works end-to-end
+ * in DCB-only mode. Each test subscribes the wired {@link SubscriptionModel} DIRECTLY with a
+ * {@link DcbSubscriptionFilter} -- not via {@link org.occurrent.dsl.dcb.blocking.DcbSubscriptions},
+ * whose in-process correctness check would mask a broken server-side match. A non-matching event
+ * delivered here means the change stream $match stage is wrong.
+ */
+@DisplayName("DCB server-side subscription filtering (DCB-only mode)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = DcbServerSideSubscriptionFilteringMongoTest.DcbOnlyApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:dcb-filter-test"
+        }
+)
+@Import(DcbServerSideSubscriptionFilteringMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class DcbServerSideSubscriptionFilteringMongoTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:dcb-filter-test");
+
+    @Autowired
+    private DcbEventStore dcbEventStore;
+
+    @Autowired
+    private SubscriptionModel subscriptionModel;
+
+    @Autowired
+    private CloudEventConverter<TestEvent> cloudEventConverter;
+
+    @Test
+    void type_filter_delivers_only_the_subscribed_type() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        String subscriptionId = "type-filter-" + UUID.randomUUID();
+
+        subscriptionModel.subscribe(subscriptionId, DcbSubscriptionFilter.filter(DcbQuery.type("OrderPlaced")), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent shouldArrive = dcbEvent("OrderPlaced", List.of("order:1"));
+        CloudEvent shouldNotArrive = dcbEvent("OrderCancelled", List.of("order:1"));
+        appendRaw(shouldArrive, shouldNotArrive);
+
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(shouldArrive.getId()));
+    }
+
+    @Test
+    void tags_all_of_filter_delivers_only_events_carrying_all_required_tags() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        String subscriptionId = "tags-filter-" + UUID.randomUUID();
+
+        subscriptionModel.subscribe(subscriptionId, DcbSubscriptionFilter.filter(DcbQuery.tagsAllOf("customer:42", "tenant:1")), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent bothTags = dcbEvent("OrderPlaced", List.of("customer:42", "tenant:1"));
+        // A superset of the required tags must still match. This guards against the $all condition under-delivering,
+        // which the in-process correctness floor could not recover since it only removes events, never adds them.
+        CloudEvent supersetTags = dcbEvent("OrderPlaced", List.of("customer:42", "tenant:1", "region:eu"));
+        CloudEvent onlyOneTag = dcbEvent("OrderPlaced", List.of("customer:42"));
+        CloudEvent noMatchingTag = dcbEvent("OrderPlaced", List.of("tenant:1", "region:eu"));
+        appendRaw(bothTags, supersetTags, onlyOneTag, noMatchingTag);
+
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactlyInAnyOrder(bothTags.getId(), supersetTags.getId()));
+    }
+
+    @Test
+    void excluded_types_filter_excludes_the_specified_type() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        String subscriptionId = "excluded-types-filter-" + UUID.randomUUID();
+
+        DcbQuery query = DcbQuery.tagsAllOfExcludingTypes(List.of("order:99"), List.of("OrderDeleted"));
+        subscriptionModel.subscribe(subscriptionId, DcbSubscriptionFilter.filter(query), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent included = dcbEvent("OrderPlaced", List.of("order:99"));
+        CloudEvent excluded = dcbEvent("OrderDeleted", List.of("order:99"));
+        appendRaw(included, excluded);
+
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(included.getId()));
+    }
+
+    @Test
+    void or_filter_delivers_union_of_both_items() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        String subscriptionId = "or-filter-" + UUID.randomUUID();
+
+        DcbQuery query = DcbQuery.anyOf(
+                org.occurrent.eventstore.api.dcb.DcbQueryItem.type("OrderPlaced"),
+                org.occurrent.eventstore.api.dcb.DcbQueryItem.tagsAllOf(List.of("vip:true"))
+        );
+        subscriptionModel.subscribe(subscriptionId, DcbSubscriptionFilter.filter(query), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent byType = dcbEvent("OrderPlaced", List.of("order:1"));
+        CloudEvent byTag = dcbEvent("CustomerUpgraded", List.of("vip:true"));
+        CloudEvent noMatch = dcbEvent("OrderCancelled", List.of("order:2"));
+        appendRaw(byType, byTag, noMatch);
+
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactlyInAnyOrder(byType.getId(), byTag.getId()));
+    }
+
+    // --- helpers ---
+
+    // The type mapper derives the CloudEvent type from the TestEvent class, so override it explicitly here to give each
+    // event the CloudEvent type the DCB query filters on. The subscription receives raw CloudEvents, so nothing reads
+    // the event back through the converter.
+    private CloudEvent dcbEvent(String type, List<String> tags) {
+        TestEvent event = new TestEvent(UUID.randomUUID().toString(), new Date(), "user", type);
+        CloudEvent ce = cloudEventConverter.toCloudEvents(Stream.of(event)).findFirst().orElseThrow();
+        CloudEvent withType = CloudEventBuilder.v1(ce).withType(type).build();
+        return DcbCloudEvents.withTags(withType, tags);
+    }
+
+    private void appendRaw(CloudEvent... events) {
+        dcbEventStore.append(List.of(events));
+    }
+
+    // --- inner application and configuration classes ---
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class DcbOnlyApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+    }
+
+    record TestEvent(String eventId, Date timestamp, String userId, String name) {
+    }
+}

--- a/subscription/core/pom.xml
+++ b/subscription/core/pom.xml
@@ -39,6 +39,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <optional>true</optional>

--- a/subscription/core/src/main/java/org/occurrent/subscription/DcbSubscriptionFilter.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/DcbSubscriptionFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+
+import java.util.Objects;
+
+/**
+ * A {@link SubscriptionFilter} for Dynamic Consistency Boundary (DCB) subscriptions, expressed as a {@link DcbQuery}.
+ * <p>
+ * This is the DCB counterpart to {@link OccurrentSubscriptionFilter}: where the stream filter wraps an Occurrent
+ * {@link org.occurrent.filter.Filter}, the DCB filter wraps a {@link DcbQuery}. A subscription model that understands
+ * it limits the delivered events to those matching the query, server-side where the backend supports it.
+ */
+@NullMarked
+public record DcbSubscriptionFilter(DcbQuery query) implements SubscriptionFilter {
+
+    public DcbSubscriptionFilter {
+        Objects.requireNonNull(query, DcbQuery.class.getSimpleName() + " cannot be null");
+    }
+
+    public static DcbSubscriptionFilter filter(DcbQuery query) {
+        return new DcbSubscriptionFilter(query);
+    }
+}

--- a/subscription/inmemory/pom.xml
+++ b/subscription/inmemory/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>inmemory-filter-matching</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
@@ -18,7 +18,6 @@ package org.occurrent.subscription.inmemory;
 
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
-import org.occurrent.filter.Filter;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.DurationToTimeoutConverter.Timeout;
@@ -30,9 +29,9 @@ import java.util.StringJoiner;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.occurrent.inmemory.filtermatching.FilterMatcher.matchesFilter;
 import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
 
 /**
@@ -43,18 +42,18 @@ public class InMemorySubscription implements Subscription, Runnable {
     private final String id;
     private final BlockingQueue<CloudEvent> queue;
     private final Consumer<CloudEvent> consumer;
-    private final Filter filter;
+    private final Predicate<CloudEvent> matcher;
     private final RetryStrategy retryStrategy;
 
     private volatile boolean shutdown;
 
     private final CountDownLatch started = new CountDownLatch(1);
 
-    InMemorySubscription(String id, BlockingQueue<CloudEvent> queue, Consumer<CloudEvent> consumer, Filter filter, RetryStrategy retryStrategy) {
+    InMemorySubscription(String id, BlockingQueue<CloudEvent> queue, Consumer<CloudEvent> consumer, Predicate<CloudEvent> matcher, RetryStrategy retryStrategy) {
         this.id = id;
         this.queue = queue;
         this.consumer = consumer;
-        this.filter = filter;
+        this.matcher = matcher;
         this.retryStrategy = retryStrategy;
         this.shutdown = false;
     }
@@ -79,12 +78,12 @@ public class InMemorySubscription implements Subscription, Runnable {
         if (this == o) return true;
         if (!(o instanceof InMemorySubscription)) return false;
         InMemorySubscription that = (InMemorySubscription) o;
-        return shutdown == that.shutdown && Objects.equals(id, that.id) && Objects.equals(queue, that.queue) && Objects.equals(consumer, that.consumer) && Objects.equals(filter, that.filter) && Objects.equals(retryStrategy, that.retryStrategy);
+        return shutdown == that.shutdown && Objects.equals(id, that.id) && Objects.equals(queue, that.queue) && Objects.equals(consumer, that.consumer) && Objects.equals(matcher, that.matcher) && Objects.equals(retryStrategy, that.retryStrategy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, queue, consumer, filter, retryStrategy, shutdown);
+        return Objects.hash(id, queue, consumer, matcher, retryStrategy, shutdown);
     }
 
     @Override
@@ -93,7 +92,7 @@ public class InMemorySubscription implements Subscription, Runnable {
                 .add("id='" + id + "'")
                 .add("queue=" + queue)
                 .add("consumer=" + consumer)
-                .add("filter=" + filter)
+                .add("matcher=" + matcher)
                 .add("retryStrategy=" + retryStrategy)
                 .add("shutdown=" + shutdown)
                 .toString();
@@ -108,7 +107,7 @@ public class InMemorySubscription implements Subscription, Runnable {
     }
 
     boolean matches(CloudEvent cloudEvent) {
-        return matchesFilter(cloudEvent, filter);
+        return matcher.test(cloudEvent);
     }
 
     @Override

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
@@ -20,8 +20,11 @@ import io.cloudevents.CloudEvent;
 import jakarta.annotation.PreDestroy;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.filter.Filter;
 import org.occurrent.retry.RetryStrategy;
+import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
@@ -34,8 +37,11 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import static org.occurrent.inmemory.filtermatching.FilterMatcher.matchesFilter;
 
 /**
  * An in-memory subscription model
@@ -119,9 +125,9 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Consumer<St
             throw new IllegalArgumentException(InMemorySubscriptionModel.class.getSimpleName() + " only supports starting from 'now' and 'default' (StartAt.now() or StartAt.subscriptionModelDefault())");
         }
 
-        final Filter f = getFilter(filter);
+        final Predicate<CloudEvent> matcher = matcherFor(filter);
 
-        InMemorySubscription subscription = new InMemorySubscription(subscriptionId, queueSupplier.get(), action, f, retryStrategy);
+        InMemorySubscription subscription = new InMemorySubscription(subscriptionId, queueSupplier.get(), action, matcher, retryStrategy);
         subscriptions.put(subscriptionId, subscription);
 
         if (!running) {
@@ -165,16 +171,20 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Consumer<St
         ExecutorShutdown.shutdownSafely(cloudEventDispatcher, 5, TimeUnit.SECONDS);
     }
 
-    private static Filter getFilter(@Nullable SubscriptionFilter filter) {
-        final Filter f;
+    private static Predicate<CloudEvent> matcherFor(@Nullable SubscriptionFilter filter) {
         if (filter == null) {
-            f = Filter.all();
-        } else if (filter instanceof OccurrentSubscriptionFilter) {
-            f = ((OccurrentSubscriptionFilter) filter).filter();
+            return cloudEvent -> matchesFilter(cloudEvent, Filter.all());
+        } else if (filter instanceof OccurrentSubscriptionFilter occurrentSubscriptionFilter) {
+            Filter f = occurrentSubscriptionFilter.filter();
+            return cloudEvent -> matchesFilter(cloudEvent, f);
+        } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
+            // Match the DCB query in process and require a DCB position, the same guard the DCB subscription DSL uses,
+            // so a non-Mongo subscribable filters DCB events without a server-side change stream match.
+            DcbQuery query = dcbSubscriptionFilter.query();
+            return cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query);
         } else {
-            throw new IllegalArgumentException(InMemorySubscriptionModel.class.getSimpleName() + " only support filters of type " + OccurrentSubscriptionFilter.class.getName());
+            throw new IllegalArgumentException(InMemorySubscriptionModel.class.getSimpleName() + " only supports filters of type " + OccurrentSubscriptionFilter.class.getName() + " and " + DcbSubscriptionFilter.class.getName());
         }
-        return f;
     }
 
     @Override

--- a/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModelDcbFilterTest.java
+++ b/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModelDcbFilterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.inmemory;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class InMemorySubscriptionModelDcbFilterTest {
+
+    private InMemorySubscriptionModel subscriptionModel;
+
+    @BeforeEach
+    void create_subscription_model() {
+        subscriptionModel = new InMemorySubscriptionModel();
+    }
+
+    @AfterEach
+    void shutdown() {
+        subscriptionModel.shutdown();
+    }
+
+    @Test
+    void delivers_matching_dcb_event_to_subscriber_with_dcb_filter() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", DcbSubscriptionFilter.filter(DcbQuery.tagsAllOf("x:1")), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = dcbEvent("TypeA", 1L, List.of("x:1"));
+        subscriptionModel.accept(Stream.of(matching));
+
+        await().untilAsserted(() -> assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    @Test
+    void does_not_deliver_event_missing_required_tag() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", DcbSubscriptionFilter.filter(DcbQuery.tagsAllOf("x:1")), received::add)
+                .waitUntilStarted();
+
+        CloudEvent nonMatching = dcbEvent("TypeA", 1L, List.of("y:2"));
+        subscriptionModel.accept(Stream.of(nonMatching));
+
+        // Give the async dispatcher a window to (incorrectly) deliver; then assert nothing arrived.
+        await().during(java.time.Duration.ofMillis(200)).atMost(java.time.Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(received).isEmpty());
+    }
+
+    @Test
+    void does_not_deliver_event_with_no_dcb_position() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", DcbSubscriptionFilter.filter(DcbQuery.tagsAllOf("x:1")), received::add)
+                .waitUntilStarted();
+
+        // An event with the right tag but no dcbposition must be rejected by the position guard.
+        CloudEvent noPosition = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType("TypeA")
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+        CloudEvent taggedButNoPosition = DcbCloudEvents.withTags(noPosition, List.of("x:1"));
+        subscriptionModel.accept(Stream.of(taggedButNoPosition));
+
+        await().during(java.time.Duration.ofMillis(200)).atMost(java.time.Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(received).isEmpty());
+    }
+
+    @Test
+    void filters_out_non_matching_and_keeps_matching_events_in_same_batch() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", DcbSubscriptionFilter.filter(DcbQuery.tagsAllOf("x:1")), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = dcbEvent("TypeA", 1L, List.of("x:1", "y:2"));
+        CloudEvent nonMatching = dcbEvent("TypeB", 2L, List.of("y:2"));
+        subscriptionModel.accept(Stream.of(matching, nonMatching));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    @Test
+    void type_filter_delivers_only_matching_type() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", DcbSubscriptionFilter.filter(DcbQuery.type("OrderPlaced")), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = dcbEvent("OrderPlaced", 1L, List.of("order:1"));
+        CloudEvent nonMatching = dcbEvent("OrderCancelled", 2L, List.of("order:1"));
+        subscriptionModel.accept(Stream.of(matching, nonMatching));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    private static CloudEvent dcbEvent(String type, long position, List<String> tags) {
+        CloudEvent base = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType(type)
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+        CloudEvent tagged = DcbCloudEvents.withTags(base, tags);
+        return DcbCloudEvents.withPosition(tagged, position);
+    }
+}

--- a/subscription/mongodb/common/base/pom.xml
+++ b/subscription/mongodb/common/base/pom.xml
@@ -44,9 +44,26 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.internal;
+
+import org.bson.Document;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbQueryItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD;
+import static org.occurrent.subscription.mongodb.MongoFilterSpecification.FULL_DOCUMENT;
+
+/**
+ * Converts a {@link DcbQuery} into a MongoDB change stream {@code $match} stage, reproducing the
+ * {@link DcbCloudEvents#matches(io.cloudevents.CloudEvent, DcbQuery)} semantics server-side: within a query item types
+ * are any-of, tags are all-of, and excluded types are none-of, and the items are OR-ed together. A position filter of
+ * {@code dcbposition > 0} is always applied so only DCB-tagged events are delivered, matching the in-process guard the
+ * DCB subscription DSL uses.
+ * <p>
+ * The change stream wraps the stored event document under {@value org.occurrent.subscription.mongodb.MongoFilterSpecification#FULL_DOCUMENT},
+ * so every field is matched under that prefix. Tag containment matches the {@value DCB_TAGS_INDEX_FIELD} array the event
+ * store writes for exactly this purpose, not the newline-joined {@code dcbtags} extension string.
+ */
+@NullMarked
+public final class DcbSubscriptionFilterConverter {
+
+    private static final String TYPE_FIELD = FULL_DOCUMENT + ".type";
+    private static final String POSITION_FIELD = FULL_DOCUMENT + "." + DcbCloudEvents.POSITION;
+    private static final String TAGS_FIELD = FULL_DOCUMENT + "." + DCB_TAGS_INDEX_FIELD;
+
+    private DcbSubscriptionFilterConverter() {
+    }
+
+    /**
+     * Returns the single {@code {$match: ...}} aggregation stage that selects the events matching {@code query}.
+     */
+    public static Document toChangeStreamMatchStage(DcbQuery query) {
+        Document conditions = new Document(POSITION_FIELD, new Document("$gt", 0));
+        if (query instanceof DcbQuery.Items items) {
+            List<Document> itemConditions = items.items().stream()
+                    .map(DcbSubscriptionFilterConverter::toItemCondition)
+                    .toList();
+            conditions.put("$or", itemConditions);
+        }
+        return new Document("$match", conditions);
+    }
+
+    private static Document toItemCondition(DcbQueryItem item) {
+        Document condition = new Document();
+        Document typeOperators = new Document();
+        if (!item.types().isEmpty()) {
+            typeOperators.put("$in", new ArrayList<>(item.types()));
+        }
+        if (!item.excludedTypes().isEmpty()) {
+            typeOperators.put("$nin", new ArrayList<>(item.excludedTypes()));
+        }
+        if (!typeOperators.isEmpty()) {
+            condition.put(TYPE_FIELD, typeOperators);
+        }
+        if (!item.tags().isEmpty()) {
+            condition.put(TAGS_FIELD, new Document("$all", new ArrayList<>(item.tags())));
+        }
+        return condition;
+    }
+}

--- a/subscription/mongodb/common/base/src/test/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverterTest.java
+++ b/subscription/mongodb/common/base/src/test/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverterTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.internal;
+
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbQueryItem;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbSubscriptionFilterConverterTest {
+
+    private static final String FULL_DOCUMENT = "fullDocument";
+    private static final String POSITION_FIELD = FULL_DOCUMENT + ".dcbposition";
+    private static final String TYPE_FIELD = FULL_DOCUMENT + ".type";
+    private static final String TAGS_FIELD = FULL_DOCUMENT + ".dcbTags";
+
+    @Test
+    void match_all_query_produces_only_the_position_condition() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(DcbQuery.all());
+
+        Document match = stage.get("$match", Document.class);
+        assertThat(match).containsKey(POSITION_FIELD);
+        assertThat(match.get(POSITION_FIELD, Document.class).getInteger("$gt")).isEqualTo(0);
+        assertThat(match).doesNotContainKey("$or");
+    }
+
+    @Test
+    void single_type_query_produces_dollar_in_on_type_field() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(DcbQuery.type("OrderPlaced"));
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(1);
+
+        Document itemCondition = (Document) orList.get(0);
+        Document typeDoc = itemCondition.get(TYPE_FIELD, Document.class);
+        assertThat(typeDoc.getList("$in", String.class)).containsExactlyInAnyOrder("OrderPlaced");
+        assertThat(typeDoc).doesNotContainKey("$nin");
+    }
+
+    @Test
+    void multiple_types_query_produces_dollar_in_with_all_types() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(DcbQuery.types("OrderPlaced", "OrderCancelled"));
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(1);
+
+        Document itemCondition = (Document) orList.get(0);
+        Document typeDoc = itemCondition.get(TYPE_FIELD, Document.class);
+        assertThat(typeDoc.getList("$in", String.class)).containsExactlyInAnyOrder("OrderPlaced", "OrderCancelled");
+    }
+
+    @Test
+    void tags_all_of_query_produces_dollar_all_on_tags_field() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(DcbQuery.tagsAllOf("order:1", "tenant:2"));
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(1);
+
+        Document itemCondition = (Document) orList.get(0);
+        assertThat(itemCondition).doesNotContainKey(TYPE_FIELD);
+        Document tagsDoc = itemCondition.get(TAGS_FIELD, Document.class);
+        assertThat(tagsDoc.getList("$all", String.class)).containsExactlyInAnyOrder("order:1", "tenant:2");
+    }
+
+    @Test
+    void excluded_types_query_produces_dollar_nin_on_type_field() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(
+                DcbQuery.tagsAllOfExcludingTypes(Set.of("order:1"), Set.of("OrderDeleted")));
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(1);
+
+        Document itemCondition = (Document) orList.get(0);
+        Document typeDoc = itemCondition.get(TYPE_FIELD, Document.class);
+        assertThat(typeDoc.getList("$nin", String.class)).containsExactlyInAnyOrder("OrderDeleted");
+        assertThat(typeDoc).doesNotContainKey("$in");
+    }
+
+    @Test
+    void type_and_tags_all_of_query_combines_dollar_in_and_dollar_all() {
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(
+                DcbQuery.typeAndTagsAllOf(Set.of("OrderPlaced"), Set.of("order:1")));
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(1);
+
+        Document itemCondition = (Document) orList.get(0);
+        Document typeDoc = itemCondition.get(TYPE_FIELD, Document.class);
+        assertThat(typeDoc.getList("$in", String.class)).containsExactlyInAnyOrder("OrderPlaced");
+
+        Document tagsDoc = itemCondition.get(TAGS_FIELD, Document.class);
+        assertThat(tagsDoc.getList("$all", String.class)).containsExactlyInAnyOrder("order:1");
+    }
+
+    @Test
+    void any_of_multiple_items_produces_one_dollar_or_entry_per_item() {
+        DcbQuery query = DcbQuery.anyOf(
+                DcbQueryItem.type("OrderPlaced"),
+                DcbQueryItem.tagsAllOf(Set.of("customer:99"))
+        );
+
+        Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(query);
+
+        Document match = stage.get("$match", Document.class);
+        assertPositionConditionPresent(match);
+
+        List<?> orList = match.getList("$or", Document.class);
+        assertThat(orList).hasSize(2);
+
+        Document first = (Document) orList.get(0);
+        Document second = (Document) orList.get(1);
+
+        // One item should have a type condition and the other a tags condition; order not guaranteed.
+        boolean firstHasType = first.containsKey(TYPE_FIELD);
+        Document typeItem = firstHasType ? first : second;
+        Document tagsItem = firstHasType ? second : first;
+
+        assertThat(typeItem.get(TYPE_FIELD, Document.class).getList("$in", String.class)).containsExactlyInAnyOrder("OrderPlaced");
+        assertThat(tagsItem.get(TAGS_FIELD, Document.class).getList("$all", String.class)).containsExactlyInAnyOrder("customer:99");
+    }
+
+    @Test
+    void every_produced_match_stage_contains_the_top_level_dollar_match_key() {
+        for (DcbQuery query : List.of(DcbQuery.all(), DcbQuery.type("T"), DcbQuery.tagsAllOf("x:1"))) {
+            Document stage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(query);
+            assertThat(stage).containsKey("$match");
+        }
+    }
+
+    private static void assertPositionConditionPresent(Document match) {
+        Document positionCondition = match.get(POSITION_FIELD, Document.class);
+        assertThat(positionCondition).isNotNull();
+        assertThat(positionCondition.getInteger("$gt")).isEqualTo(0);
+    }
+}

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -45,6 +45,7 @@ import org.occurrent.subscription.internal.ExecutorShutdown;
 import org.occurrent.subscription.mongodb.MongoFilterSpecification;
 import org.occurrent.subscription.mongodb.MongoOperationTimeSubscriptionPosition;
 import org.occurrent.subscription.mongodb.MongoResumeTokenSubscriptionPosition;
+import org.occurrent.subscription.mongodb.internal.DcbSubscriptionFilterConverter;
 import org.occurrent.subscription.mongodb.internal.DocumentAdapter;
 import org.occurrent.subscription.mongodb.internal.MongoCloudEventsToJsonDeserializer;
 import org.occurrent.subscription.mongodb.internal.MongoCommons;
@@ -209,6 +210,8 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
             Filter occurrentFilter = ((OccurrentSubscriptionFilter) filter).filter();
             Bson bson = FilterToBsonFilterConverter.convertFilterToBsonFilter(MongoFilterSpecification.FULL_DOCUMENT, timeRepresentation, occurrentFilter);
             pipeline = Collections.singletonList(match(bson));
+        } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
+            pipeline = Collections.singletonList(DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.query()));
         } else if (filter instanceof MongoFilterSpecification.MongoJsonFilterSpecification) {
             pipeline = Collections.singletonList(Document.parse(((MongoFilterSpecification.MongoJsonFilterSpecification) filter).getJson()));
         } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification) {

--- a/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
+++ b/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
@@ -24,10 +24,12 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.filter.Filter;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.mongodb.MongoFilterSpecification;
 import org.occurrent.subscription.mongodb.MongoFilterSpecification.MongoJsonFilterSpecification;
+import org.occurrent.subscription.mongodb.internal.DcbSubscriptionFilterConverter;
 import org.occurrent.subscription.mongodb.internal.DocumentAdapter;
 import org.springframework.data.mongodb.core.ChangeStreamOptions;
 import org.springframework.data.mongodb.core.ChangeStreamOptions.ChangeStreamOptionsBuilder;
@@ -51,6 +53,9 @@ public class ApplyFilterToChangeStreamOptionsBuilder {
             Filter occurrentFilter = ((OccurrentSubscriptionFilter) filter).filter();
             Criteria criteria = convertFilterToCriteria(FULL_DOCUMENT, timeRepresentation, occurrentFilter);
             changeStreamOptions = changeStreamOptionsBuilder.filter(newAggregation(match(criteria))).build();
+        } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
+            Document matchStage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.query());
+            changeStreamOptions = changeStreamOptionsBuilder.filter(matchStage).build();
         } else if (filter instanceof MongoJsonFilterSpecification) {
             changeStreamOptions = changeStreamOptionsBuilder.filter(Document.parse(((MongoJsonFilterSpecification) filter).getJson())).build();
         } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification) {

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -196,15 +196,17 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     @Override
     public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
-        if (filter != null && !(filter instanceof OccurrentSubscriptionFilter)) {
-            throw new IllegalArgumentException("Only OccurrentSubscriptionFilter is supported!");
-        }
         return isDcbMode()
                 ? subscribeDcb(subscriptionId, filter, startAt, action)
                 : subscribeStream(subscriptionId, filter, startAt, action);
     }
 
     private Subscription subscribeStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        // Stream catch-up converts the filter into an Occurrent Filter for the historical query, so only the stream
+        // filter type is supported here. The DCB path accepts a DcbSubscriptionFilter and passes it to the inner model.
+        if (filter != null && !(filter instanceof OccurrentSubscriptionFilter)) {
+            throw new IllegalArgumentException("Only OccurrentSubscriptionFilter is supported!");
+        }
         final StartAt firstStartAt;
         if (startAt.isDefault()) {
             // By default, we check if there's a subscription position stored for this subscription, if so we resume from there, otherwise,


### PR DESCRIPTION
DCB subscriptions filtered every event in process. `DcbSubscriptions` subscribed with `Filter.all()` and threw away most events in the consumer thread, so a read model that cares about a few event types or one tag boundary still received the whole DCB stream. Under load that is a lot of wasted delivery.

This makes DCB filtering server-side.

- `DcbSubscriptionFilter`, wrapping a `DcbQuery`, is now a first-class `SubscriptionFilter` alongside the stream `OccurrentSubscriptionFilter`. One converter turns a `DcbQuery` into a single change stream `$match`: types to `$in`, excluded types to `$nin`, tags to `$all` on the indexed `dcbTags` array, items OR-ed, and `dcbposition > 0` always so only DCB events arrive. The Spring and native MongoDB models both use it. The in-memory model matches the same query in process.
- `DcbSubscriptions` now subscribes with the filter and keeps its in-process check only as a correctness floor, since it wraps an arbitrary `Subscribable` and cannot assume the backend filters. A capable backend reduces the volume, the floor guarantees correctness everywhere.
- `CatchupSubscriptionModel` had one upfront guard that rejected every filter except the stream one. That guard belongs to the stream catch-up path, which converts the filter into an Occurrent `Filter`, so it now lives only there. The DCB path passes the filter straight to the inner model.
- The `dcbTags` field name was a private constant duplicated in the event store. It is now the public `OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD`, the one storage contract the writer and the subscription reader share.

On the open question of whether to split the `Filter` class itself: no. `SubscriptionFilter` is already the common seam, so the clean split is stream `Filter` for stream subscriptions and `DcbQuery` for DCB subscriptions, each an implementation over shared Mongo plumbing. There is no shared structure today that a common filter base would capture without inventing it. ADR 0023 records this.

### Verification

* `rtk mvn -pl subscription/mongodb/common/base -am -Dtest=DcbSubscriptionFilterConverterTest test`: Tests run: 8, Failures: 0, Errors: 0.
* `rtk mvn -pl subscription/inmemory -Dtest=InMemorySubscriptionModelDcbFilterTest test` plus the existing in-memory suite: green.
* `rtk mvn -pl framework/spring-boot-starter-mongodb -Dtest=DcbServerSideSubscriptionFilteringMongoTest test`: Tests run: 4, Failures: 0, Errors: 0. This subscribes the model directly, not through `DcbSubscriptions`, so a non-matching delivered event would mean the server-side `$match` is wrong.
* Catch-up regression: `CatchupSubscriptionModelTest`, `DcbCatchupSubscriptionModelTest`, `DcbCatchupSubscriptionModelMongoTest` (23 total), plus the starter `DcbCatchupSubscriptionAutoConfigurationMongoTest` and `OccurrentMongoAutoConfigurationCombinedModeTest`: green.
* `rtk mvn -pl dsl/dcb-dsl/blocking test`: green, including the DCB DSL routing through the new filter.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-subscriptions-cancel","parentHead":"22b624062488bebb79d860d3b46079a520630a68","parentPull":222,"trunk":"main"}
```
-->
