### PR TITLE
Capture DCB catch-up resume token before the bulk replay to fix tail loss

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### Changelog next version
 
+* DCB catch-up no longer drops an event that commits during the replay.
+  * `dcbposition` is reserved before the append commits (ADR 21), so the store head can run ahead of committed data and a position below the head can be an in-flight hole. If such an event committed while a catch-up replay was running, it was delivered by neither the replay, the forward-only reconciliation, nor the live change stream, because the live resume token was captured after the replay. The catch-up now captures that token before the replay, so the live change stream delivers the late commit and the handover cache dedups the overlap.
+  * Trade-off: a replay that runs longer than the change stream history makes the resume token age out, so the handover fails loudly rather than silently dropping events. Size the change stream history (the MongoDB oplog window) for very large rebuilds.
+  * See [ADR 28](doc/architecture/decisions/0028-dcb-catch-up-captures-resume-token-before-replay.md).
+
 * Added the `@DcbSubscription` annotation, the declarative DCB counterpart to `@StreamSubscription`.
   * A DCB read model can now be declared as a single annotated method. `eventTypes` and `tagsAllOf` express the `DcbQuery`, and `startAt` (BEGINNING, NOW, DEFAULT) or `startAtDcbPosition` (an explicit position, the DCB counterpart to the stream `startAtTimeEpochMillis`) together with `resumeBehavior` give history replay, resume from the stored position, and an always-replay in-memory mode that disables the competing consumer and position storage. It routes through the DCB DSL, so it gets the server-side filter, and the method can take the event plus an optional `EventMetadata` or `DcbEventMetadata`. `DcbStartAt` gained a `dynamic` factory to back the resume logic. The course-enrollment dashboard subscriber now uses `@DcbSubscription` (combining `BEGINNING` with `SAME_AS_START_AT`, since it is an in-memory model rebuilt on every boot).
   * See [ADR 27](doc/architecture/decisions/0027-dcb-subscription-annotation.md).

--- a/doc/architecture/decisions/0028-dcb-catch-up-captures-resume-token-before-replay.md
+++ b/doc/architecture/decisions/0028-dcb-catch-up-captures-resume-token-before-replay.md
@@ -1,0 +1,37 @@
+# 28. DCB catch-up captures the live resume token before the bulk replay
+
+Date: 2026-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0020 gave the DCB catch-up its shape: replay the matching history by `dcbposition`, then hand over to the live change stream, resuming it from a token captured after the replay so the token stays fresh across a long rebuild.
+
+ADR 0021 then moved `dcbposition` assignment outside the append commit transaction. A consequence is that the store head can run ahead of committed data: a position below the head can be an in-flight hole whose append has reserved the position but not yet committed. The append's own write path is immune to this because it serializes on per-attribute markers rather than positions, but the catch-up replay still reads by position.
+
+Those two combine into a delivery gap. Suppose a matching event holds a below-head position and is still in flight when the replay scans its window, then commits while the replay is still running. The replay does not see it (it was uncommitted when scanned). The reconciliation loop only scans forward from the head, so it never revisits a below-head position. And the live change stream resumes from a token captured after the replay, by which time the event has already committed, so the token sits past it. The event is delivered by none of the three paths and is silently lost. This breaks the at-least-once contract: a read model rebuilt during concurrent writes can be permanently missing an event.
+
+Position-ordered reconciliation cannot close this on its own. A below-head hole is old by position, not new, so neither a forward scan nor a newest-N count scan finds it without re-reading the whole matched range, which is unbounded for a selective query over a large store. Only a commit-ordered observer can recover it, which is exactly what the change stream is.
+
+## Decision
+
+Capture the live resume token before the bulk replay instead of after.
+
+With the token taken before the replay, an event that commits during the replay falls after the token, so the live change stream carries it on handover regardless of its position. The existing handover cache dedups the overlap between the replay and the live phase.
+
+## Consequences
+
+Positive:
+
+- The at-least-once contract holds under concurrent writes during a rebuild. A below-head event that commits mid-replay is delivered by the live phase rather than dropped.
+- The change is localized to where the token is captured. The replay, reconciliation, cache, and handover are otherwise unchanged.
+
+Negative:
+
+- The token can age out of the change stream history on a rebuild that runs longer than that history, because it is now captured earlier. When that happens the handover resume fails loudly rather than silently dropping events. Size the change stream history (the MongoDB oplog window) for very large rebuilds. A loud failure that a restart recovers from is strictly better than a silent loss that a rebuild does not.
+- The live phase re-delivers events written during the replay, deduped by the cache. The duplicate volume is bounded by the writes during the replay, not by the store size, because the historical backlog committed before the token and so is not in the live stream. Delivery is at-least-once, so duplicates are within contract.
+
+Considered and not taken: starting the live subscription before the replay and buffering its events until handover, so the cursor stays active and never ages out. That removes the oplog-window caveat entirely, but it is a large rewrite of the handover and its position-storage and lifecycle handling, for a rare edge. Capturing the token early restores correctness with a contained change, and the buffering design remains the upgrade path if the oplog-window caveat ever bites in practice.

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -91,6 +91,13 @@ import static org.occurrent.time.internal.RFC3339.RFC_3339_DATE_TIME_FORMATTER;
  * For this to work, the subscription must store the subscription position in a {@link SubscriptionPositionStorage} implementation periodically. It's possible to configure
  * how often this should happen in the {@link CatchupSubscriptionModelConfig}.
  * </p>
+ * <br>
+ * <p>
+ * In DCB mode the live resume token is captured before the bulk replay, so an event that commits during the replay is still
+ * delivered through the live change stream. The trade-off is that a replay running longer than the change stream history
+ * (the MongoDB oplog window) makes the token age out, and the handover then fails loudly rather than silently dropping
+ * events. Size the oplog for very large DCB rebuilds.
+ * </p>
  */
 @NullMarked
 public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSubscriptionModel {

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -484,19 +484,20 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         SubscriptionPosition subscriptionPosition = ((StartAtSubscriptionPosition) Objects.requireNonNull(nextStartAt)).subscriptionPosition;
         long startPosition = DcbSubscriptionPosition.dcbPositionOf(subscriptionPosition);
 
+        // Capture the live resume token before the bulk replay, not after, so an event that commits during the replay
+        // is still delivered by the live change stream. The reconciliation below only scans forward, so on its own it
+        // would miss a low position that becomes visible late. Trade-off: on a replay longer than the change stream
+        // history the token ages out and the handover fails loudly instead of silently dropping that event.
+        Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
+        StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
+        final SubscriptionPosition globalSubscriptionPosition = delegatedStartAt == null ? null : subscriptionModel.globalSubscriptionPosition();
+
         // Bulk replay: page through the DCB sequence from the resume position up to the head observed at the start, in
         // position windows so a large rebuild does not materialize the whole matched set at once. dcbposition is
         // monotonic and server-assigned, so this needs no count and no time sort, sidestepping both the clock-skew loss
         // and the estimatedDocumentCount undercount that the stream delta has to defend against (see ADR 20).
         long bulkHead = dcbEventStore.read(query, DcbReadOptions.between(startPosition, startPosition)).lastSequencePosition();
         long cursor = deliverDcbWindows(dcbEventStore, query, startPosition, bulkHead, windowSize, subscriptionId, action, null);
-
-        // Capture the live resume position *after* the bulk replay so the change-stream token stays fresh, the same
-        // reason as the stream path: a token captured before a long replay could age out of the change stream before
-        // the handover.
-        Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
-        StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
-        final SubscriptionPosition globalSubscriptionPosition = delegatedStartAt == null ? null : subscriptionModel.globalSubscriptionPosition();
 
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -21,6 +21,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.cloudevents.CloudEvent;
+import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -32,13 +33,19 @@ import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
 import org.occurrent.domain.DomainEvent;
 import org.occurrent.domain.NameDefined;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStore;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.Subscription;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionPositionStorage;
 import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
@@ -55,6 +62,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -62,6 +72,8 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
 import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
 import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPositionStorageConfig.useSubscriptionPositionStorage;
@@ -95,13 +107,16 @@ class DcbCatchupSubscriptionModelMongoTest {
     private CatchupSubscriptionModel subscription;
     private CloudEventConverter<DomainEvent> cloudEventConverter;
     private MongoClient mongoClient;
+    private MongoTemplate mongoTemplate;
+    private String eventCollectionName;
     private LocalDateTime time;
 
     @BeforeEach
     void create_instances() {
         ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events");
         mongoClient = MongoClients.create(connectionString);
-        MongoTemplate mongoTemplate = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        mongoTemplate = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        eventCollectionName = requireNonNull(connectionString.getCollection());
         MongoTransactionManager mongoTransactionManager = new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
         TimeRepresentation timeRepresentation = TimeRepresentation.RFC_3339_STRING;
         EventStoreConfig eventStoreConfig = new EventStoreConfig.Builder()
@@ -158,6 +173,110 @@ class DcbCatchupSubscriptionModelMongoTest {
             assertThat(received).containsExactly(historic1, historic2, live1, live2);
             assertThat(received).doesNotHaveDuplicates();
         });
+    }
+
+    @Test
+    void recovers_a_dcb_event_that_was_in_flight_below_the_replay_head_when_it_commits_during_catchup() {
+        // Five matching events occupy a contiguous DCB run; the middle one stands in for an in-flight, below-head hole.
+        NameDefined name1 = nameDefined("name1");
+        NameDefined name2 = nameDefined("name2");
+        NameDefined hole = nameDefined("hole");
+        NameDefined name4 = nameDefined("name4");
+        NameDefined name5 = nameDefined("name5");
+        appendTagged("name:1", name1);
+        appendTagged("name:1", name2);
+        appendTagged("name:1", hole);
+        appendTagged("name:1", name4);
+        appendTagged("name:1", name5);
+
+        // Simulate the middle event being in-flight (its dcbposition reserved outside the commit transaction) while the
+        // replay scans its window: remove its document so the replay cannot see it, while the later events keep the
+        // store head above it. Re-inserting it during the replay models the in-flight append finally committing.
+        Document holeDocument = requireNonNull(mongoTemplate.findOne(query(where("id").is(hole.eventId())), Document.class, eventCollectionName));
+        mongoTemplate.remove(query(where("id").is(hole.eventId())), eventCollectionName);
+
+        CountDownLatch bulkReadReached = new CountDownLatch(1);
+        CountDownLatch holeCommitted = new CountDownLatch(1);
+        DcbEventStore blockingDuringBulkReplay = new BlockingOnFirstWindowRead(eventStore, bulkReadReached, holeCommitted);
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        // A whole-range window forces a single bulk read that the wrapper can hold open across the hole's commit.
+        subscription = new CatchupSubscriptionModel(subscriptionModel, blockingDuringBulkReplay, DcbQuery.tagsAllOf("name:1"),
+                new CatchupSubscriptionModelConfig(100, useSubscriptionPositionStorage(storage).andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1))
+                        .dcbCatchupPositionWindowSize(1_000_000_000L));
+
+        // The catch-up runs asynchronously and blocks inside the bulk replay read, after it has read a snapshot that
+        // excludes the removed event.
+        Subscription handle = subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(0)), toDomainEvents(received));
+
+        // While the replay is blocked (it has scanned past the hole without seeing it and has not captured any
+        // post-replay token), commit the in-flight event by re-inserting its document, then let the replay finish.
+        awaitLatch(bulkReadReached);
+        mongoTemplate.insert(holeDocument, eventCollectionName);
+        holeCommitted.countDown();
+
+        handle.waitUntilStarted();
+
+        // The hole, committed during the replay at a below-head position, is recovered through the live change stream
+        // because the resume token was captured before the replay. With a post-replay token it would be lost.
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+                assertThat(received).containsExactlyInAnyOrder(name1, name2, hole, name4, name5));
+        assertThat(received).doesNotHaveDuplicates();
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch reached in time").isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Delegates to a real {@link DcbEventStore} but blocks inside the first windowed bulk-replay read until the test
+     * signals, after the read has captured its snapshot. Holding the replay open lets the test commit an in-flight,
+     * below-head event mid-replay and exercise the catch-up to live handover deterministically.
+     */
+    private static final class BlockingOnFirstWindowRead implements DcbEventStore {
+        private final DcbEventStore delegate;
+        private final CountDownLatch bulkReadReached;
+        private final CountDownLatch proceed;
+        private final AtomicBoolean blockedOnce = new AtomicBoolean(false);
+
+        private BlockingOnFirstWindowRead(DcbEventStore delegate, CountDownLatch bulkReadReached, CountDownLatch proceed) {
+            this.delegate = delegate;
+            this.bulkReadReached = bulkReadReached;
+            this.proceed = proceed;
+        }
+
+        @Override
+        public DcbEventStream read(DcbQuery query, DcbReadOptions options) {
+            DcbEventStream result = delegate.read(query, options);
+            boolean windowRead = options.afterSequencePosition().isPresent() && options.upToSequencePosition().isPresent()
+                    && options.afterSequencePosition().getAsLong() != options.upToSequencePosition().getAsLong();
+            if (windowRead && blockedOnce.compareAndSet(false, true)) {
+                bulkReadReached.countDown();
+                try {
+                    // Bounded so a test failure before the latch is counted down cannot hang this thread indefinitely.
+                    proceed.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public DcbAppendResult append(List<CloudEvent> events) {
+            return delegate.append(events);
+        }
+
+        @Override
+        public DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition) {
+            return delegate.append(events, condition);
+        }
     }
 
     private NameDefined nameDefined(String name) {


### PR DESCRIPTION
This fixes a silent event loss in the DCB catch-up subscription.

Since ADR 21 an append reserves its `dcbposition` before it commits, so the store head can run ahead of committed data and a position below the head can be an in-flight hole. If a matching event held such a position and committed while a catch-up replay was running, it fell through every path: the replay had already scanned past it, the reconciliation only scans forward, and the live change stream resumed from a token captured after the replay, so the token sat past the commit. Nothing delivered it, which breaks the at-least-once contract a read model rebuild relies on.

The fix captures the live resume token before the replay instead of after, so the commit-ordered change stream carries the late commit on handover and the existing cache dedups the overlap. ADR 28 records the reasoning and the one trade-off: on a rebuild longer than the change stream history the token can age out, so the handover fails loudly rather than dropping events, which beats a silent loss.

One honest caveat. I could not run the Mongo-backed tests locally, the change stream harness on my machine is not delivering independent of this change (the pre-existing catch-up test fails the same way with the fix reverted). The new test holds the bulk read open with a latch while it commits a below-head hole, so it separates the fixed behavior from the old one, but I am relying on CI to actually validate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/dcb-subscription-annotation","parentHead":"ffd75cba4865e0bba426e6fa53d576e660e0d2c1","parentPull":227,"trunk":"main"}
```
-->
