### PR TITLE
Add DCB support to the reactive Spring MongoDB event store

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* DCB now works on the reactive Spring MongoDB event store, which completes DCB support across every event store.
+  * `ReactorMongoEventStore` implements a new reactive `DcbEventStore` (in `eventstore-api-dcb-reactor`) with `Mono` and `Flux`, reusing the same per-attribute marker model and storage contract as the blocking and native stores. It defaults to stream-only. A reactive DCB application service, DSL, and subscriptions are not part of this and remain to be done.
+  * See [ADR 34](doc/architecture/decisions/0034-reactive-spring-mongodb-dcb-support.md).
+
 * DCB now works on the native MongoDB driver event store, not only the Spring store.
   * `MongoEventStore`, the plain synchronous-driver store, implements the same DCB read and append API as the Spring store, with the same per-attribute marker model and consistency-token semantics. The shared model now lives in a new `eventstore-mongodb-dcb-common` module so the two stores cannot drift on the storage contract, and the capability set moved to a shared `EventStoreCapability` enum in `eventstore-api-common`. The native store defaults to stream-only, so existing applications are untouched.
   * See [ADR 33](doc/architecture/decisions/0033-native-mongodb-driver-dcb-parity-via-shared-marker-model.md).

--- a/doc/architecture/decisions/0034-reactive-spring-mongodb-dcb-support.md
+++ b/doc/architecture/decisions/0034-reactive-spring-mongodb-dcb-support.md
@@ -1,0 +1,33 @@
+# 34. Reactive Spring MongoDB DCB support
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+DCB shipped for the in-memory, Spring blocking, and native driver event stores. The reactive Spring store (`ReactorMongoEventStore`) was the last event store without it. The blocking DCB API is synchronous, so a reactive store needs a `Mono`/`Flux` variant of the `DcbEventStore` interface. The reactive store already does multi-document transactions with Spring's `TransactionalOperator` and can reuse the shared marker model, so the work is mostly translating the blocking append cycle to Reactor.
+
+## Decision
+
+Add reactive DCB to `ReactorMongoEventStore`, reaching event-store parity with the blocking and native stores.
+
+### Reactive DcbEventStore interface in its own module
+
+A new module `eventstore-api-dcb-reactor` holds `org.occurrent.eventstore.api.dcb.reactor.DcbEventStore`, a `Mono`/`Flux` mirror of the blocking interface. It depends on `eventstore-api-dcb` for the shared value types and on `reactor-core`. Keeping it in its own module keeps project-reactor off the classpath of blocking-only consumers of `eventstore-api-dcb`, mirroring the existing `api/blocking` and `api/reactor` split.
+
+### Reuse the shared marker model and storage contract
+
+`ReactorMongoEventStore` reuses `DcbMarkerModel` and `DcbDocumentMapper` from `eventstore-mongodb-dcb-common` unchanged, so the on-disk contract and the per-attribute marker scheme are identical to the blocking and native stores. `EventStoreConfig` gains the same capability set and `DcbStreamIdGenerator`, defaulting to stream-only.
+
+### Reactive append mirrors the blocking semantics
+
+Positions are reserved outside the transaction. Marker increments, condition enforcement, and inserts run inside `transactionalOperator.transactional(...)`. The conditional check recomputes the consistency token within the transaction, and the in-transaction marker read participates in the reactive transaction snapshot through Reactor context propagation, confirmed by the token-conflict tests. The one reactive difference is retry. The reactive transaction does not auto-retry a transient conflict, so the transactional `Mono` is wrapped in `Retry.backoff` filtered on transient-transaction and cold-start duplicate-key errors. A `DcbAppendConditionNotFulfilledException` and a `DuplicateCloudEventException` are not retried.
+
+## Consequences
+
+- All four event stores now support DCB with the same token semantics and the same storage contract.
+- The reactive side still has no DCB application service, DSL, or subscriptions. Those are tracked as later phases in `.context/reactive-dcb-plan.md` and are demand-gated.
+- The `streamId` plus `streamVersion` unique index stays stream-mode only here too, for the same reason as the other stores. DCB correctness rests on the markers and the unique `dcbposition`.

--- a/eventstore/api/dcb-reactor/pom.xml
+++ b/eventstore/api/dcb-reactor/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eventstore-api</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>eventstore-api-dcb-reactor</artifactId>
+
+    <name>${mavenProjectName}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/eventstore/api/dcb-reactor/src/main/java/org/occurrent/eventstore/api/dcb/reactor/DcbEventStore.java
+++ b/eventstore/api/dcb-reactor/src/main/java/org/occurrent/eventstore/api/dcb/reactor/DcbEventStore.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.api.dcb.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Reactive event store operations for Dynamic Consistency Boundary reads and appends. This is the
+ * <a href="https://projectreactor.io/">project reactor</a> counterpart of the blocking
+ * {@link org.occurrent.eventstore.api.dcb.DcbEventStore}, returning {@link Mono} instead of plain values.
+ * <p>
+ * DCB is an optional capability over shared CloudEvent storage. Implementations keep storing CloudEvents in Occurrent
+ * streams while exposing reads, append conditions, tags, and sequence positions in DCB terms. The DCB value types
+ * ({@link DcbQuery}, {@link DcbReadOptions}, {@link DcbEventStream}, {@link DcbAppendCondition}, {@link DcbAppendResult})
+ * are shared with the blocking API.
+ */
+@NullMarked
+public interface DcbEventStore {
+
+    /**
+     * Reads all events that match {@code query} from the beginning of the DCB sequence.
+     */
+    default Mono<DcbEventStream> read(DcbQuery query) {
+        return read(query, DcbReadOptions.fromBeginning());
+    }
+
+    /**
+     * Reads events that match {@code query} using the supplied read options.
+     */
+    Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options);
+
+    /**
+     * Returns whether any DCB event in the store matches {@code query}.
+     */
+    default Mono<Boolean> exists(DcbQuery query) {
+        return exists(query, DcbReadOptions.fromBeginning());
+    }
+
+    /**
+     * Returns whether any DCB event matches {@code query} within the position window of {@code options}.
+     * <p>
+     * The default implementation reads the matching events. Implementations should override it with a more efficient
+     * existence check.
+     */
+    default Mono<Boolean> exists(DcbQuery query, DcbReadOptions options) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return read(query, options).map(stream -> !stream.events().isEmpty());
+    }
+
+    /**
+     * Returns the number of DCB events in the store that match {@code query}.
+     */
+    default Mono<Long> count(DcbQuery query) {
+        return count(query, DcbReadOptions.fromBeginning());
+    }
+
+    /**
+     * Returns the number of DCB events matching {@code query} within the position window of {@code options}.
+     * <p>
+     * The default implementation reads the matching events. Implementations should override it with a more efficient
+     * count.
+     */
+    default Mono<Long> count(DcbQuery query, DcbReadOptions options) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return read(query, options).map(stream -> (long) stream.events().size());
+    }
+
+    /**
+     * Appends DCB-tagged CloudEvents without an additional DCB condition.
+     * <p>
+     * The Occurrent storage stream the events are placed in is derived by the store from the events' DCB tags, so
+     * callers reason in DCB terms (tags and append conditions) rather than in storage stream ids.
+     */
+    Mono<DcbAppendResult> append(List<CloudEvent> events);
+
+    /**
+     * Appends DCB-tagged CloudEvents if {@code condition} is fulfilled.
+     * <p>
+     * The Occurrent storage stream the events are placed in is derived by the store from the events' DCB tags.
+     */
+    Mono<DcbAppendResult> append(List<CloudEvent> events, DcbAppendCondition condition);
+}

--- a/eventstore/api/pom.xml
+++ b/eventstore/api/pom.xml
@@ -31,6 +31,7 @@
         <module>reactor</module>
         <module>common</module>
         <module>dcb</module>
+        <module>dcb-reactor</module>
     </modules>
 
 </project>

--- a/eventstore/mongodb/spring/reactor/pom.xml
+++ b/eventstore/mongodb/spring/reactor/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>mongodb-spring-filter-query-conversion</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -69,6 +74,11 @@
         </dependency>
 
         <!-- Test -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
@@ -16,6 +16,9 @@
 
 package org.occurrent.eventstore.mongodb.spring.reactor;
 
+import org.occurrent.eventstore.api.EventStoreCapability;
+import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
+import org.occurrent.eventstore.api.dcb.PartitionedDcbStreamIdGenerator;
 import org.occurrent.eventstore.api.reactor.EventStoreQueries;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.springframework.data.domain.Sort;
@@ -23,11 +26,16 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 
 /**
  * Configuration for the <a href="https://projectreactor.io/">project reactor</a> Spring java driver for MongoDB EventStore
@@ -35,12 +43,15 @@ import static java.util.Objects.requireNonNull;
 public class EventStoreConfig {
     private static final Function<Query, Query> DEFAULT_QUERY_OPTIONS_FUNCTION = Function.identity();
     private static final Function<Query, Query> DEFAULT_READ_OPTIONS_FUNCTION = Function.identity();
+    private static final Set<EventStoreCapability> DEFAULT_EVENT_STORE_CAPABILITIES = Set.of(STREAM);
 
     public final String eventStoreCollectionName;
     public final TransactionalOperator transactionalOperator;
     public final TimeRepresentation timeRepresentation;
     public final Function<Query, Query> queryOptions;
     public final Function<Query, Query> readOptions;
+    public final Set<EventStoreCapability> eventStoreCapabilities;
+    public final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create a new instance of {@code EventStoreConfig}.
@@ -50,18 +61,25 @@ public class EventStoreConfig {
      * @param timeRepresentation       How time should be represented in the database
      */
     public EventStoreConfig(String eventStoreCollectionName, TransactionalOperator transactionalOperator, TimeRepresentation timeRepresentation) {
-        this(eventStoreCollectionName, transactionalOperator, timeRepresentation, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_READ_OPTIONS_FUNCTION);
+        this(eventStoreCollectionName, transactionalOperator, timeRepresentation, DEFAULT_QUERY_OPTIONS_FUNCTION, DEFAULT_READ_OPTIONS_FUNCTION, DEFAULT_EVENT_STORE_CAPABILITIES, new PartitionedDcbStreamIdGenerator());
     }
 
-    private EventStoreConfig(String eventStoreCollectionName, TransactionalOperator transactionalOperator, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions) {
+    private EventStoreConfig(String eventStoreCollectionName, TransactionalOperator transactionalOperator, TimeRepresentation timeRepresentation, Function<Query, Query> queryOptions, Function<Query, Query> readOptions, Set<EventStoreCapability> eventStoreCapabilities, DcbStreamIdGenerator dcbStreamIdGenerator) {
         requireNonNull(eventStoreCollectionName, "Event store collection name cannot be null");
         requireNonNull(transactionalOperator, TransactionalOperator.class.getSimpleName() + " cannot be null");
         requireNonNull(timeRepresentation, TimeRepresentation.class.getSimpleName() + " cannot be null");
+        requireNonNull(eventStoreCapabilities, "Event store capabilities cannot be null");
+        if (eventStoreCapabilities.isEmpty()) {
+            throw new IllegalArgumentException("Event store capabilities cannot be empty");
+        }
+        requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
         this.eventStoreCollectionName = eventStoreCollectionName;
         this.transactionalOperator = transactionalOperator;
         this.timeRepresentation = timeRepresentation;
         this.queryOptions = queryOptions == null ? DEFAULT_QUERY_OPTIONS_FUNCTION : queryOptions;
         this.readOptions = readOptions == null ? DEFAULT_READ_OPTIONS_FUNCTION : readOptions;
+        this.eventStoreCapabilities = Set.copyOf(eventStoreCapabilities);
+        this.dcbStreamIdGenerator = dcbStreamIdGenerator;
     }
 
 
@@ -70,12 +88,12 @@ public class EventStoreConfig {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig)) return false;
         EventStoreConfig that = (EventStoreConfig) o;
-        return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionalOperator, that.transactionalOperator) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions);
+        return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionalOperator, that.transactionalOperator) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventStoreCollectionName, transactionalOperator, timeRepresentation, queryOptions, readOptions);
+        return Objects.hash(eventStoreCollectionName, transactionalOperator, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities, dcbStreamIdGenerator);
     }
 
     @Override
@@ -86,6 +104,8 @@ public class EventStoreConfig {
                 .add("timeRepresentation=" + timeRepresentation)
                 .add("queryOptions=" + queryOptions)
                 .add("readOptions=" + readOptions)
+                .add("eventStoreCapabilities=" + eventStoreCapabilities)
+                .add("dcbStreamIdGenerator=" + dcbStreamIdGenerator)
                 .toString();
     }
 
@@ -95,6 +115,8 @@ public class EventStoreConfig {
         private TimeRepresentation timeRepresentation;
         private Function<Query, Query> queryOptions;
         private Function<Query, Query> readOptions;
+        private Set<EventStoreCapability> eventStoreCapabilities = DEFAULT_EVENT_STORE_CAPABILITIES;
+        private DcbStreamIdGenerator dcbStreamIdGenerator = new PartitionedDcbStreamIdGenerator();
 
         /**
          * @param eventStoreCollectionName The collection in which the events are persisted
@@ -163,8 +185,50 @@ public class EventStoreConfig {
             return this;
         }
 
+        /**
+         * Select the event-store capabilities that should be enabled for this store. The default is {@link EventStoreCapability#STREAM}.
+         * Add {@link EventStoreCapability#DCB} to enable Dynamic Consistency Boundary reads and appends.
+         *
+         * @param eventStoreCapabilities The non-empty capability set to enable.
+         * @return A same {@code Builder instance}
+         */
+        public Builder eventStoreCapabilities(Set<EventStoreCapability> eventStoreCapabilities) {
+            requireNonNull(eventStoreCapabilities, "Event store capabilities cannot be null");
+            if (eventStoreCapabilities.isEmpty()) {
+                throw new IllegalArgumentException("Event store capabilities cannot be empty");
+            }
+            this.eventStoreCapabilities = Set.copyOf(eventStoreCapabilities);
+            return this;
+        }
+
+        /**
+         * Select the event-store capabilities as a vararg, for example {@code eventStoreCapabilities(STREAM, DCB)}.
+         *
+         * @param eventStoreCapability             The first capability to enable.
+         * @param additionalEventStoreCapabilities Additional capabilities to enable.
+         * @return A same {@code Builder instance}
+         */
+        public Builder eventStoreCapabilities(EventStoreCapability eventStoreCapability, EventStoreCapability... additionalEventStoreCapabilities) {
+            requireNonNull(eventStoreCapability, "Event store capability cannot be null");
+            requireNonNull(additionalEventStoreCapabilities, "Additional event store capabilities cannot be null");
+            Set<EventStoreCapability> capabilities = new LinkedHashSet<>();
+            Stream.concat(Stream.of(eventStoreCapability), Arrays.stream(additionalEventStoreCapabilities))
+                    .map(capability -> requireNonNull(capability, "Event store capability cannot be null"))
+                    .forEach(capabilities::add);
+            return eventStoreCapabilities(capabilities);
+        }
+
+        /**
+         * @param dcbStreamIdGenerator The generator that derives the storage stream id from the events' DCB tags.
+         * @return A same {@code Builder instance}
+         */
+        public Builder dcbStreamIdGenerator(DcbStreamIdGenerator dcbStreamIdGenerator) {
+            this.dcbStreamIdGenerator = requireNonNull(dcbStreamIdGenerator, DcbStreamIdGenerator.class.getSimpleName() + " cannot be null");
+            return this;
+        }
+
         public EventStoreConfig build() {
-            return new EventStoreConfig(eventStoreCollectionName, transactionalOperator, timeRepresentation, queryOptions, readOptions);
+            return new EventStoreConfig(eventStoreCollectionName, transactionalOperator, timeRepresentation, queryOptions, readOptions, eventStoreCapabilities, dcbStreamIdGenerator);
         }
     }
 }

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -16,6 +16,8 @@
 
 package org.occurrent.eventstore.mongodb.spring.reactor;
 
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoException;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
@@ -28,16 +30,18 @@ import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.cloudevents.OccurrentExtensionGetter;
 import org.occurrent.eventstore.api.*;
+import org.occurrent.eventstore.api.dcb.*;
+import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
+import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
 import org.occurrent.eventstore.api.reactor.EventStore;
 import org.occurrent.eventstore.api.reactor.EventStoreOperations;
 import org.occurrent.eventstore.api.reactor.EventStoreQueries;
 import org.occurrent.eventstore.api.reactor.EventStream;
 import org.occurrent.eventstore.api.reactor.ReadEventStreamWithFilter;
-import org.occurrent.eventstore.api.internal.StreamReadFilterToFilterMapper;
-import org.occurrent.eventstore.api.internal.StreamReadFilterValidator;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
+import org.occurrent.eventstore.mongodb.dcb.internal.DcbMarkerModel;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator;
 import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
-import org.occurrent.eventstore.mongodb.dcb.internal.DcbDocumentMapper;
 import org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper;
 import org.occurrent.eventstore.mongodb.internal.StreamVersionDiff;
 import org.occurrent.filter.Filter;
@@ -47,22 +51,34 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
+import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
 import static org.occurrent.mongodb.spring.sortconversion.internal.SortConverter.convertToSpringSort;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 import static org.springframework.data.mongodb.SessionSynchronization.ALWAYS;
@@ -71,19 +87,28 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 /**
  * This is a reactive {@link EventStore} implementation that stores events in MongoDB using
  * Spring's {@link ReactiveMongoTemplate} that is based on <a href="https://projectreactor.io/">project reactor</a>.
- * It also supports the {@link EventStoreOperations} and {@link EventStoreQueries} contracts.
+ * It also supports the {@link EventStoreOperations} and {@link EventStoreQueries} contracts, and the reactive
+ * {@link org.occurrent.eventstore.api.dcb.reactor.DcbEventStore} contract when the {@code DCB} capability is enabled.
+ * <p>
+ * By default, only stream-based event-store operations are enabled. Configure
+ * {@link EventStoreConfig.Builder#eventStoreCapabilities(Set)} to enable DCB, or to enable both stream and DCB
+ * operations. Occurrent creates missing indexes for enabled capabilities, but it never removes indexes automatically.
  */
 @NullMarked
-public class ReactorMongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter {
+public class ReactorMongoEventStore implements EventStore, EventStoreOperations, EventStoreQueries, ReadEventStreamWithFilter, org.occurrent.eventstore.api.dcb.reactor.DcbEventStore {
 
     private static final String ID = "_id";
 
     private final ReactiveMongoTemplate mongoTemplate;
     private final String eventStoreCollectionName;
+    private final String dcbPositionCollectionName;
+    private final String dcbCheckpointCollectionName;
     private final TimeRepresentation timeRepresentation;
     private final TransactionalOperator transactionalOperator;
     private final Function<Query, Query> queryOptions;
     private final Function<Query, Query> readOptions;
+    private final Set<EventStoreCapability> eventStoreCapabilities;
+    private final DcbStreamIdGenerator dcbStreamIdGenerator;
 
     /**
      * Create a new instance of {@code SpringReactorMongoEventStore}
@@ -96,11 +121,15 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         requireNonNull(config, EventStoreConfig.class.getSimpleName() + " cannot be null");
         this.mongoTemplate = mongoTemplate;
         this.eventStoreCollectionName = config.eventStoreCollectionName;
+        this.dcbPositionCollectionName = DcbMarkerModel.positionCollectionName(eventStoreCollectionName);
+        this.dcbCheckpointCollectionName = DcbMarkerModel.checkpointCollectionName(eventStoreCollectionName);
         this.transactionalOperator = config.transactionalOperator;
         this.timeRepresentation = config.timeRepresentation;
         this.queryOptions = config.queryOptions;
         this.readOptions = config.readOptions;
-        initializeEventStore(eventStoreCollectionName, mongoTemplate).block();
+        this.eventStoreCapabilities = config.eventStoreCapabilities;
+        this.dcbStreamIdGenerator = config.dcbStreamIdGenerator;
+        initializeEventStore(eventStoreCollectionName, dcbPositionCollectionName, dcbCheckpointCollectionName, eventStoreCapabilities, mongoTemplate).block();
     }
 
     @Override
@@ -110,6 +139,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<WriteResult> write(String streamId, WriteCondition writeCondition, Flux<CloudEvent> events) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         if (writeCondition == null) {
             throw new IllegalArgumentException(WriteCondition.class.getSimpleName() + " cannot be null");
         }
@@ -137,21 +169,318 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Boolean> exists(String streamId) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         return mongoTemplate.exists(queryOptions.apply(streamIdEqualTo(streamId)), eventStoreCollectionName);
     }
 
     @Override
     public Mono<EventStream<CloudEvent>> read(String streamId, int skip, int limit) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         Mono<EventStreamImpl> eventStream = readEventStream(streamId, null, skip, limit);
         return convertToCloudEvent(timeRepresentation, eventStream);
     }
 
     @Override
     public Mono<EventStream<CloudEvent>> read(String streamId, StreamReadFilter filter, int skip, int limit) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(streamId, "Stream id cannot be null");
         requireNonNull(filter, "filter cannot be null");
         Mono<EventStreamImpl> eventStream = readEventStream(streamId, filter, skip, limit);
         return convertToCloudEvent(timeRepresentation, eventStream);
+    }
+
+    // DCB
+    @Override
+    public Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options) {
+        if (!eventStoreCapabilities.contains(DCB)) {
+            return Mono.error(capabilityError(DCB));
+        }
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        // Snapshot the consistency token BEFORE reading the events. If an append commits between these two reads, the
+        // events may include it while the token does not, which only makes a later conditional append over-cautious (a
+        // false conflict that retries) rather than miss the conflict.
+        return consistencyToken(query).flatMap(token ->
+                currentDcbPosition().flatMap(highWatermark -> {
+                    long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+                    Query mongoQuery = toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound);
+                    mongoQuery.with(Sort.by(Sort.Direction.ASC, DcbCloudEvents.POSITION));
+                    return mongoTemplate.find(queryOptions.apply(mongoQuery), Document.class, eventStoreCollectionName)
+                            .map(document -> DcbDocumentMapper.toCloudEvent(timeRepresentation, document))
+                            .collectList()
+                            .map(events -> new DcbEventStream(events, highWatermark, DcbConsistencyToken.of(token)));
+                }));
+    }
+
+    @Override
+    public Mono<Boolean> exists(DcbQuery query, DcbReadOptions options) {
+        if (!eventStoreCapabilities.contains(DCB)) {
+            return Mono.error(capabilityError(DCB));
+        }
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return currentDcbPosition().flatMap(highWatermark -> {
+            long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+            return mongoTemplate.exists(queryOptions.apply(toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound)), eventStoreCollectionName);
+        });
+    }
+
+    @Override
+    public Mono<Long> count(DcbQuery query, DcbReadOptions options) {
+        if (!eventStoreCapabilities.contains(DCB)) {
+            return Mono.error(capabilityError(DCB));
+        }
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return currentDcbPosition().flatMap(highWatermark -> {
+            long upperBound = Math.min(highWatermark, options.upToSequencePosition().orElse(highWatermark));
+            return mongoTemplate.count(queryOptions.apply(toDcbMongoQuery(query, options.afterSequencePosition().orElse(0), upperBound)), eventStoreCollectionName);
+        });
+    }
+
+    @Override
+    public Mono<DcbAppendResult> append(List<CloudEvent> events) {
+        if (!eventStoreCapabilities.contains(DCB)) {
+            return Mono.error(capabilityError(DCB));
+        }
+        return appendDcb(events, null);
+    }
+
+    @Override
+    public Mono<DcbAppendResult> append(List<CloudEvent> events, DcbAppendCondition condition) {
+        if (!eventStoreCapabilities.contains(DCB)) {
+            return Mono.error(capabilityError(DCB));
+        }
+        requireNonNull(condition, "Append condition cannot be null");
+        return appendDcb(events, condition);
+    }
+
+    private Mono<DcbAppendResult> appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
+        final List<CloudEvent> eventsToAppend;
+        try {
+            eventsToAppend = DcbMarkerModel.validateDcbEvents(events);
+        } catch (RuntimeException e) {
+            return Mono.error(e);
+        }
+        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in the
+        // same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all condition)
+        // fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        Set<String> conditionBoundaryTags = condition == null ? Set.of() : DcbCloudEvents.boundaryTags(condition.query());
+        Set<String> placementTags = conditionBoundaryTags.isEmpty() ? DcbMarkerModel.boundaryTagsOf(eventsToAppend) : conditionBoundaryTags;
+        String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
+        int eventCount = eventsToAppend.size();
+
+        // Reserve the position block once, outside the transaction. The counter findAndModify is a single atomic
+        // document update that MongoDB serializes without raising a transaction conflict. The reserved block is reused
+        // across transient-transaction-error retries, a doomed or condition-failed append abandons it, so dcbposition
+        // may have gaps (DCB permits this, see ADR 0021).
+        return reserveDcbPositions(eventCount).flatMap(firstPosition -> {
+            long lastPosition = firstPosition + eventCount - 1;
+            Mono<DcbAppendResult> transaction = transactionalOperator.transactional(
+                    currentStreamVersion(streamId).flatMap(currentStreamVersion -> {
+                        final Mono<Void> conditionAndMarkers;
+                        if (condition != null) {
+                            conditionAndMarkers = enforceAppendCondition(condition, eventsToAppend, lastPosition);
+                        } else {
+                            // An unconditional append still increments its events' markers so a concurrent conditional append on an
+                            // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
+                            // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
+                            // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
+                            // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                            conditionAndMarkers = incrementConflictMarkers(DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
+                        }
+                        return conditionAndMarkers.then(Mono.defer(() -> {
+                            List<Document> documents = convertDcbCloudEventsToDocuments(streamId, eventsToAppend, currentStreamVersion, firstPosition);
+                            return insertAllDcb(streamId, currentStreamVersion, documents).thenReturn(new DcbAppendResult(firstPosition, lastPosition, eventCount));
+                        }));
+                    }));
+            // The driver does not auto-retry a transient transaction conflict reactively, so retry it here, plus a
+            // DuplicateKeyException from two transactions first-creating the same conflict marker at once. A
+            // DcbAppendConditionNotFulfilledException and a DuplicateCloudEventException are deliberately not retried.
+            return transaction.retryWhen(Retry.backoff(15, Duration.ofMillis(10)).maxBackoff(Duration.ofMillis(500))
+                    .filter(throwable -> isTransientTransactionError(throwable) || isDuplicateKeyError(throwable))
+                    .onRetryExhaustedThrow((spec, signal) -> signal.failure()));
+        });
+    }
+
+    private Mono<Void> enforceAppendCondition(DcbAppendCondition condition, List<CloudEvent> eventsToAppend, long lastPosition) {
+        Optional<DcbConsistencyToken> expectedToken = condition.consistencyToken();
+        final Mono<Boolean> conflictMono;
+        if (expectedToken.isPresent()) {
+            // Token-carrying check: the condition carries the consistency token the command observed when it read the
+            // query. If the query's markers have advanced since, an append matching the query committed after the read,
+            // so the condition is not fulfilled. Immune to read-watermark overshoot because marker versions are bumped
+            // inside the append transaction (ADR 0021).
+            conflictMono = consistencyToken(condition.query()).map(actual -> actual != expectedToken.get().value());
+        } else {
+            // No token: an absolute "fail if any matching event exists" guard. The marker increments below still
+            // serialize concurrent unconditional guards on the same boundary so two of them cannot both pass.
+            conflictMono = mongoTemplate.exists(toDcbMongoQuery(condition.query(), 0, Long.MAX_VALUE), eventStoreCollectionName);
+        }
+        return conflictMono.flatMap(conflict -> {
+            if (conflict) {
+                return currentDcbPosition().flatMap(position -> Mono.<Void>error(new DcbAppendConditionNotFulfilledException(condition, position, "Append condition was not fulfilled.")));
+            }
+            // Increment a marker per key for the union of the query's keys and the appended events' keys. Always
+            // increment the query's markers so a concurrent matching append is serialized even when this append's own
+            // events do not match the query.
+            TreeSet<String> markerKeys = new TreeSet<>(DcbMarkerModel.queryMarkerKeys(condition.query()));
+            markerKeys.addAll(DcbMarkerModel.eventMarkerKeys(eventsToAppend));
+            return incrementConflictMarkers(markerKeys, lastPosition);
+        });
+    }
+
+    private Mono<Void> incrementConflictMarkers(Set<String> markerKeys, long lastPosition) {
+        return Flux.fromIterable(markerKeys)
+                .concatMap(key -> {
+                    Query query = new Query(where(ID).is(DcbMarkerModel.markerId(key)));
+                    Update update = new Update().inc(DcbMarkerModel.CHECKPOINT_VERSION, 1L).set(DcbMarkerModel.CHECKPOINT_LAST_POSITION, lastPosition);
+                    return mongoTemplate.upsert(query, update, dcbCheckpointCollectionName);
+                })
+                .then();
+    }
+
+    // The optimistic-concurrency token for a query: the sum of the versions of its conflict markers. Read the markers
+    // in one query so their versions come from a single consistent snapshot.
+    private Mono<Long> consistencyToken(DcbQuery query) {
+        Set<String> markerKeys = DcbMarkerModel.queryMarkerKeys(query);
+        if (markerKeys.isEmpty()) {
+            return Mono.just(0L);
+        }
+        List<String> markerIds = markerKeys.stream().map(DcbMarkerModel::markerId).toList();
+        return mongoTemplate.find(new Query(where(ID).in(markerIds)), Document.class, dcbCheckpointCollectionName)
+                .map(marker -> {
+                    Number version = (Number) marker.get(DcbMarkerModel.CHECKPOINT_VERSION);
+                    return version == null ? 0L : version.longValue();
+                })
+                .reduce(0L, Long::sum);
+    }
+
+    private Mono<Long> reserveDcbPositions(int eventCount) {
+        Query query = new Query(where(ID).is(DcbMarkerModel.DCB_POSITION_DOCUMENT_ID));
+        Update update = new Update().inc(DcbMarkerModel.DCB_COUNTER_POSITION, eventCount);
+        FindAndModifyOptions options = FindAndModifyOptions.options().upsert(true).returnNew(true);
+        return mongoTemplate.findAndModify(query, update, options, Document.class, dcbPositionCollectionName)
+                .map(updated -> ((Number) updated.get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue() - eventCount + 1)
+                // Cold-start race: when the counter document does not exist yet, concurrent upserts all try to insert it
+                // and all but one get a duplicate key. On retry the document exists and the upsert becomes an update.
+                .retryWhen(Retry.fixedDelay(5, Duration.ofMillis(20)).filter(ReactorMongoEventStore::isDuplicateKeyError));
+    }
+
+    private Mono<Long> currentDcbPosition() {
+        return mongoTemplate.findById(DcbMarkerModel.DCB_POSITION_DOCUMENT_ID, Document.class, dcbPositionCollectionName)
+                .map(document -> ((Number) document.get(DcbMarkerModel.DCB_COUNTER_POSITION)).longValue())
+                .defaultIfEmpty(0L);
+    }
+
+    private List<Document> convertDcbCloudEventsToDocuments(String streamId, List<CloudEvent> cloudEvents, long currentStreamVersion, long firstPosition) {
+        List<Document> documents = new ArrayList<>(cloudEvents.size());
+        long streamVersion = currentStreamVersion + 1;
+        long position = firstPosition;
+        for (CloudEvent cloudEvent : cloudEvents) {
+            CloudEvent dcbCloudEvent = DcbCloudEvents.withPosition(cloudEvent, position);
+            documents.add(DcbDocumentMapper.toDocument(timeRepresentation, streamId, streamVersion++, dcbCloudEvent, position));
+            position++;
+        }
+        return documents;
+    }
+
+    private Mono<Void> insertAllDcb(String streamId, long streamVersion, List<Document> documents) {
+        return mongoTemplate.insert(documents, eventStoreCollectionName)
+                .onErrorResume(throwable -> {
+                    // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
+                    // stream racing on stream_version) must stay transient so the append retry retries it, rather than
+                    // being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+                    if (isTransientTransactionError(throwable)) {
+                        return Mono.error(throwable);
+                    }
+                    MongoException mongoException = findMongoException(throwable);
+                    if (mongoException != null) {
+                        return Mono.error(translateException(new WriteContext(streamId, streamVersion, WriteCondition.anyStreamVersion()), mongoException));
+                    }
+                    return Mono.error(throwable);
+                })
+                .then();
+    }
+
+    private static UnsupportedOperationException capabilityError(EventStoreCapability capability) {
+        return new UnsupportedOperationException(capability + " capability is not enabled for this ReactorMongoEventStore");
+    }
+
+    private static boolean isTransientTransactionError(Throwable throwable) {
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof MongoException mongoException && mongoException.hasErrorLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDuplicateKeyError(Throwable throwable) {
+        // A DuplicateCloudEventException is a genuine business error (an event whose id and source already exist), not
+        // the cold-start marker or position race, and the driver duplicate-key exception is its cause, so stop and do
+        // not retry once it appears in the chain.
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof DuplicateCloudEventException) {
+                return false;
+            }
+            if (cause instanceof MongoBulkWriteException bulkWriteException) {
+                boolean duplicate = bulkWriteException.getWriteErrors().stream()
+                        .anyMatch(writeError -> ErrorCategory.fromErrorCode(writeError.getCode()) == ErrorCategory.DUPLICATE_KEY);
+                if (duplicate) {
+                    return true;
+                }
+            } else if (cause instanceof MongoException mongoException && mongoException.getCode() == 11000) {
+                return true;
+            } else if (cause instanceof DuplicateKeyException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private static MongoException findMongoException(Throwable throwable) {
+        Throwable cause = throwable;
+        for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
+            if (cause instanceof MongoException mongoException) {
+                return mongoException;
+            }
+        }
+        return null;
+    }
+
+    private static Query toDcbMongoQuery(DcbQuery query, long afterSequencePosition, long upperSequencePosition) {
+        Criteria positionCriteria = where(DcbCloudEvents.POSITION).gt(afterSequencePosition).lte(upperSequencePosition);
+        if (query instanceof DcbQuery.MatchAll) {
+            return new Query(positionCriteria);
+        }
+        List<Criteria> itemCriteria = DcbMarkerModel.dcbQueryItems(query).stream()
+                .map(ReactorMongoEventStore::toCriteria)
+                .toList();
+        return new Query(new Criteria().andOperator(positionCriteria, new Criteria().orOperator(itemCriteria)));
+    }
+
+    private static Criteria toCriteria(DcbQueryItem item) {
+        List<Criteria> criteria = new ArrayList<>();
+        if (!item.types().isEmpty()) {
+            criteria.add(where("type").in(item.types()));
+        }
+        if (!item.excludedTypes().isEmpty()) {
+            criteria.add(where("type").nin(item.excludedTypes()));
+        }
+        if (!item.tags().isEmpty()) {
+            criteria.add(where(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD).all(item.tags()));
+        }
+        return new Criteria().andOperator(criteria);
     }
 
     // Read
@@ -218,21 +547,34 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
     }
 
     // Initialization
-    private static Mono<Void> initializeEventStore(String eventStoreCollectionName, ReactiveMongoTemplate mongoTemplate) {
-        Mono<MongoCollection<Document>> createEventStoreCollection = createCollection(eventStoreCollectionName, mongoTemplate);
+    private static Mono<Void> initializeEventStore(String eventStoreCollectionName, String dcbPositionCollectionName, String dcbCheckpointCollectionName, Set<EventStoreCapability> eventStoreCapabilities, ReactiveMongoTemplate mongoTemplate) {
+        boolean dcbEnabled = eventStoreCapabilities.contains(DCB);
 
         // Cloud spec defines id + source must be unique!
-        Mono<String> indexIdAndSource = createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true));
+        Mono<Void> chain = createCollection(eventStoreCollectionName, mongoTemplate)
+                .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true)))
+                .then();
 
-        // Create a streamId + streamVersion index (note that we don't need to index stream id separately since it's covered by this compound index)
-        // Note also that this index supports when sorting both ascending and descending since MongoDB can traverse an index in both directions.
-        Mono<String> indexStreamIdAndAscendingStreamVersion = createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), new IndexOptions().unique(true));
+        // streamId + streamVersion uniqueness is a stream-mode invariant. DCB correctness rests on the per-attribute
+        // markers and the unique dcbposition, not stream version, so a DCB-only store neither needs nor creates it.
+        if (eventStoreCapabilities.contains(STREAM)) {
+            chain = chain.then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), new IndexOptions().unique(true))).then();
+        }
+
+        if (dcbEnabled) {
+            chain = chain
+                    .then(createCollection(dcbPositionCollectionName, mongoTemplate))
+                    .then(createCollection(dcbCheckpointCollectionName, mongoTemplate))
+                    .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.ascending(DcbCloudEvents.POSITION), new IndexOptions().unique(true).sparse(true)))
+                    .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions()))
+                    .then();
+        }
 
         // SessionSynchronization need to be "ALWAYS" in order for TransactionTemplate to work with mongo template!
         // See https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions.transaction-template
         mongoTemplate.setSessionSynchronization(ALWAYS);
 
-        return createEventStoreCollection.then(indexIdAndSource).then(indexStreamIdAndAscendingStreamVersion).then();
+        return chain;
     }
 
     private static Mono<String> createIndex(String eventStoreCollectionName, ReactiveMongoTemplate mongoTemplate, Bson index, IndexOptions indexOptions) {
@@ -260,6 +602,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Void> deleteEventStream(String streamId) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(streamId, "Stream id cannot be null");
 
         return mongoTemplate.remove(streamIdEqualTo(streamId), eventStoreCollectionName).then();
@@ -267,6 +612,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Void> deleteEvent(String cloudEventId, URI cloudEventSource) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(cloudEventId, "Cloud event id cannot be null");
         requireNonNull(cloudEventSource, "Cloud event source cannot be null");
 
@@ -275,6 +623,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Void> delete(Filter filter) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(filter, "Filter cannot be null");
         final Query query = FilterConverter.convertFilterToQuery(timeRepresentation, filter);
         return mongoTemplate.remove(query, eventStoreCollectionName).then();
@@ -282,6 +633,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<CloudEvent> updateEvent(String cloudEventId, URI cloudEventSource, Function<CloudEvent, CloudEvent> updateFunction) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         Function<Function<CloudEvent, CloudEvent>, Mono<CloudEvent>> logic = (fn) -> {
             Query cloudEventQuery = cloudEventIdIs(cloudEventId, cloudEventSource);
             return mongoTemplate.findOne(cloudEventQuery, Document.class, eventStoreCollectionName)
@@ -310,6 +664,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Flux<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Flux.error(capabilityError(STREAM));
+        }
         requireNonNull(filter, "Filter cannot be null");
         final Query query = queryOptions.apply(FilterConverter.convertFilterToQuery(timeRepresentation, filter));
         return readCloudEvents(query, skip, limit, sortBy)
@@ -318,6 +675,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Long> count(Filter filter) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(filter, "Filter cannot be null");
         if (filter instanceof Filter.All) {
             return mongoTemplate.createMono(eventStoreCollectionName, MongoCollection::estimatedDocumentCount);
@@ -329,6 +689,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     @Override
     public Mono<Boolean> exists(Filter filter) {
+        if (!eventStoreCapabilities.contains(STREAM)) {
+            return Mono.error(capabilityError(STREAM));
+        }
         requireNonNull(filter, "Filter cannot be null");
         if (filter instanceof Filter.All) {
             return count().map(cnt -> cnt > 0);

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.DuplicateCloudEventException;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.dcb.*;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
@@ -41,6 +42,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -287,6 +289,22 @@ class ReactorMongoEventStoreDcbTest {
             assertThat(unexpectedFailCount.get()).as("iteration %d: no unexpected failures, transient errors must be retried internally", i).isZero();
             assertThat(condFailCount.get()).as("iteration %d: the other %d appends fail the condition", i, threadCount - 1).isEqualTo(threadCount - 1);
         }
+    }
+
+    @Test
+    void appending_an_event_with_a_duplicate_id_and_source_fails_fast_without_retrying() {
+        CloudEvent event = taggedEvent("NameDefined", "name:1");
+        eventStore.append(List.of(event)).block();
+
+        // The same id and source again is a duplicate CloudEvent, a business error, not a transient conflict or the
+        // cold-start marker race. It must surface as DuplicateCloudEventException and must not be fed into the append
+        // backoff, so it fails fast instead of running the full 15-attempt retry before giving up.
+        long start = System.nanoTime();
+        StepVerifier.create(eventStore.append(List.of(event)))
+                .expectError(DuplicateCloudEventException.class)
+                .verify(Duration.ofSeconds(10));
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - start).toMillis();
+        assertThat(elapsedMillis).as("a duplicate CloudEvent must not be retried, so it fails well before the multi-second backoff").isLessThan(3000L);
     }
 
     private static CloudEvent taggedEvent(String type, String... tags) {

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
 import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
@@ -109,12 +110,13 @@ class ReactorMongoEventStoreDcbTest {
     void dcb_write_is_readable_by_tag_and_carries_position() {
         eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
 
-        DcbEventStream stream = eventStore.read(tags("name:1")).block();
-        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
-        CloudEvent event = stream.events().get(0);
-        assertThat(DcbCloudEvents.getTags(event)).containsExactly("name:1");
-        assertThat(event.getExtension(DcbCloudEvents.POSITION)).isEqualTo(1L);
-        assertThat(stream.lastSequencePosition()).isEqualTo(1);
+        DcbEventStream stream = requireNonNull(eventStore.read(tags("name:1")).block());
+        assertAll(
+                () -> assertThat(stream.events()).extracting(CloudEvent::getType).containsExactly("NameDefined"),
+                () -> assertThat(DcbCloudEvents.getTags(stream.events().get(0))).containsExactly("name:1"),
+                () -> assertThat(stream.events().get(0).getExtension(DcbCloudEvents.POSITION)).isEqualTo(1L),
+                () -> assertThat(stream.lastSequencePosition()).isEqualTo(1)
+        );
     }
 
     @Test
@@ -124,12 +126,14 @@ class ReactorMongoEventStoreDcbTest {
                 taggedEvent("NameChanged", "name:1", "tenant:1"),
                 taggedEvent("OrderPlaced", "order:1"))).block();
 
-        DcbEventStream stream = eventStore.read(
+        DcbEventStream stream = requireNonNull(eventStore.read(
                 anyOf(List.of(types(List.of("OrderPlaced")), tags(List.of("name:1", "tenant:1")))),
-                DcbReadOptions.afterSequencePosition(1)).block();
+                DcbReadOptions.afterSequencePosition(1)).block());
 
-        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameChanged", "OrderPlaced");
-        assertThat(stream.lastSequencePosition()).isEqualTo(3);
+        assertAll(
+                () -> assertThat(stream.events()).extracting(CloudEvent::getType).containsExactly("NameChanged", "OrderPlaced"),
+                () -> assertThat(stream.lastSequencePosition()).isEqualTo(3)
+        );
     }
 
     @Test
@@ -202,9 +206,11 @@ class ReactorMongoEventStoreDcbTest {
                 taggedEvent("NameDefined", "name:1"),
                 taggedEvent("OrderPlaced", "order:1"))).block();
 
-        assertThat(eventStore.exists(tags("name:1")).block()).isTrue();
-        assertThat(eventStore.exists(tags("missing:1")).block()).isFalse();
-        assertThat(eventStore.count(types(List.of("NameDefined", "OrderPlaced"))).block()).isEqualTo(2L);
+        assertAll(
+                () -> assertThat(eventStore.exists(tags("name:1")).block()).isTrue(),
+                () -> assertThat(eventStore.exists(tags("missing:1")).block()).isFalse(),
+                () -> assertThat(eventStore.count(types(List.of("NameDefined", "OrderPlaced"))).block()).isEqualTo(2L)
+        );
     }
 
     @Test
@@ -217,8 +223,10 @@ class ReactorMongoEventStoreDcbTest {
                 .count()
                 .block();
 
-        assertThat(appended).isEqualTo(8L);
-        assertThat(eventStore.count(all()).block()).isEqualTo(8L);
+        assertAll(
+                () -> assertThat(appended).isEqualTo(8L),
+                () -> assertThat(eventStore.count(all()).block()).isEqualTo(8L)
+        );
     }
 
     @Test
@@ -285,9 +293,12 @@ class ReactorMongoEventStoreDcbTest {
                 f.get();
             }
 
-            assertThat(successCount.get()).as("iteration %d: exactly one append wins (tag=%s)", i, tag).isEqualTo(1);
-            assertThat(unexpectedFailCount.get()).as("iteration %d: no unexpected failures, transient errors must be retried internally", i).isZero();
-            assertThat(condFailCount.get()).as("iteration %d: the other %d appends fail the condition", i, threadCount - 1).isEqualTo(threadCount - 1);
+            int iteration = i;
+            assertAll(
+                    () -> assertThat(successCount.get()).as("iteration %d: exactly one append wins (tag=%s)", iteration, tag).isEqualTo(1),
+                    () -> assertThat(unexpectedFailCount.get()).as("iteration %d: no unexpected failures, transient errors must be retried internally", iteration).isZero(),
+                    () -> assertThat(condFailCount.get()).as("iteration %d: the other %d appends fail the condition", iteration, threadCount - 1).isEqualTo(threadCount - 1)
+            );
         }
     }
 

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.dcb.*;
-import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
 import org.springframework.data.mongodb.ReactiveMongoTransactionManager;

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.spring.reactor;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.eventstore.api.EventStoreCapability;
+import org.occurrent.eventstore.api.dcb.*;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbAppendCondition.failIfEventsMatch;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.*;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ReactorMongoEventStoreDcbTest {
+
+    private static final URI SOURCE = URI.create("urn:test");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                .withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbreactor"));
+
+    private ReactorMongoEventStore eventStore;
+    private ReactiveMongoTemplate mongoTemplate;
+    private ReactiveMongoTransactionManager transactionManager;
+
+    @BeforeEach
+    void create_reactive_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbreactor");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        transactionManager = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        eventStore = storeWith(STREAM, DCB);
+    }
+
+    private ReactorMongoEventStore storeWith(EventStoreCapability first, EventStoreCapability... rest) {
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(transactionManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(first, rest)
+                .build();
+        return new ReactorMongoEventStore(mongoTemplate, config);
+    }
+
+    @Test
+    void dcb_write_is_readable_by_tag_and_carries_position() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+
+        DcbEventStream stream = eventStore.read(tags("name:1")).block();
+        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
+        CloudEvent event = stream.events().get(0);
+        assertThat(DcbCloudEvents.getTags(event)).containsExactly("name:1");
+        assertThat(event.getExtension(DcbCloudEvents.POSITION)).isEqualTo(1L);
+        assertThat(stream.lastSequencePosition()).isEqualTo(1);
+    }
+
+    @Test
+    void reads_events_matching_type_or_all_tags_after_sequence_position() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameChanged", "name:1", "tenant:1"),
+                taggedEvent("OrderPlaced", "order:1"))).block();
+
+        DcbEventStream stream = eventStore.read(
+                anyOf(List.of(types(List.of("OrderPlaced")), tags(List.of("name:1", "tenant:1")))),
+                DcbReadOptions.afterSequencePosition(1)).block();
+
+        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameChanged", "OrderPlaced");
+        assertThat(stream.lastSequencePosition()).isEqualTo(3);
+    }
+
+    @Test
+    void reads_tagged_events_except_excluded_types() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("NameSnapshot", "name:1"),
+                taggedEvent("OrderPlaced", "order:1"))).block();
+
+        DcbEventStream stream = eventStore.read(tags(List.of("name:1")).excludingTypes(List.of("NameSnapshot"))).block();
+
+        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
+    }
+
+    @Test
+    void conditional_append_with_stale_token_is_rejected() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+        DcbEventStream readModel = eventStore.read(tags("name:1")).block();
+
+        // Another append on the same boundary advances the marker.
+        eventStore.append(List.of(taggedEvent("NameChanged", "name:1"))).block();
+
+        StepVerifier.create(eventStore.append(
+                        List.of(taggedEvent("NameChanged", "name:1")),
+                        failIfEventsMatch(tags("name:1"), requireNonNull(readModel).consistencyToken())))
+                .expectError(DcbAppendConditionNotFulfilledException.class)
+                .verify();
+    }
+
+    @Test
+    void conditional_append_with_fresh_token_succeeds() {
+        DcbEventStream readModel = eventStore.read(tags("name:1")).block();
+
+        DcbAppendResult result = eventStore.append(
+                List.of(taggedEvent("NameDefined", "name:1")),
+                failIfEventsMatch(tags("name:1"), requireNonNull(readModel).consistencyToken())).block();
+
+        assertThat(requireNonNull(result).firstSequencePosition()).isEqualTo(1);
+    }
+
+    @Test
+    void no_token_guard_rejects_when_a_matching_event_exists() {
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+
+        StepVerifier.create(eventStore.append(
+                        List.of(taggedEvent("NameChanged", "name:1")),
+                        failIfEventsMatch(tags("name:1"))))
+                .expectError(DcbAppendConditionNotFulfilledException.class)
+                .verify();
+    }
+
+    @Test
+    void unconditional_append_makes_a_concurrent_conditional_append_on_the_same_tag_fail() {
+        // Read the boundary while empty: token is 0.
+        DcbEventStream readModel = eventStore.read(tags("name:1")).block();
+
+        // An unconditional append must still bump the tag marker, so the stale-token conditional append below is rejected.
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+
+        StepVerifier.create(eventStore.append(
+                        List.of(taggedEvent("NameChanged", "name:1")),
+                        failIfEventsMatch(tags("name:1"), requireNonNull(readModel).consistencyToken())))
+                .expectError(DcbAppendConditionNotFulfilledException.class)
+                .verify();
+    }
+
+    @Test
+    void exists_and_count_match_the_query() {
+        eventStore.append(List.of(
+                taggedEvent("NameDefined", "name:1"),
+                taggedEvent("OrderPlaced", "order:1"))).block();
+
+        assertThat(eventStore.exists(tags("name:1")).block()).isTrue();
+        assertThat(eventStore.exists(tags("missing:1")).block()).isFalse();
+        assertThat(eventStore.count(types(List.of("NameDefined", "OrderPlaced"))).block()).isEqualTo(2L);
+    }
+
+    @Test
+    void concurrent_appends_to_disjoint_boundaries_both_succeed() {
+        Long appended = Flux.range(0, 8)
+                .parallel(8)
+                .runOn(Schedulers.boundedElastic())
+                .flatMap(i -> eventStore.append(List.of(taggedEvent("Defined", "entity:" + i))))
+                .sequential()
+                .count()
+                .block();
+
+        assertThat(appended).isEqualTo(8L);
+        assertThat(eventStore.count(all()).block()).isEqualTo(8L);
+    }
+
+    @Test
+    void dcb_methods_are_rejected_when_only_stream_is_enabled() {
+        ReactorMongoEventStore streamOnly = storeWith(STREAM);
+        StepVerifier.create(streamOnly.append(List.of(taggedEvent("NameDefined", "name:1"))))
+                .expectError(UnsupportedOperationException.class)
+                .verify();
+    }
+
+    @Test
+    void stream_methods_are_rejected_when_only_dcb_is_enabled() {
+        ReactorMongoEventStore dcbOnly = storeWith(DCB);
+        StepVerifier.create(dcbOnly.exists("some-stream"))
+                .expectError(UnsupportedOperationException.class)
+                .verify();
+    }
+
+    @Test
+    void empty_capability_set_is_rejected() {
+        assertThat(org.assertj.core.api.Assertions.catchThrowable(() -> new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(transactionManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(Set.of())
+                .build()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void same_boundary_serialization_under_contention() throws Exception {
+        int threadCount = 8;
+        int iterations = 3;
+
+        for (int i = 0; i < iterations; i++) {
+            String tag = "contention-" + i;
+            DcbConsistencyToken boundaryToken = requireNonNull(eventStore.read(tags(tag)).block()).consistencyToken();
+            DcbAppendCondition condition = failIfEventsMatch(tags(tag), boundaryToken);
+
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger condFailCount = new AtomicInteger(0);
+            AtomicInteger unexpectedFailCount = new AtomicInteger(0);
+            List<Future<?>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                futures.add(pool.submit(() -> {
+                    barrier.await();
+                    try {
+                        eventStore.append(List.of(taggedEvent("SomeEvent", tag)), condition).block();
+                        successCount.incrementAndGet();
+                    } catch (DcbAppendConditionNotFulfilledException e) {
+                        condFailCount.incrementAndGet();
+                    } catch (Exception e) {
+                        unexpectedFailCount.incrementAndGet();
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<?> f : futures) {
+                f.get();
+            }
+
+            assertThat(successCount.get()).as("iteration %d: exactly one append wins (tag=%s)", i, tag).isEqualTo(1);
+            assertThat(unexpectedFailCount.get()).as("iteration %d: no unexpected failures, transient errors must be retried internally", i).isZero();
+            assertThat(condFailCount.get()).as("iteration %d: the other %d appends fail the condition", i, threadCount - 1).isEqualTo(threadCount - 1);
+        }
+    }
+
+    private static CloudEvent taggedEvent(String type, String... tags) {
+        return DcbCloudEvents.withTags(event(type), Set.of(tags));
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(SOURCE)
+                .withType(type)
+                .withTime(OffsetDateTime.now())
+                .withData("{}".getBytes(UTF_8))
+                .build();
+    }
+}


### PR DESCRIPTION
This adds DCB to the reactive Spring MongoDB event store. It was the last event store without DCB, so this completes DCB across all four stores (in-memory, Spring blocking, native, and now reactive Spring).

`ReactorMongoEventStore` implements a new reactive `DcbEventStore` (in a new `eventstore-api-dcb-reactor` module) with `Mono` and `Flux`. The interface lives in its own module so project-reactor stays off the classpath of blocking-only consumers of `eventstore-api-dcb`, the same way the stream `api/blocking` and `api/reactor` modules are split.

The store reuses `DcbMarkerModel` and `DcbDocumentMapper` from `eventstore-mongodb-dcb-common` unchanged, so the marker model and the on-disk contract are identical to the blocking and native stores. `EventStoreConfig` gains the capability set and a `DcbStreamIdGenerator`, and defaults to stream-only, so existing reactive applications are untouched.

The append mirrors the blocking semantics, translated to Reactor:

- positions reserved outside the transaction, reused across retries
- marker increments and condition enforcement inside `transactionalOperator.transactional(...)`
- a single-read consistency token, which the token-conflict tests confirm sees the reactive transaction snapshot
- a reactive `Retry.backoff` on transient-transaction and cold-start duplicate-key errors. A `DcbAppendConditionNotFulfilledException` and a `DuplicateCloudEventException` are not retried.

Tests mirror the blocking and native DCB suites with `StepVerifier`, including a same-boundary contention test where 8 parallel appends compete and exactly one wins.

The reactive side still has no DCB application service, DSL, or subscriptions. Those are the remaining phases and are demand-gated, recorded in the plan. See ADR 34 for the rationale.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
