### PR TITLE
Rename @Subscription to @StreamSubscription

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Changelog next version
 
+* `@Subscription` is superseded by the new `@StreamSubscription` and deprecated.
+  * `@StreamSubscription` is the new canonical name, paired with the upcoming `@DcbSubscription` so the annotations are symmetric. `@Subscription` still works as a deprecated alias (deprecated for removal), with its attributes and enums frozen, so existing code keeps compiling and behaving as before. The annotation processor honors both. The example applications now use `@StreamSubscription`.
+  * See [ADR 26](doc/architecture/decisions/0026-rename-subscription-annotation-to-stream-subscription.md).
+
 * A STREAM-and-DCB application now catches up both kinds of subscription.
   * `CatchupSubscriptionModel` gained a dual-mode constructor that holds both the stream query API and the DCB event store and routes each subscription to the right catch-up: a DCB subscription replays by `dcbposition`, a stream subscription replays by time. The Spring Boot starter wires this when the event store has both the STREAM and the DCB capability. Before, a combined application got only stream catch-up, so its DCB read models could not rebuild from history. STREAM-only and DCB-only applications are unchanged.
   * See [ADR 25](doc/architecture/decisions/0025-dual-mode-catch-up-for-stream-and-dcb.md).

--- a/doc/architecture/decisions/0026-rename-subscription-annotation-to-stream-subscription.md
+++ b/doc/architecture/decisions/0026-rename-subscription-annotation-to-stream-subscription.md
@@ -1,0 +1,32 @@
+# 26. Rename @Subscription to @StreamSubscription and deprecate the old name
+
+Date: 2026-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+There is one declarative subscription annotation, `@Subscription`, and it drives a stream subscription: it derives a `Filter.type(...)` from the method's event type and starts at a time. A declarative DCB subscription annotation is coming next (ADR 0027). With both in place, a bare `@Subscription` would be ambiguous about which kind it means, and the pair would be lopsided: `@Subscription` and `@DcbSubscription` instead of `@StreamSubscription` and `@DcbSubscription`.
+
+`@Subscription` is released, so it cannot be hard-renamed without breaking existing code. Java annotations also cannot alias or meta-annotate each other, so the two names have to be two annotation types, and anything that reads them has to know both.
+
+## Decision
+
+Make `@StreamSubscription` the canonical name and keep `@Subscription` as a deprecated alias.
+
+- Add `@StreamSubscription` with the same attributes and the same nested `StartPosition`, `ResumeBehavior`, and `StartupMode` enums as `@Subscription`. It is the name new code should use.
+- Mark `@Subscription` `@Deprecated(forRemoval = true)` with Javadoc pointing to `@StreamSubscription`. Keep its attributes and nested enums frozen, so existing code and existing stored references keep compiling and behaving exactly as before.
+- `OccurrentAnnotationBeanPostProcessor` scans each method for both annotations, rejects a method that carries both, and normalizes whichever it finds into one internal definition that the existing stream subscription logic consumes. The deprecated annotation's enum values map to the canonical ones by name, since the constants are identical.
+- Migrate the example applications to `@StreamSubscription`, so the examples show the canonical name.
+
+The enums are duplicated for the length of the deprecation, once on each annotation. That is the cost of keeping the old annotation a frozen, self-contained, backward-compatible type rather than having the canonical annotation reference types nested in the deprecated one. When `@Subscription` is eventually removed, its enums go with it and `@StreamSubscription` keeps its own.
+
+Do not extract the backend-agnostic processor helpers (parameter binding, start-position storage checks, startup-mode decision) yet. They are extracted in the `@DcbSubscription` work, where a second consumer actually exists, so the seams are drawn against a real second caller rather than guessed.
+
+## Consequences
+
+- The annotation pair is symmetric and unambiguous once `@DcbSubscription` lands: `@StreamSubscription` for stream subscriptions, `@DcbSubscription` for DCB ones.
+- Existing `@Subscription` code keeps working, now with a deprecation warning that points at the new name.
+- The processor carries a small normalization for the two annotation types and the duplicated enums until `@Subscription` is removed.

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/IncreaseNumberOfStartedGames.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/IncreaseNumberOfStartedGames.java
@@ -17,13 +17,13 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
 
-import org.occurrent.annotation.Subscription;
+import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.NumberGuessingGameWasStarted;
 import org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.numberofstartedgames.NumberOfStartedGames;
 import org.springframework.stereotype.Component;
 
-import static org.occurrent.annotation.Subscription.ResumeBehavior.SAME_AS_START_AT;
-import static org.occurrent.annotation.Subscription.StartPosition.BEGINNING_OF_TIME;
+import static org.occurrent.annotation.StreamSubscription.ResumeBehavior.SAME_AS_START_AT;
+import static org.occurrent.annotation.StreamSubscription.StartPosition.BEGINNING_OF_TIME;
 
 @Component
 public class IncreaseNumberOfStartedGames {
@@ -33,7 +33,7 @@ public class IncreaseNumberOfStartedGames {
         this.numberOfStartedGames = numberOfStartedGames;
     }
 
-    @Subscription(id = "countNumberOfStartedGames", startAt = BEGINNING_OF_TIME, resumeBehavior = SAME_AS_START_AT)
+    @StreamSubscription(id = "countNumberOfStartedGames", startAt = BEGINNING_OF_TIME, resumeBehavior = SAME_AS_START_AT)
     void countGameStarted(NumberGuessingGameWasStarted ignored) {
         numberOfStartedGames.increaseNumberOfStartedGames();
     }

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/LogWhenGameStartsAndEnds.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/LogWhenGameStartsAndEnds.java
@@ -17,7 +17,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
 
-import org.occurrent.annotation.Subscription;
+import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.GameEvent;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.GuessingAttemptsExhausted;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.NumberGuessingGameWasStarted;
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
 public class LogWhenGameStartsAndEnds {
     private static final Logger log = LoggerFactory.getLogger(LogWhenGameStartsAndEnds.class);
 
-    @Subscription(
+    @StreamSubscription(
             id = "LogWhenGameStartsAndEnds",
             eventTypes = {NumberGuessingGameWasStarted.class, PlayerGuessedTheRightNumber.class, GuessingAttemptsExhausted.class}
     )

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/LogWhenGuessTooSmall.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/LogWhenGuessTooSmall.java
@@ -17,21 +17,21 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
 
-import org.occurrent.annotation.Subscription;
+import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.PlayerGuessedANumberThatWasTooSmall;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import static org.occurrent.annotation.Subscription.ResumeBehavior.SAME_AS_START_AT;
-import static org.occurrent.annotation.Subscription.StartPosition.BEGINNING_OF_TIME;
-import static org.occurrent.annotation.Subscription.StartupMode.BACKGROUND;
+import static org.occurrent.annotation.StreamSubscription.ResumeBehavior.SAME_AS_START_AT;
+import static org.occurrent.annotation.StreamSubscription.StartPosition.BEGINNING_OF_TIME;
+import static org.occurrent.annotation.StreamSubscription.StartupMode.BACKGROUND;
 
 @Component
 public class LogWhenGuessTooSmall {
     private static final Logger log = LoggerFactory.getLogger(LogWhenGuessTooSmall.class);
 
-    @Subscription(
+    @StreamSubscription(
             id = "LogWhenGuessTooSmall",
             startAt = BEGINNING_OF_TIME,
             resumeBehavior = SAME_AS_START_AT,

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/WhenGameEndedThenPublishIntegrationEvent.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/WhenGameEndedThenPublishIntegrationEvent.java
@@ -16,7 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
 
-import org.occurrent.annotation.Subscription;
+import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
 import org.occurrent.dsl.subscription.blocking.EventMetadata;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.*;
@@ -44,7 +44,7 @@ class WhenGameEndedThenPublishIntegrationEvent {
         this.domainEventQueries = domainEventQueries;
     }
 
-    @Subscription(id = "WhenGameEndedThenPublishIntegrationEvent")
+    @StreamSubscription(id = "WhenGameEndedThenPublishIntegrationEvent")
     void publishIntegrationEventWhenGameEnded(EventMetadata metadata, NumberGuessingGameEnded numberGuessingGameEnded) {
         String gameId = numberGuessingGameEnded.gameId().toString();
         long streamVersion = metadata.getStreamVersion();

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/InsertGameIntoLatestGamesOverview.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/InsertGameIntoLatestGamesOverview.java
@@ -17,7 +17,7 @@
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.latestgamesoverview.impl;
 
 import org.bson.Document;
-import org.occurrent.annotation.Subscription;
+import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.example.domain.numberguessinggame.model.domainevents.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +47,7 @@ class InsertGameIntoLatestGamesOverview {
         this.mongoOperations = mongoOperations;
     }
 
-    @Subscription(id = "InsertGameIntoLatestGamesOverview")
+    @StreamSubscription(id = "InsertGameIntoLatestGamesOverview")
     @Retryable(maxAttempts = 10, backoff = @Backoff(delay = 100, multiplier = 2, maxDelay = 5000))
     void insertGame(GameEvent gameEvent) {
         log.info("Received event {}", gameEvent);

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/emailwinner/SendEmailToWinner.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/emailwinner/SendEmailToWinner.kt
@@ -15,7 +15,7 @@
  */
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.emailwinner
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.example.domain.wordguessinggame.event.GameWasWon
 import org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.support.loggerFor
 import org.springframework.stereotype.Component
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component
 class SendEmailToWinner {
     private val log = loggerFor<SendEmailToWinner>()
 
-    @Subscription(id = "WhenGameWasWonThenSendEmailToWinnerPolicy")
+    @StreamSubscription(id = "WhenGameWasWonThenSendEmailToWinnerPolicy")
     fun whenGameWasWon(gameWasWon: GameWasWon) {
         log.info("Sending email to player ${gameWasWon.winnerId} since he/she was a winner of game ${gameWasWon.gameId}")
     }

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/endedgamesoverview/WhenGameIsEndedThenAddGameToEndedGamesOverview.kt
@@ -16,7 +16,7 @@
 
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.gameplay.views.endedgamesoverview
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
 import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries
@@ -39,7 +39,7 @@ class WhenGameIsEndedThenAddGameToEndedGamesOverview(
 ) {
     private val log = loggerFor<WhenGameIsEndedThenAddGameToEndedGamesOverview>()
 
-    @Subscription(id = "WhenGameIsEndedThenAddGameToGameEndedOverview", eventTypes = [GameWasWon::class, GameWasLost::class])
+    @StreamSubscription(id = "WhenGameIsEndedThenAddGameToGameEndedOverview", eventTypes = [GameWasWon::class, GameWasLost::class])
     fun whenGameIsEndedThenAddGameToEndedGamesOverviewPolicy(e: GameEvent, metadata: EventMetadata) {
         if (!metadata.belongsToGame(e.gameId)) {
             return

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/ongoinggamesoverview/AddedOrRemoveGameFromOngoingGamesOverview.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/views/ongoinggamesoverview/AddedOrRemoveGameFromOngoingGamesOverview.kt
@@ -16,7 +16,7 @@
 
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.gameplay.views.ongoinggamesoverview
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
 import org.occurrent.dsl.subscription.blocking.EventMetadata
@@ -39,7 +39,7 @@ import java.util.UUID
 class AddedOrRemoveGameFromOngoingGamesOverview(private val mongo: MongoOperations) {
     private val log = loggerFor<AddedOrRemoveGameFromOngoingGamesOverview>()
 
-    @Subscription(id = "WhenGameWasStartedThenAddGameToOngoingGamesOverview")
+    @StreamSubscription(id = "WhenGameWasStartedThenAddGameToOngoingGamesOverview")
     fun whenGameWasStartedThenAddGameToOngoingGamesOverview(gameWasStarted: GameWasStarted, metadata: EventMetadata) {
         if (!metadata.belongsToGame(gameWasStarted.gameId)) {
             return
@@ -52,7 +52,7 @@ class AddedOrRemoveGameFromOngoingGamesOverview(private val mongo: MongoOperatio
         mongo.save(ongoingGameOverview)
     }
 
-    @Subscription(id = "WhenGameIsEndedThenRemoveGameFromOngoingGamesOverview", eventTypes = [GameWasWon::class, GameWasLost::class])
+    @StreamSubscription(id = "WhenGameIsEndedThenRemoveGameFromOngoingGamesOverview", eventTypes = [GameWasWon::class, GameWasLost::class])
     fun whenGameIsEndedThenRemoveGameFromOngoingGamesOverview(e: GameEvent, metadata: EventMetadata) {
         val gameId = when (e) {
             is GameWasWon -> e.gameId

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/pointawarding/AwardPointsToPlayerThatGuessedTheRightWord.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/pointawarding/AwardPointsToPlayerThatGuessedTheRightWord.kt
@@ -15,7 +15,7 @@
  */
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.pointawarding
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
@@ -42,7 +42,7 @@ class AwardPointsToPlayerThatGuessedTheRightWord(
     private val applicationService: DcbApplicationService<GameEvent>
 ) {
 
-    @Subscription(id = "WhenPlayerGuessedTheRightWordThenAwardPointsPolicy")
+    @StreamSubscription(id = "WhenPlayerGuessedTheRightWordThenAwardPointsPolicy")
     fun whenPlayerGuessedTheRightWord(playerGuessedTheRightWord: PlayerGuessedTheRightWord, metadata: EventMetadata) {
         if (!metadata.belongsToGame(playerGuessedTheRightWord.gameId)) {
             return

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord.kt
@@ -15,7 +15,7 @@
  */
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.wordhint
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
@@ -45,7 +45,7 @@ class RevealCharacterInWordHintAfterPlayerGuessedTheWrongWord(
     private val domainEventQueries: DcbDomainEventQueries<GameEvent>
 ) {
 
-    @Subscription(id = "WhenPlayerGuessedTheWrongWordThenRevealCharacterInWordHintPolicy")
+    @StreamSubscription(id = "WhenPlayerGuessedTheWrongWordThenRevealCharacterInWordHintPolicy")
     fun whenPlayerGuessedTheWrongWord(playerGuessedTheWrongWord: PlayerGuessedTheWrongWord, metadata: EventMetadata) {
         if (!metadata.belongsToGame(playerGuessedTheWrongWord.gameId)) {
             return

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealInitialCharactersInWordHintAfterGameIsStarted.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/wordhint/RevealInitialCharactersInWordHintAfterGameIsStarted.kt
@@ -15,7 +15,7 @@
  */
 package org.occurrent.example.domain.wordguessinggame.mongodb.spring.dcb.autoconfig.features.wordhint
 
-import org.occurrent.annotation.Subscription
+import org.occurrent.annotation.StreamSubscription
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService
 import org.occurrent.dsl.dcb.blocking.dcbPosition
 import org.occurrent.dsl.dcb.blocking.dcbTags
@@ -39,7 +39,7 @@ class RevealInitialCharactersInWordHintAfterGameIsStarted(
     private val applicationService: DcbApplicationService<GameEvent>
 ) {
 
-    @Subscription(id = "WhenGameWasStartedThenRevealInitialCharactersInWordHintPolicy")
+    @StreamSubscription(id = "WhenGameWasStartedThenRevealInitialCharactersInWordHintPolicy")
     fun whenGameWasStarted(gameWasStarted: GameWasStarted, metadata: EventMetadata) {
         if (!metadata.belongsToGame(gameWasStarted.gameId)) {
             return

--- a/framework/annotations/src/main/java/org/occurrent/annotation/StreamSubscription.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/StreamSubscription.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2023 Johan Haleby
+ *  Copyright 2026 Johan Haleby
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ package org.occurrent.annotation;
 import java.lang.annotation.*;
 
 /**
- * An annotation that can be used to start/resume subscriptions. For example:
+ * An annotation that can be used to start/resume stream subscriptions. For example:
  *
  * <pre lang="java">
- * &#64;Subscription(id = "mySubscription")
+ * &#64;StreamSubscription(id = "mySubscription")
  * void mySubscription(MyDomainEvent event) {
  *     System.out.println("Received event: " + event);
  * }
@@ -33,7 +33,7 @@ import java.lang.annotation.*;
  * <p>
  * You can also specify at which time the subscription should start:
  * <pre lang="java">
- * &#64;Subscription(id = "mySubscription", startAt = StartPosition.BEGINNING_OF_TIME)
+ * &#64;StreamSubscription(id = "mySubscription", startAt = StartPosition.BEGINNING_OF_TIME)
  * void mySubscription(MyDomainEvent event) { .. }
  * </pre>
  * This will first replay all historic events from the beginning of time and then continue subscribing to new events continuously. You can also start at a specific date
@@ -51,9 +51,9 @@ import java.lang.annotation.*;
  * <h4>Metadata</h4>
  * <p>
  * Sometimes it can be useful to get the metadata associated with the received event. For this reason, you can add a parameter to the method annotated with
- * {@code @Subscription} of type {@link org.occurrent.dsl.subscription.blocking.EventMetadata}. For example:
+ * {@code @StreamSubscription} of type {@link org.occurrent.dsl.subscription.blocking.EventMetadata}. For example:
  * <pre lang="java">
- * &#64;Subscription(id = "mySubscription")
+ * &#64;StreamSubscription(id = "mySubscription")
  * void mySubscription(MyDomainEvent event, EventMetadata metadata) {
  *   String streamId = metadata.getStreamId();
  *   long streamVersion = metadata.getStreamVersion();
@@ -61,16 +61,12 @@ import java.lang.annotation.*;
  *   ..
  * }
  * </pre>
- *
- * @deprecated Use {@link StreamSubscription} instead. This annotation is the original name for a stream subscription and
- * is kept as an alias for backward compatibility. It will be removed in a future release.
  */
-@Deprecated(forRemoval = true)
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-public @interface Subscription {
+public @interface StreamSubscription {
     /**
      * The unique identifier of the subscription.
      */
@@ -93,7 +89,7 @@ public @interface Subscription {
      * </p>
      *
      * <pre lang="java">
-     * &#64;Subscription(id="mySubscription", eventTypes = {MyEvent1.class, MyEvent2.class})
+     * &#64;StreamSubscription(id="mySubscription", eventTypes = {MyEvent1.class, MyEvent2.class})
      * void subscribeToMyEvent1Or2(MyEvent event1Or2) { .. }
      * </pre>
      * <p>
@@ -103,7 +99,7 @@ public @interface Subscription {
     Class<?>[] eventTypes() default {};
 
     /**
-     * Specify the start position to one if the predefined ones in {@link StartPosition}.
+     * Specify the start position to one of the predefined ones in {@link StartPosition}.
      */
     StartPosition startAt() default StartPosition.DEFAULT;
 
@@ -129,7 +125,7 @@ public @interface Subscription {
      * specified {@code startAt} (or epoch/iso date), then the subscription will be resumed from the last
      * received event when the application is restarted. I.e. first the subscription is caught-up
      * (by reading the events from the beginning of time in this example) and then it'll continue by listening
-     * to new events, <i>without</i>_ starting from the beginning of time when the application is restarted.
+     * to new events, <i>without</i> starting from the beginning of time when the application is restarted.
      * If you <i>always</i> want to start from the beginning of time, you can set the resume behavior to
      * {@link ResumeBehavior#SAME_AS_START_AT}. This means that the subscription will start the "catching-up"
      * even on application restarts. This can be useful for in-memory projections/read-models where you don't

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
@@ -20,10 +20,11 @@ package org.occurrent.springboot.mongo.blocking;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 import org.jspecify.annotations.NonNull;
+import org.occurrent.annotation.StreamSubscription;
+import org.occurrent.annotation.StreamSubscription.ResumeBehavior;
+import org.occurrent.annotation.StreamSubscription.StartPosition;
+import org.occurrent.annotation.StreamSubscription.StartupMode;
 import org.occurrent.annotation.Subscription;
-import org.occurrent.annotation.Subscription.ResumeBehavior;
-import org.occurrent.annotation.Subscription.StartPosition;
-import org.occurrent.annotation.Subscription.StartupMode;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.subscription.blocking.EventMetadata;
 import org.occurrent.dsl.subscription.blocking.Subscriptions;
@@ -63,7 +64,8 @@ import static org.occurrent.filter.Filter.CompositionOperator.OR;
 import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
- * Implements support for the {@link Subscription} annotation in Spring Boot
+ * Implements support for the {@link StreamSubscription} annotation, and the deprecated {@link Subscription} alias, in
+ * Spring Boot.
  */
 class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
 
@@ -78,16 +80,44 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
     public Object postProcessBeforeInitialization(Object bean, @NonNull String beanName) throws BeansException {
         Class<?> managedBeanClass = bean.getClass();
         for (Method method : managedBeanClass.getDeclaredMethods()) {
+            StreamSubscription streamSubscription = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
             Subscription subscription = AnnotationUtils.findAnnotation(method, Subscription.class);
-            if (subscription != null) {
-                processSubscribeAnnotation(bean, method, subscription);
+            if (streamSubscription != null && subscription != null) {
+                throw new IllegalArgumentException("Method %s#%s is annotated with both @StreamSubscription and the deprecated @Subscription, use only @StreamSubscription.".formatted(bean.getClass().getName(), method.getName()));
+            }
+            if (streamSubscription != null) {
+                processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(streamSubscription));
+            } else if (subscription != null) {
+                processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(subscription));
             }
         }
         return bean;
     }
 
+    /**
+     * The normalized form of a stream subscription declaration, built from either the {@link StreamSubscription}
+     * annotation or the deprecated {@link Subscription} alias. The deprecated annotation's enums are mapped to the
+     * canonical {@link StreamSubscription} enums by name, since the constants are identical.
+     */
+    private record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
+                                                long startAtTimeEpochMillis, StartPosition startAt,
+                                                ResumeBehavior resumeBehavior, StartupMode startupMode) {
+
+        static StreamSubscriptionDefinition from(StreamSubscription subscription) {
+            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
+                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode());
+        }
+
+        @SuppressWarnings("deprecation")
+        static StreamSubscriptionDefinition from(Subscription subscription) {
+            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
+                    subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
+                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()));
+        }
+    }
+
     @SuppressWarnings("unchecked")
-    private <E> void processSubscribeAnnotation(Object bean, Method method, Subscription subscription) {
+    private <E> void processSubscribeAnnotation(Object bean, Method method, StreamSubscriptionDefinition subscription) {
         String id = subscription.id();
         final Filter filter;
         List<Class<?>> parameterTypes = new ArrayList<>();
@@ -129,7 +159,7 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
                         .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
                         .peek(e -> {
                             if (!specifiedEventType.isAssignableFrom(e)) {
-                                throw new IllegalStateException("Event type %s specified in the @Subscription annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), id, bean.getClass().getName(), method.getName()));
+                                throw new IllegalStateException("Event type %s specified in the @StreamSubscription annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), id, bean.getClass().getName(), method.getName()));
                             }
                         })
                         .toList();
@@ -380,7 +410,7 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
             Class<E>[] permittedSubclasses = (Class<E>[]) specifiedEventType.getPermittedSubclasses();
             domainEventTypesToSubscribeTo = Arrays.stream(permittedSubclasses).flatMap(c -> getConcreteEventTypes(subscriptionId, c).stream()).toList();
         } else if (specifiedEventType.isInterface() || specifiedEventType.isArray() || Modifier.isAbstract(specifiedEventType.getModifiers())) {
-            String msg = "You need cannot subscribe to a non-sealed interfaces or abstract types (problem is with %s). A concrete or sealed event type is required. You can also specify event types explicitly by using @Subscription(id = \"%s\", eventTypes = [MyEvent1.class, MyEvent2.class]))";
+            String msg = "You need cannot subscribe to a non-sealed interfaces or abstract types (problem is with %s). A concrete or sealed event type is required. You can also specify event types explicitly by using @StreamSubscription(id = \"%s\", eventTypes = [MyEvent1.class, MyEvent2.class]))";
             throw new IllegalArgumentException(msg.formatted(specifiedEventType.getName(), subscriptionId));
         } else {
             domainEventTypesToSubscribeTo = List.of(specifiedEventType);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/StreamSubscriptionAnnotationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/StreamSubscriptionAnnotationMongoTest.java
@@ -1,0 +1,159 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.occurrent.annotation.StreamSubscription;
+import org.occurrent.annotation.Subscription;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that both the {@link StreamSubscription} annotation and the deprecated {@link Subscription} alias wire a working
+ * stream subscription that receives appended events, processed by the same annotation bean post processor.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = StreamSubscriptionAnnotationMongoTest.AnnotationApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=stream",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:stream-subscription-annotation-test"
+        }
+)
+@Import(StreamSubscriptionAnnotationMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+class StreamSubscriptionAnnotationMongoTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:stream-subscription-annotation-test");
+
+    @Autowired
+    private ApplicationService<TestEvent> applicationService;
+
+    @Autowired
+    private StreamAnnotatedSubscriber streamAnnotatedSubscriber;
+
+    @Autowired
+    private DeprecatedAnnotatedSubscriber deprecatedAnnotatedSubscriber;
+
+    @Test
+    void both_the_new_and_the_deprecated_annotation_receive_an_appended_event() {
+        TestEvent event = new TestEvent(UUID.randomUUID().toString(), new Date(), "name");
+        applicationService.execute(UUID.randomUUID().toString(), __ -> Stream.of(event));
+
+        await().atMost(ofSeconds(10)).untilAsserted(() -> {
+            assertThat(streamAnnotatedSubscriber.received()).extracting(TestEvent::eventId).contains(event.eventId());
+            assertThat(deprecatedAnnotatedSubscriber.received()).extracting(TestEvent::eventId).contains(event.eventId());
+        });
+    }
+
+    static class StreamAnnotatedSubscriber {
+        private final CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        @StreamSubscription(id = "streamAnnotatedSubscriber")
+        void on(TestEvent event) {
+            received.add(event);
+        }
+
+        List<TestEvent> received() {
+            return received;
+        }
+    }
+
+    static class DeprecatedAnnotatedSubscriber {
+        private final CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        @SuppressWarnings("deprecation")
+        @Subscription(id = "deprecatedAnnotatedSubscriber")
+        void on(TestEvent event) {
+            received.add(event);
+        }
+
+        List<TestEvent> received() {
+            return received;
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class AnnotationApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        StreamAnnotatedSubscriber streamAnnotatedSubscriber() {
+            return new StreamAnnotatedSubscriber();
+        }
+
+        @Bean
+        DeprecatedAnnotatedSubscriber deprecatedAnnotatedSubscriber() {
+            return new DeprecatedAnnotatedSubscriber();
+        }
+    }
+
+    record TestEvent(String eventId, Date timestamp, String name) {
+    }
+}


### PR DESCRIPTION
There is one declarative subscription annotation, `@Subscription`, and it drives a stream subscription. A declarative DCB annotation is coming next, and with both in place a bare `@Subscription` reads as ambiguous and the pair is lopsided. So the stream annotation is renamed to `@StreamSubscription`.

`@Subscription` is released, so this is a deprecation, not a hard rename.

- `@StreamSubscription` is the new canonical annotation, with the same attributes and the same nested `StartPosition`, `ResumeBehavior`, and `StartupMode` enums.
- `@Subscription` is now `@Deprecated(forRemoval = true)` with Javadoc pointing to the new name. Its attributes and enums are frozen, so existing code keeps compiling and behaving exactly as before.
- The annotation processor scans for both, rejects a method that carries both, and normalizes whichever it finds into one internal definition the stream subscribe logic consumes. The deprecated annotation's enum values map to the canonical ones by name, since the constants are identical.
- The example applications now use `@StreamSubscription`.

The backend-agnostic processor helpers are not extracted yet. That happens in the `@DcbSubscription` change, where a second consumer actually exists, so the seams get drawn against a real caller rather than guessed. ADR 0026 records the decision.

### Verification

* `rtk mvn -pl framework/spring-boot-starter-mongodb -Dtest=StreamSubscriptionAnnotationMongoTest test`: Tests run: 1, Failures: 0, Errors: 0. One `@StreamSubscription` method and one deprecated `@Subscription` method both receive an appended event.
* number-guessing example: `Tests run: 1`, green (compiles and wires the migrated annotations).
* word-guessing dcb-autoconfig example: 9 tests green, including the context bootstrap and the annotation-policy runtime test that exercises the migrated `@StreamSubscription` policies.
* `rtk mvn -pl framework/annotations,framework/spring-boot-starter-mongodb -am test-compile`: clean.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-dual-mode-catchup","parentHead":"23cf3845361f0b3ffd64de20565b38417aaa35d8","parentPull":225,"trunk":"main"}
```
-->
