### PR TITLE
Document why the streamId+streamVersion index is stream-mode only

### DIFF
--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -675,6 +675,8 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
         // Cloud spec defines id + source must be unique!
         eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true));
+        // streamId + streamVersion uniqueness is a stream-mode invariant. DCB correctness rests on the per-attribute
+        // markers and the unique dcbposition, not stream version, so a DCB-only store neither needs nor creates it.
         if (eventStoreCapabilities.contains(STREAM)) {
             // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
             // Note also that this index supports when sorting both ascending and descending since MongoDB can traverse an index in both directions.

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -726,6 +726,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         MongoCollection<Document> eventStoreCollection = mongoTemplate.getCollection(eventStoreCollectionName);
         // Cloud spec defines id + source must be unique!
         eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(CloudEventV1.ID), Indexes.ascending(CloudEventV1.SOURCE)), new IndexOptions().unique(true));
+        // streamId + streamVersion uniqueness is a stream-mode invariant. DCB correctness rests on the per-attribute
+        // markers and the unique dcbposition, not stream version, so a DCB-only store neither needs nor creates it.
         if (eventStoreCapabilities.contains(STREAM)) {
             // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
             // Note also that this index supports sorting both ascending and descending since MongoDB can traverse an index in both directions.


### PR DESCRIPTION
This adds a comment to both Mongo stores explaining why the `streamId` + `streamVersion` unique index is created only in stream mode.

It came up reviewing the native DCB work. The index looks like it is missing in a DCB-only store, but it is left out on purpose. DCB correctness rests on the per-attribute markers and the unique `dcbposition`, not on stream version, and a DCB-only store does not expose stream reads, so nothing there depends on that uniqueness. The comment says so inline so the omission is not read as a bug.

Comment-only, no behavior change.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
