### PR TITLE
Add a reactive DCB application service

### DIFF
--- a/application/service/pom.xml
+++ b/application/service/pom.xml
@@ -28,5 +28,6 @@
     
     <modules>
         <module>blocking</module>
+        <module>reactor</module>
     </modules>
 </project>

--- a/application/service/reactor/pom.xml
+++ b/application/service/reactor/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>application-service</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>${mavenProjectName}</name>
+
+    <artifactId>application-service-reactor</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/DcbApplicationService.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/DcbApplicationService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.dcb;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Reactive counterpart of the blocking DCB application service. It runs domain decisions against events selected by a
+ * Dynamic Consistency Boundary query, returning a {@link Mono} for the asynchronous read and append.
+ * <p>
+ * The domain function stays synchronous because a DCB read materializes its matching events into a list and the
+ * decision is a pure function over them. Only the read and the append are reactive.
+ */
+@NullMarked
+public interface DcbApplicationService<E> {
+
+    /**
+     * Executes a domain function for the events selected by {@code query}.
+     *
+     * @param query the DCB query that defines which existing events are relevant to the decision
+     * @param functionThatCallsDomainModel receives the current matching domain events and returns new domain events to append
+     * @return a {@link Mono} of the append result, or {@link Optional#empty()} when the domain function produced no new events
+     */
+    default Mono<Optional<DcbAppendResult>> execute(DcbQuery query, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        return execute(query, DcbExecuteOptions.empty(), functionThatCallsDomainModel);
+    }
+
+    /**
+     * Executes a domain function for the events selected by {@code query}, with the supplied {@link DcbExecuteOptions}.
+     * <p>
+     * When the options carry a side-effect, it is invoked once with the newly produced domain events after they have
+     * been appended successfully. It is not invoked when the domain function produced no new events.
+     *
+     * @param query the DCB query that defines which existing events are relevant to the decision
+     * @param options the execute options (for example a post-append side-effect)
+     * @param functionThatCallsDomainModel receives the current matching domain events and returns new domain events to append
+     * @return a {@link Mono} of the append result, or {@link Optional#empty()} when the domain function produced no new events
+     */
+    Mono<Optional<DcbAppendResult>> execute(DcbQuery query, DcbExecuteOptions<E> options, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel);
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/DcbExecuteOptions.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/DcbExecuteOptions.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.dcb;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Options used when executing a command through a reactive {@link DcbApplicationService}.
+ * <p>
+ * It carries an optional side-effect that is invoked after the produced events have been appended. The side-effect
+ * returns a {@link Mono} so it can do non-blocking work, and it is composed into the returned {@code Mono} after the
+ * append, outside the retry, so it runs once on success rather than once per attempt.
+ * <p>
+ * Unlike the stream execute options, it has no read-filter option on purpose. In DCB the
+ * {@link org.occurrent.eventstore.api.dcb.DcbQuery} passed to {@code execute} is both the read filter and the
+ * consistency boundary, so a separate filter here would be redundant and misleading.
+ *
+ * @param <E> The application service event type.
+ */
+@NullMarked
+public final class DcbExecuteOptions<E> {
+    private final @Nullable Function<Stream<E>, Mono<Void>> sideEffect;
+
+    private DcbExecuteOptions(@Nullable Function<Stream<E>, Mono<Void>> sideEffect) {
+        this.sideEffect = sideEffect;
+    }
+
+    /**
+     * Create empty options, i.e. no side-effect.
+     *
+     * @param <E> The application service event type.
+     * @return Empty execute options.
+     */
+    public static <E> DcbExecuteOptions<E> empty() {
+        return new DcbExecuteOptions<>(null);
+    }
+
+    /**
+     * Alias for {@link #empty()} intended to read naturally in fluent call sites.
+     *
+     * @param <E> The application service event type.
+     * @return Empty execute options.
+     */
+    public static <E> DcbExecuteOptions<E> options() {
+        return empty();
+    }
+
+    /**
+     * Set the side-effect to invoke after a successful append.
+     * <p>
+     * The side-effect is invoked once with the events produced by the current execution after those events have been
+     * appended successfully. It is not invoked when the domain function produced no new events.
+     *
+     * @param sideEffect   Side-effect that receives the newly produced domain events and returns a {@link Mono} that
+     *                     completes when the side-effect is done.
+     * @param <E_SPECIFIC> The side-effect event type for the returned options.
+     * @return New options with the side-effect applied.
+     */
+    public <E_SPECIFIC extends E> DcbExecuteOptions<E_SPECIFIC> sideEffect(Function<Stream<E_SPECIFIC>, Mono<Void>> sideEffect) {
+        return new DcbExecuteOptions<>(Objects.requireNonNull(sideEffect, "sideEffect cannot be null"));
+    }
+
+    /**
+     * Return the configured post-append side-effect, or {@code null} if none has been configured.
+     */
+    public @Nullable Function<Stream<E>, Mono<Void>> sideEffect() {
+        return sideEffect;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        DcbExecuteOptions<?> that = (DcbExecuteOptions<?>) obj;
+        return Objects.equals(this.sideEffect, that.sideEffect);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sideEffect);
+    }
+
+    @Override
+    public String toString() {
+        return "DcbExecuteOptions[sideEffect=" + sideEffect + ']';
+    }
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationService.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationService.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.dcb;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Default reactive {@link DcbApplicationService} implementation.
+ * <p>
+ * It coordinates a reactive {@link DcbEventStore}, a {@link CloudEventConverter}, and a {@link TagGenerator} so
+ * application code keeps domain decisions expressed in domain events while DCB metadata is applied at the CloudEvent
+ * boundary. Storage stream placement is configured on the {@link DcbEventStore}.
+ */
+@NullMarked
+public class GenericDcbApplicationService<E> implements DcbApplicationService<E> {
+    private final DcbEventStore eventStore;
+    private final CloudEventConverter<E> cloudEventConverter;
+    private final TagGenerator<E> tagGenerator;
+    private final Retry retry;
+
+    /**
+     * Creates a service with the default retry policy for optimistic DCB conflicts.
+     */
+    public GenericDcbApplicationService(DcbEventStore eventStore, CloudEventConverter<E> cloudEventConverter, TagGenerator<E> tagGenerator) {
+        this(eventStore, cloudEventConverter, tagGenerator, defaultRetry());
+    }
+
+    /**
+     * Creates a service with explicit collaborators for event conversion, DCB tagging, and retries after DCB append
+     * conflicts. Storage stream placement is configured on the {@link DcbEventStore}, not here.
+     */
+    public GenericDcbApplicationService(DcbEventStore eventStore, CloudEventConverter<E> cloudEventConverter, TagGenerator<E> tagGenerator, Retry retry) {
+        if (eventStore == null) throw new IllegalArgumentException(DcbEventStore.class.getSimpleName() + " cannot be null");
+        if (cloudEventConverter == null) throw new IllegalArgumentException(CloudEventConverter.class.getSimpleName() + " cannot be null");
+        if (tagGenerator == null) throw new IllegalArgumentException(TagGenerator.class.getSimpleName() + " cannot be null");
+        if (retry == null) throw new IllegalArgumentException(Retry.class.getSimpleName() + " cannot be null");
+
+        this.eventStore = eventStore;
+        this.cloudEventConverter = cloudEventConverter;
+        this.tagGenerator = tagGenerator;
+        this.retry = retry;
+    }
+
+    @Override
+    public Mono<Optional<DcbAppendResult>> execute(DcbQuery query, DcbExecuteOptions<E> options, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(query, "Query cannot be null");
+        Objects.requireNonNull(options, DcbExecuteOptions.class.getSimpleName() + " cannot be null");
+        Objects.requireNonNull(functionThatCallsDomainModel, "Function that calls domain model cannot be null");
+
+        @Nullable Function<Stream<E>, Mono<Void>> sideEffect = options.sideEffect();
+
+        // The read, decide, and append run as one unit and retry from a fresh read on a DCB conflict, so the decision
+        // always runs against the current events. The side-effect is composed after the retry so it runs once on
+        // success, not per attempt.
+        Mono<Result<E>> readDecideAppend = Mono.defer(() -> eventStore.read(query).flatMap(eventStream -> {
+            Stream<E> domainEvents = cloudEventConverter.toDomainEvents(eventStream.stream());
+            List<E> newDomainEvents = emptyStreamIfNull(functionThatCallsDomainModel.apply(domainEvents)).toList();
+            if (newDomainEvents.isEmpty()) {
+                return Mono.just(new Result<>(Optional.<DcbAppendResult>empty(), List.<E>of()));
+            }
+            List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(newDomainEvents.stream()).toList();
+            List<CloudEvent> dcbEvents = addTags(newDomainEvents, cloudEvents);
+            DcbAppendCondition appendCondition = DcbAppendCondition.failIfEventsMatch(query, eventStream.consistencyToken());
+            return eventStore.append(dcbEvents, appendCondition).map(result -> new Result<>(Optional.of(result), newDomainEvents));
+        })).retryWhen(retry);
+
+        return readDecideAppend.flatMap(result -> {
+            if (sideEffect == null || result.appendResult().isEmpty()) {
+                return Mono.just(result.appendResult());
+            }
+            return sideEffect.apply(result.newDomainEvents().stream()).thenReturn(result.appendResult());
+        });
+    }
+
+    private List<CloudEvent> addTags(List<E> domainEvents, List<CloudEvent> cloudEvents) {
+        if (domainEvents.size() != cloudEvents.size()) {
+            throw new IllegalStateException(CloudEventConverter.class.getSimpleName() + " must preserve the number of events when converting to CloudEvents");
+        }
+        ArrayList<CloudEvent> dcbEvents = new ArrayList<>(domainEvents.size());
+        for (int i = 0; i < domainEvents.size(); i++) {
+            dcbEvents.add(DcbCloudEvents.withTags(cloudEvents.get(i), tagGenerator.tags(domainEvents.get(i))));
+        }
+        return dcbEvents;
+    }
+
+    private static <T> Stream<T> emptyStreamIfNull(@Nullable Stream<T> stream) {
+        return stream == null ? Stream.empty() : stream;
+    }
+
+    /**
+     * Returns the default reactive retry policy for optimistic DCB conflicts. It retries a
+     * {@link DcbAppendConditionNotFulfilledException} up to five times with exponential backoff and rethrows the
+     * original failure when the attempts are exhausted.
+     */
+    public static Retry defaultRetry() {
+        return Retry.backoff(5, Duration.ofMillis(100))
+                .maxBackoff(Duration.ofSeconds(2))
+                .filter(DcbAppendConditionNotFulfilledException.class::isInstance)
+                .onRetryExhaustedThrow((spec, signal) -> signal.failure());
+    }
+
+    private record Result<E>(Optional<DcbAppendResult> appendResult, List<E> newDomainEvents) {
+    }
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/TagGenerator.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/TagGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.dcb;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Set;
+
+/**
+ * Derives DCB tags from domain events before they are stored as CloudEvents.
+ * <p>
+ * Tags describe the Dynamic Consistency Boundary that future reads and append
+ * conditions can match. The application service stores them in the {@code dcbtags}
+ * CloudEvent extension.
+ */
+@FunctionalInterface
+@NullMarked
+public interface TagGenerator<E> {
+
+    /**
+     * Returns the DCB tags that should be attached to {@code event}.
+     *
+     * @param event the domain event about to be written
+     * @return the tags that make the event visible to relevant DCB queries
+     */
+    Set<String> tags(E event);
+}

--- a/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationServiceTest.java
+++ b/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
 import org.occurrent.eventstore.api.dcb.DcbAppendResult;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbEventStream;
@@ -180,6 +181,47 @@ class GenericDcbApplicationServiceTest {
                 .containsExactly("NameDefined", "NameChangedByOther", "NameChangedByService");
     }
 
+    @Test
+    void runs_the_side_effect_once_even_when_the_append_retries_after_a_conflict() {
+        eventStore.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1")))).block();
+        CloudEvent conflictingEvent = DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameChangedByOther", "name:1")), Set.of("name:1"));
+        ConflictingOnceDcbEventStore conflictingStore = new ConflictingOnceDcbEventStore(eventStore, conflictingEvent);
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicInteger sideEffectInvocations = new AtomicInteger();
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(conflictingStore, converter(), event -> Set.of(event.name()));
+
+        applicationService.execute(tags("name:1"),
+                DcbExecuteOptions.<DomainEvent>options().sideEffect(events -> Mono.fromRunnable(sideEffectInvocations::incrementAndGet)),
+                events -> {
+                    attempts.incrementAndGet();
+                    return Stream.of(new DomainEvent("NameChangedByService", "name:1"));
+                }).block();
+
+        // The decider runs twice (the first append conflicts, the second succeeds), but the side-effect is composed
+        // after the retry, so it fires once on the committed result, not once per attempt.
+        assertThat(attempts).hasValue(2);
+        assertThat(sideEffectInvocations).hasValue(1);
+    }
+
+    @Test
+    void rethrows_the_condition_failure_when_the_retries_are_exhausted() {
+        eventStore.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1")))).block();
+        AlwaysConflictingDcbEventStore conflictingStore = new AlwaysConflictingDcbEventStore(eventStore, converter());
+        AtomicInteger attempts = new AtomicInteger();
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(conflictingStore, converter(), event -> Set.of(event.name()));
+
+        StepVerifier.create(applicationService.execute(tags("name:1"), events -> {
+                    attempts.incrementAndGet();
+                    return Stream.of(new DomainEvent("NameChangedByService", "name:1"));
+                }))
+                .expectError(DcbAppendConditionNotFulfilledException.class)
+                .verify();
+
+        // The default policy retries five times before giving up, so the decider runs six times and the original
+        // condition failure surfaces rather than a retry-exhausted wrapper.
+        assertThat(attempts).hasValue(6);
+    }
+
     private static CloudEventConverter<DomainEvent> converter() {
         return new CloudEventConverter<>() {
             @Override
@@ -237,6 +279,37 @@ class GenericDcbApplicationServiceTest {
                 return delegate.append(List.of(conflictingEvent)).then(delegate.append(events, condition));
             }
             return delegate.append(events, condition);
+        }
+    }
+
+    /**
+     * A reactive DCB event store that commits a fresh conflicting matching event before every conditional append, so
+     * the carried consistency token is always stale and the condition never holds. It drives the retry policy to
+     * exhaustion.
+     */
+    private static class AlwaysConflictingDcbEventStore implements DcbEventStore {
+        private final DcbEventStore delegate;
+        private final CloudEventConverter<DomainEvent> converter;
+
+        private AlwaysConflictingDcbEventStore(DcbEventStore delegate, CloudEventConverter<DomainEvent> converter) {
+            this.delegate = delegate;
+            this.converter = converter;
+        }
+
+        @Override
+        public Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options) {
+            return delegate.read(query, options);
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events) {
+            return delegate.append(events);
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events, DcbAppendCondition condition) {
+            CloudEvent interloper = DcbCloudEvents.withTags(converter.toCloudEvent(new DomainEvent("NameChangedByOther", "name:1")), Set.of("name:1"));
+            return delegate.append(List.of(interloper)).then(delegate.append(events, condition));
         }
     }
 }

--- a/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationServiceTest.java
+++ b/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/dcb/GenericDcbApplicationServiceTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.dcb;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+import static org.occurrent.eventstore.api.dcb.DcbQuery.tags;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GenericDcbApplicationServiceTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbappservice"));
+
+    private ReactorMongoEventStore eventStore;
+
+    @BeforeEach
+    void create_reactive_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbappservice");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager transactionManager = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(transactionManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+    }
+
+    @Test
+    void reads_by_dcb_query_and_appends_with_tags_from_domain_events() {
+        eventStore.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1")))).block();
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter(), event -> Set.of(event.name()));
+
+        Optional<DcbAppendResult> result = applicationService.execute(tags("name:1"), events -> {
+            List<DomainEvent> currentEvents = events.toList();
+            assertThat(currentEvents).extracting(DomainEvent::type).containsExactly("NameDefined");
+            return Stream.of(new DomainEvent("NameChanged", "name:1"));
+        }).block();
+
+        assertThat(result).isPresent();
+        assertThat(requireNonNull(result).get().eventCount()).isEqualTo(1);
+        DcbEventStream eventStream = eventStore.read(tags("name:1")).block();
+        assertThat(requireNonNull(eventStream).events()).extracting(CloudEvent::getType).containsExactly("NameDefined", "NameChanged");
+        assertThat(DcbCloudEvents.getTags(eventStream.events().get(1))).containsExactly("name:1");
+    }
+
+    @Test
+    void does_not_append_when_domain_function_returns_no_events() {
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter(), event -> Set.of(event.name()));
+
+        StepVerifier.create(applicationService.execute(tags("name:1"), events -> Stream.empty()))
+                .expectNext(Optional.empty())
+                .verifyComplete();
+
+        assertThat(requireNonNull(eventStore.read(tags("name:1")).block()).events()).isEmpty();
+    }
+
+    @Test
+    void runs_the_side_effect_once_after_a_successful_append() {
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter(), event -> Set.of(event.name()));
+        AtomicInteger sideEffectInvocations = new AtomicInteger();
+
+        applicationService.execute(tags("name:1"),
+                DcbExecuteOptions.<DomainEvent>options().sideEffect(events -> Mono.fromRunnable(() -> {
+                    assertThat(events.map(DomainEvent::type).toList()).containsExactly("NameDefined");
+                    sideEffectInvocations.incrementAndGet();
+                })),
+                events -> Stream.of(new DomainEvent("NameDefined", "name:1"))).block();
+
+        assertThat(sideEffectInvocations).hasValue(1);
+    }
+
+    @Test
+    void does_not_run_the_side_effect_when_no_events_are_produced() {
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter(), event -> Set.of(event.name()));
+        AtomicInteger sideEffectInvocations = new AtomicInteger();
+
+        applicationService.execute(tags("name:1"),
+                DcbExecuteOptions.<DomainEvent>options().sideEffect(events -> Mono.fromRunnable(sideEffectInvocations::incrementAndGet)),
+                events -> Stream.empty()).block();
+
+        assertThat(sideEffectInvocations).hasValue(0);
+    }
+
+    @Test
+    void retries_from_a_fresh_dcb_read_when_append_condition_detects_a_conflict() {
+        eventStore.append(List.of(DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameDefined", "name:1")), Set.of("name:1")))).block();
+        CloudEvent conflictingEvent = DcbCloudEvents.withTags(converter().toCloudEvent(new DomainEvent("NameChangedByOther", "name:1")), Set.of("name:1"));
+        ConflictingOnceDcbEventStore conflictingStore = new ConflictingOnceDcbEventStore(eventStore, conflictingEvent);
+        AtomicInteger attempts = new AtomicInteger();
+        GenericDcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(conflictingStore, converter(), event -> Set.of(event.name()));
+
+        Optional<DcbAppendResult> result = applicationService.execute(tags("name:1"), events -> {
+            int attempt = attempts.incrementAndGet();
+            List<DomainEvent> currentEvents = events.toList();
+            if (attempt == 1) {
+                assertThat(currentEvents).extracting(DomainEvent::type).containsExactly("NameDefined");
+            } else {
+                assertThat(currentEvents).extracting(DomainEvent::type).containsExactly("NameDefined", "NameChangedByOther");
+            }
+            return Stream.of(new DomainEvent("NameChangedByService", "name:1"));
+        }).block();
+
+        assertThat(result).isPresent();
+        assertThat(attempts).hasValue(2);
+        assertThat(requireNonNull(eventStore.read(tags("name:1")).block()).events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined", "NameChangedByOther", "NameChangedByService");
+    }
+
+    private static CloudEventConverter<DomainEvent> converter() {
+        return new CloudEventConverter<>() {
+            @Override
+            public CloudEvent toCloudEvent(DomainEvent domainEvent) {
+                return CloudEventBuilder.v1()
+                        .withId(UUID.randomUUID().toString())
+                        .withSource(URI.create("urn:test"))
+                        .withType(domainEvent.type())
+                        .withData(domainEvent.name().getBytes(UTF_8))
+                        .build();
+            }
+
+            @Override
+            public DomainEvent toDomainEvent(CloudEvent cloudEvent) {
+                return new DomainEvent(cloudEvent.getType(), new String(requireNonNull(cloudEvent.getData()).toBytes(), UTF_8));
+            }
+
+            @Override
+            public String getCloudEventType(Class<? extends DomainEvent> type) {
+                return type.getName();
+            }
+        };
+    }
+
+    private record DomainEvent(String type, String name) {
+    }
+
+    /**
+     * A reactive DCB event store that, on the first conditional append, first commits a conflicting matching event so
+     * the carried consistency token is stale and the append fails once, then delegates normally on later attempts.
+     */
+    private static class ConflictingOnceDcbEventStore implements DcbEventStore {
+        private final DcbEventStore delegate;
+        private final CloudEvent conflictingEvent;
+        private final AtomicBoolean conflictInserted = new AtomicBoolean();
+
+        private ConflictingOnceDcbEventStore(DcbEventStore delegate, CloudEvent conflictingEvent) {
+            this.delegate = delegate;
+            this.conflictingEvent = conflictingEvent;
+        }
+
+        @Override
+        public Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options) {
+            return delegate.read(query, options);
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events) {
+            return delegate.append(events);
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events, DcbAppendCondition condition) {
+            if (conflictInserted.compareAndSet(false, true)) {
+                return delegate.append(List.of(conflictingEvent)).then(delegate.append(events, condition));
+            }
+            return delegate.append(events, condition);
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added a reactive DCB application service (`application-service-reactor`).
+  * `DcbApplicationService` runs the read, decide, and append cycle against the reactive DCB event store and returns a `Mono`, retrying from a fresh read on a DCB conflict. The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, and the post-append side-effect is reactive (`Function<Stream<E>, Mono<Void>>`). This is the first reactive application service in Occurrent.
+  * See [ADR 35](doc/architecture/decisions/0035-reactive-dcb-application-service.md).
+
 * DCB now works on the reactive Spring MongoDB event store, which completes DCB support across every event store.
   * `ReactorMongoEventStore` implements a new reactive `DcbEventStore` (in `eventstore-api-dcb-reactor`) with `Mono` and `Flux`, reusing the same per-attribute marker model and storage contract as the blocking and native stores. It defaults to stream-only. A reactive DCB application service, DSL, and subscriptions are not part of this and remain to be done.
   * See [ADR 34](doc/architecture/decisions/0034-reactive-spring-mongodb-dcb-support.md).

--- a/doc/architecture/decisions/0035-reactive-dcb-application-service.md
+++ b/doc/architecture/decisions/0035-reactive-dcb-application-service.md
@@ -1,0 +1,37 @@
+# 35. Reactive DCB application service
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+The reactive Spring store gained DCB support (ADR 34), but the reactive side had no application service for any use case. The blocking `DcbApplicationService` runs the read, decide, and append cycle and retries from a fresh read on a DCB conflict. Reactive callers (for example a WebFlux endpoint) had to drive that cycle by hand against the reactive event store. This is the first reactive application service in the repo.
+
+## Decision
+
+Add a reactive `DcbApplicationService` in a new module `application/service/reactor` (artifact `application-service-reactor`, package `org.occurrent.application.service.reactor.dcb`), mirroring the blocking service's behavior on top of the reactive event store.
+
+### The domain function stays synchronous
+
+`execute` returns `Mono<Optional<DcbAppendResult>>`, but the domain function is `Function<Stream<E>, Stream<E>>`, the same shape as the blocking service. Only the read and append I/O are reactive. A domain decision is a pure function, and the reactive read already materializes its matched events into a list, so a `Flux<E>` domain function would add reactive ceremony to pure logic with no streaming benefit and would not compose with the existing synchronous deciders. Keeping the function synchronous also makes migration from the blocking service a one-line return-type change.
+
+### Read, decide, and append as one retried unit
+
+The read, convert, decide, tag, and append run inside a single `Mono`, wrapped in `Retry.backoff` filtered on `DcbAppendConditionNotFulfilledException`. A retry re-subscribes the `Mono`, so each attempt reads fresh and decides against the current events, matching the blocking service. The default retry mirrors the blocking policy (five attempts, 100ms to 2s backoff).
+
+### Reactive side-effect
+
+`DcbExecuteOptions` carries a `Function<Stream<E>, Mono<Void>>` side-effect rather than the blocking `Consumer<Stream<E>>`, so a post-append side-effect can do non-blocking work. It is composed after the retry, so it runs once on a successful append with the newly produced events, and not on the no-new-events path. A side-effect with no I/O wraps in `Mono.fromRunnable`, which is the right tradeoff for allowing non-blocking side-effects.
+
+### Reuse and duplication
+
+The service reuses the existing `CloudEventConverter`, which is synchronous and shared. `TagGenerator` is a one-method functional interface duplicated into the reactive package rather than depending on `application-service-blocking`, which would point the reactive module at the blocking one.
+
+## Consequences
+
+- Reactive callers get the same read-decide-append-with-conflict-retry ergonomics the blocking side has, returning a `Mono` that composes into a reactive pipeline.
+- The reactive DCB DSL and subscriptions are still missing. They are the remaining phases in `.context/reactive-dcb-plan.md` and are demand-gated.
+- `TagGenerator` now exists in two packages. If a third consumer appears, hoisting it to a shared module is the time to do it, not now.


### PR DESCRIPTION
Phase 2 of reactive DCB. This adds a reactive DCB application service, the counterpart to the blocking `DcbApplicationService`, built on the reactive DCB event store from the Phase 1 PR below it in the stack.

It is the first reactive application service in Occurrent, so a couple of design calls are worth flagging for review:

- `execute` returns `Mono<Optional<DcbAppendResult>>`, but the domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, the same shape as the blocking service. A domain decision is pure, and the reactive read already materializes its matched events into a list, so a `Flux<E>` domain function would add reactive ceremony to pure logic for no benefit and would not compose with the existing deciders. Only the read and append I/O are reactive. Tell me if you would rather the function be `Flux<E>` based.
- The post-append side-effect is `Function<Stream<E>, Mono<Void>>` rather than the blocking `Consumer<Stream<E>>`, so it can do non-blocking work. A side-effect with no I/O wraps in `Mono.fromRunnable`.

The read, decide, tag, and append run as one `Mono` wrapped in `Retry.backoff` filtered on `DcbAppendConditionNotFulfilledException`, so each retry reads fresh, matching the blocking service. The side-effect is composed after the retry, so it runs once on a successful append and not on the no-new-events path.

It reuses the existing `CloudEventConverter`, which is synchronous and shared, and duplicates the one-method `TagGenerator` into the reactive package rather than pointing the reactive module at the blocking one.

Tests mirror the blocking application-service tests with `StepVerifier`: read-decide-append with tags, no append on empty domain output, the side-effect running once after success and skipped when nothing is produced, and a retry from a fresh read when a conflict makes the carried token stale.

The reactive DCB DSL and subscriptions are the remaining phases and stay demand-gated. See ADR 35.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-dcb-store","parentHead":"7cfe7f0aa9e13cdee988a0c7cc2715c6a0e7f1e2","parentPull":242,"trunk":"main"}
```
-->
