### PR TITLE
Dual-mode catch-up for STREAM-and-DCB apps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Changelog next version
 
+* A STREAM-and-DCB application now catches up both kinds of subscription.
+  * `CatchupSubscriptionModel` gained a dual-mode constructor that holds both the stream query API and the DCB event store and routes each subscription to the right catch-up: a DCB subscription replays by `dcbposition`, a stream subscription replays by time. The Spring Boot starter wires this when the event store has both the STREAM and the DCB capability. Before, a combined application got only stream catch-up, so its DCB read models could not rebuild from history. STREAM-only and DCB-only applications are unchanged.
+  * See [ADR 25](doc/architecture/decisions/0025-dual-mode-catch-up-for-stream-and-dcb.md).
+
 * Stream and DCB subscriptions now have separate typed start positions and model views.
   * `DcbStartAt` is the DCB counterpart to `StartAt`, expressing only DCB starts (`now`, `subscriptionModelDefault`, `beginning`, `afterPosition`). `DcbSubscriptionModel` and `StreamSubscriptionModel` are typed facades over the shared `SubscriptionModel`, obtained with `from(subscriptionModel)`. A DCB subscription can no longer be handed a time-based position and a stream subscription can no longer be handed a `dcbposition`, which used to fail quietly at runtime. The shared durable, competing-consumer, and catch-up machinery is unchanged, the split is types and thin adapters.
   * `DcbSubscriptions` now takes a `DcbStartAt` instead of a generic `StartAt`. `DcbSubscriptionPosition` moved to the `org.occurrent.subscription` package.

--- a/doc/architecture/decisions/0025-dual-mode-catch-up-for-stream-and-dcb.md
+++ b/doc/architecture/decisions/0025-dual-mode-catch-up-for-stream-and-dcb.md
@@ -1,0 +1,31 @@
+# 25. Dual-mode catch-up for STREAM-and-DCB applications
+
+Date: 2026-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0020 gave `CatchupSubscriptionModel` a DCB mode that replays history by `dcbposition`, and ADR 0022 wired it in the Spring Boot starter for DCB-only applications. Both left one case open: an application that has both the STREAM and the DCB capability.
+
+A `CatchupSubscriptionModel` instance was stream or DCB, never both. The mode was fixed at construction: one set of constructors took an `EventStoreQueries` for stream catch-up, another took a `DcbEventStore` and a `DcbQuery` for DCB catch-up, and `subscribe` routed every subscription to that one mode through an `isDcbMode()` flag. So in a STREAM-and-DCB application the starter wired the stream catch-up model, and DCB subscriptions on it got no catch-up: they could only see events written after they subscribed. ADR 0022 named this as the remaining follow-up.
+
+What makes a clean fix possible now: a DCB subscription is identifiable. After ADR 0023 a DCB subscription carries a `DcbSubscriptionFilter`, and a DCB resume carries a `DcbSubscriptionPosition`. So the model can tell a DCB subscription from a stream one per call, rather than per instance.
+
+## Decision
+
+Make `CatchupSubscriptionModel` able to hold both catch-up backends and route each subscription to the right one.
+
+- Add a dual-mode constructor `CatchupSubscriptionModel(subscriptionModel, eventStoreQueries, dcbEventStore, dcbQuery, config)` that keeps both the stream query API and the DCB store.
+- Route per subscription in `subscribe`. A model with only one backend routes there, preserving the original single-mode behavior exactly. A dual-mode model routes by the subscription's nature: a `DcbSubscriptionFilter` or a resume from a `DcbSubscriptionPosition` goes to DCB catch-up, everything else goes to stream catch-up. The old per-instance `isDcbMode()` flag is gone.
+- In the Spring Boot starter, build the dual-mode model when the event store has both STREAM and DCB capabilities. STREAM-only and DCB-only keep their existing single-mode wiring. The DCB side is still constructed with `DcbQuery.all()`, the shared query every `DcbSubscriptions` subscription narrows in its own consumer, exactly as in DCB-only mode (ADR 0022).
+
+The DCB replay still uses the model's `DcbQuery` and the stream replay still uses the time-based query, so the two modes are the ones already proven by ADR 0020 and the existing stream catch-up. This change only lets one instance offer both and pick per subscription. The durable, competing-consumer, and change-stream machinery underneath is untouched.
+
+## Consequences
+
+- A STREAM-and-DCB application now gets catch-up for both its stream subscriptions and its DCB subscriptions from the single wired subscription model. This closes the follow-up ADR 0022 deferred.
+- The routing depends on a DCB subscription carrying a `DcbSubscriptionFilter` or a `DcbSubscriptionPosition`. That holds for the `DcbSubscriptions` DSL and the typed `DcbSubscriptionModel`, which always pass the DCB filter. A caller that hand-rolls a DCB subscription with a stream filter and no DCB position would be routed to stream catch-up, which is the same ambiguity the type split in ADR 0024 removes at the typed entry points.
+- Single-mode behavior is unchanged, so DCB-only and STREAM-only applications are unaffected.

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -152,18 +152,21 @@ public class OccurrentMongoAutoConfiguration<E> {
         DurableSubscriptionModel durableSubscriptionModel = new DurableSubscriptionModel(mongoSubscriptionModel, storage);
         CatchupSubscriptionModelConfig catchupConfig = new CatchupSubscriptionModelConfig(useSubscriptionPositionStorage(storage)
                 .andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1000));
-        SubscriptionModel subscriptionModel = durableSubscriptionModel;
-        if (eventStoreProperties.getCapabilities().contains(STREAM)) {
-            // Stream catch-up replays by event time over the stream query API.
+        // DCB catch-up replays by dcbposition over the DCB event store. The DcbQuery.all() is shared by every
+        // DcbSubscriptions subscription, which each narrow to their own DcbQuery in the consumer, so a single
+        // all-matching catch-up is correct. Stream catch-up replays by event time over the stream query API.
+        boolean stream = eventStoreProperties.getCapabilities().contains(STREAM);
+        DcbEventStore dcbStore = eventStoreProperties.getCapabilities().contains(DCB) ? dcbEventStore.getIfAvailable() : null;
+        SubscriptionModel subscriptionModel;
+        if (stream && dcbStore != null) {
+            // STREAM and DCB together: one dual-mode model routes each subscription to stream or DCB catch-up.
+            subscriptionModel = new CatchupSubscriptionModel(durableSubscriptionModel, eventStoreQueries, dcbStore, DcbQuery.all(), catchupConfig);
+        } else if (stream) {
             subscriptionModel = new CatchupSubscriptionModel(durableSubscriptionModel, eventStoreQueries, catchupConfig);
-        } else if (eventStoreProperties.getCapabilities().contains(DCB)) {
-            // DCB-only catch-up replays by dcbposition over the DCB event store. The model is constructed with
-            // DcbQuery.all() because it is shared by every DcbSubscriptions subscription. Each subscription narrows
-            // to its own DcbQuery in the DcbSubscriptions consumer, so a single all-matching catch-up is correct.
-            DcbEventStore store = dcbEventStore.getIfAvailable();
-            if (store != null) {
-                subscriptionModel = new CatchupSubscriptionModel(durableSubscriptionModel, store, DcbQuery.all(), catchupConfig);
-            }
+        } else if (dcbStore != null) {
+            subscriptionModel = new CatchupSubscriptionModel(durableSubscriptionModel, dcbStore, DcbQuery.all(), catchupConfig);
+        } else {
+            subscriptionModel = durableSubscriptionModel;
         }
         return new CompetingConsumerSubscriptionModel(subscriptionModel, competingConsumerStrategy);
     }

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
@@ -1,0 +1,306 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.dcb.TagGenerator;
+import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.api.blocking.SubscriptionModel;
+import org.occurrent.subscription.blocking.durable.catchup.StartAtTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that in a STREAM-and-DCB combined-capability context both a stream subscription and a DCB
+ * subscription can replay history written before they subscribe, from the single auto-configured
+ * {@link SubscriptionModel}. Prior to the dual-mode {@code CatchupSubscriptionModel} constructor a
+ * combined-capability app only got stream catch-up; DCB subscriptions started live.
+ */
+@DisplayName("Dual-mode catch-up auto-configuration (STREAM + DCB)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = DcbDualModeCatchupAutoConfigurationMongoTest.CombinedModeApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=stream,dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:dual-mode-catchup-test"
+        }
+)
+@Import(DcbDualModeCatchupAutoConfigurationMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class DcbDualModeCatchupAutoConfigurationMongoTest {
+
+    private static final String STREAM_TAG = "kind:stream";
+    private static final String DCB_TAG = "kind:dcb";
+    private static final URI SOURCE = URI.create("urn:occurrent:dual-mode-catchup-test");
+
+    @Autowired
+    private ApplicationService<TestEvent> applicationService;
+
+    @Autowired
+    private DcbEventStore dcbEventStore;
+
+    @Autowired
+    private DcbSubscriptions<TestEvent> dcbSubscriptions;
+
+    @Autowired
+    private SubscriptionModel subscriptionModel;
+
+    @Autowired
+    private CloudEventConverter<TestEvent> cloudEventConverter;
+
+    @Test
+    void stream_subscription_replays_historic_stream_events_appended_before_subscribe() {
+        // Given - stream events written before the subscription starts
+        TestEvent historic1 = streamEvent("s-historic-1");
+        TestEvent historic2 = streamEvent("s-historic-2");
+        appendStream(historic1, historic2);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        // When - stream subscription catches up from the beginning of time
+        subscriptionModel.subscribe(
+                        "stream-catchup-" + UUID.randomUUID(),
+                        StartAtTime.beginningOfTime(),
+                        ce -> {
+                            TestEvent event = cloudEventConverter.toDomainEvent(ce);
+                            if (STREAM_TAG.equals(ce.getSubject())) {
+                                received.add(event);
+                            }
+                        })
+                .waitUntilStarted();
+
+        // Then - historic stream events are delivered via catch-up
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(historic1, historic2));
+    }
+
+    @Test
+    void dcb_subscription_replays_historic_dcb_events_appended_before_subscribe() {
+        // Given - DCB events written before the subscription starts
+        TestEvent historic1 = dcbEvent("d-historic-1");
+        TestEvent historic2 = dcbEvent("d-historic-2");
+        TestEvent historic3 = dcbEvent("d-historic-3");
+        appendDcb(historic1, historic2, historic3);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        // When - DCB subscription catches up from position 0
+        dcbSubscriptions
+                .subscribe(
+                        "dcb-catchup-" + UUID.randomUUID(),
+                        DcbQuery.tagsAllOf(DCB_TAG),
+                        DcbStartAt.beginning(),
+                        received::add)
+                .waitUntilStarted();
+
+        // Then - historic DCB events are delivered via DCB catch-up
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(historic1, historic2, historic3));
+    }
+
+    @Test
+    void both_stream_and_dcb_subscriptions_replay_their_respective_histories_from_one_wired_model() {
+        // Given - events of both kinds written before any subscription starts
+        TestEvent streamHistoric = streamEvent("both-stream-historic");
+        TestEvent dcbHistoric = dcbEvent("both-dcb-historic");
+        appendStream(streamHistoric);
+        appendDcb(dcbHistoric);
+
+        CopyOnWriteArrayList<TestEvent> streamReceived = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<TestEvent> dcbReceived = new CopyOnWriteArrayList<>();
+
+        // When - both subscriptions start after the events are already written
+        subscriptionModel.subscribe(
+                        "both-stream-" + UUID.randomUUID(),
+                        StartAtTime.beginningOfTime(),
+                        ce -> {
+                            if (STREAM_TAG.equals(ce.getSubject())) {
+                                streamReceived.add(cloudEventConverter.toDomainEvent(ce));
+                            }
+                        })
+                .waitUntilStarted();
+
+        dcbSubscriptions
+                .subscribe(
+                        "both-dcb-" + UUID.randomUUID(),
+                        DcbQuery.tagsAllOf(DCB_TAG),
+                        DcbStartAt.beginning(),
+                        dcbReceived::add)
+                .waitUntilStarted();
+
+        // Then - each subscription receives its own historical events, not the other kind
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(streamReceived).contains(streamHistoric);
+            assertThat(dcbReceived).contains(dcbHistoric);
+        });
+    }
+
+    @Test
+    void dcb_subscription_does_not_receive_stream_only_events() {
+        // Given
+        TestEvent streamOnly = streamEvent("noise-stream");
+        TestEvent dcbOnly = dcbEvent("signal-dcb");
+        appendStream(streamOnly);
+        appendDcb(dcbOnly);
+
+        CopyOnWriteArrayList<TestEvent> dcbReceived = new CopyOnWriteArrayList<>();
+
+        // When
+        dcbSubscriptions
+                .subscribe(
+                        "isolation-dcb-" + UUID.randomUUID(),
+                        DcbQuery.tagsAllOf(DCB_TAG),
+                        DcbStartAt.beginning(),
+                        dcbReceived::add)
+                .waitUntilStarted();
+
+        // Then - the DCB subscription receives only the DCB event, not the stream-only one
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(dcbReceived).contains(dcbOnly).doesNotContain(streamOnly));
+    }
+
+    @Test
+    void dcb_subscription_delivers_live_event_after_catch_up_completes() {
+        // Given - one historic event before subscribe, one live event after
+        TestEvent historic = dcbEvent("live-test-historic");
+        appendDcb(historic);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        dcbSubscriptions
+                .subscribe(
+                        "live-dcb-" + UUID.randomUUID(),
+                        DcbQuery.tagsAllOf(DCB_TAG),
+                        DcbStartAt.beginning(),
+                        received::add)
+                .waitUntilStarted();
+
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(historic));
+
+        // When - a live event arrives after catch-up
+        TestEvent live = dcbEvent("live-test-live");
+        appendDcb(live);
+
+        // Then - the live event is delivered without duplication
+        await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(received).contains(historic, live);
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    // --- helpers ---
+
+    private TestEvent streamEvent(String name) {
+        return new TestEvent(UUID.randomUUID().toString(), new Date(), STREAM_TAG, name);
+    }
+
+    private TestEvent dcbEvent(String name) {
+        return new TestEvent(UUID.randomUUID().toString(), new Date(), DCB_TAG, name);
+    }
+
+    private void appendStream(TestEvent... events) {
+        String streamId = UUID.randomUUID().toString();
+        applicationService.execute(streamId, __ -> Stream.of(events));
+    }
+
+    private void appendDcb(TestEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(ce -> DcbCloudEvents.withTags(ce, List.of(DCB_TAG)))
+                .toList();
+        dcbEventStore.append(cloudEvents);
+    }
+
+    // --- inner application and configuration classes ---
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class CombinedModeApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .subjectMapper(TestEvent::kind)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        TagGenerator<TestEvent> testEventTagGenerator() {
+            return event -> Set.of(event.kind());
+        }
+    }
+
+    record TestEvent(String eventId, Date timestamp, String kind, String name) {
+    }
+}

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -167,8 +167,23 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         this.config = Objects.requireNonNull(config, "config cannot be null");
     }
 
-    private boolean isDcbMode() {
-        return dcbEventStore != null;
+    /**
+     * Create a dual-mode instance that catches up both stream subscriptions (by time, over {@code eventStoreQueries})
+     * and DCB subscriptions (by {@code dcbposition}, over {@code dcbEventStore}). Each subscription is routed by its
+     * filter and start position, so a single model serves a STREAM-and-DCB application. See ADR 25.
+     *
+     * @param subscriptionModel The subscription that'll be used to subscribe to new events <i>after</i> catch-up is completed.
+     * @param eventStoreQueries The API that will be used for stream catch-up.
+     * @param dcbEventStore     The DCB event store that will be used for DCB catch-up replay.
+     * @param dcbQuery          The DCB query that selects the events a DCB subscription delivers.
+     * @param config            The configuration to use.
+     */
+    public CatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, DcbEventStore dcbEventStore, DcbQuery dcbQuery, CatchupSubscriptionModelConfig config) {
+        this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
+        this.eventStoreQueries = Objects.requireNonNull(eventStoreQueries, "eventStoreQueries cannot be null");
+        this.dcbEventStore = Objects.requireNonNull(dcbEventStore, "dcbEventStore cannot be null");
+        this.dcbQuery = Objects.requireNonNull(dcbQuery, "dcbQuery cannot be null");
+        this.config = Objects.requireNonNull(config, "config cannot be null");
     }
 
     /**
@@ -196,9 +211,30 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     @Override
     public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
-        return isDcbMode()
+        return routesToDcb(filter, startAt)
                 ? subscribeDcb(subscriptionId, filter, startAt, action)
                 : subscribeStream(subscriptionId, filter, startAt, action);
+    }
+
+    // Decide whether a subscription is a DCB or a stream subscription. A single-mode model has only one store, so it
+    // always routes there (preserving the original behavior). A dual-mode model routes a DCB subscription, which either
+    // carries a DcbSubscriptionFilter (set by the DcbSubscriptions DSL, the DcbSubscriptionModel facade, and the
+    // @DcbSubscription annotation) or starts at an explicit DcbSubscriptionPosition, to the DCB path. Only an
+    // already-resolved start position is inspected, never a dynamic one, so routing reads no subscription-position
+    // storage.
+    private boolean routesToDcb(@Nullable SubscriptionFilter filter, StartAt startAt) {
+        if (dcbEventStore == null) {
+            return false;
+        }
+        if (eventStoreQueries == null) {
+            return true;
+        }
+        return filter instanceof DcbSubscriptionFilter || startsAtExplicitDcbPosition(startAt);
+    }
+
+    private static boolean startsAtExplicitDcbPosition(StartAt startAt) {
+        return startAt instanceof StartAtSubscriptionPosition position
+                && DcbSubscriptionPosition.isDcbSubscriptionPosition(position.subscriptionPosition);
     }
 
     private Subscription subscribeStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {


### PR DESCRIPTION
A `CatchupSubscriptionModel` was stream or DCB, fixed at construction. So a STREAM-and-DCB application got only stream catch-up, and its DCB subscriptions could not replay history: they saw only events written after they subscribed. ADR 0022 named this as the remaining follow-up.

This lets one model catch up both kinds.

- A dual-mode constructor holds both the stream query API and the DCB event store. `subscribe` routes each subscription to the right catch-up: a `DcbSubscriptionFilter`, or a resume from a `DcbSubscriptionPosition`, replays by `dcbposition`, everything else replays by time. The old per-instance `isDcbMode()` flag is gone.
- A single-backend model still routes to its one backend, so DCB-only and STREAM-only behavior is unchanged.
- The Spring Boot starter wires the dual-mode model when the event store has both the STREAM and the DCB capability.

The routing is reliable because a DCB subscription carries a `DcbSubscriptionFilter` after the server-side filtering change, and a DCB resume carries a `DcbSubscriptionPosition`. The durable, competing-consumer, and change-stream machinery underneath is untouched. ADR 0025 records the decision.

### Verification

* `rtk mvn -pl framework/spring-boot-starter-mongodb -Dtest=DcbDualModeCatchupAutoConfigurationMongoTest test`: Tests run: 5, Failures: 0, Errors: 0. Covers both a stream and a DCB subscription replaying their own histories from the one wired model, a DCB subscription not bleeding in stream-only events, and no duplication at the catch-up to live handover.
* Single-mode regression `rtk mvn -pl subscription/util/blocking/catchup-subscription test`: `CatchupSubscriptionModelTest` 16, `DcbCatchupSubscriptionModelTest` 6, `DcbCatchupSubscriptionModelMongoTest` 1.
* `rtk mvn -pl framework/spring-boot-starter-mongodb -Dtest=OccurrentMongoAutoConfigurationCombinedModeTest,DcbCatchupSubscriptionAutoConfigurationMongoTest test`: 3 and 1, green.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-subscription-model-split","parentHead":"43934bc967a05350a3789567f491d4a91e4419cf","parentPull":224,"trunk":"main"}
```
-->
