### PR TITLE
Split stream and DCB subscription models

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### Changelog next version
 
+* Stream and DCB subscriptions now have separate typed start positions and model views.
+  * `DcbStartAt` is the DCB counterpart to `StartAt`, expressing only DCB starts (`now`, `subscriptionModelDefault`, `beginning`, `afterPosition`). `DcbSubscriptionModel` and `StreamSubscriptionModel` are typed facades over the shared `SubscriptionModel`, obtained with `from(subscriptionModel)`. A DCB subscription can no longer be handed a time-based position and a stream subscription can no longer be handed a `dcbposition`, which used to fail quietly at runtime. The shared durable, competing-consumer, and catch-up machinery is unchanged, the split is types and thin adapters.
+  * `DcbSubscriptions` now takes a `DcbStartAt` instead of a generic `StartAt`. `DcbSubscriptionPosition` moved to the `org.occurrent.subscription` package.
+  * See [ADR 24](doc/architecture/decisions/0024-stream-and-dcb-subscription-model-split.md).
+
 * DCB subscriptions now filter server-side.
   * A new `DcbSubscriptionFilter`, wrapping a `DcbQuery`, is a first-class `SubscriptionFilter` alongside the stream `OccurrentSubscriptionFilter`. The Spring and native MongoDB subscription models translate it into a change stream `$match`, so a DCB read model that cares about a few event types or a tag boundary no longer receives every DCB event and discards most of them in the consumer. The in-memory model honors it in process. `DcbSubscriptions` now subscribes with it and keeps a small in-process check only as a correctness floor for backends that do not filter.
   * Tag containment matches the indexed `dcbTags` array the event store already writes, exposed as the public constant `OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD`.

--- a/doc/architecture/decisions/0024-stream-and-dcb-subscription-model-split.md
+++ b/doc/architecture/decisions/0024-stream-and-dcb-subscription-model-split.md
@@ -1,0 +1,38 @@
+# 24. Split the subscription model and start position into stream and DCB types
+
+Date: 2026-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+A subscription has two flavors now: stream subscriptions filtered by an Occurrent `Filter` and started at a time, and DCB subscriptions filtered by a `DcbQuery` and started at a `dcbposition`. Both go through one `SubscriptionModel` whose `subscribe` takes a `SubscriptionFilter` and a `StartAt`, and `StartAt` is a shared union over every position type.
+
+So nothing stops a caller mixing the two. A DCB subscription can be handed a `StartAt.subscriptionPosition(TimeBasedSubscriptionPosition)`, and a stream subscription a `DcbSubscriptionPosition`. The mismatch is only reconciled at runtime, and the failure is quiet: a time-based start on a DCB subscription does not replay, it silently goes live. The `DcbSubscriptions` DSL took a generic `StartAt`, so it carried the same hole.
+
+The goal is to make those illegal states unrepresentable, with a full split into separate model and start-position types rather than only a position marker.
+
+The constraint is that the machinery underneath is genuinely shared. DCB events flow through the same MongoDB change stream as stream events (ADR 0017), and the durable, competing-consumer, and catch-up decorators wrap one subscription model for both. So the split has to live at the API and the filter/position/query type level, over a shared core, not as a fork of the decorator lifecycle.
+
+The `dcbposition` start type, `DcbSubscriptionPosition`, lived in the catch-up module, which sits above the subscription API. A DCB start type that produces it cannot then live in the API or core where the typed model interfaces belong.
+
+## Decision
+
+Split at the type and facade level, leaving the shared lifecycle untouched.
+
+- Move `DcbSubscriptionPosition` down to `subscription-core` (package `org.occurrent.subscription`), next to the other `SubscriptionPosition` value types. It depends only on `SubscriptionPosition` and `StringBasedSubscriptionPosition`, both already in core, so the move is clean. DCB is unreleased, so the package change costs nothing. This is the prefactor that lets the start type live low enough.
+- Add `DcbStartAt` in `subscription-core`, the DCB counterpart to `StartAt`. It is a distinct sealed type that can only express DCB starts: `now()`, `subscriptionModelDefault()`, `beginning()` (replay from the start of the DCB sequence), and `afterPosition(lastProcessedPosition)` (resume after a known position). `toStartAt()` bridges to the generic `StartAt` the shared model consumes. Because it is a separate type, a DCB start cannot carry a time-based position and vice versa.
+- Add `DcbSubscriptionModel` and `StreamSubscriptionModel` in `subscription-api-blocking`, typed facades over the shared `SubscriptionModel`. `DcbSubscriptionModel.subscribe` takes a `DcbQuery` and a `DcbStartAt`, `StreamSubscriptionModel.subscribe` takes a `Filter` and a `StartAt`. Neither exposes the low-level `subscribe(SubscriptionFilter, StartAt, ...)`, so neither can be handed the other's filter or position. Each is obtained with a static `from(SubscriptionModel)` that returns an adapter translating the typed call into the low-level one (building a `DcbSubscriptionFilter` or wrapping the `Filter` in an `OccurrentSubscriptionFilter`, and converting the start position) and forwarding every life-cycle call to the delegate. The decorator stack is not changed or forked.
+- Rebase the `DcbSubscriptions` DSL on `DcbSubscriptionModel` and `DcbStartAt`. Its start parameter is now a `DcbStartAt`, and it builds a `DcbSubscriptionModel` from the injected `SubscriptionModel`.
+
+Do not add auto-configured beans for the two facade interfaces yet. The `from(SubscriptionModel)` factories are enough, and `DcbSubscriptions` already gives the DCB-typed entry point. Decide bean wiring in the `@DcbSubscription` work, where a wired typed model is actually consumed, to avoid churning the characterized bean set now.
+
+## Consequences
+
+- A DCB subscription cannot be given a stream filter or a time-based start, and a stream subscription cannot be given a DCB query or a `dcbposition`, at the typed entry points. The mismatch that used to fail quietly at runtime is now a compile error.
+- The shared durable, competing-consumer, catch-up, and change-stream machinery is untouched. The split is types and thin adapters, so there is one subscription lifecycle, not two.
+- `DcbSubscriptionPosition` moved package. This is a source-incompatible change for any code importing it, which is acceptable while DCB is unreleased.
+- The raw `SubscriptionModel` still exists and still takes any `SubscriptionFilter` and `StartAt`, for advanced or genuinely mixed use. The facades are the safe default, not a cage. A caller who wants the union can still reach it.
+- The facade interfaces are obtained by wrapping, not by the concrete models implementing them. This keeps the generic decorator stack free of DCB and stream specifics, at the cost of the facade not being the bean type injected today. That tradeoff is revisited when the annotation work wires a typed model.

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -21,10 +21,9 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.subscription.blocking.EventMetadata;
-import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
-import org.occurrent.subscription.DcbSubscriptionFilter;
-import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.api.blocking.DcbSubscriptionModel;
 import org.occurrent.subscription.api.blocking.Subscribable;
 import org.occurrent.subscription.api.blocking.Subscription;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
@@ -49,17 +48,21 @@ import static java.util.Objects.requireNonNull;
  * start. Call {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before
  * you continue (for example to avoid missing the first events of a brand new subscription). Call {@link #cancel(String)}
  * to stop and remove a subscription, for example when a per-connection subscription is no longer needed.
+ * <p>
+ * This DSL is for ephemeral, per-connection subscriptions that you start and cancel by hand, such as a Server-Sent-Events
+ * feed scoped to one request. For a persistent, framework-managed subscription, such as a read model that catches up
+ * from history on startup, use the {@code @DcbSubscription} annotation instead.
  *
  * @param <E> the domain event type
  */
 @NullMarked
 public final class DcbSubscriptions<E> {
 
-    private final SubscriptionModel subscriptionModel;
+    private final DcbSubscriptionModel subscriptionModel;
     private final CloudEventConverter<E> cloudEventConverter;
 
     public DcbSubscriptions(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
-        this.subscriptionModel = requireNonNull(subscriptionModel, SubscriptionModel.class.getSimpleName() + " cannot be null");
+        this.subscriptionModel = DcbSubscriptionModel.from(requireNonNull(subscriptionModel, SubscriptionModel.class.getSimpleName() + " cannot be null"));
         this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
     }
 
@@ -73,7 +76,7 @@ public final class DcbSubscriptions<E> {
     /**
      * Subscribes to live DCB events that match {@code query}, starting at {@code startAt}.
      */
-    public Subscription subscribe(String subscriptionId, DcbQuery query, @Nullable StartAt startAt, Consumer<E> fn) {
+    public Subscription subscribe(String subscriptionId, DcbQuery query, @Nullable DcbStartAt startAt, Consumer<E> fn) {
         requireNonNull(fn, "Subscription function cannot be null");
         return subscribeWithMetadata(subscriptionId, query, startAt, (metadata, event) -> fn.accept(event));
     }
@@ -92,24 +95,20 @@ public final class DcbSubscriptions<E> {
      * Subscribes to live DCB events that match {@code query}, starting at {@code startAt} and exposing DCB metadata
      * to the callback.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, @Nullable StartAt startAt, BiConsumer<DcbEventMetadata, E> fn) {
+    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, @Nullable DcbStartAt startAt, BiConsumer<DcbEventMetadata, E> fn) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(query, "Query cannot be null");
         requireNonNull(fn, "Subscription function cannot be null");
 
-        // A capable subscription model filters DCB events server-side from the DcbSubscriptionFilter. The in-process
-        // check stays as a correctness floor for any Subscribable that does not honor the filter.
+        // The DcbSubscriptionModel scopes delivery to the query (server-side where the backend supports it, and an
+        // in-process floor in the typed adapter otherwise), so this callback only converts and dispatches.
         Consumer<CloudEvent> consumer = cloudEvent -> {
-            if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
-                E event = cloudEventConverter.toDomainEvent(cloudEvent);
-                fn.accept(DcbEventMetadata.from(toEventMetadata(cloudEvent)), event);
-            }
+            E event = cloudEventConverter.toDomainEvent(cloudEvent);
+            fn.accept(DcbEventMetadata.from(toEventMetadata(cloudEvent)), event);
         };
 
-        DcbSubscriptionFilter filter = DcbSubscriptionFilter.filter(query);
-        return startAt == null
-                ? subscriptionModel.subscribe(subscriptionId, filter, consumer)
-                : subscriptionModel.subscribe(subscriptionId, filter, startAt, consumer);
+        DcbStartAt startAtToUse = startAt == null ? DcbStartAt.subscriptionModelDefault() : startAt;
+        return subscriptionModel.subscribe(subscriptionId, query, startAtToUse, consumer);
     }
 
     /**

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
@@ -22,8 +22,8 @@ import org.occurrent.application.converter.get
 import org.occurrent.dsl.subscription.blocking.EventMetadata
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
 import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.subscription.DcbStartAt
 import org.occurrent.subscription.DcbSubscriptionFilter
-import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.api.blocking.Subscribable
 import org.occurrent.subscription.api.blocking.Subscription
 
@@ -55,7 +55,7 @@ fun <E : Any> Subscribable.subscribeDcb(
     subscriptionId: String,
     cloudEventConverter: CloudEventConverter<E>,
     query: DcbQuery = DcbQuery.all(),
-    startAt: StartAt? = null,
+    startAt: DcbStartAt? = null,
     fn: (E) -> Unit
 ): Subscription =
     subscribeDcb(subscriptionId, cloudEventConverter, query, startAt) { _, event -> fn(event) }
@@ -72,7 +72,7 @@ fun <E : Any> Subscribable.subscribeDcb(
     subscriptionId: String,
     cloudEventConverter: CloudEventConverter<E>,
     query: DcbQuery = DcbQuery.all(),
-    startAt: StartAt? = null,
+    startAt: DcbStartAt? = null,
     waitUntilStarted: Boolean = true,
     fn: (EventMetadata, E) -> Unit
 ): Subscription {
@@ -90,7 +90,7 @@ fun <E : Any> Subscribable.subscribeDcb(
     val subscription = if (startAt == null) {
         subscribe(subscriptionId, filter, consumer)
     } else {
-        subscribe(subscriptionId, filter, startAt, consumer)
+        subscribe(subscriptionId, filter, startAt.toStartAt(), consumer)
     }
 
     return subscription.apply {

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardSubscriber.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardSubscriber.kt
@@ -26,16 +26,15 @@ import org.occurrent.example.domain.courseenrollment.features.enrollment.model.S
 import org.occurrent.example.domain.courseenrollment.features.enrollment.model.StudentUnenrolledFromCourse
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentDeregistered
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentRegistered
-import org.occurrent.subscription.StartAt
-import org.occurrent.subscription.blocking.durable.catchup.DcbSubscriptionPosition
+import org.occurrent.subscription.DcbStartAt
 import org.springframework.stereotype.Component
 
 /**
  * Feeds the [CourseDashboard] read model from a DCB subscription.
  *
- * Starting at [DcbSubscriptionPosition] zero makes the subscription replay the whole DCB history by dcbposition on every
- * boot and then switch to live delivery, so the in-memory read model is rebuilt from scratch each start. This catch-up
- * is only available because the starter wires a DCB-mode catch-up subscription model in DCB-only mode.
+ * Starting at [DcbStartAt.beginning] makes the subscription replay the whole DCB history by dcbposition on every boot and
+ * then switch to live delivery, so the in-memory read model is rebuilt from scratch each start. This catch-up is only
+ * available because the starter wires a DCB-mode catch-up subscription model in DCB-only mode.
  */
 @Component
 class CourseDashboardSubscriber(
@@ -45,7 +44,7 @@ class CourseDashboardSubscriber(
 
     @PostConstruct
     fun start() {
-        dcbSubscriptions.subscribe("course-dashboard", DcbQuery.all(), StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0))) { event ->
+        dcbSubscriptions.subscribe("course-dashboard", DcbQuery.all(), DcbStartAt.beginning()) { event ->
             if (event is CourseDefined || event is CourseCancelled || event is StudentRegistered || event is StudentDeregistered ||
                 event is StudentEnrolledInCourse || event is StudentUnenrolledFromCourse) {
                 courseDashboard.update(event)

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbCatchupSubscriptionAutoConfigurationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbCatchupSubscriptionAutoConfigurationMongoTest.java
@@ -31,8 +31,8 @@ import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
-import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.blocking.durable.catchup.DcbSubscriptionPosition;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -108,7 +108,7 @@ class DcbCatchupSubscriptionAutoConfigurationMongoTest {
                 .subscribe(
                         "test-catchup-" + UUID.randomUUID(),
                         DcbQuery.tagsAllOf(TAG),
-                        StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)),
+                        DcbStartAt.beginning(),
                         received::add)
                 .waitUntilStarted();
 

--- a/subscription/api/blocking/pom.xml
+++ b/subscription/api/blocking/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <optional>true</optional>

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/AbstractDelegatingSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/AbstractDelegatingSubscriptionModelAdapter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.blocking;
+
+import org.jspecify.annotations.NullMarked;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Shared base for the typed subscription-model facades. It holds the wrapped {@link SubscriptionModel} and forwards
+ * every life-cycle call to it, so each facade adapter only has to implement its own typed {@code subscribe}.
+ */
+@NullMarked
+abstract class AbstractDelegatingSubscriptionModelAdapter implements SubscriptionModelLifeCycle {
+
+    final SubscriptionModel delegate;
+
+    AbstractDelegatingSubscriptionModelAdapter(SubscriptionModel delegate) {
+        this.delegate = requireNonNull(delegate, SubscriptionModel.class.getSimpleName() + " cannot be null");
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public void start(boolean resumeSubscriptionsAutomatically) {
+        delegate.start(resumeSubscriptionsAutomatically);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return delegate.isRunning();
+    }
+
+    @Override
+    public boolean isRunning(String subscriptionId) {
+        return delegate.isRunning(subscriptionId);
+    }
+
+    @Override
+    public boolean isPaused(String subscriptionId) {
+        return delegate.isPaused(subscriptionId);
+    }
+
+    @Override
+    public Subscription resumeSubscription(String subscriptionId) {
+        return delegate.resumeSubscription(subscriptionId);
+    }
+
+    @Override
+    public void pauseSubscription(String subscriptionId) {
+        delegate.pauseSubscription(subscriptionId);
+    }
+
+    @Override
+    public void cancelSubscription(String subscriptionId) {
+        delegate.cancelSubscription(subscriptionId);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+
+import java.util.function.Consumer;
+
+/**
+ * A typed view of a {@link SubscriptionModel} for Dynamic Consistency Boundary (DCB) subscriptions. It accepts a
+ * {@link DcbQuery} and a {@link DcbStartAt}, so a DCB subscription cannot be handed a stream {@code Filter} or a
+ * time-based start position. It is a facade over the shared subscription model, not a separate lifecycle: obtain one
+ * with {@link #from(SubscriptionModel)} and the typed calls are translated to the underlying model.
+ */
+@NullMarked
+public interface DcbSubscriptionModel extends SubscriptionModelLifeCycle {
+
+    /**
+     * Subscribe to DCB events matching {@code query}, starting at {@code startAt}.
+     */
+    Subscription subscribe(String subscriptionId, DcbQuery query, DcbStartAt startAt, Consumer<CloudEvent> action);
+
+    /**
+     * Subscribe to DCB events matching {@code query} at the subscription model default position.
+     */
+    default Subscription subscribe(String subscriptionId, DcbQuery query, Consumer<CloudEvent> action) {
+        return subscribe(subscriptionId, query, DcbStartAt.subscriptionModelDefault(), action);
+    }
+
+    /**
+     * Subscribe to every DCB event at the subscription model default position.
+     */
+    default Subscription subscribe(String subscriptionId, Consumer<CloudEvent> action) {
+        return subscribe(subscriptionId, DcbQuery.all(), action);
+    }
+
+    /**
+     * Create a DCB view over an existing {@link SubscriptionModel}. The returned model translates DCB queries and start
+     * positions into the filter and start position the delegate understands, and forwards all life-cycle calls to it.
+     */
+    static DcbSubscriptionModel from(SubscriptionModel delegate) {
+        return new DcbSubscriptionModelAdapter(delegate);
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModelAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Translates {@link DcbSubscriptionModel} calls into the shared {@link SubscriptionModel}, building a
+ * {@link DcbSubscriptionFilter} from the query and converting the {@link DcbStartAt} to a generic start position. All
+ * life-cycle calls forward to the delegate (see {@link AbstractDelegatingSubscriptionModelAdapter}).
+ */
+@NullMarked
+final class DcbSubscriptionModelAdapter extends AbstractDelegatingSubscriptionModelAdapter implements DcbSubscriptionModel {
+
+    DcbSubscriptionModelAdapter(SubscriptionModel delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public Subscription subscribe(String subscriptionId, DcbQuery query, DcbStartAt startAt, Consumer<CloudEvent> action) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");
+        requireNonNull(action, "Subscription action cannot be null");
+        // The DcbSubscriptionFilter is honored server-side for live delivery, but a DCB catch-up replays by the
+        // model-level query, so an in-process check keeps the subscription scoped to its own query during catch-up too
+        // (and stays correct for any backend that does not honor the filter).
+        Consumer<CloudEvent> scopedToQuery = cloudEvent -> {
+            if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
+                action.accept(cloudEvent);
+            }
+        };
+        return delegate.subscribe(subscriptionId, DcbSubscriptionFilter.filter(query), startAt.toStartAt(), scopedToQuery);
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.StartAt;
+
+import java.util.function.Consumer;
+
+/**
+ * A typed view of a {@link SubscriptionModel} for stream subscriptions. It accepts an Occurrent {@link Filter} (not a
+ * DCB query) and the standard {@link StartAt}. It is a facade over the shared subscription model: obtain one with
+ * {@link #from(SubscriptionModel)} and the typed calls are translated to the underlying model. The start position stays
+ * the generic {@link StartAt} here. The DCB-only start type {@link org.occurrent.subscription.DcbStartAt} is paired with
+ * {@link DcbSubscriptionModel}, which is where the start position is also constrained to DCB.
+ */
+@NullMarked
+public interface StreamSubscriptionModel extends SubscriptionModelLifeCycle {
+
+    /**
+     * Subscribe to events matching {@code filter}, starting at {@code startAt}.
+     */
+    Subscription subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action);
+
+    /**
+     * Subscribe to events matching {@code filter} at the subscription model default position.
+     */
+    default Subscription subscribe(String subscriptionId, Filter filter, Consumer<CloudEvent> action) {
+        return subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), action);
+    }
+
+    /**
+     * Subscribe to every event at the subscription model default position.
+     */
+    default Subscription subscribe(String subscriptionId, Consumer<CloudEvent> action) {
+        return subscribe(subscriptionId, Filter.all(), action);
+    }
+
+    /**
+     * Create a stream view over an existing {@link SubscriptionModel}. The returned model wraps the {@link Filter} in an
+     * {@code OccurrentSubscriptionFilter} for the delegate, and forwards all life-cycle calls to it.
+     */
+    static StreamSubscriptionModel from(SubscriptionModel delegate) {
+        return new StreamSubscriptionModelAdapter(delegate);
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModelAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.OccurrentSubscriptionFilter;
+import org.occurrent.subscription.StartAt;
+
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Translates {@link StreamSubscriptionModel} calls into the shared {@link SubscriptionModel}, wrapping the
+ * {@link Filter} in an {@link OccurrentSubscriptionFilter}. All life-cycle calls forward to the delegate (see
+ * {@link AbstractDelegatingSubscriptionModelAdapter}).
+ */
+@NullMarked
+final class StreamSubscriptionModelAdapter extends AbstractDelegatingSubscriptionModelAdapter implements StreamSubscriptionModel {
+
+    StreamSubscriptionModelAdapter(SubscriptionModel delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public Subscription subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
+        requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
+        requireNonNull(action, "Subscription action cannot be null");
+        return delegate.subscribe(subscriptionId, OccurrentSubscriptionFilter.filter(filter), startAt, action);
+    }
+}

--- a/subscription/core/src/main/java/org/occurrent/subscription/DcbStartAt.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/DcbStartAt.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Specifies where a DCB subscription should start. This is the DCB counterpart to {@link StartAt}: it can only express
+ * DCB start positions (a {@code dcbposition} or one of the relative starts), never a time-based stream position, so a
+ * DCB subscription cannot be handed a position that belongs to a stream subscription.
+ * <p>
+ * Convert to the generic {@link StartAt} the shared subscription model consumes with {@link #toStartAt()}.
+ */
+@NullMarked
+public sealed interface DcbStartAt {
+
+    /**
+     * Convert this DCB start position into the generic {@link StartAt} understood by the shared subscription model.
+     */
+    StartAt toStartAt();
+
+    /**
+     * Start subscribing at this moment in time, delivering only events written from now on (no history replay).
+     */
+    static DcbStartAt now() {
+        return Relative.NOW;
+    }
+
+    /**
+     * Start subscribing at the subscription model default. Typically this resumes from the last stored DCB position if
+     * one exists, otherwise it behaves like {@link #now()}.
+     */
+    static DcbStartAt subscriptionModelDefault() {
+        return Relative.DEFAULT;
+    }
+
+    /**
+     * Start subscribing from the beginning of the DCB sequence, replaying the whole history by {@code dcbposition} before
+     * switching to live delivery. Shorthand for {@code afterPosition(0)} (DCB positions are assigned from {@code 1}, so
+     * "after 0" is the first event). The history replay is performed by a catch-up-capable subscription model (the Spring
+     * Boot stack includes one), so a subscription model without catch-up support may not replay past events from this
+     * position.
+     */
+    static DcbStartAt beginning() {
+        return afterPosition(0);
+    }
+
+    /**
+     * Start subscribing after the given DCB sequence position, delivering events from {@code lastProcessedPosition + 1}
+     * onward. This is resume semantics: {@code lastProcessedPosition} is the position you have already processed, so the
+     * event at that position is not redelivered. Use {@code 0} (or {@link #beginning()}) to replay the whole history,
+     * since DCB positions are assigned from {@code 1}.
+     */
+    static DcbStartAt afterPosition(long lastProcessedPosition) {
+        return new AtPosition(lastProcessedPosition);
+    }
+
+    enum Relative implements DcbStartAt {
+        NOW {
+            @Override
+            public StartAt toStartAt() {
+                return StartAt.now();
+            }
+        },
+        DEFAULT {
+            @Override
+            public StartAt toStartAt() {
+                return StartAt.subscriptionModelDefault();
+            }
+        }
+    }
+
+    record AtPosition(long lastProcessedPosition) implements DcbStartAt {
+        public AtPosition {
+            if (lastProcessedPosition < 0) {
+                throw new IllegalArgumentException("DCB position cannot be negative, was " + lastProcessedPosition);
+            }
+        }
+
+        @Override
+        public StartAt toStartAt() {
+            return StartAt.subscriptionPosition(DcbSubscriptionPosition.of(lastProcessedPosition));
+        }
+    }
+}

--- a/subscription/core/src/main/java/org/occurrent/subscription/DcbSubscriptionPosition.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/DcbSubscriptionPosition.java
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package org.occurrent.subscription.blocking.durable.catchup;
+package org.occurrent.subscription;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.occurrent.subscription.StringBasedSubscriptionPosition;
-import org.occurrent.subscription.SubscriptionPosition;
 
 import java.util.Objects;
 
 /**
  * A {@link SubscriptionPosition} that points at a DCB sequence position ({@code dcbposition}). It is used by
- * {@link CatchupSubscriptionModel} in DCB mode to resume a catch-up replay from where it left off.
+ * the catch-up subscription model in DCB mode to resume a catch-up replay from where it left off.
  * <p>
  * The string form is self-describing ({@code "dcbposition:<n>"}) so that it round-trips through a
  * {@code SubscriptionPositionStorage} (which reads positions back as a {@link StringBasedSubscriptionPosition}) and

--- a/subscription/core/src/test/java/org/occurrent/subscription/DcbStartAtTest.java
+++ b/subscription/core/src/test/java/org/occurrent/subscription/DcbStartAtTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbStartAtTest {
+
+    @Test
+    void now_maps_to_StartAt_now() {
+        StartAt startAt = DcbStartAt.now().toStartAt();
+        assertThat(startAt.isNow()).isTrue();
+    }
+
+    @Test
+    void subscription_model_default_maps_to_StartAt_default() {
+        StartAt startAt = DcbStartAt.subscriptionModelDefault().toStartAt();
+        assertThat(startAt.isDefault()).isTrue();
+    }
+
+    @Test
+    void beginning_maps_to_dcb_position_zero() {
+        StartAt startAt = DcbStartAt.beginning().toStartAt();
+        assertThat(startAt).isInstanceOf(StartAt.StartAtSubscriptionPosition.class);
+        assertThat(((StartAt.StartAtSubscriptionPosition) startAt).subscriptionPosition).isEqualTo(DcbSubscriptionPosition.of(0));
+    }
+
+    @Test
+    void after_position_maps_to_the_given_dcb_position() {
+        StartAt startAt = DcbStartAt.afterPosition(5).toStartAt();
+        assertThat(startAt).isInstanceOf(StartAt.StartAtSubscriptionPosition.class);
+        assertThat(((StartAt.StartAtSubscriptionPosition) startAt).subscriptionPosition).isEqualTo(DcbSubscriptionPosition.of(5));
+    }
+
+    @Test
+    void after_position_rejects_a_negative_position_eagerly() {
+        assertThatThrownBy(() -> DcbStartAt.afterPosition(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("negative");
+    }
+}

--- a/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/DcbSubscriptionModelTest.java
+++ b/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/DcbSubscriptionModelTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.inmemory;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.api.blocking.DcbSubscriptionModel;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The typed {@link DcbSubscriptionModel} facade over the shared {@link InMemorySubscriptionModel}. It only accepts a
+ * {@link DcbQuery} and a {@link DcbStartAt}, so a time-based stream position cannot be passed to it: that is a
+ * compile-time guarantee, not something a runtime test can express.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbSubscriptionModelTest {
+
+    private InMemorySubscriptionModel delegate;
+    private DcbSubscriptionModel dcbSubscriptionModel;
+
+    @BeforeEach
+    void create_subscription_model() {
+        delegate = new InMemorySubscriptionModel();
+        dcbSubscriptionModel = DcbSubscriptionModel.from(delegate);
+    }
+
+    @AfterEach
+    void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Test
+    void delivers_only_query_matching_dcb_events() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        dcbSubscriptionModel.subscribe("sub", DcbQuery.tagsAllOf("x:1"), DcbStartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = dcbEvent("TypeA", 1L, List.of("x:1"));
+        CloudEvent nonMatching = dcbEvent("TypeA", 2L, List.of("y:2"));
+        delegate.accept(Stream.of(matching, nonMatching));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    @Test
+    void the_no_start_position_overload_subscribes_at_the_default() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        dcbSubscriptionModel.subscribe("sub", DcbQuery.type("OrderPlaced"), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = dcbEvent("OrderPlaced", 1L, List.of("order:1"));
+        delegate.accept(Stream.of(matching));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    @Test
+    void cancel_through_the_facade_stops_delivery() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        dcbSubscriptionModel.subscribe("sub", DcbQuery.tagsAllOf("x:1"), DcbStartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent first = dcbEvent("TypeA", 1L, List.of("x:1"));
+        delegate.accept(Stream.of(first));
+        await().untilAsserted(() -> assertThat(received).extracting(CloudEvent::getId).containsExactly(first.getId()));
+
+        dcbSubscriptionModel.cancelSubscription("sub");
+
+        delegate.accept(Stream.of(dcbEvent("TypeA", 2L, List.of("x:1"))));
+        await().during(Duration.ofMillis(200)).atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(received).extracting(CloudEvent::getId).containsExactly(first.getId()));
+    }
+
+    private static CloudEvent dcbEvent(String type, long position, List<String> tags) {
+        CloudEvent base = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType(type)
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+        return DcbCloudEvents.withPosition(DcbCloudEvents.withTags(base, tags), position);
+    }
+}

--- a/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/StreamSubscriptionModelTest.java
+++ b/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/StreamSubscriptionModelTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.inmemory;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.StreamSubscriptionModel;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The typed {@link StreamSubscriptionModel} facade over the shared {@link InMemorySubscriptionModel}. It wraps the
+ * Occurrent {@link Filter} in an {@code OccurrentSubscriptionFilter} for the delegate and forwards life-cycle calls, so
+ * a DCB query cannot be passed to it: that is a compile-time guarantee, not something a runtime test can express.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StreamSubscriptionModelTest {
+
+    private InMemorySubscriptionModel delegate;
+    private StreamSubscriptionModel streamSubscriptionModel;
+
+    @BeforeEach
+    void create_subscription_model() {
+        delegate = new InMemorySubscriptionModel();
+        streamSubscriptionModel = StreamSubscriptionModel.from(delegate);
+    }
+
+    @AfterEach
+    void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Test
+    void delivers_only_filter_matching_events() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        streamSubscriptionModel.subscribe("sub", Filter.type("OrderPlaced"), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matching = event("OrderPlaced");
+        CloudEvent nonMatching = event("OrderCancelled");
+        delegate.accept(Stream.of(matching, nonMatching));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(matching.getId()));
+    }
+
+    @Test
+    void the_no_filter_overload_subscribes_to_every_event() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        streamSubscriptionModel.subscribe("sub", received::add)
+                .waitUntilStarted();
+
+        CloudEvent first = event("OrderPlaced");
+        CloudEvent second = event("OrderCancelled");
+        delegate.accept(Stream.of(first, second));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactly(first.getId(), second.getId()));
+    }
+
+    @Test
+    void cancel_through_the_facade_stops_delivery() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        streamSubscriptionModel.subscribe("sub", Filter.type("OrderPlaced"), StartAt.now(), received::add)
+                .waitUntilStarted();
+
+        CloudEvent first = event("OrderPlaced");
+        delegate.accept(Stream.of(first));
+        await().untilAsserted(() -> assertThat(received).extracting(CloudEvent::getId).containsExactly(first.getId()));
+
+        streamSubscriptionModel.cancelSubscription("sub");
+
+        delegate.accept(Stream.of(event("OrderPlaced")));
+        await().during(Duration.ofMillis(200)).atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(received).extracting(CloudEvent::getId).containsExactly(first.getId()));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType(type)
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+    }
+}

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -37,6 +37,7 @@ import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionPositionStorage;

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
@@ -31,6 +31,7 @@ import org.occurrent.domain.NameDefined;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionPosition;


### PR DESCRIPTION
Stream and DCB subscriptions shared one `SubscriptionModel` and one `StartAt`, so nothing stopped a caller mixing them. A DCB subscription could be handed a time-based position and a stream one a `dcbposition`, reconciled only at runtime, and the failure was quiet: a time-based start on a DCB subscription did not replay, it silently went live.

This splits the start position and the model view into separate stream and DCB types, leaving the machinery underneath shared.

- `DcbStartAt` is the DCB counterpart to `StartAt`. It expresses only DCB starts (`now`, `subscriptionModelDefault`, `beginning`, `position(n)`) and bridges to the generic `StartAt` with `toStartAt()`. Because it is a separate type, a DCB start cannot carry a time-based position and the reverse cannot happen either.
- `DcbSubscriptionModel` and `StreamSubscriptionModel` are typed facades over the shared `SubscriptionModel`, obtained with `from(subscriptionModel)`. The DCB one takes a `DcbQuery` and a `DcbStartAt`, the stream one a `Filter` and a `StartAt`. Neither exposes the low-level mixed `subscribe`, so neither can be given the other's filter or position. Each adapter translates the typed call into the low-level one and forwards every life-cycle call to the delegate.
- `DcbSubscriptions` now takes a `DcbStartAt`.

The constraint here is that the durable, competing-consumer, and catch-up decorators wrap one subscription model for both flavors, and DCB events flow through the same change stream as stream events (ADR 0017). So this is types and thin adapters over a shared core, not a fork of the lifecycle.

To let `DcbStartAt` live low enough to be referenced from the API and core, `DcbSubscriptionPosition` moved down to `subscription-core` (package `org.occurrent.subscription`), next to the other position value types. It is a source-incompatible move, which is fine while DCB is unreleased.

The raw `SubscriptionModel` still takes any filter and start position, for advanced or genuinely mixed use. The facades are the safe default, not a cage.

ADR 0024 records the decision, including why the facades are obtained by wrapping rather than by the concrete models implementing them, and that bean wiring for the typed models is deferred to the `@DcbSubscription` work where it is consumed.

### Verification

* `rtk mvn -pl subscription/core,subscription/api/blocking,subscription/inmemory,dsl/dcb-dsl/blocking -am test`: `DcbStartAtTest` 4, `DcbSubscriptionModelTest` 3, `InMemorySubscriptionModelDcbFilterTest` 5, `DcbSubscriptionsTest` 3, `DcbDslKotlinTest` 8, all green.
* Catch-up regression (the relocation changes their imports): `CatchupSubscriptionModelTest` 16, `DcbCatchupSubscriptionModelTest` 6, `DcbCatchupSubscriptionModelMongoTest` 1.
* `rtk mvn -Pexamples-module -pl example/domain/course-enrollment test`: `CourseEnrollmentTest` 5, `CourseEnrollmentWebTest` 9.
* Because a class moved into `subscription-core`, focused runs need an install of the changed upstream first.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-subscription-filter","parentHead":"d0a71df327aa7b4e0e88b1c72817e14f51933ae5","parentPull":223,"trunk":"main"}
```
-->
