### PR TITLE
Extract shared Mongo DCB code into a dedicated module

### DIFF
--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/EventStoreCapability.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/EventStoreCapability.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package org.occurrent.eventstore.mongodb.spring.blocking;
+package org.occurrent.eventstore.api;
 
 /**
- * Selects which event-store APIs and MongoDB support structures a {@link SpringMongoEventStore} should enable.
+ * Selects which event-store APIs and supporting storage structures an event store should enable.
  * <p>
- * Capabilities control indexes, support collections, and fail-fast guards. They do not change the stored CloudEvent format.
+ * Capabilities control indexes, support collections, and fail-fast guards. They do not change the stored CloudEvent
+ * format. A store that supports both modes can enable both capabilities at once.
  */
-public enum SpringMongoEventStoreCapability {
+public enum EventStoreCapability {
     /**
      * Enables stream-based event-store reads, writes, queries, and operations.
      */

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
@@ -38,14 +38,6 @@ import static org.occurrent.time.internal.RFC3339.RFC_3339_DATE_TIME_FORMATTER;
  * into a MongoDB {@link Document} and vice versa.
  */
 public class OccurrentCloudEventMongoDocumentMapper {
-    /**
-     * The name of the indexed array field that holds an event's DCB tags in the stored MongoDB document, kept alongside
-     * the newline-joined {@code dcbtags} CloudEvent extension so that tag containment can be queried with {@code $all}.
-     * This is the storage contract shared between the event store, which writes it, and a DCB subscription, which
-     * matches a change stream against it.
-     */
-    public static final String DCB_TAGS_INDEX_FIELD = "dcbTags";
-    private static final String DCB_POSITION = "dcbposition";
 
     public static Document convertToDocument(TimeRepresentation timeRepresentation, String streamId, long streamVersion, CloudEvent cloudEvent) {
         Document cloudEventDocument = DocumentCloudEventWriter.toDocument(cloudEvent);
@@ -77,8 +69,6 @@ public class OccurrentCloudEventMongoDocumentMapper {
     public static CloudEvent convertToCloudEvent(TimeRepresentation timeRepresentation, Document cloudEventDocument) {
         Document document = new Document(cloudEventDocument);
         document.remove("_id");
-        document.remove(DCB_TAGS_INDEX_FIELD);
-        Object dcbPosition = document.remove(DCB_POSITION);
 
         if (timeRepresentation == DATE) {
             Object time = document.get("time"); // Be a bit nice and don't enforce Date here if TimeRepresentation has been changed
@@ -92,14 +82,6 @@ public class OccurrentCloudEventMongoDocumentMapper {
 
         CloudEvent cloudEvent = DocumentCloudEventReader.toCloudEvent(document);
         // When converting to JSON (document.toJson()) the stream version is interpreted as an int in Jackson, we convert it manually to long afterwards.
-        CloudEventBuilder cloudEventBuilder = CloudEventBuilder.v1(cloudEvent).withExtension(OccurrentCloudEventExtension.STREAM_VERSION, document.getLong(OccurrentCloudEventExtension.STREAM_VERSION));
-        if (dcbPosition instanceof Number number) {
-            cloudEventBuilder.withExtension(DCB_POSITION, number.longValue());
-        } else if (dcbPosition instanceof String string) {
-            cloudEventBuilder.withExtension(DCB_POSITION, Long.parseLong(string));
-        } else if (dcbPosition != null) {
-            throw new IllegalStateException("Expected " + DCB_POSITION + " to be a Number or String but was " + dcbPosition.getClass().getName());
-        }
-        return cloudEventBuilder.build();
+        return CloudEventBuilder.v1(cloudEvent).withExtension(OccurrentCloudEventExtension.STREAM_VERSION, document.getLong(OccurrentCloudEventExtension.STREAM_VERSION)).build();
     }
 }

--- a/eventstore/mongodb/dcb-common/pom.xml
+++ b/eventstore/mongodb/dcb-common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2020 Johan Haleby
+  ~ Copyright 2026 Johan Haleby
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>subscription-mongodb-common</artifactId>
         <groupId>org.occurrent</groupId>
+        <artifactId>eventstore-mongodb</artifactId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>subscription-mongodb-base</artifactId>
+    <artifactId>eventstore-mongodb-dcb-common</artifactId>
 
     <name>${mavenProjectName}</name>
 
@@ -34,9 +34,8 @@
             <artifactId>mongodb-driver-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.occurrent</groupId>
-            <artifactId>subscription-core</artifactId>
-            <version>${project.version}</version>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
@@ -45,12 +44,12 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
-            <artifactId>eventstore-mongodb-dcb-common</artifactId>
+            <artifactId>eventstore-api-dcb</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
-            <artifactId>eventstore-api-dcb</artifactId>
+            <artifactId>mongodb-timerepresentation</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -63,6 +62,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbDocumentMapper.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbDocumentMapper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.dcb.internal;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.Document;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+
+import java.util.ArrayList;
+
+/**
+ * Maps DCB events between a {@link CloudEvent} and a MongoDB {@link Document}. It wraps the stream-only
+ * {@link OccurrentCloudEventMongoDocumentMapper} and adds the DCB storage fields the stream mapper does not know about.
+ * This is the single home for the DCB storage contract shared between the event store, which writes the fields, and a
+ * DCB subscription, which matches a change stream against them.
+ */
+@NullMarked
+public final class DcbDocumentMapper {
+
+    /**
+     * The name of the indexed array field that holds an event's DCB tags in the stored MongoDB document, kept alongside
+     * the newline-joined {@code dcbtags} CloudEvent extension so that tag containment can be queried with {@code $all}.
+     */
+    public static final String DCB_TAGS_INDEX_FIELD = "dcbTags";
+
+    private DcbDocumentMapper() {
+    }
+
+    /**
+     * Converts a DCB CloudEvent to a stored document, adding the DCB position field and the indexed tags array on top of
+     * the stream document the common mapper produces.
+     */
+    public static Document toDocument(TimeRepresentation timeRepresentation, String streamId, long streamVersion, CloudEvent dcbCloudEvent, long position) {
+        Document document = OccurrentCloudEventMongoDocumentMapper.convertToDocument(timeRepresentation, streamId, streamVersion, dcbCloudEvent);
+        document.put(DcbCloudEvents.POSITION, position);
+        document.put(DCB_TAGS_INDEX_FIELD, new ArrayList<>(DcbCloudEvents.getTags(dcbCloudEvent)));
+        return document;
+    }
+
+    /**
+     * Converts a stored document back to a CloudEvent. The DCB index fields are stripped before delegating to the
+     * stream mapper, and the DCB position is reattached as a CloudEvent extension. A plain stream document carries
+     * neither field, so this also handles stream events and is safe as the single deserialization point for both.
+     */
+    public static CloudEvent toCloudEvent(TimeRepresentation timeRepresentation, Document cloudEventDocument) {
+        Object dcbPosition = cloudEventDocument.get(DcbCloudEvents.POSITION);
+        Document stripped = new Document(cloudEventDocument);
+        stripped.remove(DCB_TAGS_INDEX_FIELD);
+        stripped.remove(DcbCloudEvents.POSITION);
+
+        CloudEvent cloudEvent = OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent(timeRepresentation, stripped);
+        if (dcbPosition == null) {
+            return cloudEvent;
+        }
+
+        CloudEventBuilder cloudEventBuilder = CloudEventBuilder.v1(cloudEvent);
+        if (dcbPosition instanceof Number number) {
+            cloudEventBuilder.withExtension(DcbCloudEvents.POSITION, number.longValue());
+        } else if (dcbPosition instanceof String string) {
+            cloudEventBuilder.withExtension(DcbCloudEvents.POSITION, Long.parseLong(string));
+        } else {
+            throw new IllegalStateException("Expected " + DcbCloudEvents.POSITION + " to be a Number or String but was " + dcbPosition.getClass().getName());
+        }
+        return cloudEventBuilder.build();
+    }
+}

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.dcb.internal;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbQueryItem;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The driver-agnostic DCB marker model and storage contract shared by the MongoDB event stores. It derives the conflict
+ * markers a query and an append touch, names the support collections and documents, and validates and canonicalizes DCB
+ * events. Keeping this in one place is what guarantees the two MongoDB stores write the same on-disk contract, which the
+ * optimistic-concurrency check depends on.
+ */
+@NullMarked
+public final class DcbMarkerModel {
+
+    public static final String DCB_POSITION_DOCUMENT_ID = "dcb";
+    public static final String DCB_COUNTER_POSITION = "position";
+    public static final String CHECKPOINT_LAST_POSITION = "lastPosition";
+    public static final String CHECKPOINT_VERSION = "version";
+
+    private static final String MARKER_ID_PREFIX = "marker:";
+    private static final String POSITION_COLLECTION_SUFFIX = "_dcb_position";
+    private static final String CHECKPOINT_COLLECTION_SUFFIX = "_dcb_checkpoints";
+
+    private DcbMarkerModel() {
+    }
+
+    public static String positionCollectionName(String eventStoreCollectionName) {
+        return eventStoreCollectionName + POSITION_COLLECTION_SUFFIX;
+    }
+
+    public static String checkpointCollectionName(String eventStoreCollectionName) {
+        return eventStoreCollectionName + CHECKPOINT_COLLECTION_SUFFIX;
+    }
+
+    public static String markerId(String key) {
+        return MARKER_ID_PREFIX + key;
+    }
+
+    public static Set<String> queryMarkerKeys(DcbQuery query) {
+        if (query instanceof DcbQuery.MatchAll) {
+            return Set.of("all");
+        }
+        // Decompose into one key per attribute (a key per tag, a key per type) and NEVER combine them into a single
+        // "type:X+tag:t" key. Skew-safety (ADR 0021) depends on this: a conflicting event shares a marker via whichever
+        // single attribute made it match, and a combined key would share nothing with an event that carries only one
+        // of the attributes through a different query.
+        TreeSet<String> keys = new TreeSet<>();
+        for (DcbQueryItem item : dcbQueryItems(query)) {
+            item.tags().forEach(tag -> keys.add("tag:" + tag));
+            item.types().forEach(type -> keys.add("type:" + type));
+        }
+        return keys;
+    }
+
+    // A query here is either a single DcbQueryItem alternative or an Items list (MatchAll is handled by the callers).
+    public static List<DcbQueryItem> dcbQueryItems(DcbQuery query) {
+        if (query instanceof DcbQueryItem item) {
+            return List.of(item);
+        }
+        return ((DcbQuery.Items) query).items();
+    }
+
+    public static Set<String> eventMarkerKeys(List<CloudEvent> events) {
+        TreeSet<String> keys = new TreeSet<>();
+        for (CloudEvent event : events) {
+            DcbCloudEvents.getTags(event).forEach(tag -> keys.add("tag:" + tag));
+            keys.add("type:" + event.getType());
+        }
+        return keys;
+    }
+
+    public static Set<String> boundaryTagsOf(List<CloudEvent> events) {
+        return events.stream().flatMap(event -> DcbCloudEvents.getTags(event).stream()).collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    public static List<CloudEvent> validateDcbEvents(List<CloudEvent> events) {
+        requireNonNull(events, "Events cannot be null");
+        List<CloudEvent> copy = List.copyOf(events);
+        if (copy.isEmpty()) {
+            throw new IllegalArgumentException("Events cannot be empty");
+        }
+        return copy.stream()
+                .map(event -> DcbCloudEvents.withTags(event, DcbCloudEvents.getTags(event)))
+                .toList();
+    }
+}

--- a/eventstore/mongodb/pom.xml
+++ b/eventstore/mongodb/pom.xml
@@ -30,6 +30,7 @@
     <modules>
         <module>native</module>
         <module>common</module>
+        <module>dcb-common</module>
         <module>spring</module>
     </modules>
 </project>

--- a/eventstore/mongodb/spring/blocking/pom.xml
+++ b/eventstore/mongodb/spring/blocking/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-dcb-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>mongodb-spring-filter-query-conversion</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
@@ -18,6 +18,7 @@ package org.occurrent.eventstore.mongodb.spring.blocking;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
 import org.occurrent.eventstore.api.dcb.PartitionedDcbStreamIdGenerator;
@@ -35,7 +36,7 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Configuration for the blocking Spring java driver for MongoDB EventStore
@@ -44,14 +45,14 @@ import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventS
 public class EventStoreConfig {
     private static final Function<Query, Query> DEFAULT_QUERY_OPTIONS_FUNCTION = Function.identity();
     private static final Function<Query, Query> DEFAULT_READ_OPTIONS_FUNCTION = Function.identity();
-    private static final Set<SpringMongoEventStoreCapability> DEFAULT_EVENT_STORE_CAPABILITIES = Set.of(STREAM);
+    private static final Set<EventStoreCapability> DEFAULT_EVENT_STORE_CAPABILITIES = Set.of(STREAM);
 
     public final String eventStoreCollectionName;
     public final TransactionTemplate transactionTemplate;
     public final TimeRepresentation timeRepresentation;
     public final Function<Query, Query> queryOptions;
     public final Function<Query, Query> readOptions;
-    public final Set<SpringMongoEventStoreCapability> eventStoreCapabilities;
+    public final Set<EventStoreCapability> eventStoreCapabilities;
     public final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
@@ -65,7 +66,7 @@ public class EventStoreConfig {
         this(eventStoreCollectionName, transactionTemplate, timeRepresentation, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_READ_OPTIONS_FUNCTION, DEFAULT_EVENT_STORE_CAPABILITIES, new PartitionedDcbStreamIdGenerator());
     }
 
-    private EventStoreConfig(String eventStoreCollectionName, TransactionTemplate transactionTemplate, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions, Set<SpringMongoEventStoreCapability> eventStoreCapabilities, DcbStreamIdGenerator dcbStreamIdGenerator) {
+    private EventStoreConfig(String eventStoreCollectionName, TransactionTemplate transactionTemplate, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions, Set<EventStoreCapability> eventStoreCapabilities, DcbStreamIdGenerator dcbStreamIdGenerator) {
         requireNonNull(eventStoreCollectionName, "Event store collection name cannot be null");
         requireNonNull(transactionTemplate, TransactionTemplate.class.getSimpleName() + " cannot be null");
         requireNonNull(timeRepresentation, TimeRepresentation.class.getSimpleName() + " cannot be null");
@@ -117,7 +118,7 @@ public class EventStoreConfig {
         private TimeRepresentation timeRepresentation;
         private Function<Query, Query> queryOptions = DEFAULT_QUERY_OPTIONS_FUNCTION;
         private Function<Query, Query> readOptions = DEFAULT_READ_OPTIONS_FUNCTION;
-        private Set<SpringMongoEventStoreCapability> eventStoreCapabilities = DEFAULT_EVENT_STORE_CAPABILITIES;
+        private Set<EventStoreCapability> eventStoreCapabilities = DEFAULT_EVENT_STORE_CAPABILITIES;
         private DcbStreamIdGenerator dcbStreamIdGenerator = new PartitionedDcbStreamIdGenerator();
 
         /**
@@ -196,14 +197,14 @@ public class EventStoreConfig {
         /**
          * Select the event-store capabilities that should be enabled for this store.
          * <p>
-         * The default is {@link SpringMongoEventStoreCapability#STREAM}. Add {@link SpringMongoEventStoreCapability#DCB}
+         * The default is {@link EventStoreCapability#STREAM}. Add {@link EventStoreCapability#DCB}
          * to enable Dynamic Consistency Boundary indexes, support collections, and API operations.
          *
          * @param eventStoreCapabilities The non-empty capability set to enable.
          * @return The same {@code Builder} instance.
          */
         @NullMarked
-        public Builder eventStoreCapabilities(Set<SpringMongoEventStoreCapability> eventStoreCapabilities) {
+        public Builder eventStoreCapabilities(Set<EventStoreCapability> eventStoreCapabilities) {
             requireNonNull(eventStoreCapabilities, "Event store capabilities cannot be null");
             if (eventStoreCapabilities.isEmpty()) {
                 throw new IllegalArgumentException("Event store capabilities cannot be empty");
@@ -223,10 +224,10 @@ public class EventStoreConfig {
          * @return The same {@code Builder} instance.
          */
         @NullMarked
-        public Builder eventStoreCapabilities(SpringMongoEventStoreCapability eventStoreCapability, SpringMongoEventStoreCapability... additionalEventStoreCapabilities) {
+        public Builder eventStoreCapabilities(EventStoreCapability eventStoreCapability, EventStoreCapability... additionalEventStoreCapabilities) {
             requireNonNull(eventStoreCapability, "Event store capability cannot be null");
             requireNonNull(additionalEventStoreCapabilities, "Additional event store capabilities cannot be null");
-            Set<SpringMongoEventStoreCapability> capabilities = new LinkedHashSet<>();
+            Set<EventStoreCapability> capabilities = new LinkedHashSet<>();
             capabilities.add(eventStoreCapability);
             Arrays.stream(additionalEventStoreCapabilities)
                     .map(capability -> requireNonNull(capability, "Event store capability cannot be null"))

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -34,6 +34,8 @@ import org.occurrent.eventstore.api.blocking.*;
 import org.occurrent.eventstore.api.dcb.*;
 import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
 import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbMarkerModel;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
 import org.occurrent.eventstore.mongodb.internal.StreamVersionDiff;
 import org.occurrent.filter.Filter;
@@ -65,11 +67,10 @@ import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
-import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD;
-import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper.DCB_TAGS_INDEX_FIELD;
 import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToDocument;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
 import static org.occurrent.functionalsupport.internal.FunctionalSupport.autoClose;
 import static org.occurrent.functionalsupport.internal.FunctionalSupport.mapWithIndex;
 import static org.occurrent.mongodb.spring.sortconversion.internal.SortConverter.convertToSpringSort;
@@ -90,10 +91,6 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class SpringMongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter, DcbEventStore {
 
     private static final String ID = "_id";
-    private static final String DCB_POSITION_DOCUMENT_ID = "dcb";
-    private static final String DCB_COUNTER_POSITION = "position";
-    private static final String CHECKPOINT_LAST_POSITION = "lastPosition";
-    private static final String CHECKPOINT_VERSION = "version";
 
     private final MongoTemplate mongoTemplate;
     private final String eventStoreCollectionName;
@@ -103,7 +100,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     private final TransactionTemplate transactionTemplate;
     private final Function<Query, Query> queryOptions;
     private final Function<Query, Query> readOptions;
-    private final Set<SpringMongoEventStoreCapability> eventStoreCapabilities;
+    private final Set<EventStoreCapability> eventStoreCapabilities;
     private final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
@@ -117,8 +114,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireNonNull(config, EventStoreConfig.class.getSimpleName() + " cannot be null");
         this.mongoTemplate = mongoTemplate;
         this.eventStoreCollectionName = config.eventStoreCollectionName;
-        this.dcbPositionCollectionName = eventStoreCollectionName + "_dcb_position";
-        this.dcbCheckpointCollectionName = eventStoreCollectionName + "_dcb_checkpoints";
+        this.dcbPositionCollectionName = DcbMarkerModel.positionCollectionName(eventStoreCollectionName);
+        this.dcbCheckpointCollectionName = DcbMarkerModel.checkpointCollectionName(eventStoreCollectionName);
         this.transactionTemplate = config.transactionTemplate;
         this.timeRepresentation = config.timeRepresentation;
         this.queryOptions = config.queryOptions;
@@ -132,7 +129,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     public EventStream<CloudEvent> read(String streamId, int skip, int limit) {
         requireStreamCapability();
         final EventStream<Document> eventStream = readEventStream(streamId, null, skip, limit);
-        return requireNonNull(eventStream).map(document -> convertToCloudEvent(timeRepresentation, document));
+        return requireNonNull(eventStream).map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -204,7 +201,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound);
         mongoQuery.with(Sort.by(Sort.Direction.ASC, DcbCloudEvents.POSITION));
         List<CloudEvent> events = mongoTemplate.find(queryOptions.apply(mongoQuery), Document.class, eventStoreCollectionName).stream()
-                .map(document -> convertToCloudEvent(timeRepresentation, document))
+                .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document))
                 .toList();
         return new DcbEventStream(events, highWatermark, DcbConsistencyToken.of(consistencyTokenValue));
     }
@@ -302,7 +299,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
                 return Optional.empty();
             }
 
-            CloudEvent currentCloudEvent = convertToCloudEvent(timeRepresentation, document);
+            CloudEvent currentCloudEvent = DcbDocumentMapper.toCloudEvent(timeRepresentation, document);
             CloudEvent updatedCloudEvent = fn.apply(currentCloudEvent);
             if (updatedCloudEvent == null) {
                 throw new IllegalArgumentException("Cloud event update function is not allowed to return null");
@@ -327,7 +324,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireNonNull(sortBy, SortBy.class.getSimpleName() + " cannot be null");
         final Query query = queryOptions.apply(FilterConverter.convertFilterToQuery(timeRepresentation, filter));
         return readCloudEvents(query, skip, limit, sortBy)
-                .map(document -> convertToCloudEvent(timeRepresentation, document));
+                .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     @Override
@@ -347,12 +344,12 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
-        List<CloudEvent> eventsToAppend = validateDcbEvents(events);
+        List<CloudEvent> eventsToAppend = DcbMarkerModel.validateDcbEvents(events);
         // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
         // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
         // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
         Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
-        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
+        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? DcbMarkerModel.boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
 
         // Reserve the position block once, outside the transaction. The counter findAndModify is a single atomic
@@ -372,7 +369,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
                 // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
                 // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
                 // under MongoDB snapshot isolation (write skew). See ADR 0021.
-                incrementConflictMarkers(eventMarkerKeys(eventsToAppend), lastPosition);
+                incrementConflictMarkers(DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
             }
 
             List<Document> documents = convertDcbCloudEventsToDocuments(streamId, eventsToAppend, currentStreamVersion, firstPosition);
@@ -425,20 +422,13 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return false;
     }
 
-    private static Set<String> boundaryTagsOf(List<CloudEvent> events) {
-        return events.stream().flatMap(event -> DcbCloudEvents.getTags(event).stream()).collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
-    }
-
     private List<Document> convertDcbCloudEventsToDocuments(String streamId, List<CloudEvent> cloudEvents, long currentStreamVersion, long firstPosition) {
         List<Document> documents = new ArrayList<>(cloudEvents.size());
         long streamVersion = currentStreamVersion + 1;
         long position = firstPosition;
         for (CloudEvent cloudEvent : cloudEvents) {
             CloudEvent dcbCloudEvent = DcbCloudEvents.withPosition(cloudEvent, position);
-            Document document = convertToDocument(timeRepresentation, streamId, streamVersion++, dcbCloudEvent);
-            document.put(DcbCloudEvents.POSITION, position);
-            document.put(DCB_TAGS_INDEX_FIELD, new ArrayList<>(DcbCloudEvents.getTags(dcbCloudEvent)));
-            documents.add(document);
+            documents.add(DcbDocumentMapper.toDocument(timeRepresentation, streamId, streamVersion++, dcbCloudEvent, position));
             position++;
         }
         return documents;
@@ -468,8 +458,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         // force a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs this
         // check against the winner's committed increment. Always increment the query's markers so a concurrent matching
         // append is serialized even when this append's own events do not match the query.
-        java.util.TreeSet<String> markerKeys = new java.util.TreeSet<>(queryMarkerKeys(condition.query()));
-        markerKeys.addAll(eventMarkerKeys(eventsToAppend));
+        java.util.TreeSet<String> markerKeys = new java.util.TreeSet<>(DcbMarkerModel.queryMarkerKeys(condition.query()));
+        markerKeys.addAll(DcbMarkerModel.eventMarkerKeys(eventsToAppend));
         incrementConflictMarkers(markerKeys, lastPosition);
     }
 
@@ -485,8 +475,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     // own concurrency problem and out of proportion to the need today.
     private void incrementConflictMarkers(Set<String> markerKeys, long lastPosition) {
         for (String key : markerKeys) {
-            Query query = new Query(where(ID).is("marker:" + key));
-            Update update = new Update().inc(CHECKPOINT_VERSION, 1L).set(CHECKPOINT_LAST_POSITION, lastPosition);
+            Query query = new Query(where(ID).is(DcbMarkerModel.markerId(key)));
+            Update update = new Update().inc(DcbMarkerModel.CHECKPOINT_VERSION, 1L).set(DcbMarkerModel.CHECKPOINT_LAST_POSITION, lastPosition);
             mongoTemplate.upsert(query, update, dcbCheckpointCollectionName);
         }
     }
@@ -497,55 +487,22 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     // inside the append transaction (not when positions are reserved), this token reflects only committed appends and is
     // therefore immune to the read-watermark overshoot that a position-based check suffers (ADR 0021).
     private long consistencyToken(DcbQuery query) {
-        Set<String> markerKeys = queryMarkerKeys(query);
+        Set<String> markerKeys = DcbMarkerModel.queryMarkerKeys(query);
         if (markerKeys.isEmpty()) {
             return 0;
         }
         // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading them
         // one by one could tear across a concurrent append and capture a sum that matches a later state, masking a real
         // conflict (ADR 31).
-        List<String> markerIds = markerKeys.stream().map(key -> "marker:" + key).toList();
+        List<String> markerIds = markerKeys.stream().map(DcbMarkerModel::markerId).toList();
         long sum = 0;
         for (Document marker : mongoTemplate.find(new Query(where(ID).in(markerIds)), Document.class, dcbCheckpointCollectionName)) {
-            Number version = (Number) marker.get(CHECKPOINT_VERSION);
+            Number version = (Number) marker.get(DcbMarkerModel.CHECKPOINT_VERSION);
             if (version != null) {
                 sum += version.longValue();
             }
         }
         return sum;
-    }
-
-    private static Set<String> queryMarkerKeys(DcbQuery query) {
-        if (query instanceof DcbQuery.MatchAll) {
-            return Set.of("all");
-        }
-        // Decompose into one key per attribute (a key per tag, a key per type) and NEVER combine them into a single
-        // "type:X+tag:t" key. Skew-safety (ADR 0021) depends on this: a conflicting event shares a marker via whichever
-        // single attribute made it match, and a combined key would share nothing with an event that carries only one
-        // of the attributes through a different query.
-        java.util.TreeSet<String> keys = new java.util.TreeSet<>();
-        for (DcbQueryItem item : dcbQueryItems(query)) {
-            item.tags().forEach(tag -> keys.add("tag:" + tag));
-            item.types().forEach(type -> keys.add("type:" + type));
-        }
-        return keys;
-    }
-
-    // A query here is either a single DcbQueryItem alternative or an Items list (MatchAll is handled by the callers).
-    private static List<DcbQueryItem> dcbQueryItems(DcbQuery query) {
-        if (query instanceof DcbQueryItem item) {
-            return List.of(item);
-        }
-        return ((DcbQuery.Items) query).items();
-    }
-
-    private static Set<String> eventMarkerKeys(List<CloudEvent> events) {
-        java.util.TreeSet<String> keys = new java.util.TreeSet<>();
-        for (CloudEvent event : events) {
-            DcbCloudEvents.getTags(event).forEach(tag -> keys.add("tag:" + tag));
-            keys.add("type:" + event.getType());
-        }
-        return keys;
     }
 
     /**
@@ -562,29 +519,18 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
                 .maxAttempts(5)
                 .retryIf(SpringMongoEventStore::isDuplicateKeyError)
                 .execute(() -> {
-                    Query query = new Query(where(ID).is(DCB_POSITION_DOCUMENT_ID));
-                    Update update = new Update().inc(DCB_COUNTER_POSITION, eventCount);
+                    Query query = new Query(where(ID).is(DcbMarkerModel.DCB_POSITION_DOCUMENT_ID));
+                    Update update = new Update().inc(DcbMarkerModel.DCB_COUNTER_POSITION, eventCount);
                     FindAndModifyOptions options = FindAndModifyOptions.options().upsert(true).returnNew(true);
                     Document updated = mongoTemplate.findAndModify(query, update, options, Document.class, dcbPositionCollectionName);
-                    long lastPosition = ((Number) requireNonNull(updated, "DCB position document cannot be null").get(DCB_COUNTER_POSITION)).longValue();
+                    long lastPosition = ((Number) requireNonNull(updated, "DCB position document cannot be null").get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue();
                     return lastPosition - eventCount + 1;
                 });
     }
 
     private long currentDcbPosition() {
-        Document document = mongoTemplate.findById(DCB_POSITION_DOCUMENT_ID, Document.class, dcbPositionCollectionName);
-        return document == null ? 0 : ((Number) document.get(DCB_COUNTER_POSITION)).longValue();
-    }
-
-    private static List<CloudEvent> validateDcbEvents(List<CloudEvent> events) {
-        requireNonNull(events, "Events cannot be null");
-        List<CloudEvent> copy = List.copyOf(events);
-        if (copy.isEmpty()) {
-            throw new IllegalArgumentException("Events cannot be empty");
-        }
-        return copy.stream()
-                .map(event -> DcbCloudEvents.withTags(event, DcbCloudEvents.getTags(event)))
-                .toList();
+        Document document = mongoTemplate.findById(DcbMarkerModel.DCB_POSITION_DOCUMENT_ID, Document.class, dcbPositionCollectionName);
+        return document == null ? 0 : ((Number) document.get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue();
     }
 
     @Override
@@ -593,7 +539,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireNonNull(streamId, "Stream id cannot be null");
         requireNonNull(filter, "filter cannot be null");
         final EventStream<Document> eventStream = readEventStream(streamId, filter, skip, limit);
-        return requireNonNull(eventStream).map(document -> convertToCloudEvent(timeRepresentation, document));
+        return requireNonNull(eventStream).map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     @NullUnmarked
@@ -697,7 +643,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         if (query instanceof DcbQuery.MatchAll) {
             return new Query(positionCriteria);
         }
-        List<Criteria> itemCriteria = dcbQueryItems(query).stream()
+        List<Criteria> itemCriteria = DcbMarkerModel.dcbQueryItems(query).stream()
                 .map(SpringMongoEventStore::toCriteria)
                 .toList();
         return new Query(new Criteria().andOperator(positionCriteria, new Criteria().orOperator(itemCriteria)));
@@ -765,7 +711,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     // Initialization
-    private static void initializeEventStore(String eventStoreCollectionName, String dcbPositionCollectionName, String dcbCheckpointCollectionName, Set<SpringMongoEventStoreCapability> eventStoreCapabilities, MongoTemplate mongoTemplate) {
+    private static void initializeEventStore(String eventStoreCollectionName, String dcbPositionCollectionName, String dcbCheckpointCollectionName, Set<EventStoreCapability> eventStoreCapabilities, MongoTemplate mongoTemplate) {
         if (!mongoTemplate.collectionExists(eventStoreCollectionName)) {
             mongoTemplate.createCollection(eventStoreCollectionName);
         }
@@ -803,7 +749,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         requireCapability(DCB);
     }
 
-    private void requireCapability(SpringMongoEventStoreCapability capability) {
+    private void requireCapability(EventStoreCapability capability) {
         if (!eventStoreCapabilities.contains(capability)) {
             throw new UnsupportedOperationException(capability + " capability is not enabled for this SpringMongoEventStore");
         }

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreCapabilityTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreCapabilityTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.occurrent.cloudevents.OccurrentExtensionGetter;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.StreamReadFilter;
 import org.occurrent.eventstore.api.WriteCondition;
@@ -56,8 +57,8 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 @Testcontainers
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -121,10 +122,10 @@ class SpringMongoEventStoreCapabilityTest {
         assertThatThrownBy(() -> eventStoreConfig(Set.of()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Event store capabilities cannot be empty");
-        assertThatThrownBy(() -> eventStoreConfig((Set<SpringMongoEventStoreCapability>) null))
+        assertThatThrownBy(() -> eventStoreConfig((Set<EventStoreCapability>) null))
                 .isExactlyInstanceOf(NullPointerException.class)
                 .hasMessage("Event store capabilities cannot be null");
-        assertThatThrownBy(() -> eventStoreConfig(STREAM, (SpringMongoEventStoreCapability) null))
+        assertThatThrownBy(() -> eventStoreConfig(STREAM, (EventStoreCapability) null))
                 .isExactlyInstanceOf(NullPointerException.class)
                 .hasMessage("Event store capability cannot be null");
     }
@@ -296,11 +297,11 @@ class SpringMongoEventStoreCapabilityTest {
                 .hasMessage("DCB capability is not enabled for this SpringMongoEventStore");
     }
 
-    private EventStoreConfig.Builder eventStoreConfig(SpringMongoEventStoreCapability capability, SpringMongoEventStoreCapability... additionalCapabilities) {
+    private EventStoreConfig.Builder eventStoreConfig(EventStoreCapability capability, EventStoreCapability... additionalCapabilities) {
         return eventStoreConfigBuilder().eventStoreCapabilities(capability, additionalCapabilities);
     }
 
-    private EventStoreConfig.Builder eventStoreConfig(Set<SpringMongoEventStoreCapability> capabilities) {
+    private EventStoreConfig.Builder eventStoreConfig(Set<EventStoreCapability> capabilities) {
         return eventStoreConfigBuilder().eventStoreCapabilities(capabilities);
     }
 

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
@@ -60,8 +60,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.types;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Adversarial concurrency tests for the DCB write path (ADR 0021).

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbReadWatermarkTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbReadWatermarkTest.java
@@ -57,8 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Reproduction for the read-watermark overshoot lost-conflict bug (finding 2).

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -51,8 +51,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.*;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 @Testcontainers
 @DisplayNameGeneration(ReplaceUnderscores.class)

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbUnconditionalMarkerTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbUnconditionalMarkerTest.java
@@ -52,8 +52,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
 import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Regression test for the unconditional-append write-skew gap (ADR 0021).

--- a/eventstore/mongodb/spring/reactor/pom.xml
+++ b/eventstore/mongodb/spring/reactor/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-dcb-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>mongodb-spring-sort-conversion</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -37,6 +37,7 @@ import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
 import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
 import org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper;
 import org.occurrent.eventstore.mongodb.internal.StreamVersionDiff;
 import org.occurrent.filter.Filter;
@@ -247,7 +248,10 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
     }
 
     private static CloudEvent convertToCloudEvent(TimeRepresentation timeRepresentation, Document document) {
-        return OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent(timeRepresentation, document);
+        // Use the DCB-aware mapper so that DCB storage fields (dcbTags, dcbposition) are handled rather than leaked as
+        // CloudEvent extensions when this store reads a collection that a DCB-enabled store also writes to. It is a
+        // no-op for plain stream events.
+        return DcbDocumentMapper.toCloudEvent(timeRepresentation, document);
     }
 
     private static boolean isSkipOrLimitDefined(int skip, int limit) {

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -77,8 +77,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPositionStorageConfig.useSubscriptionPositionStorage;
 import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModelConfig.withConfig;
 

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentProperties.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentProperties.java
@@ -19,7 +19,7 @@ package org.occurrent.springboot.mongo.blocking;
 
 import org.occurrent.application.service.blocking.generic.GenericApplicationService;
 import org.occurrent.eventstore.api.WriteConditionNotFulfilledException;
-import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.retry.RetryStrategy;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,7 +28,7 @@ import java.net.URI;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 @ConfigurationProperties(prefix = "occurrent")
 public class OccurrentProperties {
@@ -135,10 +135,10 @@ public class OccurrentProperties {
         /**
          * The event-store capabilities to enable.
          * <p>
-         * Defaults to stream-based event sourcing. Add {@link SpringMongoEventStoreCapability#DCB}
+         * Defaults to stream-based event sourcing. Add {@link EventStoreCapability#DCB}
          * to enable Dynamic Consistency Boundary infrastructure and APIs.
          */
-        private Set<SpringMongoEventStoreCapability> capabilities = Set.of(STREAM);
+        private Set<EventStoreCapability> capabilities = Set.of(STREAM);
 
         /**
          * If the event store should be enabled (i.e. created as Spring Bean)
@@ -170,11 +170,11 @@ public class OccurrentProperties {
             this.timeRepresentation = timeRepresentation;
         }
 
-        public Set<SpringMongoEventStoreCapability> getCapabilities() {
+        public Set<EventStoreCapability> getCapabilities() {
             return capabilities;
         }
 
-        public void setCapabilities(Set<SpringMongoEventStoreCapability> capabilities) {
+        public void setCapabilities(Set<EventStoreCapability> capabilities) {
             if (capabilities == null || capabilities.isEmpty()) {
                 throw new IllegalArgumentException("occurrent.event-store.capabilities must contain at least one capability");
             }

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnDcbEventStoreCapabilityCondition.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnDcbEventStoreCapabilityCondition.java
@@ -18,7 +18,7 @@
 package org.occurrent.springboot.mongo.blocking;
 
 import org.jspecify.annotations.NonNull;
-import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Condition;
@@ -27,14 +27,14 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.util.Set;
 
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 class OnDcbEventStoreCapabilityCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
-        Set<SpringMongoEventStoreCapability> capabilities = Binder.get(context.getEnvironment())
-                .bind("occurrent.event-store.capabilities", Bindable.setOf(SpringMongoEventStoreCapability.class))
+        Set<EventStoreCapability> capabilities = Binder.get(context.getEnvironment())
+                .bind("occurrent.event-store.capabilities", Bindable.setOf(EventStoreCapability.class))
                 .orElse(Set.of(STREAM));
         return capabilities.contains(DCB);
     }

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnDomainEventQueriesCapabilityCondition.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnDomainEventQueriesCapabilityCondition.java
@@ -18,7 +18,7 @@
 package org.occurrent.springboot.mongo.blocking;
 
 import org.jspecify.annotations.NonNull;
-import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Condition;
@@ -27,14 +27,14 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.util.Set;
 
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 class OnDomainEventQueriesCapabilityCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
-        Set<SpringMongoEventStoreCapability> capabilities = Binder.get(context.getEnvironment())
-                .bind("occurrent.event-store.capabilities", Bindable.setOf(SpringMongoEventStoreCapability.class))
+        Set<EventStoreCapability> capabilities = Binder.get(context.getEnvironment())
+                .bind("occurrent.event-store.capabilities", Bindable.setOf(EventStoreCapability.class))
                 .orElse(Set.of(STREAM));
         return capabilities.contains(STREAM) || capabilities.contains(DCB);
     }

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnStreamEventStoreCapabilityCondition.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OnStreamEventStoreCapabilityCondition.java
@@ -18,7 +18,7 @@
 package org.occurrent.springboot.mongo.blocking;
 
 import org.jspecify.annotations.NonNull;
-import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Condition;
@@ -27,13 +27,13 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.util.Set;
 
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 class OnStreamEventStoreCapabilityCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
-        Set<SpringMongoEventStoreCapability> capabilities = Binder.get(context.getEnvironment())
-                .bind("occurrent.event-store.capabilities", Bindable.setOf(SpringMongoEventStoreCapability.class))
+        Set<EventStoreCapability> capabilities = Binder.get(context.getEnvironment())
+                .bind("occurrent.event-store.capabilities", Bindable.setOf(EventStoreCapability.class))
                 .orElse(Set.of(STREAM));
         return capabilities.contains(STREAM);
     }

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
@@ -30,7 +30,7 @@ import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.query.blocking.DomainEventQueries;
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
-import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.subscription.api.blocking.DelegatingSubscriptionModel;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.DurableSubscriptionModel;
@@ -74,7 +74,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
 
             OccurrentProperties properties = context.getBean(OccurrentProperties.class);
             assertThat(properties.getEventStore().getCollection()).isEqualTo("events-v2");
-            assertThat(properties.getEventStore().getCapabilities()).containsExactly(SpringMongoEventStoreCapability.STREAM);
+            assertThat(properties.getEventStore().getCapabilities()).containsExactly(EventStoreCapability.STREAM);
             assertThat(properties.getSubscription().getCollection()).isEqualTo("subscriptions-v2");
             assertThat(properties.getCloudEventConverter().getCloudEventSource()).isEqualTo(URI.create("urn:occurrent:test"));
             assertThat(properties.getApplicationService().isEnableDefaultRetryStrategy()).isFalse();
@@ -117,7 +117,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
             OccurrentProperties properties = context.getBean(OccurrentProperties.class);
 
             assertThat(properties.getEventStore().getCapabilities())
-                    .containsExactlyInAnyOrder(SpringMongoEventStoreCapability.STREAM, SpringMongoEventStoreCapability.DCB);
+                    .containsExactlyInAnyOrder(EventStoreCapability.STREAM, EventStoreCapability.DCB);
         });
     }
 
@@ -126,7 +126,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
         eventStoreConfigContextRunner().run(context -> {
             EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
 
-            assertThat(eventStoreConfig.eventStoreCapabilities).containsExactly(SpringMongoEventStoreCapability.STREAM);
+            assertThat(eventStoreConfig.eventStoreCapabilities).containsExactly(EventStoreCapability.STREAM);
         });
     }
 
@@ -138,7 +138,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
                     EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
 
                     assertThat(eventStoreConfig.eventStoreCapabilities)
-                            .containsExactlyInAnyOrder(SpringMongoEventStoreCapability.STREAM, SpringMongoEventStoreCapability.DCB);
+                            .containsExactlyInAnyOrder(EventStoreCapability.STREAM, EventStoreCapability.DCB);
                 });
     }
 
@@ -149,7 +149,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
                 .run(context -> {
                     EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
 
-                    assertThat(eventStoreConfig.eventStoreCapabilities).containsExactly(SpringMongoEventStoreCapability.DCB);
+                    assertThat(eventStoreConfig.eventStoreCapabilities).containsExactly(EventStoreCapability.DCB);
                 });
     }
 
@@ -158,7 +158,7 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
         contextRunner.withPropertyValues("occurrent.event-store.capabilities=dcb").run(context -> {
             OccurrentProperties properties = context.getBean(OccurrentProperties.class);
 
-            assertThat(properties.getEventStore().getCapabilities()).containsExactly(SpringMongoEventStoreCapability.DCB);
+            assertThat(properties.getEventStore().getCapabilities()).containsExactly(EventStoreCapability.DCB);
         });
     }
 

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
@@ -25,7 +25,7 @@ import org.occurrent.eventstore.api.dcb.DcbQueryItem;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.DCB_TAGS_INDEX_FIELD;
+import static org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper.DCB_TAGS_INDEX_FIELD;
 import static org.occurrent.subscription.mongodb.MongoFilterSpecification.FULL_DOCUMENT;
 
 /**

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCloudEventsToJsonDeserializer.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCloudEventsToJsonDeserializer.java
@@ -21,7 +21,7 @@ import com.mongodb.client.model.changestream.OperationType;
 import io.cloudevents.CloudEvent;
 import org.bson.Document;
 import org.jspecify.annotations.NullMarked;
-import org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 
 import java.util.Optional;
@@ -35,7 +35,7 @@ public class MongoCloudEventsToJsonDeserializer {
 
     public static Optional<CloudEvent> deserializeToCloudEvent(ChangeStreamDocument<Document> changeStreamDocument, TimeRepresentation timeRepresentation) {
         return changeStreamDocumentToCloudEventAsJson(changeStreamDocument)
-                .map(document -> OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent(timeRepresentation, document));
+                .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     private static Optional<Document> changeStreamDocumentToCloudEventAsJson(ChangeStreamDocument<Document> changeStreamDocument) {

--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
@@ -85,8 +85,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.occurrent.filter.Filter.all;
 import static org.occurrent.filter.Filter.id;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.subscription.mongodb.MongoFilterSpecification.MongoBsonFilterSpecification.filter;
 import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModelConfig.withConfig;
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -74,8 +74,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.DCB;
-import static org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.subscription.blocking.durable.catchup.SubscriptionPositionStorageConfig.useSubscriptionPositionStorage;
 
 /**


### PR DESCRIPTION
This is the groundwork for adding DCB to the native MongoDB driver event store. Right now the DCB logic lives inside the Spring store, so the native store cannot reach it without copying the part that must never differ between the two drivers, the marker model and the on-disk storage contract.

I pulled that shared code into a new `eventstore-mongodb-dcb-common` module:

- `DcbMarkerModel` holds the marker-key derivation, the checkpoint and position constants, the collection naming, and the DCB event validation.
- `DcbDocumentMapper` holds the DCB storage contract, the `dcbTags` index field and the `dcbposition` handling, that used to sit in the common stream mapper. The common mapper is stream-only again.

I also moved the capability set into a shared `EventStoreCapability` enum in `eventstore-api-common`, because `STREAM` and `DCB` are not Spring specific or even Mongo specific. That replaces `SpringMongoEventStoreCapability`. The Spring store, the subscription base module, and the Spring Boot starter now point at the shared types.

Nothing changes behavior. The Spring store calls the moved helpers instead of its own private copies, and no test logic changed beyond swapping the capability type. The existing Spring DCB tests, the subscription tests, and the starter tests all pass.

The next PR adds the native store DCB implementation on top of this.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
