### PR TITLE
Add the @DcbSubscription annotation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Changelog next version
 
+* Added the `@DcbSubscription` annotation, the declarative DCB counterpart to `@StreamSubscription`.
+  * A DCB read model can now be declared as a single annotated method. `eventTypes` and `tagsAllOf` express the `DcbQuery`, and `startAt` (BEGINNING, NOW, DEFAULT) or `startAtDcbPosition` (an explicit position, the DCB counterpart to the stream `startAtTimeEpochMillis`) together with `resumeBehavior` give history replay, resume from the stored position, and an always-replay in-memory mode that disables the competing consumer and position storage. It routes through the DCB DSL, so it gets the server-side filter, and the method can take the event plus an optional `EventMetadata` or `DcbEventMetadata`. `DcbStartAt` gained a `dynamic` factory to back the resume logic. The course-enrollment dashboard subscriber now uses `@DcbSubscription` (combining `BEGINNING` with `SAME_AS_START_AT`, since it is an in-memory model rebuilt on every boot).
+  * See [ADR 27](doc/architecture/decisions/0027-dcb-subscription-annotation.md).
+
 * `@Subscription` is superseded by the new `@StreamSubscription` and deprecated.
   * `@StreamSubscription` is the new canonical name, paired with the upcoming `@DcbSubscription` so the annotations are symmetric. `@Subscription` still works as a deprecated alias (deprecated for removal), with its attributes and enums frozen, so existing code keeps compiling and behaving as before. The annotation processor honors both. The example applications now use `@StreamSubscription`.
   * See [ADR 26](doc/architecture/decisions/0026-rename-subscription-annotation-to-stream-subscription.md).

--- a/doc/architecture/decisions/0027-dcb-subscription-annotation.md
+++ b/doc/architecture/decisions/0027-dcb-subscription-annotation.md
@@ -1,0 +1,33 @@
+# 27. Add the @DcbSubscription annotation
+
+Date: 2026-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0026 renamed `@Subscription` to `@StreamSubscription` in anticipation of a declarative DCB annotation. This is that annotation.
+
+Until now a DCB subscription was programmatic: inject the `DcbSubscriptions` DSL and call `subscribe(id, query, startAt, handler)` by hand, as the course-enrollment dashboard did with `DcbQuery.all()`, `DcbStartAt.beginning()`, and an in-handler type check. A stream subscription, by contrast, is a single annotated method. The catch-up ergonomics make the declarative form clearly worth having for DCB too: the annotation can express the query and the start position, and the processor can resolve the first-run-then-resume and always-replay behavior that is fiddly to write by hand.
+
+The stream processor already resolves all of that for the stream path. Its start-position logic builds a dynamic `StartAt` that replays from the beginning on the first run and resumes from the stored position afterwards, and, for the always-replay case, returns null for the competing-consumer and durable models so an in-memory read model is not split across instances and does not persist a position. The same shape is needed for DCB, only over `dcbposition` instead of time.
+
+## Decision
+
+Add `@DcbSubscription`, the DCB analog of `@StreamSubscription`.
+
+- Attributes: `id`, `eventTypes` (the domain event classes, resolved to CloudEvent types through the converter, exactly as `@StreamSubscription` does, defaulting to the method's event parameter), `tagsAllOf` (the DCB tag boundary), `startAt` (a `DcbStartPosition` of BEGINNING, NOW, or DEFAULT), `startAtDcbPosition` (an explicit position to start after, the DCB counterpart to the stream `startAtTimeEpochMillis`, mutually exclusive with a non-DEFAULT `startAt`), `resumeBehavior`, and `startupMode`. The processor builds the `DcbQuery` from the event types and tags: neither gives `all()`, types only gives `types(...)`, tags only gives `tagsAllOf(...)`, both give `typeAndTagsAllOf(...)`.
+- The processor resolves the start position by mirroring the stream path over DCB positions. BEGINNING with the default resume replays from `dcbposition` 0 on the first run and resumes from the stored position afterwards. BEGINNING with `SAME_AS_START_AT` always replays, and disables the competing consumer and durable position storage for that subscription so an always-rebuilt in-memory read model sees every event and keeps no checkpoint. NOW is live only, DEFAULT resumes or goes live.
+- To express the first-run-then-resume and always-replay starts, `DcbStartAt` gains a `dynamic` factory mirroring `StartAt.dynamic`, including the null-to-delegate contract. This is the typed DCB counterpart the processor needs.
+- The DCB path routes through the `DcbSubscriptions` DSL, so it inherits the server-side filter and the in-process correctness floor. The method receives the domain event and, optionally, the generic `EventMetadata` or the DCB-specific `DcbEventMetadata`.
+- The backend-agnostic processor helpers (the event and metadata parameter binding, the concrete-event-type resolution) are now extracted and shared between the stream and DCB paths. ADR 0026 deferred this until a second consumer existed, and now it does, so the seams are drawn against a real caller rather than guessed.
+- The course-enrollment `CourseDashboardSubscriber` is migrated to `@DcbSubscription`, replacing the hand-rolled subscription and the in-handler type check.
+
+## Consequences
+
+- The annotation pair is complete and symmetric: `@StreamSubscription` for stream subscriptions, `@DcbSubscription` for DCB ones, sharing one processor.
+- A DCB read model can be declared with a single annotated method and get history replay, resume, and the always-replay in-memory mode without hand-rolling the start position.
+- `DcbStartAt` gains a `dynamic` factory, which also makes the typed DCB start positions as expressive as the stream ones for advanced callers.
+- The example demonstrates the declarative DCB subscription end to end.

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardSubscriber.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardSubscriber.kt
@@ -16,9 +16,9 @@
 
 package org.occurrent.example.domain.courseenrollment.features.coursedashboard.readmodel
 
-import jakarta.annotation.PostConstruct
-import org.occurrent.dsl.dcb.blocking.DcbSubscriptions
-import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.annotation.DcbSubscription
+import org.occurrent.annotation.DcbSubscription.DcbStartPosition
+import org.occurrent.annotation.DcbSubscription.ResumeBehavior
 import org.occurrent.example.domain.courseenrollment.common.DomainEvent
 import org.occurrent.example.domain.courseenrollment.features.coursemanagement.model.CourseCancelled
 import org.occurrent.example.domain.courseenrollment.features.coursemanagement.model.CourseDefined
@@ -26,29 +26,28 @@ import org.occurrent.example.domain.courseenrollment.features.enrollment.model.S
 import org.occurrent.example.domain.courseenrollment.features.enrollment.model.StudentUnenrolledFromCourse
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentDeregistered
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentRegistered
-import org.occurrent.subscription.DcbStartAt
 import org.springframework.stereotype.Component
 
 /**
- * Feeds the [CourseDashboard] read model from a DCB subscription.
+ * Feeds the [CourseDashboard] read model from a DCB subscription declared with [DcbSubscription].
  *
- * Starting at [DcbStartAt.beginning] makes the subscription replay the whole DCB history by dcbposition on every boot and
- * then switch to live delivery, so the in-memory read model is rebuilt from scratch each start. This catch-up is only
- * available because the starter wires a DCB-mode catch-up subscription model in DCB-only mode.
+ * The read model is in-memory only, so it must be rebuilt from the whole DCB history on every boot. That is why this
+ * combines [DcbStartPosition.BEGINNING] with [ResumeBehavior.SAME_AS_START_AT]: BEGINNING alone would replay only the
+ * first time and then resume from the stored position on later restarts, which would leave the in-memory model missing
+ * all history before that position. SAME_AS_START_AT replays from the beginning on every boot (and keeps no checkpoint).
+ * This catch-up is only available because the starter wires a DCB-mode catch-up subscription model in DCB-only mode. The
+ * event types are narrowed on the annotation, so the subscription receives only the dashboard's events server-side.
  */
 @Component
-class CourseDashboardSubscriber(
-    private val dcbSubscriptions: DcbSubscriptions<DomainEvent>,
-    private val courseDashboard: CourseDashboard
-) {
+class CourseDashboardSubscriber(private val courseDashboard: CourseDashboard) {
 
-    @PostConstruct
-    fun start() {
-        dcbSubscriptions.subscribe("course-dashboard", DcbQuery.all(), DcbStartAt.beginning()) { event ->
-            if (event is CourseDefined || event is CourseCancelled || event is StudentRegistered || event is StudentDeregistered ||
-                event is StudentEnrolledInCourse || event is StudentUnenrolledFromCourse) {
-                courseDashboard.update(event)
-            }
-        }.waitUntilStarted()
+    @DcbSubscription(
+        id = "course-dashboard",
+        eventTypes = [CourseDefined::class, CourseCancelled::class, StudentRegistered::class, StudentDeregistered::class, StudentEnrolledInCourse::class, StudentUnenrolledFromCourse::class],
+        startAt = DcbStartPosition.BEGINNING,
+        resumeBehavior = ResumeBehavior.SAME_AS_START_AT
+    )
+    fun update(event: DomainEvent) {
+        courseDashboard.update(event)
     }
 }

--- a/framework/annotations/src/main/java/org/occurrent/annotation/DcbSubscription.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/DcbSubscription.java
@@ -1,0 +1,185 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Starts or resumes a Dynamic Consistency Boundary (DCB) subscription. It is the DCB counterpart to
+ * {@link StreamSubscription}: where the stream annotation filters by an Occurrent {@code Filter} and starts at a time,
+ * this one filters by a DCB query (event types and tags) and starts at a {@code dcbposition}. For example:
+ *
+ * <pre lang="java">
+ * &#64;DcbSubscription(id = "courseDashboard", startAt = DcbStartPosition.BEGINNING)
+ * void onEvent(CourseEvent event) {
+ *     dashboard.update(event);
+ * }
+ * </pre>
+ *
+ * <h4>Which DCB subscription API to use</h4>
+ * <p>
+ * Use this annotation for a persistent, durable subscription managed by the framework, such as a read model that
+ * catches up from history on startup. For an ephemeral, per-connection subscription that you start and cancel by hand
+ * (for example a Server-Sent-Events feed scoped to one HTTP request), inject and use the {@code DcbSubscriptions} DSL
+ * instead. The {@code DcbSubscriptionModel} interface is the lower-level, CloudEvent-level typed view that both build
+ * on, and most application code does not use it directly.
+ * </p>
+ *
+ * <h4>Query</h4>
+ * <p>
+ * The subscription delivers the DCB events matching its query. The query is built from {@link #eventTypes()} and
+ * {@link #tagsAllOf()}: event types are matched as any-of (translated to CloudEvent types through the configured
+ * converter), tags are matched as all-of. When {@link #eventTypes()} is empty the event types are taken from the
+ * method's event parameter (a sealed parameter expands to its concrete subtypes), the same way
+ * {@link StreamSubscription} does, so the query is always scoped to the resolved event types. Add {@link #tagsAllOf()}
+ * to narrow further to a tag boundary.
+ * </p>
+ *
+ * <h4>Start Position</h4>
+ * <p>
+ * {@link #startAt()} selects one of the {@link DcbStartPosition} values. {@link DcbStartPosition#BEGINNING} replays
+ * the whole DCB sequence by {@code dcbposition} before switching to live delivery, so a read model can be rebuilt
+ * from history. As with {@link StreamSubscription}, the replay happens the first time the subscription starts, and on
+ * later restarts it resumes from the last received event, unless {@link #resumeBehavior()} says otherwise.
+ * </p>
+ *
+ * <h4>Metadata</h4>
+ * <p>
+ * The annotated method may take the metadata associated with the event as a second parameter, either the generic
+ * {@link org.occurrent.dsl.subscription.blocking.EventMetadata} or the DCB specific
+ * {@code org.occurrent.dsl.dcb.blocking.DcbEventMetadata}, which also exposes the DCB position and tags.
+ * </p>
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface DcbSubscription {
+    /**
+     * The unique identifier of the subscription.
+     */
+    String id();
+
+    /**
+     * Specify the event types to subscribe to. When empty, the event type is taken from the method's event parameter
+     * (a sealed type is expanded to its concrete subtypes). The types are matched as any-of and translated to
+     * CloudEvent types through the configured converter to build the DCB query.
+     */
+    Class<?>[] eventTypes() default {};
+
+    /**
+     * Specify the DCB tags the events must all carry, the consistency boundary the subscription is scoped to. Matched
+     * as all-of. When empty the subscription is not scoped by tags.
+     */
+    String[] tagsAllOf() default {};
+
+    /**
+     * Specify the start position as one of the predefined {@link DcbStartPosition} values. Mutually exclusive with
+     * {@link #startAtDcbPosition()}, which starts from a specific position instead of a predefined one.
+     */
+    DcbStartPosition startAt() default DcbStartPosition.DEFAULT;
+
+    /**
+     * Start after a specific DCB sequence position, that is deliver events from {@code startAtDcbPosition + 1} onward,
+     * which is useful to rewind a durable read model to a known-good position. This is the DCB counterpart to
+     * {@link StreamSubscription#startAtTimeEpochMillis()}. The default of {@code -1} means unset, in which case
+     * {@link #startAt()} is used. Mutually exclusive with a non-{@link DcbStartPosition#DEFAULT} {@link #startAt()}, and
+     * {@link #resumeBehavior()} applies the same way it does to {@link DcbStartPosition#BEGINNING}.
+     */
+    long startAtDcbPosition() default -1;
+
+    /**
+     * Specify if the resume behavior for the subscription should differ from when it is started. By default
+     * ({@link ResumeBehavior#DEFAULT}), a subscription that starts by replaying history (from
+     * {@link DcbStartPosition#BEGINNING} or from a {@link #startAtDcbPosition()}) replays only the first time it is
+     * started and then resumes from the last received event on application restart. That is the right behavior for a
+     * durable read model that persists what it builds.
+     * <p>
+     * An in-memory read model is different: it keeps no durable state, so it has to replay the whole history on every
+     * boot. For that, combine {@link DcbStartPosition#BEGINNING} with {@link ResumeBehavior#SAME_AS_START_AT}, which
+     * replays from the beginning on every restart and keeps no checkpoint. With the default resume behavior an in-memory
+     * model would, after a restart, resume mid-sequence and silently miss all history before the stored position.
+     */
+    ResumeBehavior resumeBehavior() default ResumeBehavior.DEFAULT;
+
+    /**
+     * Specify how the subscription should behave during startup.
+     */
+    StartupMode startupMode() default StartupMode.DEFAULT;
+
+    /**
+     * The predefined DCB start positions.
+     */
+    enum DcbStartPosition {
+        /**
+         * Replay the whole DCB sequence from the beginning (by {@code dcbposition}) before switching to live delivery.
+         */
+        BEGINNING,
+        /**
+         * Start from "now", delivering only events written after the subscription starts.
+         */
+        NOW,
+        /**
+         * Use the default behavior of the subscription model. Typically this resumes from the last stored position if
+         * the subscription has run before, otherwise it behaves like {@link #NOW}.
+         */
+        DEFAULT
+    }
+
+    /**
+     * Specifies how a subscription should be resumed once the application is restarted.
+     */
+    enum ResumeBehavior {
+        /**
+         * Always start at the same position as specified by the {@link DcbStartPosition}. Even if a subscription
+         * position (checkpoint) is stored, it is ignored on restart and the subscription resumes from the specified
+         * {@link DcbStartPosition}.
+         */
+        SAME_AS_START_AT,
+        /**
+         * Use the default resume behavior. For example, if {@link DcbStartPosition} is {@link DcbStartPosition#BEGINNING}
+         * and {@code ResumeBehavior} is {@link ResumeBehavior#DEFAULT}, the subscription replays from the beginning the
+         * first time it runs, then resumes from the last received event on restart.
+         */
+        DEFAULT
+    }
+
+    /**
+     * Specify how the subscription should behave during startup.
+     */
+    enum StartupMode {
+        /**
+         * Occurrent determines the startup mode from the other properties of the subscription. It uses
+         * {@link #BACKGROUND} when the subscription needs to replay history before subscribing to new events (for
+         * example when {@link #startAt()} is {@link DcbStartPosition#BEGINNING}), otherwise {@link #WAIT_UNTIL_STARTED}.
+         */
+        DEFAULT,
+        /**
+         * The subscription waits until it has started fully before Spring continues starting the rest of the
+         * application. Most of the time this is recommended because otherwise a request could reach the application
+         * before the subscription has bootstrapped, which a brand new subscription could miss.
+         */
+        WAIT_UNTIL_STARTED,
+        /**
+         * The subscription does not wait until it has started fully, it starts in the background. This is mainly useful
+         * when the subscription replays a lot of history (such as from the beginning) and waiting for the replay to
+         * finish before the application starts would take too long.
+         */
+        BACKGROUND
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
@@ -20,15 +20,20 @@ package org.occurrent.springboot.mongo.blocking;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 import org.jspecify.annotations.NonNull;
+import org.occurrent.annotation.DcbSubscription;
 import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.annotation.StreamSubscription.ResumeBehavior;
 import org.occurrent.annotation.StreamSubscription.StartPosition;
 import org.occurrent.annotation.StreamSubscription.StartupMode;
 import org.occurrent.annotation.Subscription;
 import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.dcb.blocking.DcbEventMetadata;
+import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.subscription.blocking.EventMetadata;
 import org.occurrent.dsl.subscription.blocking.Subscriptions;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.filter.Filter;
+import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.SubscriptionPositionStorage;
 import org.occurrent.subscription.blocking.competingconsumers.CompetingConsumerSubscriptionModel;
@@ -55,6 +60,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,8 +71,8 @@ import static org.occurrent.filter.Filter.CompositionOperator.OR;
 import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
- * Implements support for the {@link StreamSubscription} annotation, and the deprecated {@link Subscription} alias, in
- * Spring Boot.
+ * Implements support for the {@link StreamSubscription} and {@link DcbSubscription} annotations, and the deprecated
+ * {@link Subscription} alias, in Spring Boot.
  */
 class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
 
@@ -82,13 +89,17 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         for (Method method : managedBeanClass.getDeclaredMethods()) {
             StreamSubscription streamSubscription = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
             Subscription subscription = AnnotationUtils.findAnnotation(method, Subscription.class);
-            if (streamSubscription != null && subscription != null) {
-                throw new IllegalArgumentException("Method %s#%s is annotated with both @StreamSubscription and the deprecated @Subscription, use only @StreamSubscription.".formatted(bean.getClass().getName(), method.getName()));
+            DcbSubscription dcbSubscription = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
+            long annotationCount = Stream.of(streamSubscription, subscription, dcbSubscription).filter(Objects::nonNull).count();
+            if (annotationCount > 1) {
+                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @StreamSubscription, @DcbSubscription and the deprecated @Subscription, use only one.".formatted(bean.getClass().getName(), method.getName()));
             }
             if (streamSubscription != null) {
                 processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(streamSubscription));
             } else if (subscription != null) {
                 processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(subscription));
+            } else if (dcbSubscription != null) {
+                processDcbSubscribeAnnotation(bean, method, dcbSubscription);
             }
         }
         return bean;
@@ -101,18 +112,18 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
      */
     private record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
                                                 long startAtTimeEpochMillis, StartPosition startAt,
-                                                ResumeBehavior resumeBehavior, StartupMode startupMode) {
+                                                ResumeBehavior resumeBehavior, StartupMode startupMode, String annotationName) {
 
         static StreamSubscriptionDefinition from(StreamSubscription subscription) {
             return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode());
+                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode(), "@StreamSubscription");
         }
 
         @SuppressWarnings("deprecation")
         static StreamSubscriptionDefinition from(Subscription subscription) {
             return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
                     subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
-                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()));
+                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()), "@Subscription");
         }
     }
 
@@ -120,54 +131,15 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
     private <E> void processSubscribeAnnotation(Object bean, Method method, StreamSubscriptionDefinition subscription) {
         String id = subscription.id();
         final Filter filter;
-        List<Class<?>> parameterTypes = new ArrayList<>();
+        final List<Class<?>> parameterTypes;
         if (method.getParameterCount() >= 1) {
             CloudEventConverter<E> cloudEventTypeMapper = applicationContext.getBean(CloudEventConverter.class);
-
-            for (Class<?> parameterType : method.getParameterTypes()) {
-                if (EventMetadata.class.isAssignableFrom(parameterType)) {
-                    if (parameterTypes.contains(parameterType)) {
-                        throw new IllegalArgumentException("EventMetadata already specified");
-                    }
-                    parameterTypes.add(parameterType);
-                } else {
-                    if (parameterTypes.isEmpty()) {
-                        parameterTypes.add(parameterType);
-                    } else if (parameterTypes.size() == 2) {
-                        throw new IllegalArgumentException("Already specified parameters");
-                    } else if (parameterTypes.contains(EventMetadata.class)) {
-                        parameterTypes.add(parameterType);
-                    } else {
-                        throw new IllegalArgumentException("Already specified event parameter");
-                    }
-                }
-            }
-
-            if (parameterTypes.isEmpty() || parameterTypes.size() == 1 && parameterTypes.contains(EventMetadata.class)) {
-                throw new IllegalArgumentException("You need to declare an event type");
-            }
-
-            //noinspection OptionalGetWithoutIsPresent
-            Class<E> specifiedEventType = (Class<E>) parameterTypes.stream().filter(not(EventMetadata.class::isAssignableFrom)).findFirst().get();
-            Class<?>[] eventTypesSpecifiedInAnnotation = subscription.eventTypes();
-
-            final List<Class<E>> domainEventTypesToSubscribeTo;
-            if (eventTypesSpecifiedInAnnotation.length == 0) {
-                domainEventTypesToSubscribeTo = getConcreteEventTypes(id, specifiedEventType);
-            } else {
-                domainEventTypesToSubscribeTo = Arrays.stream(eventTypesSpecifiedInAnnotation)
-                        .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
-                        .peek(e -> {
-                            if (!specifiedEventType.isAssignableFrom(e)) {
-                                throw new IllegalStateException("Event type %s specified in the @StreamSubscription annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), id, bean.getClass().getName(), method.getName()));
-                            }
-                        })
-                        .toList();
-            }
+            parameterTypes = analyzeParameters(method, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, subscription.eventTypes(), subscription.annotationName());
 
             if (domainEventTypesToSubscribeTo.size() == 1) {
-                String cloudEventType = cloudEventTypeMapper.getCloudEventType(domainEventTypesToSubscribeTo.get(0));
-                filter = Filter.type(cloudEventType);
+                filter = Filter.type(cloudEventTypeMapper.getCloudEventType(domainEventTypesToSubscribeTo.get(0)));
             } else {
                 List<Filter> typeFilters = domainEventTypesToSubscribeTo.stream()
                         .map(cloudEventTypeMapper::getCloudEventType)
@@ -176,30 +148,11 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
                 filter = new Filter.CompositionFilter(OR, typeFilters);
             }
         } else {
-            filter = Filter.all();
+            throw new IllegalArgumentException("A subscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
         }
 
-
         Function2<EventMetadata, E, Unit> consumer = (metadata, event) -> {
-            final Object[] arguments;
-            if (parameterTypes.size() == 1) {
-                // Method annotated with @Subscription only specified domain event
-                arguments = new Object[]{event};
-            } else {
-                // Method annotated with @Subscription specifies domain event and metadata
-                arguments = Stream.of(metadata, event).sorted((o1, o2) -> {
-                    int index1 = parameterTypes.indexOf(o1.getClass());
-                    int index2 = parameterTypes.indexOf(o2.getClass());
-                    return Integer.compare(index1, index2);
-                }).toArray(Object[]::new);
-            }
-
-            try {
-                method.setAccessible(true);
-                method.invoke(bean, arguments);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            invoke(method, bean, bindArguments(parameterTypes, event, metadata, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter));
             return Unit.INSTANCE;
         };
 
@@ -210,6 +163,136 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         boolean shouldWaitUntilStarted = shouldWaitUntilStarted(startPositionToUse, subscription.startupMode());
         Subscriptions<E> subscribable = applicationContext.getBean(Subscriptions.class);
 
+        applyStartupWorkarounds();
+
+        subscribable.subscribe(id, filter(filter), startAt, shouldWaitUntilStarted, consumer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> void processDcbSubscribeAnnotation(Object bean, Method method, DcbSubscription annotation) {
+        String id = annotation.id();
+        final DcbQuery query;
+        final List<Class<?>> parameterTypes;
+        if (method.getParameterCount() >= 1) {
+            CloudEventConverter<E> cloudEventConverter = applicationContext.getBean(CloudEventConverter.class);
+            parameterTypes = analyzeParameters(method, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@DcbSubscription");
+            List<String> cloudEventTypes = domainEventTypesToSubscribeTo.stream().map(cloudEventConverter::getCloudEventType).toList();
+            query = buildDcbQuery(cloudEventTypes, List.of(annotation.tagsAllOf()));
+        } else {
+            throw new IllegalArgumentException("A @DcbSubscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
+        }
+
+        BiConsumer<DcbEventMetadata, E> consumer = (dcbMetadata, event) -> {
+            Object metadataArgument = parameterTypes.contains(DcbEventMetadata.class) ? dcbMetadata : dcbMetadata.eventMetadata();
+            invoke(method, bean, bindArguments(parameterTypes, event, metadataArgument, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter));
+        };
+
+        long startAtDcbPosition = annotation.startAtDcbPosition();
+        if (startAtDcbPosition >= 0 && annotation.startAt() != DcbSubscription.DcbStartPosition.DEFAULT) {
+            throw new IllegalArgumentException("Specify either startAt or startAtDcbPosition for @DcbSubscription '%s', not both.".formatted(id));
+        }
+        DcbStartAt startAt = generateDcbStartAt(id, annotation.startAt(), startAtDcbPosition, annotation.resumeBehavior());
+        boolean replaysHistory = startAtDcbPosition >= 0 || annotation.startAt() == DcbSubscription.DcbStartPosition.BEGINNING;
+        boolean shouldWaitUntilStarted = shouldWaitUntilStartedDcb(replaysHistory, annotation.startupMode());
+        DcbSubscriptions<E> dcbSubscriptions = applicationContext.getBean(DcbSubscriptions.class);
+
+        applyStartupWorkarounds();
+
+        var subscription = dcbSubscriptions.subscribeWithMetadata(id, query, startAt, consumer);
+        if (shouldWaitUntilStarted) {
+            subscription.waitUntilStarted();
+        }
+    }
+
+    private static boolean isStreamMetadataParameter(Class<?> parameterType) {
+        return EventMetadata.class.isAssignableFrom(parameterType);
+    }
+
+    private static boolean isDcbMetadataParameter(Class<?> parameterType) {
+        return EventMetadata.class.isAssignableFrom(parameterType) || DcbEventMetadata.class.isAssignableFrom(parameterType);
+    }
+
+    private static List<Class<?>> analyzeParameters(Method method, Predicate<Class<?>> isMetadataParameter) {
+        List<Class<?>> parameterTypes = new ArrayList<>();
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            if (isMetadataParameter.test(parameterType)) {
+                if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
+                    throw new IllegalArgumentException("A subscription method may declare at most one metadata parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                }
+                parameterTypes.add(parameterType);
+            } else {
+                if (parameterTypes.isEmpty()) {
+                    parameterTypes.add(parameterType);
+                } else if (parameterTypes.size() == 2) {
+                    throw new IllegalArgumentException("A subscription method may declare an event parameter and at most one metadata parameter, but %s#%s declares more.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                } else if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
+                    parameterTypes.add(parameterType);
+                } else {
+                    throw new IllegalArgumentException("A subscription method may declare only one event parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                }
+            }
+        }
+        return parameterTypes;
+    }
+
+    private static Class<?> eventTypeOf(List<Class<?>> parameterTypes, Predicate<Class<?>> isMetadataParameter) {
+        return parameterTypes.stream().filter(not(isMetadataParameter)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("You need to declare an event type"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E> List<Class<E>> resolveDomainEventTypes(String id, Object bean, Method method, Class<E> specifiedEventType, Class<?>[] eventTypesSpecifiedInAnnotation, String annotationName) {
+        if (eventTypesSpecifiedInAnnotation.length == 0) {
+            return getConcreteEventTypes(id, specifiedEventType);
+        }
+        return Arrays.stream(eventTypesSpecifiedInAnnotation)
+                .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
+                .peek(e -> {
+                    if (!specifiedEventType.isAssignableFrom(e)) {
+                        throw new IllegalStateException("Event type %s specified in the %s annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), annotationName, id, bean.getClass().getName(), method.getName()));
+                    }
+                })
+                .toList();
+    }
+
+    private static DcbQuery buildDcbQuery(List<String> cloudEventTypes, List<String> tagsAllOf) {
+        boolean hasTypes = !cloudEventTypes.isEmpty();
+        boolean hasTags = !tagsAllOf.isEmpty();
+        if (!hasTypes && !hasTags) {
+            return DcbQuery.all();
+        } else if (hasTypes && hasTags) {
+            return DcbQuery.typeAndTagsAllOf(cloudEventTypes, tagsAllOf);
+        } else if (hasTypes) {
+            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new));
+        } else {
+            return DcbQuery.tagsAllOf(tagsAllOf.get(0), tagsAllOf.stream().skip(1).toArray(String[]::new));
+        }
+    }
+
+    private static Object[] bindArguments(List<Class<?>> parameterTypes, Object event, Object metadata, Predicate<Class<?>> isMetadataParameter) {
+        if (parameterTypes.size() == 1) {
+            return new Object[]{event};
+        }
+        // Place each argument by which declared parameter slot is the metadata type, not by runtime assignability. A
+        // broad event parameter (for example Object) is assignable from the metadata value too, so an isInstance check
+        // would misplace it, this keys off the declared types instead and honors a metadata-first parameter order.
+        Object first = isMetadataParameter.test(parameterTypes.get(0)) ? metadata : event;
+        Object second = first == metadata ? event : metadata;
+        return new Object[]{first, second};
+    }
+
+    private static void invoke(Method method, Object bean, Object[] arguments) {
+        try {
+            method.setAccessible(true);
+            method.invoke(bean, arguments);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void applyStartupWorkarounds() {
         // These are workarounds for https://github.com/spring-projects/spring-framework/issues/32904
         applicationContext.getBean(MongoOperations.class);
         try {
@@ -217,8 +300,45 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         } catch (NoSuchBeanDefinitionException ignored) {
         }
         // End workarounds
+    }
 
-        subscribable.subscribe(id, filter(filter), startAt, shouldWaitUntilStarted, consumer);
+    private static boolean shouldWaitUntilStartedDcb(boolean replaysHistory, DcbSubscription.StartupMode startupMode) {
+        return switch (startupMode) {
+            // A subscription that replays history may have a lot to read, so by default it starts in the background.
+            case DEFAULT -> !replaysHistory;
+            case WAIT_UNTIL_STARTED -> true;
+            case BACKGROUND -> false;
+        };
+    }
+
+    private DcbStartAt generateDcbStartAt(String subscriptionId, DcbSubscription.DcbStartPosition startPosition, long startAtDcbPosition, DcbSubscription.ResumeBehavior resumeBehavior) {
+        if (startAtDcbPosition >= 0) {
+            // Start after a specific position, applying the same replay-then-resume logic BEGINNING uses.
+            return replayThenResume(subscriptionId, DcbStartAt.afterPosition(startAtDcbPosition), resumeBehavior);
+        }
+        return switch (startPosition) {
+            case NOW -> DcbStartAt.now();
+            case DEFAULT -> DcbStartAt.subscriptionModelDefault();
+            case BEGINNING -> replayThenResume(subscriptionId, DcbStartAt.beginning(), resumeBehavior);
+        };
+    }
+
+    // Replay from replayStart, then on later restarts either resume from the stored position (DEFAULT) or replay again
+    // (SAME_AS_START_AT). SAME_AS_START_AT also disables the competing consumer and durable position storage by
+    // delegating to the parent subscription model for those layers, so an in-memory read model rebuilt on every boot
+    // sees every event and keeps no checkpoint.
+    private DcbStartAt replayThenResume(String subscriptionId, DcbStartAt replayStart, DcbSubscription.ResumeBehavior resumeBehavior) {
+        return switch (resumeBehavior) {
+            case SAME_AS_START_AT -> DcbStartAt.dynamic(ctx -> {
+                boolean isCompetingConsumerSubscription = CompetingConsumerSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                boolean isDurableSubscription = DurableSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                return isCompetingConsumerSubscription || isDurableSubscription ? null : replayStart;
+            });
+            case DEFAULT -> DcbStartAt.dynamic(ctx -> {
+                SubscriptionPositionStorage subscriptionPositionStorage = applicationContext.getBean(SubscriptionPositionStorage.class);
+                return subscriptionPositionStorage.exists(subscriptionId) ? DcbStartAt.subscriptionModelDefault() : replayStart;
+            });
+        };
     }
 
     // TODO Also check resume behavior if subscription exists!
@@ -410,7 +530,7 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
             Class<E>[] permittedSubclasses = (Class<E>[]) specifiedEventType.getPermittedSubclasses();
             domainEventTypesToSubscribeTo = Arrays.stream(permittedSubclasses).flatMap(c -> getConcreteEventTypes(subscriptionId, c).stream()).toList();
         } else if (specifiedEventType.isInterface() || specifiedEventType.isArray() || Modifier.isAbstract(specifiedEventType.getModifiers())) {
-            String msg = "You need cannot subscribe to a non-sealed interfaces or abstract types (problem is with %s). A concrete or sealed event type is required. You can also specify event types explicitly by using @StreamSubscription(id = \"%s\", eventTypes = [MyEvent1.class, MyEvent2.class]))";
+            String msg = "You cannot subscribe to a non-sealed interface, abstract type, or array (problem is with %s for subscription '%s'). A concrete or sealed event type is required, or list the event types explicitly with the annotation's eventTypes attribute (for example eventTypes = {MyEvent1.class, MyEvent2.class}).";
             throw new IllegalArgumentException(msg.formatted(specifiedEventType.getName(), subscriptionId));
         } else {
             domainEventTypesToSubscribeTo = List.of(specifiedEventType);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionAnnotationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionAnnotationMongoTest.java
@@ -1,0 +1,212 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import io.cloudevents.CloudEvent;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.DcbSubscription;
+import org.occurrent.annotation.DcbSubscription.DcbStartPosition;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that a {@link DcbSubscription} method is wired in DCB-only mode: it replays the DCB history appended before
+ * startup, then receives live events, and its {@code eventTypes} narrowing keeps non-matching events out. The history
+ * is appended by a bean the subscriber {@link DependsOn}, so it exists before the annotation subscription starts.
+ */
+@DisplayName("DcbSubscription annotation (DCB-only mode)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = DcbSubscriptionAnnotationMongoTest.DcbOnlyApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:dcb-annotation-test"
+        }
+)
+@Import(DcbSubscriptionAnnotationMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class DcbSubscriptionAnnotationMongoTest {
+
+    static final String TAG = "test:annotation";
+    private static final URI SOURCE = URI.create("urn:occurrent:dcb-annotation-test");
+
+    @Autowired
+    private DcbEventStore dcbEventStore;
+
+    @Autowired
+    private CloudEventConverter<TestEvent> cloudEventConverter;
+
+    @Autowired
+    private RecordingDashboard recordingDashboard;
+
+    @Test
+    void replays_history_then_receives_live_events_and_excludes_non_matching_types() {
+        // The two Included events were appended before startup by HistoryAppender, so the BEGINNING subscription
+        // replays them.
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(recordingDashboard.received()).extracting(TestEvent::name).containsExactly("historic-1", "historic-2"));
+
+        // A live Included event arrives after the catch-up phase.
+        append(new Included("live-1"));
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(recordingDashboard.received()).extracting(TestEvent::name).containsExactly("historic-1", "historic-2", "live-1"));
+
+        // An Excluded event must never reach the subscription, since eventTypes narrows to Included only.
+        append(new Excluded("excluded-1"));
+        await().during(ofSeconds(2)).atMost(ofSeconds(5)).untilAsserted(() ->
+                assertThat(recordingDashboard.received()).extracting(TestEvent::name).containsExactly("historic-1", "historic-2", "live-1"));
+    }
+
+    private void append(TestEvent... events) {
+        appendTagged(dcbEventStore, cloudEventConverter, events);
+    }
+
+    private static void appendTagged(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> converter, TestEvent... events) {
+        List<CloudEvent> cloudEvents = converter.toCloudEvents(Stream.of(events))
+                .map(ce -> DcbCloudEvents.withTags(ce, List.of(TAG)))
+                .toList();
+        dcbEventStore.append(cloudEvents);
+    }
+
+    // --- inner application and configuration classes ---
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class DcbOnlyApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        // Appends the DCB history before the subscriber starts, so the BEGINNING subscription has something to replay.
+        @Bean
+        HistoryAppender historyAppender(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> cloudEventConverter) {
+            return new HistoryAppender(dcbEventStore, cloudEventConverter);
+        }
+
+        // DependsOn the appender so the history is in place before this bean's @DcbSubscription starts replaying.
+        @Bean
+        @DependsOn("historyAppender")
+        RecordingDashboard recordingDashboard() {
+            return new RecordingDashboard();
+        }
+    }
+
+    static class HistoryAppender {
+        private final DcbEventStore dcbEventStore;
+        private final CloudEventConverter<TestEvent> cloudEventConverter;
+
+        HistoryAppender(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> cloudEventConverter) {
+            this.dcbEventStore = dcbEventStore;
+            this.cloudEventConverter = cloudEventConverter;
+        }
+
+        @PostConstruct
+        void appendHistory() {
+            appendTagged(dcbEventStore, cloudEventConverter, new Included("historic-1"), new Included("historic-2"));
+        }
+    }
+
+    static class RecordingDashboard {
+        private final CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        @DcbSubscription(id = "dcb-annotation-dashboard", eventTypes = Included.class, startAt = DcbStartPosition.BEGINNING)
+        void onEvent(TestEvent event) {
+            received.add(event);
+        }
+
+        List<TestEvent> received() {
+            return received;
+        }
+    }
+
+    sealed interface TestEvent {
+        String eventId();
+
+        Date timestamp();
+
+        String name();
+    }
+
+    record Included(String eventId, Date timestamp, String name) implements TestEvent {
+        Included(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+
+    record Excluded(String eventId, Date timestamp, String name) implements TestEvent {
+        Excluded(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionMetadataBindingMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionMetadataBindingMongoTest.java
@@ -1,0 +1,291 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.DcbSubscription;
+import org.occurrent.annotation.DcbSubscription.DcbStartPosition;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.dsl.dcb.blocking.DcbEventMetadata;
+import org.occurrent.dsl.subscription.blocking.EventMetadata;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that the {@link DcbSubscription} annotation processor correctly binds the metadata parameter
+ * regardless of its declared position in the method signature. Three binding configurations are exercised:
+ *
+ * - event-first, DcbEventMetadata second (dcbPosition and dcbTags populated)
+ * - metadata-first, event second (this is the argument-ordering bug that bindArguments fixed)
+ * - event-first, generic EventMetadata second (dcbTags readable through the raw data map)
+ */
+@DisplayName("DcbSubscription metadata parameter binding")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = DcbSubscriptionMetadataBindingMongoTest.MetadataBindingApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:dcb-metadata-binding-test"
+        }
+)
+@Import(DcbSubscriptionMetadataBindingMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class DcbSubscriptionMetadataBindingMongoTest {
+
+    static final String TAG = "test:metadata-binding";
+    private static final URI SOURCE = URI.create("urn:occurrent:dcb-metadata-binding-test");
+
+    @Autowired
+    private DcbEventStore dcbEventStore;
+
+    @Autowired
+    private CloudEventConverter<MyEvent> cloudEventConverter;
+
+    @Autowired
+    private EventFirstDcbMetadataReceiver eventFirstDcbMetadataReceiver;
+
+    @Autowired
+    private MetadataFirstReceiver metadataFirstReceiver;
+
+    @Autowired
+    private EventFirstGenericMetadataReceiver eventFirstGenericMetadataReceiver;
+
+    // --- tests ---
+
+    @Test
+    void event_first_dcb_metadata_second_binds_both_with_position_and_tags_populated() {
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(eventFirstDcbMetadataReceiver.receivedEvents()).hasSize(1);
+            assertThat(eventFirstDcbMetadataReceiver.receivedEvents().get(0).name()).isEqualTo("meta-event-1");
+        });
+        DcbEventMetadata m = eventFirstDcbMetadataReceiver.receivedMetadata().get(0);
+        assertThat(m.dcbPosition()).isPresent();
+        assertThat(m.dcbTags()).contains(TAG);
+    }
+
+    @Test
+    void metadata_first_event_second_binds_the_correct_parameter_slots() {
+        // Before the bindArguments fix this threw "argument type mismatch" at invocation time
+        // because the processor placed the event object into the first (metadata-typed) slot.
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(metadataFirstReceiver.receivedEvents()).hasSize(1);
+            assertThat(metadataFirstReceiver.receivedEvents().get(0).name()).isEqualTo("meta-event-2");
+        });
+        DcbEventMetadata m = metadataFirstReceiver.receivedMetadata().get(0);
+        assertThat(m.dcbPosition()).isPresent();
+        assertThat(m.dcbTags()).contains(TAG);
+    }
+
+    @Test
+    void generic_event_metadata_second_exposes_dcb_tags_through_raw_data_map() {
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(eventFirstGenericMetadataReceiver.receivedEvents()).hasSize(1);
+            assertThat(eventFirstGenericMetadataReceiver.receivedEvents().get(0).name()).isEqualTo("meta-event-3");
+        });
+        EventMetadata m = eventFirstGenericMetadataReceiver.receivedMetadata().get(0);
+        assertThat(m.getData()).containsKey(DcbCloudEvents.TAGS);
+        // Unwrap via DcbEventMetadata to assert the decoded tag value round-trips correctly.
+        assertThat(DcbEventMetadata.from(m).dcbTags()).contains(TAG);
+    }
+
+    // --- helpers ---
+
+    private void append(String tag, MyEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(ce -> DcbCloudEvents.withTags(ce, List.of(tag)))
+                .toList();
+        dcbEventStore.append(cloudEvents);
+    }
+
+    // --- container configuration ---
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    // --- application under test ---
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class MetadataBindingApplication {
+
+        @Bean
+        CloudEventTypeMapper<MyEvent> myEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<MyEvent> myEventCloudEventConverter(CloudEventTypeMapper<MyEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<MyEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .idMapper(MyEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        HistorySeeder historySeeder(DcbEventStore store, CloudEventConverter<MyEvent> converter) {
+            return new HistorySeeder(store, converter);
+        }
+
+        @Bean
+        @DependsOn("historySeeder")
+        EventFirstDcbMetadataReceiver eventFirstDcbMetadataReceiver() {
+            return new EventFirstDcbMetadataReceiver();
+        }
+
+        @Bean
+        @DependsOn("historySeeder")
+        MetadataFirstReceiver metadataFirstReceiver() {
+            return new MetadataFirstReceiver();
+        }
+
+        @Bean
+        @DependsOn("historySeeder")
+        EventFirstGenericMetadataReceiver eventFirstGenericMetadataReceiver() {
+            return new EventFirstGenericMetadataReceiver();
+        }
+    }
+
+    // --- history seeder ---
+
+    static class HistorySeeder {
+
+        HistorySeeder(DcbEventStore store, CloudEventConverter<MyEvent> converter) {
+            List<CloudEvent> batch = converter.toCloudEvents(Stream.of(
+                            new MyEvent("meta-event-1"),
+                            new MyEvent("meta-event-2"),
+                            new MyEvent("meta-event-3")
+                    ))
+                    .map(ce -> DcbCloudEvents.withTags(ce, List.of(TAG)))
+                    .toList();
+            store.append(batch);
+        }
+    }
+
+    // --- receivers (one per subscription so ids are unique) ---
+
+    static class EventFirstDcbMetadataReceiver {
+        private final CopyOnWriteArrayList<MyEvent> events = new CopyOnWriteArrayList<>();
+        private final CopyOnWriteArrayList<DcbEventMetadata> metadata = new CopyOnWriteArrayList<>();
+
+        @DcbSubscription(
+                id = "meta-binding-event-first-dcb",
+                eventTypes = MyEvent.class,
+                startAt = DcbStartPosition.BEGINNING
+        )
+        void on(MyEvent event, DcbEventMetadata meta) {
+            if ("meta-event-1".equals(event.name())) {
+                events.add(event);
+                metadata.add(meta);
+            }
+        }
+
+        List<MyEvent> receivedEvents() { return events; }
+        List<DcbEventMetadata> receivedMetadata() { return metadata; }
+    }
+
+    static class MetadataFirstReceiver {
+        private final CopyOnWriteArrayList<MyEvent> events = new CopyOnWriteArrayList<>();
+        private final CopyOnWriteArrayList<DcbEventMetadata> metadata = new CopyOnWriteArrayList<>();
+
+        // Metadata is declared FIRST -- this is the ordering the fixed bindArguments must handle correctly.
+        @DcbSubscription(
+                id = "meta-binding-metadata-first",
+                eventTypes = MyEvent.class,
+                startAt = DcbStartPosition.BEGINNING
+        )
+        void on(DcbEventMetadata meta, MyEvent event) {
+            if ("meta-event-2".equals(event.name())) {
+                events.add(event);
+                metadata.add(meta);
+            }
+        }
+
+        List<MyEvent> receivedEvents() { return events; }
+        List<DcbEventMetadata> receivedMetadata() { return metadata; }
+    }
+
+    static class EventFirstGenericMetadataReceiver {
+        private final CopyOnWriteArrayList<MyEvent> events = new CopyOnWriteArrayList<>();
+        private final CopyOnWriteArrayList<EventMetadata> metadata = new CopyOnWriteArrayList<>();
+
+        @DcbSubscription(
+                id = "meta-binding-event-first-generic",
+                eventTypes = MyEvent.class,
+                startAt = DcbStartPosition.BEGINNING
+        )
+        void on(MyEvent event, EventMetadata meta) {
+            if ("meta-event-3".equals(event.name())) {
+                events.add(event);
+                metadata.add(meta);
+            }
+        }
+
+        List<MyEvent> receivedEvents() { return events; }
+        List<EventMetadata> receivedMetadata() { return metadata; }
+    }
+
+    // --- domain model ---
+
+    record MyEvent(String eventId, Date timestamp, String name) {
+        MyEvent(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionStartAtPositionAnnotationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbSubscriptionStartAtPositionAnnotationMongoTest.java
@@ -1,0 +1,186 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.DcbSubscription;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Verifies that startAtDcbPosition delivers events strictly after the specified DCB sequence position.
+ * Three events are appended before the subscription starts (positions 1, 2, 3). A subscription with
+ * startAtDcbPosition = 1 must receive only positions 2 and 3, never position 1.
+ */
+@DisplayName("DcbSubscription startAtDcbPosition (DCB-only mode)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = DcbSubscriptionStartAtPositionAnnotationMongoTest.DcbOnlyApplication.class,
+        properties = {
+                "occurrent.event-store.capabilities=dcb",
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:dcb-start-at-position-test"
+        }
+)
+@Import(DcbSubscriptionStartAtPositionAnnotationMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class DcbSubscriptionStartAtPositionAnnotationMongoTest {
+
+    static final String TAG = "test:start-at-position";
+    private static final URI SOURCE = URI.create("urn:occurrent:dcb-start-at-position-test");
+
+    @Autowired
+    private RecordingSubscriber recordingSubscriber;
+
+    @Test
+    void subscription_with_startAtDcbPosition_1_skips_the_first_event_and_delivers_positions_2_and_3() {
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(recordingSubscriber.received())
+                        .extracting(TestEvent::name)
+                        .containsExactlyInAnyOrder("event-2", "event-3"));
+
+        // The first event must never appear, even after the subscription has settled.
+        assertThat(recordingSubscriber.received())
+                .extracting(TestEvent::name)
+                .doesNotContain("event-1");
+    }
+
+    // --- inner application and configuration classes ---
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MongoDbContainerConfiguration {
+
+        @Bean
+        @ServiceConnection
+        MongoDBContainer mongoDbContainer() {
+            return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class DcbOnlyApplication {
+
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), SOURCE)
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        // Appends three distinguishable events before the subscription starts.
+        // DCB positions are assigned sequentially from 1 on a fresh store, so they get 1, 2, 3.
+        @Bean
+        HistoryAppender historyAppender(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> cloudEventConverter) {
+            return new HistoryAppender(dcbEventStore, cloudEventConverter);
+        }
+
+        // DependsOn the appender so all three events exist before the subscription begins replaying.
+        @Bean
+        @DependsOn("historyAppender")
+        RecordingSubscriber recordingSubscriber() {
+            return new RecordingSubscriber();
+        }
+    }
+
+    static class HistoryAppender {
+        private final DcbEventStore dcbEventStore;
+        private final CloudEventConverter<TestEvent> cloudEventConverter;
+
+        HistoryAppender(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> cloudEventConverter) {
+            this.dcbEventStore = dcbEventStore;
+            this.cloudEventConverter = cloudEventConverter;
+        }
+
+        @PostConstruct
+        void appendHistory() {
+            appendTagged(dcbEventStore, cloudEventConverter,
+                    new TestEvent("event-1"),
+                    new TestEvent("event-2"),
+                    new TestEvent("event-3"));
+        }
+    }
+
+    static class RecordingSubscriber {
+        private final CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        // startAtDcbPosition = 1 means: deliver events from position 2 onward (exclusive resume semantics).
+        @DcbSubscription(id = "dcb-start-at-position-subscriber", startAtDcbPosition = 1)
+        void onEvent(TestEvent event) {
+            received.add(event);
+        }
+
+        List<TestEvent> received() {
+            return received;
+        }
+    }
+
+    private static void appendTagged(DcbEventStore dcbEventStore, CloudEventConverter<TestEvent> converter, TestEvent... events) {
+        List<io.cloudevents.CloudEvent> cloudEvents = converter.toCloudEvents(Stream.of(events))
+                .map(ce -> DcbCloudEvents.withTags(ce, List.of(TAG)))
+                .toList();
+        dcbEventStore.append(cloudEvents);
+    }
+
+    record TestEvent(String eventId, Date timestamp, String name) {
+        TestEvent(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
@@ -28,6 +28,10 @@ import java.util.function.Consumer;
  * {@link DcbQuery} and a {@link DcbStartAt}, so a DCB subscription cannot be handed a stream {@code Filter} or a
  * time-based start position. It is a facade over the shared subscription model, not a separate lifecycle: obtain one
  * with {@link #from(SubscriptionModel)} and the typed calls are translated to the underlying model.
+ * <p>
+ * This is the lower-level, CloudEvent-level typed view. Most application code does not use it directly: use the
+ * {@code @DcbSubscription} annotation for a persistent framework-managed subscription, or the {@code DcbSubscriptions}
+ * DSL for an ephemeral per-connection one.
  */
 @NullMarked
 public interface DcbSubscriptionModel extends SubscriptionModelLifeCycle {

--- a/subscription/core/src/main/java/org/occurrent/subscription/DcbStartAt.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/DcbStartAt.java
@@ -17,6 +17,12 @@
 package org.occurrent.subscription;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.subscription.StartAt.SubscriptionModelContext;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Specifies where a DCB subscription should start. This is the DCB counterpart to {@link StartAt}: it can only express
@@ -69,6 +75,16 @@ public sealed interface DcbStartAt {
         return new AtPosition(lastProcessedPosition);
     }
 
+    /**
+     * Create a DCB start position that is resolved each time the subscription is started, for example to start from the
+     * beginning the first time and then resume from the stored position. The function receives the subscription model
+     * context and may return {@code null} to signal that the subscription should not start at this layer and should
+     * delegate to the parent subscription model, the same contract as {@link StartAt#dynamic(Function)}.
+     */
+    static DcbStartAt dynamic(Function<SubscriptionModelContext, @Nullable DcbStartAt> function) {
+        return new Dynamic(requireNonNull(function, "Dynamic DcbStartAt function cannot be null"));
+    }
+
     enum Relative implements DcbStartAt {
         NOW {
             @Override
@@ -94,6 +110,20 @@ public sealed interface DcbStartAt {
         @Override
         public StartAt toStartAt() {
             return StartAt.subscriptionPosition(DcbSubscriptionPosition.of(lastProcessedPosition));
+        }
+    }
+
+    record Dynamic(Function<SubscriptionModelContext, @Nullable DcbStartAt> function) implements DcbStartAt {
+        public Dynamic {
+            requireNonNull(function, "Dynamic DcbStartAt function cannot be null");
+        }
+
+        @Override
+        public StartAt toStartAt() {
+            return StartAt.dynamic(context -> {
+                DcbStartAt resolved = function.apply(context);
+                return resolved == null ? null : resolved.toStartAt();
+            });
         }
     }
 }

--- a/subscription/core/src/test/java/org/occurrent/subscription/DcbStartAtTest.java
+++ b/subscription/core/src/test/java/org/occurrent/subscription/DcbStartAtTest.java
@@ -58,4 +58,25 @@ class DcbStartAtTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("negative");
     }
+
+    @Test
+    void dynamic_returning_null_propagates_null_to_the_caller() {
+        // A read-model delegate that always returns null signals "no opinion" to the subscription model.
+        StartAt.SubscriptionModelContext ctx = new StartAt.SubscriptionModelContext(Object.class);
+
+        StartAt resolved = DcbStartAt.dynamic(ignored -> null).toStartAt().get(ctx);
+
+        assertThat(resolved).isNull();
+    }
+
+    @Test
+    void dynamic_returning_beginning_resolves_to_dcb_position_zero() {
+        StartAt.SubscriptionModelContext ctx = new StartAt.SubscriptionModelContext(Object.class);
+
+        StartAt resolved = DcbStartAt.dynamic(ignored -> DcbStartAt.beginning()).toStartAt().get(ctx);
+
+        assertThat(resolved).isInstanceOf(StartAt.StartAtSubscriptionPosition.class);
+        assertThat(((StartAt.StartAtSubscriptionPosition) resolved).subscriptionPosition)
+                .isEqualTo(DcbSubscriptionPosition.of(0));
+    }
 }


### PR DESCRIPTION
This is the last PR in the DCB subscription stack. It adds `@DcbSubscription`, the declarative DCB counterpart to `@StreamSubscription`, so a DCB read model is a single annotated method instead of an injected `DcbSubscriptions` DSL and a hand-rolled start position.

- `@DcbSubscription` takes `id`, `eventTypes` and `tagsAllOf` (which become the `DcbQuery`: neither gives all, types only, tags only, or both), `startAt` (BEGINNING, NOW, DEFAULT), `resumeBehavior`, and `startupMode`.
- The processor resolves the start position the same way the stream path does, over `dcbposition` instead of time. BEGINNING with the default resume replays from the start on the first run and resumes from the stored position afterwards. BEGINNING with `SAME_AS_START_AT` always replays, and disables the competing consumer and the durable position storage for that subscription, so an always-rebuilt in-memory read model sees every event and keeps no checkpoint.
- `DcbStartAt` gained a `dynamic` factory, the typed DCB counterpart to `StartAt.dynamic`, to back that resume logic.
- The DCB path routes through the `DcbSubscriptions` DSL, so it inherits the server-side filter and the in-process correctness floor. The method takes the event and, optionally, the generic `EventMetadata` or the DCB-specific `DcbEventMetadata`.
- The backend-agnostic processor helpers (parameter binding, concrete-event-type resolution) are now extracted and shared between the stream and DCB paths. The rename PR deferred this until a second consumer existed, and now it does.
- The course-enrollment `CourseDashboardSubscriber` is migrated to `@DcbSubscription`, replacing the hand-rolled subscription and the in-handler type check.

ADR 0027 records the decision.

### Verification

* `rtk mvn -pl framework/spring-boot-starter-mongodb -Dtest=DcbSubscriptionAnnotationMongoTest test`: Tests run: 1, Failures: 0, Errors: 0. A `@DcbSubscription(startAt = BEGINNING)` method replays two events appended before startup, then receives a live event, and never receives an event excluded by `eventTypes`.
* `rtk mvn -Pexamples-module -pl example/domain/course-enrollment test`: `CourseEnrollmentTest` 5 and `CourseEnrollmentWebTest` 9, with the dashboard now fed by the migrated `@DcbSubscription`.
* `rtk mvn -pl subscription/core,framework/annotations,framework/spring-boot-starter-mongodb -am test-compile`: clean.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/stream-subscription-annotation","parentHead":"c5e591a5b68abdfd4050b92a162df54a56bf58e8","parentPull":226,"trunk":"main"}
```
-->
