### PR TITLE
Add DCB support to the native MongoDB driver event store

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* DCB now works on the native MongoDB driver event store, not only the Spring store.
+  * `MongoEventStore`, the plain synchronous-driver store, implements the same DCB read and append API as the Spring store, with the same per-attribute marker model and consistency-token semantics. The shared model now lives in a new `eventstore-mongodb-dcb-common` module so the two stores cannot drift on the storage contract, and the capability set moved to a shared `EventStoreCapability` enum in `eventstore-api-common`. The native store defaults to stream-only, so existing applications are untouched.
+  * See [ADR 33](doc/architecture/decisions/0033-native-mongodb-driver-dcb-parity-via-shared-marker-model.md).
+
 * DCB catch-up delivers an event even when it commits during the replay.
   * `dcbposition` is reserved before the append commits (ADR 21), so the store head can run ahead of committed data and a position below the head can be an in-flight hole. The catch-up captures the live resume token before the replay, so an event that commits at such a position while the replay runs is delivered by the live change stream, and the handover cache dedups the overlap.
   * Trade-off: a replay that runs longer than the change stream history makes the resume token age out, so the handover fails loudly rather than silently dropping events. Size the change stream history (the MongoDB oplog window) for very large rebuilds.

--- a/doc/architecture/decisions/0033-native-mongodb-driver-dcb-parity-via-shared-marker-model.md
+++ b/doc/architecture/decisions/0033-native-mongodb-driver-dcb-parity-via-shared-marker-model.md
@@ -1,0 +1,43 @@
+# 33. Native MongoDB driver DCB parity via a shared marker model
+
+Date: 2026-06-29
+
+## Status
+
+Accepted
+
+## Context
+
+DCB shipped for the in-memory store and the Spring blocking MongoDB store. The native MongoDB driver store (`MongoEventStore`) was still stream-only, so an application that uses the plain synchronous driver without Spring could not use DCB at all.
+
+The DCB write path is subtle. Its correctness rests on a per-attribute marker model and a storage contract that ADR 21 and ADR 31 describe: positions reserved outside the transaction, one version marker per tag and per type (never combined), a consistency token that sums those versions, and a single-read snapshot of the markers. Two MongoDB stores that write the same collections must agree on every part of that contract, or optimistic concurrency breaks silently.
+
+## Decision
+
+Add DCB to the native driver `MongoEventStore` so it reaches behavioral parity with the Spring blocking store, and share the parts that must not differ between the two drivers rather than copying them.
+
+### Share the marker model and storage contract
+
+Extract the driver-agnostic DCB code into a new `eventstore-mongodb-dcb-common` module:
+
+- `DcbMarkerModel` owns the marker-key derivation, the checkpoint and position field constants, the support-collection naming, and DCB event validation.
+- `DcbDocumentMapper` owns the DCB storage contract, the `dcbTags` index array and the `dcbposition` field, and the DCB-aware document-to-CloudEvent conversion. The stream-only common mapper no longer knows about DCB.
+
+Both Mongo stores depend on this module, so the on-disk contract has a single source of truth. The same module backs the DCB subscription code, which also reads the `dcbTags` field and deserializes DCB events.
+
+### Reimplement the orchestration per driver
+
+The read and append orchestration stays per store, because it is tied to each driver's API. The native store uses `ClientSession.withTransaction`, the synchronous driver's `Bson` filters, and `findOneAndUpdate` for the position counter, where the Spring store uses `MongoTemplate`, `Criteria`, and `TransactionTemplate`. The native store mirrors the Spring semantics: positions reserved outside the transaction, marker versions bumped inside it, the token-sum conflict check for a token-carrying condition and a live-existence check otherwise, and the same partition placement by boundary tags. A shared abstraction over these two driver APIs would be more complex than the two concrete versions, so the orchestration is not shared.
+
+The one driver difference worth noting is retry. The synchronous driver's `withTransaction` already retries a `TransientTransactionError` and re-runs the body, which re-evaluates the condition. The Spring `TransactionTemplate` does not, which is why the Spring store wraps the transaction in an explicit retry. The native store keeps a thin retry too, mainly for the cold-start duplicate-key race on a marker or the position counter, which is not labeled transient and so is not retried by `withTransaction`.
+
+### Share the capability vocabulary
+
+The event-store capability set (`STREAM`, `DCB`) moved into a shared `EventStoreCapability` enum in `eventstore-api-common`, replacing the Spring-specific enum, because a capability is neither Spring nor Mongo specific. The native `EventStoreConfig` gains the same capability set and `DcbStreamIdGenerator` the Spring config already had, defaulting to stream-only so existing native applications are untouched.
+
+## Consequences
+
+- The native driver store supports DCB with the same guarantees and the same token semantics as the Spring store. Tokens stay opaque and are still not comparable across stores.
+- The marker model and storage contract cannot drift between the two Mongo stores, because they share one copy.
+- The native store now creates the DCB support collections and indexes when the DCB capability is enabled, and gates each method by capability.
+- The high-cardinality marker growth noted in ADR 21 applies to the native store as well, since it shares the same marker model. Nothing reclaims markers automatically.

--- a/eventstore/mongodb/native/pom.xml
+++ b/eventstore/mongodb/native/pom.xml
@@ -41,6 +41,16 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-dcb-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>mongodb-native-filter-bsonfilter-conversion</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
@@ -24,11 +24,20 @@ import org.bson.conversions.Bson;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
+import org.occurrent.eventstore.api.EventStoreCapability;
+import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
+import org.occurrent.eventstore.api.dcb.PartitionedDcbStreamIdGenerator;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Configuration for the synchronous java driver MongoDB EventStore
@@ -36,10 +45,13 @@ import java.util.function.Function;
 @NullMarked
 public class EventStoreConfig {
     private static final Function<FindIterable<Document>, FindIterable<Document>> DEFAULT_QUERY_OPTIONS_FUNCTION = Function.identity();
+    private static final Set<EventStoreCapability> DEFAULT_EVENT_STORE_CAPABILITIES = Set.of(STREAM);
 
     public final TransactionOptions transactionOptions;
     public final TimeRepresentation timeRepresentation;
     public final Function<FindIterable<Document>, FindIterable<Document>> queryOptions;
+    public final Set<EventStoreCapability> eventStoreCapabilities;
+    public final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create an {@link EventStoreConfig} indicating to the event store that it should represent time according to the supplied
@@ -64,14 +76,21 @@ public class EventStoreConfig {
      * @see TimeRepresentation
      */
     public EventStoreConfig(TimeRepresentation timeRepresentation, @Nullable TransactionOptions transactionOptions) {
-        this(timeRepresentation, transactionOptions, DEFAULT_QUERY_OPTIONS_FUNCTION);
+        this(timeRepresentation, transactionOptions, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_EVENT_STORE_CAPABILITIES, new PartitionedDcbStreamIdGenerator());
     }
 
-    private EventStoreConfig(TimeRepresentation timeRepresentation, @Nullable TransactionOptions transactionOptions, Function<FindIterable<Document>, FindIterable<Document>> queryOptions) {
+    private EventStoreConfig(TimeRepresentation timeRepresentation, @Nullable TransactionOptions transactionOptions, Function<FindIterable<Document>, FindIterable<Document>> queryOptions, Set<EventStoreCapability> eventStoreCapabilities, DcbStreamIdGenerator dcbStreamIdGenerator) {
         Objects.requireNonNull(timeRepresentation, "Time representation cannot be null");
+        requireNonNull(eventStoreCapabilities, "Event store capabilities cannot be null");
+        if (eventStoreCapabilities.isEmpty()) {
+            throw new IllegalArgumentException("Event store capabilities cannot be empty");
+        }
+        requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
         this.transactionOptions = Objects.requireNonNullElseGet(transactionOptions, () -> TransactionOptions.builder().build());
         this.timeRepresentation = timeRepresentation;
         this.queryOptions = queryOptions;
+        this.eventStoreCapabilities = Set.copyOf(eventStoreCapabilities);
+        this.dcbStreamIdGenerator = dcbStreamIdGenerator;
     }
 
     @Override
@@ -79,12 +98,12 @@ public class EventStoreConfig {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig)) return false;
         EventStoreConfig that = (EventStoreConfig) o;
-        return Objects.equals(transactionOptions, that.transactionOptions) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions);
+        return Objects.equals(transactionOptions, that.transactionOptions) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(transactionOptions, timeRepresentation, queryOptions);
+        return Objects.hash(transactionOptions, timeRepresentation, queryOptions, eventStoreCapabilities, dcbStreamIdGenerator);
     }
 
     @Override
@@ -93,6 +112,8 @@ public class EventStoreConfig {
                 .add("transactionOptions=" + transactionOptions)
                 .add("timeRepresentation=" + timeRepresentation)
                 .add("queryOptions=" + queryOptions)
+                .add("eventStoreCapabilities=" + eventStoreCapabilities)
+                .add("dcbStreamIdGenerator=" + dcbStreamIdGenerator)
                 .toString();
     }
 
@@ -101,6 +122,8 @@ public class EventStoreConfig {
         private TransactionOptions transactionOptions;
         private TimeRepresentation timeRepresentation;
         private Function<FindIterable<Document>, FindIterable<Document>> queryOptions = DEFAULT_QUERY_OPTIONS_FUNCTION;
+        private Set<EventStoreCapability> eventStoreCapabilities = DEFAULT_EVENT_STORE_CAPABILITIES;
+        private DcbStreamIdGenerator dcbStreamIdGenerator = new PartitionedDcbStreamIdGenerator();
 
         /**
          * @param transactionOptions The default {@link TransactionOptions} that the event store will use when starting transactions. May be <code>null</code>.
@@ -138,9 +161,62 @@ public class EventStoreConfig {
             return this;
         }
 
+        /**
+         * Select the event-store capabilities that should be enabled for this store.
+         * <p>
+         * The default is {@link EventStoreCapability#STREAM}. Add {@link EventStoreCapability#DCB} to enable Dynamic
+         * Consistency Boundary reads and appends, or enable both at once.
+         *
+         * @param eventStoreCapabilities The non-empty capability set to enable.
+         * @return The same {@code Builder} instance.
+         */
+        @NullMarked
+        public Builder eventStoreCapabilities(Set<EventStoreCapability> eventStoreCapabilities) {
+            requireNonNull(eventStoreCapabilities, "Event store capabilities cannot be null");
+            if (eventStoreCapabilities.isEmpty()) {
+                throw new IllegalArgumentException("Event store capabilities cannot be empty");
+            }
+            this.eventStoreCapabilities = Set.copyOf(eventStoreCapabilities);
+            return this;
+        }
+
+        /**
+         * Select the event-store capabilities that should be enabled for this store.
+         * <p>
+         * This vararg form is convenient when composing capabilities, for example
+         * {@code eventStoreCapabilities(STREAM, DCB)}.
+         *
+         * @param eventStoreCapability            The first capability to enable.
+         * @param additionalEventStoreCapabilities Additional capabilities to enable.
+         * @return The same {@code Builder} instance.
+         */
+        @NullMarked
+        public Builder eventStoreCapabilities(EventStoreCapability eventStoreCapability, EventStoreCapability... additionalEventStoreCapabilities) {
+            requireNonNull(eventStoreCapability, "Event store capability cannot be null");
+            requireNonNull(additionalEventStoreCapabilities, "Additional event store capabilities cannot be null");
+            Set<EventStoreCapability> capabilities = new LinkedHashSet<>();
+            capabilities.add(eventStoreCapability);
+            Stream.of(additionalEventStoreCapabilities)
+                    .map(capability -> requireNonNull(capability, "Event store capability cannot be null"))
+                    .forEach(capabilities::add);
+            return eventStoreCapabilities(capabilities);
+        }
+
+        /**
+         * Configure how the storage stream id is derived from a DCB append's boundary tags.
+         *
+         * @param dcbStreamIdGenerator The generator that derives the storage stream id from the events' DCB tags.
+         * @return The same {@code Builder} instance.
+         */
+        @NullMarked
+        public Builder dcbStreamIdGenerator(DcbStreamIdGenerator dcbStreamIdGenerator) {
+            this.dcbStreamIdGenerator = requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
+            return this;
+        }
+
         @NullMarked
         public EventStoreConfig build() {
-            return new EventStoreConfig(timeRepresentation, transactionOptions, queryOptions);
+            return new EventStoreConfig(timeRepresentation, transactionOptions, queryOptions, eventStoreCapabilities, dcbStreamIdGenerator);
         }
     }
 }

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -534,9 +534,14 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     private static boolean isDuplicateKeyError(Throwable throwable) {
         // A cold-marker race can surface the duplicate key wrapped rather than at the top, so walk the cause chain the
-        // same bounded way as the transient-transaction check.
+        // same bounded way as the transient-transaction check. A DuplicateCloudEventException is a genuine business
+        // error (an event whose id and source already exist), not the cold-start race, and the driver duplicate-key
+        // exception is its cause, so stop and do not retry once it appears in the chain.
         Throwable cause = throwable;
         for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof DuplicateCloudEventException) {
+                return false;
+            }
             if (cause instanceof MongoBulkWriteException bulkWriteException) {
                 boolean duplicate = bulkWriteException.getWriteErrors().stream()
                         .anyMatch(writeError -> ErrorCategory.fromErrorCode(writeError.getCode()) == ErrorCategory.DUPLICATE_KEY);

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -16,13 +16,19 @@
 
 package org.occurrent.eventstore.mongodb.nativedriver;
 
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoException;
 import com.mongodb.TransactionOptions;
 import com.mongodb.client.*;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.UpdateResult;
 import io.cloudevents.CloudEvent;
 import org.bson.Document;
@@ -37,19 +43,26 @@ import org.occurrent.eventstore.api.blocking.EventStoreOperations;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.blocking.EventStream;
 import org.occurrent.eventstore.api.blocking.ReadEventStreamWithFilter;
+import org.occurrent.eventstore.api.dcb.*;
 import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
 import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbMarkerModel;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
 import org.occurrent.eventstore.mongodb.internal.StreamVersionDiff;
 import org.occurrent.filter.Filter;
 import org.occurrent.mongodb.spring.filterbsonfilterconversion.internal.FilterToBsonFilterConverter;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.retry.Backoff;
 import org.occurrent.retry.RetryStrategy;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -62,29 +75,40 @@ import static com.mongodb.client.model.Sorts.descending;
 import static java.util.Objects.requireNonNull;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.eventstore.api.SortBy.*;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
 import static org.occurrent.eventstore.api.WriteCondition.StreamVersionWriteCondition;
 import static org.occurrent.eventstore.api.WriteCondition.anyStreamVersion;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
-import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToCloudEvent;
 import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToDocument;
 import static org.occurrent.functionalsupport.internal.FunctionalSupport.mapWithIndex;
 
 /**
  * This is an {@link EventStore} that stores events in MongoDB using the "native" synchronous java driver MongoDB.
  * It also supports the {@link EventStoreOperations} and {@link EventStoreQueries} contracts.
+ * <p>
+ * By default, only stream-based event-store operations are enabled. Configure
+ * {@link EventStoreConfig.Builder#eventStoreCapabilities(Set)} to enable DCB, or to enable both stream and DCB
+ * operations. Occurrent creates missing indexes for enabled capabilities, but it never removes indexes automatically.
+ * For large production collections, create new indexes out-of-band before enabling a new capability.
  */
 @NullMarked
-public class MongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter {
+public class MongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter, DcbEventStore {
     private static final String ID = "_id";
     private static final String NATURAL = "$natural";
 
+    private final MongoDatabase database;
     private final MongoCollection<Document> eventCollection;
+    private final MongoCollection<Document> dcbPositionCollection;
+    private final MongoCollection<Document> dcbCheckpointCollection;
     private final MongoClient mongoClient;
     private final TimeRepresentation timeRepresentation;
     private final TransactionOptions transactionOptions;
     private final Function<FindIterable<Document>, FindIterable<Document>> queryOptions;
+    private final Set<EventStoreCapability> eventStoreCapabilities;
+    private final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create a new instance of {@code MongoEventStore}
@@ -114,25 +138,33 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         requireNonNull(eventCollection, "Event collection must be defined");
         requireNonNull(config, EventStoreConfig.class.getSimpleName() + " cannot be null");
         this.mongoClient = mongoClient;
+        this.database = database;
         this.eventCollection = eventCollection;
+        String eventCollectionName = eventCollection.getNamespace().getCollectionName();
+        this.dcbPositionCollection = database.getCollection(DcbMarkerModel.positionCollectionName(eventCollectionName));
+        this.dcbCheckpointCollection = database.getCollection(DcbMarkerModel.checkpointCollectionName(eventCollectionName));
         transactionOptions = config.transactionOptions;
         this.timeRepresentation = config.timeRepresentation;
         this.queryOptions = config.queryOptions;
-        initializeEventStore(eventCollection, database);
+        this.eventStoreCapabilities = config.eventStoreCapabilities;
+        this.dcbStreamIdGenerator = config.dcbStreamIdGenerator;
+        initializeEventStore(eventCollection, database, eventStoreCapabilities, dcbPositionCollection.getNamespace().getCollectionName(), dcbCheckpointCollection.getNamespace().getCollectionName());
     }
 
     @Override
     public EventStream<CloudEvent> read(String streamId, int skip, int limit) {
+        requireStreamCapability();
         EventStream<Document> eventStream = readEventStream(streamId, null, skip, limit);
-        return eventStream.map(document -> convertToCloudEvent(timeRepresentation, document));
+        return eventStream.map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     @Override
     public EventStream<CloudEvent> read(String streamId, StreamReadFilter filter, int skip, int limit) {
+        requireStreamCapability();
         requireNonNull(streamId, "Stream id cannot be null");
         requireNonNull(filter, "filter cannot be null");
         EventStream<Document> eventStream = readEventStream(streamId, filter, skip, limit);
-        return eventStream.map(document -> convertToCloudEvent(timeRepresentation, document));
+        return eventStream.map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     private EventStreamImpl<Document> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
@@ -200,6 +232,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     @Override
     public WriteResult write(String streamId, WriteCondition writeCondition, Stream<CloudEvent> events) {
+        requireStreamCapability();
         if (writeCondition == null) {
             throw new IllegalArgumentException(WriteCondition.class.getSimpleName() + " cannot be null");
         }
@@ -253,6 +286,270 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         return mapWithIndex(cloudEvents, currentStreamVersion, pair -> convertToDocument(timeRepresentation, streamId, pair.t1, pair.t2)).toList();
     }
 
+    @Override
+    public DcbEventStream read(DcbQuery query, DcbReadOptions options) {
+        requireDcbCapability();
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+
+        // Snapshot the consistency token BEFORE reading the events. If an append commits between these two reads, the
+        // events may include it while the token does not, which only makes a later conditional append over-cautious (a
+        // false conflict that retries) rather than miss the conflict.
+        long consistencyTokenValue = consistencyToken(null, query);
+        long highWatermark = currentDcbPosition();
+        long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+        Bson mongoQuery = toDcbBsonQuery(query, options.afterSequencePosition().orElse(0), upperBound);
+        FindIterable<Document> documents = eventCollection.find(mongoQuery).sort(ascending(DcbCloudEvents.POSITION));
+        List<CloudEvent> events = StreamSupport.stream(queryOptions.apply(documents).spliterator(), false)
+                .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document))
+                .toList();
+        return new DcbEventStream(events, highWatermark, DcbConsistencyToken.of(consistencyTokenValue));
+    }
+
+    @Override
+    public DcbAppendResult append(List<CloudEvent> events) {
+        requireDcbCapability();
+        return appendDcb(events, null);
+    }
+
+    @Override
+    public DcbAppendResult append(List<CloudEvent> events, DcbAppendCondition condition) {
+        requireDcbCapability();
+        requireNonNull(condition, "Append condition cannot be null");
+        return appendDcb(events, condition);
+    }
+
+    @Override
+    public boolean exists(DcbQuery query, DcbReadOptions options) {
+        requireDcbCapability();
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return eventCollection.countDocuments(toDcbBsonQuery(query, lowerBound(options), upperBound(options))) > 0;
+    }
+
+    @Override
+    public long count(DcbQuery query, DcbReadOptions options) {
+        requireDcbCapability();
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return eventCollection.countDocuments(toDcbBsonQuery(query, lowerBound(options), upperBound(options)));
+    }
+
+    private long lowerBound(DcbReadOptions options) {
+        return options.afterSequencePosition().orElse(0);
+    }
+
+    private long upperBound(DcbReadOptions options) {
+        long highWatermark = currentDcbPosition();
+        return Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+    }
+
+    private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
+        List<CloudEvent> eventsToAppend = DcbMarkerModel.validateDcbEvents(events);
+        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
+        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
+        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
+        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? DcbMarkerModel.boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
+        String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
+
+        // Reserve the position block once, outside the transaction. The counter findAndModify is a single atomic
+        // document update that MongoDB serializes without raising a transaction conflict. The reserved block is reused
+        // across transient-transaction-error retries, a doomed or condition-failed append abandons it, so dcbposition
+        // may have gaps (DCB permits this, see ADR 0021).
+        long firstPosition = reserveDcbPositions(eventsToAppend.size());
+        long lastPosition = firstPosition + eventsToAppend.size() - 1;
+
+        return executeWithTransientRetry(() -> {
+            try (ClientSession clientSession = mongoClient.startSession()) {
+                return clientSession.withTransaction(() -> {
+                    long currentStreamVersion = currentStreamVersion(streamId, clientSession);
+                    if (condition != null) {
+                        enforceAppendCondition(clientSession, condition, eventsToAppend, lastPosition);
+                    } else {
+                        // An unconditional append still increments its events' markers so a concurrent conditional append on an
+                        // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
+                        // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
+                        // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
+                        // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                        incrementConflictMarkers(clientSession, DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
+                    }
+
+                    List<Document> documents = convertDcbCloudEventsToDocuments(streamId, eventsToAppend, currentStreamVersion, firstPosition);
+                    insertAllDcb(clientSession, streamId, currentStreamVersion, documents);
+                    return new DcbAppendResult(firstPosition, lastPosition, eventsToAppend.size());
+                }, transactionOptions);
+            }
+        });
+    }
+
+    private List<Document> convertDcbCloudEventsToDocuments(String streamId, List<CloudEvent> cloudEvents, long currentStreamVersion, long firstPosition) {
+        List<Document> documents = new ArrayList<>(cloudEvents.size());
+        long streamVersion = currentStreamVersion + 1;
+        long position = firstPosition;
+        for (CloudEvent cloudEvent : cloudEvents) {
+            CloudEvent dcbCloudEvent = DcbCloudEvents.withPosition(cloudEvent, position);
+            documents.add(DcbDocumentMapper.toDocument(timeRepresentation, streamId, streamVersion++, dcbCloudEvent, position));
+            position++;
+        }
+        return documents;
+    }
+
+    private void enforceAppendCondition(ClientSession clientSession, DcbAppendCondition condition, List<CloudEvent> eventsToAppend, long lastPosition) {
+        Optional<DcbConsistencyToken> expectedToken = condition.consistencyToken();
+        final boolean conflict;
+        if (expectedToken.isPresent()) {
+            // Token-carrying check: the condition carries the consistency token the command observed when it read the
+            // query (DcbEventStream.consistencyToken()). If the query's markers have advanced since, an append matching
+            // the query committed after the read, so the condition is not fulfilled. Unlike a position-based existence
+            // check this is immune to read-watermark overshoot, because marker versions are bumped inside the append
+            // transaction (at commit), not when positions are reserved (ADR 0021).
+            conflict = consistencyToken(clientSession, condition.query()) != expectedToken.get().value();
+        } else {
+            // No token: an absolute "fail if any matching event exists" guard. Check the live events rather than the
+            // marker versions, so this means "currently exists" (matching the in-memory store, and surviving deletes and
+            // marker pruning) rather than "ever appended". The marker increments below still serialize concurrent
+            // unconditional guards on the same boundary so two of them cannot both pass.
+            conflict = eventCollection.find(clientSession, toDcbBsonQuery(condition.query(), 0, Long.MAX_VALUE)).limit(1).first() != null;
+        }
+        if (conflict) {
+            throw new DcbAppendConditionNotFulfilledException(condition, currentDcbPosition(), "Append condition was not fulfilled.");
+        }
+        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increments
+        // force a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs this
+        // check against the winner's committed increment. Always increment the query's markers so a concurrent matching
+        // append is serialized even when this append's own events do not match the query.
+        java.util.TreeSet<String> markerKeys = new java.util.TreeSet<>(DcbMarkerModel.queryMarkerKeys(condition.query()));
+        markerKeys.addAll(DcbMarkerModel.eventMarkerKeys(eventsToAppend));
+        incrementConflictMarkers(clientSession, markerKeys, lastPosition);
+    }
+
+    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker (per
+    // ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
+    // monotonically increasing version is also the optimistic-concurrency token: a reader snapshots the versions of a
+    // query's markers (see consistencyToken), and an append fails if any of them changed since. The stored lastPosition
+    // is informational.
+    // The marker collection holds one document per distinct tag and per distinct type that has taken part in an append,
+    // and nothing reclaims them automatically, so a high-cardinality tag (a tag per entity) grows the collection without
+    // bound. An operator can prune markers during quiescence (a later append recreates any it still needs).
+    private void incrementConflictMarkers(ClientSession clientSession, Set<String> markerKeys, long lastPosition) {
+        for (String key : markerKeys) {
+            dcbCheckpointCollection.updateOne(clientSession, eq(ID, DcbMarkerModel.markerId(key)),
+                    Updates.combine(Updates.inc(DcbMarkerModel.CHECKPOINT_VERSION, 1L), Updates.set(DcbMarkerModel.CHECKPOINT_LAST_POSITION, lastPosition)),
+                    new UpdateOptions().upsert(true));
+        }
+    }
+
+    // The optimistic-concurrency token for a query: the sum of the versions of its conflict markers. The sum is
+    // monotonically increasing (every append increments at least one marker by one), so it changes if and only if some
+    // append touched at least one of the query's markers since the reader observed it. Because the versions are bumped
+    // inside the append transaction (not when positions are reserved), this token reflects only committed appends and is
+    // therefore immune to the read-watermark overshoot that a position-based check suffers (ADR 0021).
+    private long consistencyToken(@Nullable ClientSession clientSession, DcbQuery query) {
+        Set<String> markerKeys = DcbMarkerModel.queryMarkerKeys(query);
+        if (markerKeys.isEmpty()) {
+            return 0;
+        }
+        // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading them
+        // one by one could tear across a concurrent append and capture a sum that matches a later state, masking a real
+        // conflict (ADR 31).
+        List<String> markerIds = markerKeys.stream().map(DcbMarkerModel::markerId).toList();
+        Bson markerFilter = in(ID, markerIds);
+        FindIterable<Document> markers = clientSession == null ? dcbCheckpointCollection.find(markerFilter) : dcbCheckpointCollection.find(clientSession, markerFilter);
+        long sum = 0;
+        for (Document marker : markers) {
+            Number version = (Number) marker.get(DcbMarkerModel.CHECKPOINT_VERSION);
+            if (version != null) {
+                sum += version.longValue();
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * Reserves a contiguous block of {@code eventCount} DCB positions by incrementing one global counter document. Every
+     * DCB append passes through this single document, so it is a serialization point and an inherent throughput ceiling
+     * for the store as a whole under very high append rates. It is kept outside the append transaction (ADR 21) so it
+     * does not turn into transaction conflicts, but the global monotonic sequence cannot be sharded away.
+     */
+    private long reserveDcbPositions(int eventCount) {
+        // Retry the cold-start race: when the counter document does not exist yet, concurrent upserts all try to insert
+        // it and all but one get a duplicate key. On retry the document exists, so the upsert becomes an update.
+        return RetryStrategy.retry()
+                .backoff(Backoff.fixed(20))
+                .maxAttempts(5)
+                .retryIf(MongoEventStore::isDuplicateKeyError)
+                .execute(() -> {
+                    Document updated = dcbPositionCollection.findOneAndUpdate(
+                            eq(ID, DcbMarkerModel.DCB_POSITION_DOCUMENT_ID),
+                            Updates.inc(DcbMarkerModel.DCB_COUNTER_POSITION, (long) eventCount),
+                            new FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER));
+                    long lastPosition = ((Number) requireNonNull(updated, "DCB position document cannot be null").get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue();
+                    return lastPosition - eventCount + 1;
+                });
+    }
+
+    private long currentDcbPosition() {
+        Document document = dcbPositionCollection.find(eq(ID, DcbMarkerModel.DCB_POSITION_DOCUMENT_ID)).first();
+        return document == null ? 0 : ((Number) document.get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue();
+    }
+
+    private void insertAllDcb(ClientSession clientSession, String streamId, long streamVersion, List<Document> documents) {
+        try {
+            eventCollection.insertMany(clientSession, documents);
+        } catch (MongoException e) {
+            // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
+            // stream racing on stream_version) must stay transient so executeWithTransientRetry retries it, rather
+            // than being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+            if (isTransientTransactionError(e)) {
+                throw e;
+            }
+            throw translateException(new WriteContext(streamId, streamVersion, anyStreamVersion()), e);
+        }
+    }
+
+    // Retry the append transaction on a MongoDB TransientTransactionError (the error label is present when two
+    // transactions conflict, e.g. a write-write conflict on a shared marker). The native driver's withTransaction
+    // already retries a transient transaction error on its own, so at this layer the retry mainly covers the
+    // cold-marker DuplicateKeyException race where two transactions first-create the same marker at once.
+    // DcbAppendConditionNotFulfilledException is deliberately NOT retried here: it propagates to the application
+    // service, which re-reads and retries the whole command.
+    private static <T> T executeWithTransientRetry(Supplier<T> action) {
+        return RetryStrategy.exponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(500), 2.0f)
+                .maxAttempts(15)
+                .retryIf(throwable -> isTransientTransactionError(throwable) || isDuplicateKeyError(throwable))
+                .execute(action);
+    }
+
+    private static boolean isTransientTransactionError(Throwable throwable) {
+        // Bounded walk so a cyclic cause chain (self-cause or a longer A -> B -> A cycle) cannot spin forever.
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof MongoException mongoException && mongoException.hasErrorLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDuplicateKeyError(Throwable throwable) {
+        // A cold-marker race can surface the duplicate key wrapped rather than at the top, so walk the cause chain the
+        // same bounded way as the transient-transaction check.
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof MongoBulkWriteException bulkWriteException) {
+                boolean duplicate = bulkWriteException.getWriteErrors().stream()
+                        .anyMatch(writeError -> ErrorCategory.fromErrorCode(writeError.getCode()) == ErrorCategory.DUPLICATE_KEY);
+                if (duplicate) {
+                    return true;
+                }
+            } else if (cause instanceof MongoException mongoException && mongoException.getCode() == 11000) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean isFulfilled(long currentStreamVersion, WriteCondition writeCondition) {
         if (writeCondition.isAnyStreamVersion()) {
             return true;
@@ -268,21 +565,25 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     @Override
     public boolean exists(String streamId) {
+        requireStreamCapability();
         return eventCollection.countDocuments(eq(STREAM_ID, streamId)) > 0;
     }
 
     @Override
     public void deleteEventStream(String streamId) {
+        requireStreamCapability();
         eventCollection.deleteMany(eq(STREAM_ID, streamId));
     }
 
     @Override
     public void deleteEvent(String cloudEventId, URI cloudEventSource) {
+        requireStreamCapability();
         eventCollection.deleteOne(uniqueCloudEvent(cloudEventId, cloudEventSource));
     }
 
     @Override
     public void delete(Filter filter) {
+        requireStreamCapability();
         requireNonNull(filter, "Filter cannot be null");
         final Bson bson = FilterToBsonFilterConverter.convertFilterToBsonFilter(timeRepresentation, filter);
         eventCollection.deleteMany(bson);
@@ -290,6 +591,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     @Override
     public Optional<CloudEvent> updateEvent(String cloudEventId, URI cloudEventSource, Function<CloudEvent, CloudEvent> updateFunction) {
+        requireStreamCapability();
         requireNonNull(updateFunction, "Update function cannot be null");
 
         Bson cloudEvent = uniqueCloudEvent(cloudEventId, cloudEventSource);
@@ -307,7 +609,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         if (document == null) {
             return Optional.empty();
         } else {
-            CloudEvent currentCloudEvent = convertToCloudEvent(timeRepresentation, document);
+            CloudEvent currentCloudEvent = DcbDocumentMapper.toCloudEvent(timeRepresentation, document);
             CloudEvent updatedCloudEvent = fn.apply(currentCloudEvent);
             if (updatedCloudEvent == null) {
                 throw new IllegalArgumentException("Cloud event update function is not allowed to return null");
@@ -324,14 +626,16 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     @Override
     public Stream<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        requireStreamCapability();
         requireNonNull(filter, "Filter cannot be null");
         final Bson query = FilterToBsonFilterConverter.convertFilterToBsonFilter(timeRepresentation, filter);
         return readCloudEvents(query, skip, limit, sortBy)
-                .map(document -> convertToCloudEvent(timeRepresentation, document));
+                .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document));
     }
 
     @Override
     public long count(Filter filter) {
+        requireStreamCapability();
         requireNonNull(filter, "Filter cannot be null");
         if (filter instanceof Filter.All) {
             return eventCollection.estimatedDocumentCount();
@@ -343,6 +647,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     @Override
     public boolean exists(Filter filter) {
+        requireStreamCapability();
         requireNonNull(filter, "Filter cannot be null");
         return count(filter) > 0;
     }
@@ -350,16 +655,30 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
     private record EventStreamImpl<T>(String id, long version, Stream<T> events) implements EventStream<T> {
     }
 
-    private static void initializeEventStore(MongoCollection<Document> eventStoreCollection, MongoDatabase mongoDatabase) {
+    private static void initializeEventStore(MongoCollection<Document> eventStoreCollection, MongoDatabase mongoDatabase, Set<EventStoreCapability> eventStoreCapabilities, String dcbPositionCollectionName, String dcbCheckpointCollectionName) {
         String eventStoreCollectionName = eventStoreCollection.getNamespace().getCollectionName();
         if (!collectionExists(mongoDatabase, eventStoreCollectionName)) {
             mongoDatabase.createCollection(eventStoreCollectionName);
         }
+        boolean dcbEnabled = eventStoreCapabilities.contains(DCB);
+        if (dcbEnabled && !collectionExists(mongoDatabase, dcbPositionCollectionName)) {
+            mongoDatabase.createCollection(dcbPositionCollectionName);
+        }
+        if (dcbEnabled && !collectionExists(mongoDatabase, dcbCheckpointCollectionName)) {
+            mongoDatabase.createCollection(dcbCheckpointCollectionName);
+        }
+
         // Cloud spec defines id + source must be unique!
         eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true));
-        // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
-        // Note also that this index supports when sorting both ascending and descending since MongoDB can traverse an index in both directions.
-        eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), new IndexOptions().unique(true));
+        if (eventStoreCapabilities.contains(STREAM)) {
+            // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
+            // Note also that this index supports when sorting both ascending and descending since MongoDB can traverse an index in both directions.
+            eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), new IndexOptions().unique(true));
+        }
+        if (dcbEnabled) {
+            eventStoreCollection.createIndex(Indexes.ascending(DcbCloudEvents.POSITION), new IndexOptions().unique(true).sparse(true));
+            eventStoreCollection.createIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD));
+        }
     }
 
     private static boolean collectionExists(MongoDatabase mongoDatabase, String collectionName) {
@@ -371,12 +690,51 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         return false;
     }
 
+    private void requireStreamCapability() {
+        requireCapability(STREAM);
+    }
+
+    private void requireDcbCapability() {
+        requireCapability(DCB);
+    }
+
+    private void requireCapability(EventStoreCapability capability) {
+        if (!eventStoreCapabilities.contains(capability)) {
+            throw new UnsupportedOperationException(capability + " capability is not enabled for this MongoEventStore");
+        }
+    }
+
     private static Bson streamIdEqualTo(String streamId) {
         return eq(STREAM_ID, streamId);
     }
 
     private static Bson streamIdAndStreamVersionLessThanOrEqualTo(String streamId, long version) {
         return and(streamIdEqualTo(streamId), lte(STREAM_VERSION, version));
+    }
+
+    private static Bson toDcbBsonQuery(DcbQuery query, long afterSequencePosition, long upperSequencePosition) {
+        Bson positionFilter = and(gt(DcbCloudEvents.POSITION, afterSequencePosition), lte(DcbCloudEvents.POSITION, upperSequencePosition));
+        if (query instanceof DcbQuery.MatchAll) {
+            return positionFilter;
+        }
+        List<Bson> itemFilters = DcbMarkerModel.dcbQueryItems(query).stream()
+                .map(MongoEventStore::toBsonFilter)
+                .toList();
+        return and(positionFilter, or(itemFilters));
+    }
+
+    private static Bson toBsonFilter(DcbQueryItem item) {
+        List<Bson> filters = new ArrayList<>();
+        if (!item.types().isEmpty()) {
+            filters.add(in("type", item.types()));
+        }
+        if (!item.excludedTypes().isEmpty()) {
+            filters.add(nin("type", item.excludedTypes()));
+        }
+        if (!item.tags().isEmpty()) {
+            filters.add(com.mongodb.client.model.Filters.all(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD, item.tags()));
+        }
+        return and(filters);
     }
 
     private static Bson uniqueCloudEvent(String cloudEventId, URI cloudEventSource) {

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreCapabilityTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreCapabilityTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.nativedriver;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.cloudevents.OccurrentExtensionGetter;
+import org.occurrent.eventstore.api.EventStoreCapability;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import org.occurrent.eventstore.api.WriteCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.filter.Filter;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MongoEventStoreCapabilityTest {
+
+    private static final String EVENT_COLLECTION = "events";
+    private static final String CLOUD_EVENT_ID_SOURCE_INDEX = "id_1_source_1";
+    private static final String STREAM_INDEX = "streamid_1_streamversion_1";
+    private static final String DCB_POSITION_INDEX = "dcbposition_1";
+    private static final String DCB_TAGS_INDEX = "dcbTags_1";
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                .withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".capabilities"));
+
+    private MongoClient mongoClient;
+    private String databaseName;
+
+    @BeforeEach
+    void create_mongo_client() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".capabilities");
+        mongoClient = MongoClients.create(connectionString);
+        databaseName = requireNonNull(connectionString.getDatabase());
+    }
+
+    @AfterEach
+    void close_mongo_client() {
+        mongoClient.close();
+    }
+
+    @Test
+    void event_store_config_defaults_to_stream_capability() {
+        EventStoreConfig config = eventStoreConfig(STREAM).build();
+        EventStoreConfig defaultConfig = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .build();
+
+        assertThat(defaultConfig.eventStoreCapabilities).containsExactly(STREAM);
+        assertThat(config.eventStoreCapabilities).containsExactly(STREAM);
+    }
+
+    @Test
+    void event_store_config_accepts_set_and_vararg_capabilities() {
+        EventStoreConfig dcbOnly = eventStoreConfig(Set.of(DCB)).build();
+        EventStoreConfig streamAndDcb = eventStoreConfig(STREAM, DCB).build();
+
+        assertThat(dcbOnly.eventStoreCapabilities).containsExactly(DCB);
+        assertThat(streamAndDcb.eventStoreCapabilities).containsExactlyInAnyOrder(STREAM, DCB);
+    }
+
+    @Test
+    void event_store_config_rejects_empty_and_null_capabilities() {
+        assertThatThrownBy(() -> eventStoreConfig(Set.of()))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Event store capabilities cannot be empty");
+        assertThatThrownBy(() -> eventStoreConfig((Set<EventStoreCapability>) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("Event store capabilities cannot be null");
+        assertThatThrownBy(() -> eventStoreConfig(STREAM, (EventStoreCapability) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("Event store capability cannot be null");
+    }
+
+    @Test
+    void stream_capability_initializes_only_stream_indexes() {
+        newEventStore(eventStoreConfig(STREAM).build());
+
+        assertThat(indexNames()).contains(STREAM_INDEX);
+        assertThat(indexNames()).doesNotContain(DCB_POSITION_INDEX, DCB_TAGS_INDEX);
+        assertThat(index(CLOUD_EVENT_ID_SOURCE_INDEX))
+                .containsEntry("key", new Document("id", 1).append("source", 1))
+                .containsEntry("unique", true);
+        assertThat(index(STREAM_INDEX))
+                .containsEntry("key", new Document("streamid", 1).append("streamversion", 1))
+                .containsEntry("unique", true);
+        assertThat(collectionExists(EVENT_COLLECTION + "_dcb_position")).isFalse();
+        assertThat(collectionExists(EVENT_COLLECTION + "_dcb_checkpoints")).isFalse();
+    }
+
+    @Test
+    void dcb_capability_initializes_only_dcb_indexes_and_support_collections() {
+        newEventStore(eventStoreConfig(DCB).build());
+
+        assertThat(indexNames()).contains(DCB_POSITION_INDEX, DCB_TAGS_INDEX);
+        assertThat(indexNames()).doesNotContain(STREAM_INDEX);
+        assertThat(index(CLOUD_EVENT_ID_SOURCE_INDEX))
+                .containsEntry("key", new Document("id", 1).append("source", 1))
+                .containsEntry("unique", true);
+        assertThat(index(DCB_POSITION_INDEX))
+                .containsEntry("key", new Document("dcbposition", 1))
+                .containsEntry("unique", true)
+                .containsEntry("sparse", true);
+        assertThat(index(DCB_TAGS_INDEX)).containsEntry("key", new Document("dcbTags", 1));
+        assertThat(collectionExists(EVENT_COLLECTION + "_dcb_position")).isTrue();
+        assertThat(collectionExists(EVENT_COLLECTION + "_dcb_checkpoints")).isTrue();
+    }
+
+    @Test
+    void stream_and_dcb_capabilities_initialize_both_index_sets() {
+        newEventStore(eventStoreConfig(STREAM, DCB).build());
+
+        assertThat(indexNames()).contains(STREAM_INDEX, DCB_POSITION_INDEX, DCB_TAGS_INDEX);
+    }
+
+    @Test
+    void dcb_operations_fail_without_dcb_capability() {
+        MongoEventStore eventStore = newEventStore(eventStoreConfig(STREAM).build());
+
+        assertUnsupportedDcbOperation(() -> eventStore.read(tags("name:1")));
+        assertUnsupportedDcbOperation(() -> eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))));
+        assertUnsupportedDcbOperation(() -> eventStore.append(List.of(taggedEvent("NameDefined", "name:1")), DcbAppendCondition.failIfEventsMatch(tags("name:1"))));
+    }
+
+    @Test
+    void stream_operations_fail_without_stream_capability() {
+        MongoEventStore eventStore = newEventStore(eventStoreConfig(DCB).build());
+
+        assertUnsupportedStreamOperation(() -> eventStore.write("name:1", WriteCondition.anyStreamVersion(), java.util.stream.Stream.of(event("NameDefined"))));
+        assertUnsupportedStreamOperation(() -> eventStore.read("name:1"));
+        assertUnsupportedStreamOperation(() -> eventStore.read("name:1", 0, 10));
+        assertUnsupportedStreamOperation(() -> eventStore.read("name:1", StreamReadFilter.type("NameDefined"), 0, 10));
+        assertUnsupportedStreamOperation(() -> eventStore.exists("name:1"));
+        assertUnsupportedStreamOperation(() -> eventStore.exists(Filter.all()));
+        assertUnsupportedStreamOperation(() -> eventStore.deleteEventStream("name:1"));
+        assertUnsupportedStreamOperation(() -> eventStore.deleteEvent("event:1", URI.create("urn:test")));
+        assertUnsupportedStreamOperation(() -> eventStore.delete(Filter.all()));
+        assertUnsupportedStreamOperation(() -> eventStore.updateEvent("event:1", URI.create("urn:test"), cloudEvent -> cloudEvent));
+        assertUnsupportedStreamOperation(() -> eventStore.query(Filter.all(), 0, 10, SortBy.unsorted()));
+        assertUnsupportedStreamOperation(() -> eventStore.count(Filter.all()));
+    }
+
+    @Test
+    void both_stream_and_dcb_operations_work_when_both_capabilities_are_enabled() {
+        MongoEventStore eventStore = newEventStore(eventStoreConfig(STREAM, DCB).build());
+
+        eventStore.write("name:1", WriteCondition.anyStreamVersion(), java.util.stream.Stream.of(event("NameDefined")));
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+
+        assertThat(eventStore.read("name:1").events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
+        assertThat(eventStore.read(tags("name:1")).events()).extracting(CloudEvent::getType).containsExactly("NameChanged");
+    }
+
+    @Test
+    void dcb_only_events_still_have_occurrent_stream_metadata() {
+        MongoEventStore dcbOnly = newEventStore(eventStoreConfig(DCB).build());
+        dcbOnly.append(List.of(taggedEvent("NameDefined", "name:1"), taggedEvent("NameChanged", "name:1")));
+
+        List<CloudEvent> events = dcbOnly.read(tags("name:1")).events();
+
+        assertThat(events).hasSize(2);
+        assertThat(events).extracting(OccurrentExtensionGetter::getStreamId).allSatisfy(streamId -> assertThat(streamId).startsWith("dcb:partition:"));
+        assertThat(OccurrentExtensionGetter.getStreamId(events.get(0))).isEqualTo(OccurrentExtensionGetter.getStreamId(events.get(1)));
+        assertThat(events).extracting(OccurrentExtensionGetter::getStreamVersion).containsExactly(1L, 2L);
+    }
+
+    @Test
+    void dcb_events_are_readable_through_the_stream_api_by_their_derived_partition_stream() {
+        MongoEventStore both = newEventStore(eventStoreConfig(STREAM, DCB).build());
+        both.append(List.of(taggedEvent("NameDefined", "name:1")));
+        both.append(List.of(taggedEvent("OrderPlaced", "order:1")));
+
+        assertThat(both.read(tags("name:1")).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
+        assertThat(both.read(tags("order:1")).events()).extracting(CloudEvent::getType).containsExactly("OrderPlaced");
+
+        String nameStreamId = OccurrentExtensionGetter.getStreamId(both.read(tags("name:1")).events().get(0));
+        String orderStreamId = OccurrentExtensionGetter.getStreamId(both.read(tags("order:1")).events().get(0));
+        assertThat(nameStreamId).startsWith("dcb:partition:");
+        assertThat(orderStreamId).startsWith("dcb:partition:");
+        assertThat(both.read(nameStreamId).events()).extracting(CloudEvent::getType).contains("NameDefined");
+        assertThat(both.read(orderStreamId).events()).extracting(CloudEvent::getType).contains("OrderPlaced");
+    }
+
+    private MongoEventStore newEventStore(EventStoreConfig config) {
+        return new MongoEventStore(mongoClient, databaseName, EVENT_COLLECTION, config);
+    }
+
+    private List<String> indexNames() {
+        return StreamSupport.stream(mongoClient.getDatabase(databaseName).getCollection(EVENT_COLLECTION).listIndexes(Document.class).spliterator(), false)
+                .map(index -> index.getString("name"))
+                .toList();
+    }
+
+    private Document index(String name) {
+        return StreamSupport.stream(mongoClient.getDatabase(databaseName).getCollection(EVENT_COLLECTION).listIndexes(Document.class).spliterator(), false)
+                .filter(index -> name.equals(index.getString("name")))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private boolean collectionExists(String collectionName) {
+        for (String name : mongoClient.getDatabase(databaseName).listCollectionNames()) {
+            if (name.equals(collectionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void assertUnsupportedStreamOperation(ThrowingCallable operation) {
+        assertThatThrownBy(operation)
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("STREAM capability is not enabled for this MongoEventStore");
+    }
+
+    private static void assertUnsupportedDcbOperation(ThrowingCallable operation) {
+        assertThatThrownBy(operation)
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("DCB capability is not enabled for this MongoEventStore");
+    }
+
+    private EventStoreConfig.Builder eventStoreConfig(EventStoreCapability capability, EventStoreCapability... additionalCapabilities) {
+        return eventStoreConfigBuilder().eventStoreCapabilities(capability, additionalCapabilities);
+    }
+
+    private EventStoreConfig.Builder eventStoreConfig(Set<EventStoreCapability> capabilities) {
+        return eventStoreConfigBuilder().eventStoreCapabilities(capabilities);
+    }
+
+    private EventStoreConfig.Builder eventStoreConfigBuilder() {
+        return new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING);
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("urn:test"))
+                .withType(type)
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
@@ -1,0 +1,644 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.nativedriver;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.dcb.*;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.types;
+
+/**
+ * Adversarial concurrency tests for the native driver DCB write path (ADR 0021).
+ * <p>
+ * Each scenario drives real threads to a barrier so appends race in earnest. Assertions focus on safety invariants:
+ * write-skew is NEVER permitted (never two concurrent conflicting successes), and
+ * DcbAppendConditionNotFulfilledException is the only loser exception (transient errors must be retried internally).
+ */
+@Testcontainers
+@Timeout(180)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MongoEventStoreDcbConcurrencyTest {
+
+    private static final URI SOURCE = URI.create("urn:test:concurrency");
+    private static final int ITERATIONS = 50;
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                .withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(
+            new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_concurrency"));
+
+    private MongoEventStore eventStore;
+    private MongoClient mongoClient;
+    private String databaseName;
+    private static final String COLLECTION = "events";
+
+    @BeforeEach
+    void create_mongo_native_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_concurrency");
+        mongoClient = MongoClients.create(connectionString);
+        databaseName = requireNonNull(connectionString.getDatabase());
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new MongoEventStore(mongoClient, databaseName, COLLECTION, config);
+    }
+
+    @AfterEach
+    void close_mongo_client() {
+        mongoClient.close();
+    }
+
+    @Test
+    void type_vs_tag_write_skew_is_prevented() throws Exception {
+        AtomicLong streamCounter = new AtomicLong(0);
+        MongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        int successes = 0;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String type = "TypeX_" + i;
+            String tag = "tag-x-" + i;
+
+            DcbEventStream boundaryA = isolatedStore.read(types(type));
+            DcbEventStream boundaryB = isolatedStore.read(tags(tag));
+            DcbConsistencyToken tokenA = boundaryA.consistencyToken();
+            DcbConsistencyToken tokenB = boundaryB.consistencyToken();
+
+            DcbAppendCondition condA = failIfEventsMatch(types(type), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(tags(tag), tokenB);
+
+            CloudEvent eventA = taggedEvent(type, tag);
+            CloudEvent eventB = taggedEvent(type, tag);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventA), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventB), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both appends succeeded (type-vs-tag write skew)", i)
+                    .isLessThanOrEqualTo(1);
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+
+            if (aSucceeded || bSucceeded) successes++;
+        }
+
+        assertThat(successes).isEqualTo(ITERATIONS);
+    }
+
+    @Test
+    void tag_vs_tag_write_skew_is_prevented() throws Exception {
+        AtomicLong streamCounter = new AtomicLong(0);
+        MongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String sharedTag = "shared-tag-" + i;
+            String extraTagA = "extra-a-" + i;
+
+            DcbConsistencyToken tokenA = isolatedStore.read(tags(sharedTag)).consistencyToken();
+            DcbConsistencyToken tokenB = isolatedStore.read(tags(sharedTag, extraTagA)).consistencyToken();
+
+            DcbAppendCondition condA = failIfEventsMatch(tags(sharedTag), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(tags(sharedTag, extraTagA), tokenB);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent("SomeType", sharedTag, extraTagA)), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent("SomeType", sharedTag, extraTagA)), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both tag-vs-tag appends succeeded (write skew)", i)
+                    .isLessThanOrEqualTo(1);
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither tag-vs-tag append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    @Test
+    void type_vs_type_write_skew_is_prevented() throws Exception {
+        AtomicLong streamCounter = new AtomicLong(0);
+        MongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:stream:" + streamCounter.getAndIncrement());
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String sharedType = "SharedType_" + i;
+            String tag = "tt-tag-" + i;
+
+            DcbConsistencyToken tokenA = isolatedStore.read(types(sharedType)).consistencyToken();
+            DcbConsistencyToken tokenB = isolatedStore.read(types(sharedType)).consistencyToken();
+
+            DcbAppendCondition condA = failIfEventsMatch(types(sharedType), tokenA);
+            DcbAppendCondition condB = failIfEventsMatch(types(sharedType), tokenB);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent(sharedType, tag)), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(taggedEvent(sharedType, tag)), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both type-vs-type appends succeeded (write skew)", i)
+                    .isLessThanOrEqualTo(1);
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither type-vs-type append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    @Test
+    void same_boundary_serialization_under_contention() throws Exception {
+        int threadCount = 8;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String tag = "contention-" + i;
+
+            DcbConsistencyToken boundaryToken = eventStore.read(tags(tag)).consistencyToken();
+            DcbAppendCondition condition = failIfEventsMatch(tags(tag), boundaryToken);
+
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger condFailCount = new AtomicInteger(0);
+            AtomicInteger unexpectedFailCount = new AtomicInteger(0);
+            List<Future<Void>> futures = new ArrayList<>();
+
+            final int iteration = i;
+            for (int t = 0; t < threadCount; t++) {
+                final int threadIdx = t;
+                futures.add(pool.submit(() -> {
+                    barrier.await();
+                    try {
+                        eventStore.append(List.of(taggedEvent("SomeEvent", tag)), condition);
+                        successCount.incrementAndGet();
+                    } catch (DcbAppendConditionNotFulfilledException e) {
+                        condFailCount.incrementAndGet();
+                    } catch (Exception e) {
+                        unexpectedFailCount.incrementAndGet();
+                        System.err.println("Unexpected exception in iteration " + iteration + " thread " + threadIdx + ": " + e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(successCount.get())
+                    .as("Iteration %d: expected exactly one success under contention (tag=%s)", i, tag)
+                    .isEqualTo(1);
+            assertThat(unexpectedFailCount.get())
+                    .as("Iteration %d: unexpected (non-DcbAppendConditionNotFulfilledException) failures must be zero (transient errors must be retried internally)", i)
+                    .isZero();
+            assertThat(condFailCount.get())
+                    .as("Iteration %d: expected %d DcbAppendConditionNotFulfilledException failures", i, threadCount - 1)
+                    .isEqualTo(threadCount - 1);
+        }
+    }
+
+    @Test
+    void disjoint_boundaries_do_not_falsely_serialize() throws Exception {
+        int threadCount = 8;
+
+        MongoEventStore disjointStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "disjoint:stream:" + String.join(",", new java.util.TreeSet<>(tags)));
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                final String distinctTag = "disjoint-iter" + i + "-t" + t;
+                final String distinctType = "DisjointEvent-iter" + i + "-t" + t;
+                futures.add(pool.submit(() -> {
+                    DcbConsistencyToken token = disjointStore.read(tags(distinctTag)).consistencyToken();
+                    DcbAppendCondition cond = failIfEventsMatch(tags(distinctTag), token);
+                    barrier.await();
+                    try {
+                        disjointStore.append(List.of(taggedEvent(distinctType, distinctTag)), cond);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                        System.err.println("Unexpected failure for disjoint tag " + distinctTag + ": " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(successCount.get())
+                    .as("Iteration %d: all %d disjoint-boundary appends should succeed (no false conflicts)", i, threadCount)
+                    .isEqualTo(threadCount);
+            assertThat(failCount.get())
+                    .as("Iteration %d: no disjoint-boundary append should fail", i)
+                    .isZero();
+        }
+    }
+
+    @Test
+    void disjoint_boundaries_sharing_a_partition_stream_are_retried_to_success() throws Exception {
+        int threadCount = 6;
+        MongoEventStore sharedStreamStore = buildEventStoreWithStreamIdGenerator(tags -> "shared:partition:stream");
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            List<Throwable> failures = new java.util.concurrent.CopyOnWriteArrayList<>();
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                final String distinctTag = "shared-iter" + i + "-t" + t;
+                final String distinctType = "SharedStreamEvent-iter" + i + "-t" + t;
+                futures.add(pool.submit(() -> {
+                    DcbConsistencyToken token = sharedStreamStore.read(tags(distinctTag)).consistencyToken();
+                    DcbAppendCondition cond = failIfEventsMatch(tags(distinctTag), token);
+                    barrier.await();
+                    try {
+                        sharedStreamStore.append(List.of(taggedEvent(distinctType, distinctTag)), cond);
+                        successCount.incrementAndGet();
+                    } catch (Throwable e) {
+                        failures.add(e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(failures)
+                    .as("Iteration %d: disjoint boundaries on a shared stream must all be retried to success, not fail", i)
+                    .isEmpty();
+            assertThat(successCount.get())
+                    .as("Iteration %d: all %d appends should succeed", i, threadCount)
+                    .isEqualTo(threadCount);
+        }
+    }
+
+    @Test
+    void multi_marker_boundary_serialization_under_contention() throws Exception {
+        int threadCount = 8;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String tag1 = "mm-t1-" + i;
+            String tag2 = "mm-t2-" + i;
+
+            DcbQuery multiMarkerQuery = tags(tag1, tag2);
+            DcbConsistencyToken boundaryToken = eventStore.read(multiMarkerQuery).consistencyToken();
+            DcbAppendCondition condition = failIfEventsMatch(multiMarkerQuery, boundaryToken);
+
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger condFailCount = new AtomicInteger(0);
+            AtomicReference<Throwable> firstUnexpected = new AtomicReference<>();
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                futures.add(pool.submit(() -> {
+                    barrier.await();
+                    try {
+                        eventStore.read(multiMarkerQuery).consistencyToken();
+                        eventStore.append(List.of(taggedEvent("MultiMarkerEvent", tag1, tag2)), condition);
+                        successCount.incrementAndGet();
+                    } catch (DcbAppendConditionNotFulfilledException e) {
+                        condFailCount.incrementAndGet();
+                    } catch (Exception e) {
+                        firstUnexpected.compareAndSet(null, e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            Throwable unexpected = firstUnexpected.get();
+            if (unexpected != null) {
+                throw new AssertionError("Iteration " + i + ": unexpected (non-DcbAppendConditionNotFulfilledException) failure under multi-marker contention", unexpected);
+            }
+
+            assertThat(successCount.get())
+                    .as("Iteration %d: expected exactly one success under multi-marker contention (tags=%s,%s)", i, tag1, tag2)
+                    .isEqualTo(1);
+            assertThat(condFailCount.get())
+                    .as("Iteration %d: expected %d DcbAppendConditionNotFulfilledException failures", i, threadCount - 1)
+                    .isEqualTo(threadCount - 1);
+        }
+    }
+
+    @Test
+    void tokenless_conditional_append_prevents_double_commit() throws Exception {
+        AtomicLong streamCounter = new AtomicLong(0);
+        MongoEventStore isolatedStore = buildEventStoreWithStreamIdGenerator(
+                tags -> "isolated:tokenless:stream:" + streamCounter.getAndIncrement());
+
+        int successes = 0;
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            String tag = "tokenless-" + i;
+
+            DcbAppendCondition condA = failIfEventsMatch(tags(tag));
+            DcbAppendCondition condB = failIfEventsMatch(tags(tag));
+
+            CloudEvent eventA = taggedEvent("TokenlessEvent", tag);
+            CloudEvent eventB = taggedEvent("TokenlessEvent", tag);
+
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+
+            Future<Boolean> futA = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventA), condA);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            Future<Boolean> futB = pool.submit(() -> {
+                barrier.await();
+                try {
+                    isolatedStore.append(List.of(eventB), condB);
+                    return true;
+                } catch (DcbAppendConditionNotFulfilledException e) {
+                    return false;
+                }
+            });
+
+            pool.shutdown();
+            boolean aSucceeded = futA.get();
+            boolean bSucceeded = futB.get();
+
+            int iterSuccesses = (aSucceeded ? 1 : 0) + (bSucceeded ? 1 : 0);
+
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: both tokenless conditional appends succeeded (double-commit)", i)
+                    .isLessThanOrEqualTo(1);
+            assertThat(iterSuccesses)
+                    .as("Iteration %d: neither tokenless conditional append succeeded", i)
+                    .isGreaterThanOrEqualTo(1);
+
+            if (aSucceeded || bSucceeded) successes++;
+        }
+
+        assertThat(successes).isEqualTo(ITERATIONS);
+    }
+
+    @Test
+    void dcb_queries_are_index_backed() {
+        eventStore.append(List.of(
+                taggedEvent("SeedType", "explain-tag"),
+                taggedEvent("SeedType", "explain-tag"),
+                taggedEvent("SeedType", "explain-tag")));
+
+        MongoCollection<Document> collection = mongoClient.getDatabase(databaseName).getCollection(COLLECTION);
+
+        Document tagReadQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("$or", List.of(
+                        new Document("dcbTags", new Document("$all", List.of("explain-tag")))
+                ))
+        ));
+        Document tagReadExplain = collection.find(tagReadQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+        assertThat(extractWinningPlanStage(tagReadExplain))
+                .as("Tag read query should use IXSCAN, not COLLSCAN or unrecognized stage. Full explain: %s", tagReadExplain.toJson())
+                .isEqualTo("IXSCAN");
+
+        Document typeReadQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("$or", List.of(
+                        new Document("type", new Document("$in", List.of("SeedType")))
+                ))
+        ));
+        Document typeReadExplain = collection.find(typeReadQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+        assertThat(extractWinningPlanStage(typeReadExplain))
+                .as("Type read query should use IXSCAN (dcbposition index), not COLLSCAN or unrecognized stage. Full explain: %s", typeReadExplain.toJson())
+                .isEqualTo("IXSCAN");
+
+        Document existenceQuery = new Document("$and", List.of(
+                new Document("dcbposition", new Document("$gt", 0).append("$lte", Long.MAX_VALUE)),
+                new Document("$or", List.of(
+                        new Document("dcbTags", new Document("$all", List.of("explain-tag")))
+                ))
+        ));
+        Document existenceExplain = collection.find(existenceQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+        assertThat(extractWinningPlanStage(existenceExplain))
+                .as("Existence/conflict check query should use IXSCAN, not COLLSCAN or unrecognized stage. Full explain: %s", existenceExplain.toJson())
+                .isEqualTo("IXSCAN");
+    }
+
+    private MongoEventStore buildEventStoreWithStreamIdGenerator(DcbStreamIdGenerator streamIdGenerator) {
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .dcbStreamIdGenerator(streamIdGenerator)
+                .build();
+        return new MongoEventStore(mongoClient, databaseName, COLLECTION, config);
+    }
+
+    private static String extractWinningPlanStage(Document explainDoc) {
+        Document queryPlanner = explainDoc.get("queryPlanner", Document.class);
+        if (queryPlanner == null) {
+            return "UNKNOWN";
+        }
+        Document winningPlan = queryPlanner.get("winningPlan", Document.class);
+        if (winningPlan == null) {
+            return "UNKNOWN";
+        }
+        Document plan = winningPlan;
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            String stage = plan.getString("stage");
+            if ("IXSCAN".equals(stage) || "COLLSCAN".equals(stage) || "COUNT_SCAN".equals(stage)) {
+                return stage;
+            }
+            Document input = plan.get("inputStage", Document.class);
+            if (input != null) {
+                plan = input;
+            } else {
+                @SuppressWarnings("unchecked")
+                List<Document> inputStages = (List<Document>) plan.get("inputStages");
+                if (inputStages != null && !inputStages.isEmpty()) {
+                    plan = inputStages.get(0);
+                } else {
+                    return stage != null ? stage : "UNKNOWN";
+                }
+            }
+        }
+        return "UNKNOWN";
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.nativedriver;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.DuplicateCloudEventException;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.dcb.*;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.*;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MongoEventStoreDcbTest {
+
+    private static final URI SOURCE = URI.create("urn:test");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                .withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb"));
+
+    private MongoEventStore eventStore;
+    private MongoClient mongoClient;
+
+    @BeforeEach
+    void create_mongo_native_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb");
+        mongoClient = MongoClients.create(connectionString);
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new MongoEventStore(mongoClient, requireNonNull(connectionString.getDatabase()), "events", config);
+    }
+
+    @AfterEach
+    void close_mongo_client() {
+        mongoClient.close();
+    }
+
+    @Test
+    void dcb_writes_are_visible_to_normal_event_store_queries() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.all(SortBy.natural(SortBy.SortDirection.ASCENDING)))
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined");
+        CloudEvent dcbEvent = eventStore.read(tags("name:1")).events().get(0);
+        assertThat(DcbCloudEvents.getTags(dcbEvent)).containsExactly("name:1");
+        assertThat(dcbEvent.getExtension(DcbCloudEvents.POSITION)).isEqualTo(1L);
+    }
+
+    @Test
+    void reads_events_matching_type_or_all_tags_after_sequence_position() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1", "tenant:1"),
+                taggedEvent("OrderPlaced", "order:1")));
+
+        DcbEventStream eventStream = eventStore.read(
+                anyOf(List.of(
+                        DcbQuery.types(List.of("OrderPlaced")),
+                        DcbQuery.tags(List.of("name:1", "tenant:1")))),
+                DcbReadOptions.afterSequencePosition(1));
+
+        assertThat(eventStream.events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameChanged", "OrderPlaced");
+        assertThat(eventStream.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void reads_tagged_events_except_excluded_types() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameSnapshot", "name:1"),
+                taggedEvent("OrderPlaced", "order:1")));
+
+        DcbEventStream eventStream = eventStore.read(tags(List.of("name:1")).excludingTypes(List.of("NameSnapshot")));
+
+        assertThat(eventStream.events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined");
+    }
+
+    @Test
+    void reads_type_and_tagged_events_except_excluded_types() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:1")));
+
+        DcbEventStream eventStream = eventStore.read(types(List.of("NameDefined", "NameChanged")).tags(List.of("name:1")).excludingTypes(List.of("OrderPlaced")));
+
+        assertThat(eventStream.events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined", "NameChanged");
+    }
+
+    @Test
+    void applies_excluded_types_per_query_item() {
+        eventStore.append(List.of(
+                taggedEvent("NameSnapshot", "name:1"),
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("OrderPlaced", "order:1")));
+
+        DcbEventStream eventStream = eventStore.read(anyOf(List.of(
+                DcbQuery.tags(List.of("name:1")).excludingTypes(List.of("NameSnapshot")),
+                DcbQuery.tags(List.of("order:1")))));
+
+        assertThat(eventStream.events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined", "OrderPlaced");
+    }
+
+    @Test
+    void rejects_append_when_matching_event_exists_after_condition_position() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        DcbEventStream readModel = eventStore.read(tags("name:1"));
+
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+
+        assertThatThrownBy(() -> eventStore.append(
+                List.of(taggedEvent("NameChanged", "name:1")),
+                failIfEventsMatch(tags("name:1"), readModel.consistencyToken())))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    @Test
+    void append_condition_conservatively_conflicts_on_an_excluded_type_sharing_a_tag() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        DcbQuery query = tags(List.of("name:1")).excludingTypes(List.of("NameSnapshot"));
+        DcbEventStream readModel = eventStore.read(query);
+
+        // An excluded-type event is appended after the read. It does not match the query (reads exclude it precisely,
+        // see reads_tagged_events_except_excluded_types), but it shares the positive tag name:1, whose marker the consistency
+        // token is derived from. The token model over-approximates and conservatively conflicts: it is sound (it never
+        // misses a real conflict) at the cost of a false conflict here, which self-heals through the application service
+        // (it re-reads the still-excluded boundary and retries). See ADR 0021.
+        eventStore.append(List.of(taggedEvent("NameSnapshot", "name:1")));
+
+        assertThatThrownBy(() -> eventStore.append(
+                List.of(taggedEvent("NameChanged", "name:1")),
+                failIfEventsMatch(query, readModel.consistencyToken())))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    @Test
+    void append_condition_rejects_non_excluded_event_types_after_condition_position() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+        DcbQuery query = tags(List.of("name:1")).excludingTypes(List.of("NameSnapshot"));
+        DcbEventStream readModel = eventStore.read(query);
+
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+
+        assertThatThrownBy(() -> eventStore.append(
+                List.of(taggedEvent("NameImported", "name:1")),
+                failIfEventsMatch(query, readModel.consistencyToken())))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    @Test
+    void exists_and_count_honour_the_read_options_position_window() {
+        eventStore.append(List.of(taggedEvent("E", "t")));   // position 1
+        eventStore.append(List.of(taggedEvent("E", "t")));   // position 2
+        eventStore.append(List.of(taggedEvent("E", "t")));   // position 3
+
+        assertThat(eventStore.count(tags("t"))).isEqualTo(3);
+        assertThat(eventStore.count(tags("t"), DcbReadOptions.afterSequencePosition(1))).isEqualTo(2);
+        assertThat(eventStore.count(tags("t"), DcbReadOptions.upToSequencePosition(2))).isEqualTo(2);
+        assertThat(eventStore.count(tags("t"), DcbReadOptions.between(1, 2))).isEqualTo(1);
+
+        assertThat(eventStore.exists(tags("t"))).isTrue();
+        assertThat(eventStore.exists(tags("t"), DcbReadOptions.between(2, 3))).isTrue();
+        assertThat(eventStore.exists(tags("t"), DcbReadOptions.afterSequencePosition(3))).isFalse();
+        assertThat(eventStore.exists(tags("missing"))).isFalse();
+    }
+
+    @Test
+    void match_all_condition_does_not_detect_a_tag_scoped_append_documenting_the_known_limitation() {
+        // ADR 0021: a MatchAll condition is keyed on a single "all" marker that only other MatchAll appends touch, so it
+        // is NOT skew-safe against a tag-scoped or type-scoped append. This test pins that documented limitation so a
+        // future change cannot silently alter it.
+        DcbEventStream readModel = eventStore.read(all());
+
+        // A tag-scoped append commits after the MatchAll read. It bumps the name:1 tag and NameDefined type markers, but
+        // not the "all" marker that the MatchAll condition is keyed on.
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        // The MatchAll condition therefore does not observe it and the append succeeds, even though an event was written
+        // after the read. A tag-scoped condition on name:1 would correctly conflict here.
+        DcbAppendResult result = eventStore.append(
+                List.of(taggedEvent("NameChanged", "name:2")),
+                failIfEventsMatch(all(), readModel.consistencyToken()));
+
+        assertThat(result.firstSequencePosition()).isEqualTo(2);
+    }
+
+    @Test
+    void no_token_append_condition_reflects_current_existence_not_past_appends() {
+        DcbQuery query = tags("name:1");
+        CloudEvent existing = taggedEvent("NameDefined", "name:1");
+        eventStore.append(List.of(existing));
+
+        // While a matching event exists, the no-token guard conflicts.
+        assertThatThrownBy(() -> eventStore.append(List.of(taggedEvent("NameChanged", "name:1")), failIfEventsMatch(query)))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
+
+        // After the matching event is deleted, the no-token guard succeeds again. It means "currently exists", not
+        // "ever appended": the no-token path checks the live events, not the never-decremented marker versions, so it
+        // matches the in-memory store and survives deletes.
+        eventStore.deleteEvent(existing.getId(), existing.getSource());
+        DcbAppendResult result = eventStore.append(List.of(taggedEvent("NameChanged", "name:1")), failIfEventsMatch(query));
+        assertThat(result.eventCount()).isEqualTo(1);
+    }
+
+    @Test
+    void abandons_reserved_position_block_when_duplicate_cloud_event_fails_insert() {
+        CloudEvent cloudEvent = taggedEvent("NameDefined", "name:1");
+        eventStore.append(List.of(cloudEvent));
+
+        assertThatThrownBy(() -> eventStore.append(List.of(cloudEvent)))
+                .isExactlyInstanceOf(DuplicateCloudEventException.class);
+
+        // Positions are reserved outside the transaction (ADR 0021), so the failed append abandons its reserved block
+        // and dcbposition has a gap. The next successful append lands after the abandoned block.
+        DcbAppendResult appendResult = eventStore.append(List.of(taggedEvent("NameChanged", "name:1")));
+        assertThat(appendResult.firstSequencePosition()).isEqualTo(3);
+        assertThat(appendResult.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void same_stale_append_condition_rejects_second_append_and_abandons_its_position_block() {
+        DcbEventStream readModel = eventStore.read(tags("name:1"));
+        DcbAppendCondition appendCondition = failIfEventsMatch(tags("name:1"), readModel.consistencyToken());
+
+        DcbAppendResult firstAppend = eventStore.append(List.of(taggedEvent("NameDefined", "name:1")), appendCondition);
+        assertThat(firstAppend).isEqualTo(new DcbAppendResult(1, 1, 1));
+
+        assertThatThrownBy(() -> eventStore.append(List.of(taggedEvent("NameChanged", "name:1")), appendCondition))
+                .isExactlyInstanceOf(DcbAppendConditionNotFulfilledException.class);
+
+        // The condition-failed append abandons its reserved position block (ADR 0021), so dcbposition has a gap and the
+        // next successful append lands at position 3 rather than 2.
+        DcbAppendResult nextAppend = eventStore.append(List.of(taggedEvent("NameChanged", "name:2")));
+        assertThat(nextAppend).isEqualTo(new DcbAppendResult(3, 3, 1));
+    }
+
+    @Test
+    void does_not_inspect_payload_when_matching_tags() {
+        CloudEvent cloudEvent = DcbCloudEvents.withTags(CloudEventBuilder.v1(event("NameDefined"))
+                .withDataContentType("application/json")
+                .withData("{\"tags\":[\"name:1\"]}".getBytes(UTF_8))
+                .build(), Set.of("name:2"));
+
+        eventStore.append(List.of(cloudEvent));
+
+        assertThat(eventStore.read(tags("name:1")).events()).isEmpty();
+        assertThat(eventStore.read(tags("name:2")).events()).hasSize(1);
+    }
+
+    @Test
+    void last_sequence_position_is_the_store_head_not_the_max_matched_position() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:2")));
+
+        // The query matches only the two "name:1" events (positions 1 and 2), but the store head is 3.
+        DcbEventStream matchesSome = eventStore.read(tags("name:1"));
+        assertThat(matchesSome.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(matchesSome.lastSequencePosition()).isEqualTo(3);
+
+        // A query that matches nothing still observes the store head.
+        DcbEventStream matchesNone = eventStore.read(tags("name:absent"));
+        assertThat(matchesNone.events()).isEmpty();
+        assertThat(matchesNone.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void exists_and_count_report_matching_dcb_events() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "order:1")));
+
+        assertThat(eventStore.exists(tags("name:1"))).isTrue();
+        assertThat(eventStore.exists(tags("absent:1"))).isFalse();
+        assertThat(eventStore.count(tags("name:1"))).isEqualTo(2);
+        assertThat(eventStore.count(all())).isEqualTo(3);
+    }
+
+    @Test
+    void read_honors_up_to_sequence_position_upper_bound() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1"),
+                taggedEvent("OrderPlaced", "name:1")));
+
+        DcbEventStream upToTwo = eventStore.read(tags("name:1"), DcbReadOptions.upToSequencePosition(2));
+
+        assertThat(upToTwo.events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(upToTwo.lastSequencePosition()).isEqualTo(3);
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbUnconditionalMarkerTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbUnconditionalMarkerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.nativedriver;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbConsistencyToken;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
+
+/**
+ * Regression test for the unconditional-append write-skew gap (ADR 0021), native driver variant.
+ * <p>
+ * An unconditional {@link org.occurrent.eventstore.api.dcb.DcbEventStore#append(List)} must still bump the conflict
+ * markers derived from its events. Otherwise a later conditional append on an overlapping tag observes an unchanged
+ * consistency token and wrongly succeeds, even though a matching event was committed after it read the boundary.
+ */
+@Testcontainers
+@Timeout(120)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MongoEventStoreDcbUnconditionalMarkerTest {
+
+    private static final URI SOURCE = URI.create("urn:test:unconditional-marker");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(
+            new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_unconditional_marker"));
+
+    private MongoEventStore eventStore;
+    private MongoClient mongoClient;
+
+    @BeforeEach
+    void create_event_store() {
+        ConnectionString connectionString = connectionString();
+        mongoClient = MongoClients.create(connectionString);
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new MongoEventStore(mongoClient, requireNonNull(connectionString.getDatabase()), "events", config);
+    }
+
+    @AfterEach
+    void close_mongo_client() {
+        mongoClient.close();
+    }
+
+    @Test
+    void unconditional_append_is_detected_by_a_later_conditional_append_on_an_overlapping_tag() {
+        String tag = "shared-tag";
+
+        // A command reads the (empty) boundary.
+        DcbConsistencyToken token = eventStore.read(tags(tag)).consistencyToken();
+
+        // An unconditional append commits a matching event.
+        eventStore.append(List.of(taggedEvent("UnconditionalEvent", tag)));
+
+        // A conditional append carrying the token observed before the unconditional append must be rejected: the
+        // unconditional append committed a matching event, which advanced the tag marker so the token has changed.
+        DcbAppendCondition condition = failIfEventsMatch(tags(tag), token);
+        Throwable thrown = catchThrowable(() ->
+                eventStore.append(List.of(taggedEvent("ConditionalEvent", tag)), condition));
+
+        assertThat(thrown)
+                .as("The conditional append must fail because an unconditional append committed a matching event after "
+                        + "the boundary was read. Without event-derived markers on the unconditional append, the "
+                        + "consistency token does not move and the conflict is missed (write skew).")
+                .isInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    private ConnectionString connectionString() {
+        return new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcb_unconditional_marker");
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}


### PR DESCRIPTION
This adds DCB to the native MongoDB driver event store, so an application on the plain synchronous driver gets the same Dynamic Consistency Boundary support the Spring store already has. It builds on the shared module from the previous PR.

`MongoEventStore` now implements `DcbEventStore`. It mirrors the Spring store's semantics, translated to the native driver:

- positions reserved outside the transaction, marker versions bumped inside it
- a consistency-token sum for a token-carrying condition, and a live existence check when there is no token
- partition placement by the condition's boundary tags
- a transient and duplicate-key retry around `ClientSession.withTransaction`

The marker model and the on-disk storage contract are not reimplemented. They come from `eventstore-mongodb-dcb-common`, so the two Mongo stores cannot drift. `EventStoreConfig` gains the capability set and the stream-id generator, and defaults to stream-only, so existing native applications are untouched.

I ported the Spring DCB test suite to the native store: read and append round-trips, conflict on a stale token, write-skew prevention across the type and tag dimensions, same-boundary serialization with exactly one winner, disjoint-boundary parallelism, the unconditional-append marker case, and capability gating. All 38 pass alongside the existing native stream tests.

One Spring test is not ported, the read-watermark overshoot test. Its deterministic reproduction subclasses Spring's `TransactionTemplate` to pause an append after it reserves its position but before it commits. The native store uses `ClientSession.withTransaction` directly and exposes no equivalent seam, so that exact interleaving cannot be expressed without faking it. The property it guards, that the token reflects only committed marker versions and not reserved positions, is the same token mechanism exercised by the unconditional-marker and concurrency tests.

See ADR 33 for the rationale.

---

This supersedes #237, which GitHub auto-closed when the stacked base PR #236 merged and its branch was pruned. The content is identical and rebased onto the merged `main`.

Open question carried over from #237, for a follow-up rather than this PR: in a `DCB`-only store the `(streamid, streamversion)` unique index is not created, so two concurrent disjoint-boundary appends that hash to the same partition stream can commit duplicate stream versions. It is benign for DCB operation, since stream reads are disabled in that mode and DCB reads order by the unique `dcbposition`, and the Spring store behaves the same way, so I would rather harden both stores in a separate change tied to ADR 21 than fold it in here.