### PR TITLE
Add a reactive DCB DSL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added a reactive DCB DSL (`dcb-dsl-reactor`).
+  * Reactive `DcbDomainEventQueries` returns matched domain events as a `Flux` and a `Mono<DcbDomainEventStream>` with the consistency token for a conditional append, built directly on the reactive DCB event store. Kotlin decider extensions run a decider through the reactive DCB application service and return a `Mono`. The live `subscribeDcb` helper and DCB subscription metadata are not part of this and come with reactive DCB subscriptions.
+  * See [ADR 36](doc/architecture/decisions/0036-reactive-dcb-dsl.md).
+
 * Added a reactive DCB application service (`application-service-reactor`).
   * `DcbApplicationService` runs the read, decide, and append cycle against the reactive DCB event store and returns a `Mono`, retrying from a fresh read on a DCB conflict. The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, and the post-append side-effect is reactive (`Function<Stream<E>, Mono<Void>>`). This is the first reactive application service in Occurrent.
   * See [ADR 35](doc/architecture/decisions/0035-reactive-dcb-application-service.md).

--- a/doc/architecture/decisions/0036-reactive-dcb-dsl.md
+++ b/doc/architecture/decisions/0036-reactive-dcb-dsl.md
@@ -1,0 +1,35 @@
+# 36. Reactive DCB DSL
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+The blocking DCB DSL (`dcb-dsl-blocking`) gives application code a query helper (`DcbDomainEventQueries`) and Kotlin decider extensions over the blocking DCB application service. The reactive side had neither. This adds the DCB-specific reactive DSL on top of the reactive event store (ADR 34) and the reactive application service (ADR 35).
+
+## Decision
+
+Add a `dsl/dcb-dsl/reactor` module (artifact `dcb-dsl-reactor`, package `org.occurrent.dsl.dcb.reactor`) with the reactive query helper and the reactive decider extensions.
+
+### Query helper built directly on the reactive event store
+
+The blocking `DcbDomainEventQueries` wraps a `DomainEventQueries` (the general blocking query DSL) and delegates ordinary stream queries to it. There is no reactive `DomainEventQueries`, and building one is a non-DCB concern. So the reactive `DcbDomainEventQueries` is built directly on the reactive `DcbEventStore` plus a `CloudEventConverter`, and provides only the DCB query methods: `Flux<E> query(DcbQuery)` and `Mono<DcbDomainEventStream<E>> queryWithPosition(DcbQuery)`. It does not offer the general stream-query delegation the blocking version has, because that part is exactly what would need a reactive `DomainEventQueries`. `DcbDomainEventStream` is a small result record duplicated into the reactive package rather than depending on the blocking DSL.
+
+### Decider extensions return Mono, with a non-null state constraint
+
+The Kotlin decider extensions mirror the blocking ones. The reactive application service runs the domain decision synchronously inside a `Function<Stream<E>, Stream<E>>`, so the decider runs synchronously the same way, and only the result is reactive. `execute` returns `Mono<DcbAppendResult>` (empty on a no-op command), `executeAndReturnDecision` returns `Mono<Decider.Decision<S, E>>`, and `executeAndReturnEvents` returns `Mono<List<E>>`.
+
+`executeAndReturnState` returns `Mono<S>` and therefore binds `S` to a non-null type, because a `Mono` cannot carry a null value. A decider whose folded state can be null (the common "does not exist yet" initial state) cannot use `executeAndReturnState` reactively. That is inherent to `Mono`, not a shortcut. Such a decider uses `executeAndReturnDecision` and reads its state, or `executeAndReturnEvents`, both of which allow a null state. A null-friendly `Mono<Optional<S>>` variant can be added later if it is wanted.
+
+### Out of scope
+
+The blocking DSL also has a live `subscribeDcb` helper and DCB subscription metadata. Those belong with reactive DCB subscriptions and are deferred to the next phase, so this module has no subscription surface.
+
+## Consequences
+
+- Reactive callers can run DCB queries that return domain events as a `Flux`, capture the consistency token for a conditional append, and run deciders through the reactive application service, all returning composable `Mono`/`Flux`.
+- `DcbDomainEventStream` now exists in two packages. As with the duplicated `TagGenerator`, a shared home is the right move only once a third consumer appears.
+- The reactive DCB subscriptions and the live `subscribeDcb` helper remain, tracked in `.context/reactive-dcb-plan.md` as the last phase.

--- a/dsl/dcb-dsl/pom.xml
+++ b/dsl/dcb-dsl/pom.xml
@@ -28,5 +28,6 @@
     <artifactId>dcb-dsl</artifactId>
     <modules>
         <module>blocking</module>
+        <module>reactor</module>
     </modules>
 </project>

--- a/dsl/dcb-dsl/reactor/pom.xml
+++ b/dsl/dcb-dsl/reactor/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dcb-dsl</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dcb-dsl-reactor</artifactId>
+
+    <name>${mavenProjectName}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>application-service-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>decider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Queries a reactive DCB event store and converts the matched CloudEvents into your domain event type.
+ *
+ * <p>This is the reactive counterpart to the blocking {@code DcbDomainEventQueries}. It is built directly on a
+ * reactive {@link DcbEventStore} and a {@link CloudEventConverter}, and exposes only the DCB query methods. The
+ * reactive side has no general {@code DomainEventQueries} to wrap, so the stream-oriented query delegation of the
+ * blocking version is intentionally absent.</p>
+ *
+ * @param <E> the domain event type
+ */
+@NullMarked
+public class DcbDomainEventQueries<E> {
+
+    private final DcbEventStore dcbEventStore;
+    private final CloudEventConverter<E> cloudEventConverter;
+
+    public DcbDomainEventQueries(DcbEventStore dcbEventStore, CloudEventConverter<E> cloudEventConverter) {
+        this.dcbEventStore = requireNonNull(dcbEventStore, DcbEventStore.class.getSimpleName() + " cannot be null");
+        this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
+    }
+
+    /**
+     * Queries matching DCB events from the beginning of the DCB sequence.
+     */
+    public Flux<E> query(DcbQuery query) {
+        return query(query, DcbReadOptions.fromBeginning());
+    }
+
+    /**
+     * Queries matching DCB events using the supplied read options, converting the matched CloudEvents to domain events.
+     */
+    public Flux<E> query(DcbQuery query, DcbReadOptions options) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return dcbEventStore.read(query, options).flatMapMany(eventStream -> Flux.fromStream(cloudEventConverter.toDomainEvents(eventStream.stream())));
+    }
+
+    /**
+     * Queries matching DCB events and returns both the domain events and the observed DCB sequence position.
+     */
+    public Mono<DcbDomainEventStream<E>> queryWithPosition(DcbQuery query) {
+        return queryWithPosition(query, DcbReadOptions.fromBeginning());
+    }
+
+    /**
+     * Queries matching DCB events using the supplied read options and returns the domain events, the observed DCB
+     * sequence position, and the consistency token for a later conditional append.
+     */
+    public Mono<DcbDomainEventStream<E>> queryWithPosition(DcbQuery query, DcbReadOptions options) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(options, "Read options cannot be null");
+        return dcbEventStore.read(query, options).map(eventStream ->
+                new DcbDomainEventStream<>(cloudEventConverter.toDomainEvents(eventStream.stream()).toList(), eventStream.lastSequencePosition(), eventStream.consistencyToken()));
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventStream.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventStream.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbConsistencyToken;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Domain-event result of a DCB read.
+ *
+ * @param events the domain events matched by the DCB query
+ * @param lastSequencePosition the latest DCB sequence position observed by the read, or {@code 0} when none has been observed. A global cursor, not a safe optimistic-concurrency boundary on its own
+ * @param consistencyToken the optimistic-concurrency boundary observed by the read. Pass it to {@link DcbAppendCondition#failIfEventsMatch(org.occurrent.eventstore.api.dcb.DcbQuery, DcbConsistencyToken)} for a conditional append
+ */
+@NullMarked
+public record DcbDomainEventStream<E>(List<E> events, long lastSequencePosition, DcbConsistencyToken consistencyToken) {
+
+    public DcbDomainEventStream {
+        requireNonNull(events, "Events cannot be null");
+        requireNonNull(consistencyToken, "Consistency token cannot be null");
+        if (lastSequencePosition < 0) {
+            throw new IllegalArgumentException("Last sequence position cannot be negative");
+        }
+        events = List.copyOf(events);
+    }
+
+    /**
+     * Convenience for callers that do not need the optimistic-concurrency token, defaulting it to the position.
+     */
+    public DcbDomainEventStream(List<E> events, long lastSequencePosition) {
+        this(events, lastSequencePosition, DcbConsistencyToken.of(lastSequencePosition));
+    }
+
+    /**
+     * Streams the domain events returned by the read.
+     */
+    public Stream<E> stream() {
+        return events.stream();
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
@@ -79,12 +79,16 @@ inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.exec
     decider: Decider<C, S, SubE>
 ): Mono<Decider.Decision<S, E>> {
     val widened: Decider<C, S, E> = decider.adaptEvents()
-    val decision = AtomicReference<Decider.Decision<S, E>>()
-    return execute(query) { events: Stream<E> ->
-        val result = widened.decideOnEvents(events.toList(), commands)
-        decision.set(result)
-        result.events.stream()
-    }.then(Mono.fromCallable { decision.get() })
+    // Defer so the AtomicReference is created per subscription. A shared one would let concurrent or repeat
+    // subscribers see each other's decision.
+    return Mono.defer {
+        val decision = AtomicReference<Decider.Decision<S, E>>()
+        execute(query) { events: Stream<E> ->
+            val result = widened.decideOnEvents(events.toList(), commands)
+            decision.set(result)
+            result.events.stream()
+        }.then(Mono.fromCallable { requireNotNull(decision.get()) { "The decider produced no decision" } })
+    }
 }
 
 /**

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor
+
+import org.occurrent.application.service.reactor.dcb.DcbApplicationService
+import org.occurrent.dsl.decider.Decider
+import org.occurrent.dsl.decider.adaptEvents
+import org.occurrent.eventstore.api.dcb.DcbAppendResult
+import org.occurrent.eventstore.api.dcb.DcbQuery
+import reactor.core.publisher.Mono
+import java.util.concurrent.atomic.AtomicReference
+import java.util.stream.Stream
+
+// The decider's event type may be a subtype of the service's event type [E]. These overloads widen it with `adaptEvents`,
+// so a feature decider over its own narrow event type can run directly against an injected DcbApplicationService over the
+// broader domain event type, without the caller calling `adaptEvents`. When the decider already uses [E] it is a no-op.
+// The decision itself is synchronous because the reactive service runs the domain function synchronously, only the read
+// and append I/O are reactive.
+
+/**
+ * Execute a decider command where [query] is the DCB decision boundary,
+ * equivalent to the stream id in stream-based decider helpers.
+ *
+ * Returns a [Mono] of the [DcbAppendResult], or an empty [Mono] when the decider produced no new events (a no-op
+ * command). This is the Kotlin-idiomatic counterpart to the Java [DcbApplicationService.execute] which returns a
+ * `Mono<Optional<DcbAppendResult>>`.
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.execute(
+    query: DcbQuery,
+    command: C,
+    decider: Decider<C, S, SubE>
+): Mono<DcbAppendResult> = execute(query, listOf(command), decider)
+
+/**
+ * Execute decider commands in order where [query] is the DCB decision boundary.
+ *
+ * Returns a [Mono] of the [DcbAppendResult], or an empty [Mono] when the decider produced no new events.
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.execute(
+    query: DcbQuery,
+    commands: List<C>,
+    decider: Decider<C, S, SubE>
+): Mono<DcbAppendResult> {
+    val widened: Decider<C, S, E> = decider.adaptEvents()
+    return execute(query) { events: Stream<E> ->
+        widened.decideOnEventsAndReturnEvents(events.toList(), commands).stream()
+    }.flatMap { Mono.justOrEmpty(it) }
+}
+
+/**
+ * Execute a command and return the folded state plus the new events decided for [query].
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnDecision(
+    query: DcbQuery,
+    command: C,
+    decider: Decider<C, S, SubE>
+): Mono<Decider.Decision<S, E>> = executeAndReturnDecision(query, listOf(command), decider)
+
+/**
+ * Execute commands and return the folded state plus the new events decided for [query].
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnDecision(
+    query: DcbQuery,
+    commands: List<C>,
+    decider: Decider<C, S, SubE>
+): Mono<Decider.Decision<S, E>> {
+    val widened: Decider<C, S, E> = decider.adaptEvents()
+    val decision = AtomicReference<Decider.Decision<S, E>>()
+    return execute(query) { events: Stream<E> ->
+        val result = widened.decideOnEvents(events.toList(), commands)
+        decision.set(result)
+        result.events.stream()
+    }.then(Mono.fromCallable { decision.get() })
+}
+
+/**
+ * Execute a command and return the folded state after the decision.
+ *
+ * The state is bound to a non-null type because a [Mono] cannot carry a null value. A decider whose folded state can be
+ * null (the common "does not exist yet" initial state) should use [executeAndReturnDecision] and read its state, or
+ * [executeAndReturnEvents], instead.
+ */
+inline fun <C : Any, S : Any, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnState(query: DcbQuery, command: C, decider: Decider<C, S, SubE>): Mono<S> =
+    executeAndReturnDecision(query, command, decider).map { it.state }
+
+/**
+ * Execute commands and return the folded state after the decision.
+ */
+inline fun <C : Any, S : Any, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnState(query: DcbQuery, commands: List<C>, decider: Decider<C, S, SubE>): Mono<S> =
+    executeAndReturnDecision(query, commands, decider).map { it.state }
+
+/**
+ * Execute a command and return the new events decided for [query].
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnEvents(query: DcbQuery, command: C, decider: Decider<C, S, SubE>): Mono<List<E>> =
+    executeAndReturnDecision(query, command, decider).map { it.events }
+
+/**
+ * Execute commands and return the new events decided for [query].
+ */
+inline fun <C : Any, S, reified SubE : E, E : Any> DcbApplicationService<E>.executeAndReturnEvents(query: DcbQuery, commands: List<C>, decider: Decider<C, S, SubE>): Mono<List<E>> =
+    executeAndReturnDecision(query, commands, decider).map { it.events }

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor
+
+import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.api.dcb.DcbReadOptions
+import reactor.core.publisher.Mono
+
+/**
+ * Query that collects the matching domain events into a [Mono] of a [List].
+ *
+ * The [query] family already returns a [reactor.core.publisher.Flux], which is the idiomatic reactive shape, so this is
+ * only a convenience for callers that want the whole result as one list.
+ *
+ * @see DcbDomainEventQueries.query
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForList(
+    query: DcbQuery,
+    options: DcbReadOptions = DcbReadOptions.fromBeginning()
+): Mono<List<T>> =
+    this.query(query, options).collectList()

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
@@ -19,6 +19,7 @@ package org.occurrent.dsl.dcb.reactor
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.mongodb.ConnectionString
 import com.mongodb.reactivestreams.client.MongoClients
+import io.cloudevents.CloudEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayNameGeneration
@@ -36,8 +37,13 @@ import org.occurrent.dsl.decider.Decider
 import org.occurrent.dsl.decider.decider
 import org.occurrent.eventstore.api.EventStoreCapability.DCB
 import org.occurrent.eventstore.api.EventStoreCapability.STREAM
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition
+import org.occurrent.eventstore.api.dcb.DcbAppendResult
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents
+import org.occurrent.eventstore.api.dcb.DcbEventStream
 import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.api.dcb.DcbReadOptions
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore
 import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation
@@ -48,8 +54,11 @@ import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.mongodb.MongoDBContainer
+import reactor.core.publisher.Mono
 import java.net.URI
 import java.time.LocalDateTime
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Stream
 
 @Testcontainers
@@ -140,6 +149,34 @@ class DcbReactorDslTest {
         assertThat(stream.consistencyToken()).isNotNull
     }
 
+    @Test
+    fun executeAndReturnDecision_returns_the_committed_decision_after_a_conflict_retry() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+        val interloper = DcbCloudEvents.withTags(converter.toCloudEvent(NameWasChanged("event-99", time, "name", "Interloper")), setOf("name:name"))
+        val conflictingStore = ConflictingOnceDcbEventStore(eventStore, interloper)
+        val service = GenericDcbApplicationService(conflictingStore, converter, { event -> setOf(tagFor(event)) }, GenericDcbApplicationService.defaultRetry())
+        val deciderRuns = AtomicInteger()
+        val countingDecider: Decider<NameCommand, String?, DomainEvent> = decider(
+            initialState = null,
+            decide = { command, _ ->
+                deciderRuns.incrementAndGet()
+                when (command) {
+                    is DefineName -> listOf(NameDefined("event-1", time, "name", command.name))
+                    is ChangeName -> listOf(NameWasChanged("event-2", time, "name", command.name))
+                }
+            },
+            evolve = { _, event -> event.name() }
+        )
+
+        val decision = service.executeAndReturnDecision(nameQuery("name"), ChangeName("John Doe"), countingDecider).block()
+
+        // The first append conflicts on the interloper, the retry reruns the decider against the fresh read, and
+        // executeAndReturnDecision returns the committed attempt's decision, not the first attempt's.
+        assertThat(deciderRuns).hasValue(2)
+        assertThat(decision!!.events).containsExactly(NameWasChanged("event-2", time, "name", "John Doe"))
+        assertThat(decision.state).isEqualTo("John Doe")
+    }
+
     private fun nameDecider(): Decider<NameCommand, String?, DomainEvent> =
         decider(
             initialState = null,
@@ -169,6 +206,28 @@ class DcbReactorDslTest {
     private sealed interface NameCommand
     private data class DefineName(val name: String) : NameCommand
     private data class ChangeName(val name: String) : NameCommand
+
+    /**
+     * A reactive DCB event store that, on the first conditional append, first commits a conflicting matching event so
+     * the carried consistency token is stale and the append fails once, then delegates normally on later attempts.
+     */
+    private class ConflictingOnceDcbEventStore(
+        private val delegate: DcbEventStore,
+        private val conflictingEvent: CloudEvent
+    ) : DcbEventStore {
+        private val conflictInserted = AtomicBoolean()
+
+        override fun read(query: DcbQuery, options: DcbReadOptions): Mono<DcbEventStream> = delegate.read(query, options)
+
+        override fun append(events: MutableList<CloudEvent>): Mono<DcbAppendResult> = delegate.append(events)
+
+        override fun append(events: MutableList<CloudEvent>, condition: DcbAppendCondition): Mono<DcbAppendResult> =
+            if (conflictInserted.compareAndSet(false, true)) {
+                delegate.append(listOf(conflictingEvent)).then(delegate.append(events, condition))
+            } else {
+                delegate.append(events, condition)
+            }
+    }
 
     companion object {
         @Container

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.ConnectionString
+import com.mongodb.reactivestreams.client.MongoClients
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.occurrent.application.converter.CloudEventConverter
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter
+import org.occurrent.application.service.reactor.dcb.DcbApplicationService
+import org.occurrent.application.service.reactor.dcb.GenericDcbApplicationService
+import org.occurrent.domain.DomainEvent
+import org.occurrent.domain.NameDefined
+import org.occurrent.domain.NameWasChanged
+import org.occurrent.dsl.decider.Decider
+import org.occurrent.dsl.decider.decider
+import org.occurrent.eventstore.api.EventStoreCapability.DCB
+import org.occurrent.eventstore.api.EventStoreCapability.STREAM
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents
+import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.mongodb.MongoDBContainer
+import java.net.URI
+import java.time.LocalDateTime
+import java.util.stream.Stream
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DcbReactorDslTest {
+
+    private lateinit var eventStore: ReactorMongoEventStore
+    private lateinit var converter: CloudEventConverter<DomainEvent>
+    private lateinit var applicationService: DcbApplicationService<DomainEvent>
+    private lateinit var queries: DcbDomainEventQueries<DomainEvent>
+    private lateinit var time: LocalDateTime
+
+    @BeforeEach
+    fun create_instances() {
+        val connectionString = ConnectionString(mongoDBContainer.replicaSetUrl + ".dcbreactordsl")
+        val mongoClient = MongoClients.create(connectionString)
+        val mongoTemplate = ReactiveMongoTemplate(mongoClient, connectionString.database!!)
+        val transactionManager = ReactiveMongoTransactionManager(SimpleReactiveMongoDatabaseFactory(mongoClient, connectionString.database!!))
+        val config = EventStoreConfig.Builder()
+            .eventStoreCollectionName("events")
+            .transactionConfig(transactionManager)
+            .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+            .eventStoreCapabilities(STREAM, DCB)
+            .build()
+        eventStore = ReactorMongoEventStore(mongoTemplate, config)
+        converter = JacksonCloudEventConverter.Builder<DomainEvent>(ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build()
+        applicationService = GenericDcbApplicationService(eventStore, converter, { event -> setOf(tagFor(event)) }, GenericDcbApplicationService.defaultRetry())
+        queries = DcbDomainEventQueries(eventStore, converter)
+        time = LocalDateTime.now()
+    }
+
+    @Test
+    fun command_execution_appends_decider_produced_events() {
+        val result = applicationService.execute(nameQuery("name"), DefineName("Jane Doe"), nameDecider()).block()
+
+        assertThat(result).isNotNull
+        assertThat(result!!.eventCount()).isEqualTo(1)
+        assertThat(readNameEvents("name")).containsExactly(NameDefined("event-1", time, "name", "Jane Doe"))
+    }
+
+    @Test
+    fun no_op_decisions_return_an_empty_mono() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+
+        val result = applicationService.execute(nameQuery("name"), DefineName("Jane Doe"), nameDecider()).block()
+
+        assertThat(result).isNull()
+        assertThat(readNameEvents("name")).containsExactly(NameDefined("event-0", time, "name", "Jane Doe"))
+    }
+
+    @Test
+    fun executeAndReturnDecision_returns_folded_state_plus_new_events() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+
+        val decision = applicationService.executeAndReturnDecision(nameQuery("name"), ChangeName("John Doe"), nameDecider()).block()
+
+        assertThat(decision!!.state).isEqualTo("John Doe")
+        assertThat(decision.events).containsExactly(NameWasChanged("event-2", time, "name", "John Doe"))
+    }
+
+    @Test
+    fun executeAndReturnEvents_returns_the_new_events() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+
+        val events = applicationService.executeAndReturnEvents(nameQuery("name"), ChangeName("Jane Roe"), nameDecider()).block()
+
+        assertThat(events).containsExactly(NameWasChanged("event-2", time, "name", "Jane Roe"))
+    }
+
+    @Test
+    fun query_returns_the_matching_domain_events() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+
+        val events = queries.query(nameQuery("name")).collectList().block()
+
+        assertThat(events).containsExactly(NameDefined("event-0", time, "name", "Jane Doe"))
+    }
+
+    @Test
+    fun queryWithPosition_returns_events_position_and_a_usable_consistency_token() {
+        append(NameDefined("event-0", time, "name", "Jane Doe"))
+
+        val stream = queries.queryWithPosition(nameQuery("name")).block()
+
+        assertThat(stream!!.events()).containsExactly(NameDefined("event-0", time, "name", "Jane Doe"))
+        assertThat(stream.lastSequencePosition()).isEqualTo(1)
+        // The token reads cleanly and is non-null, usable for a later conditional append.
+        assertThat(stream.consistencyToken()).isNotNull
+    }
+
+    private fun nameDecider(): Decider<NameCommand, String?, DomainEvent> =
+        decider(
+            initialState = null,
+            decide = { command, state ->
+                when (command) {
+                    is DefineName -> if (state == null) listOf(NameDefined("event-1", time, "name", command.name)) else emptyList()
+                    is ChangeName -> listOf(NameWasChanged("event-2", time, "name", command.name))
+                }
+            },
+            evolve = { _, event -> event.name() }
+        )
+
+    private fun append(vararg events: DomainEvent) {
+        val cloudEvents = converter.toCloudEvents(Stream.of(*events))
+            .map { event -> DcbCloudEvents.withTags(event, setOf("name:name")) }
+            .toList()
+        eventStore.append(cloudEvents).block()
+    }
+
+    private fun readNameEvents(nameId: String): List<DomainEvent> =
+        queries.query(nameQuery(nameId)).collectList().block()!!
+
+    private fun nameQuery(nameId: String): DcbQuery = DcbQuery.tags("name:$nameId")
+
+    private fun tagFor(event: DomainEvent): String = "name:${event.userId()}"
+
+    private sealed interface NameCommand
+    private data class DefineName(val name: String) : NameCommand
+    private data class ChangeName(val name: String) : NameCommand
+
+    companion object {
+        @Container
+        @JvmStatic
+        private val mongoDBContainer: MongoDBContainer = MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().apply {
+            withReuse(true)
+            portBindings = listOf("27017:27017")
+        }
+    }
+
+    @RegisterExtension
+    val flushMongoDBExtension = FlushMongoDBExtension(ConnectionString(mongoDBContainer.replicaSetUrl + ".dcbreactordsl"))
+}


### PR DESCRIPTION
Phase 3 of reactive DCB. This adds the DCB-specific reactive DSL on top of the reactive event store (Phase 1) and the reactive application service (Phase 2) below it in the stack.

New `dcb-dsl-reactor` module:

- A reactive `DcbDomainEventQueries`. `query(DcbQuery)` returns the matched domain events as a `Flux<E>`, and `queryWithPosition(DcbQuery)` returns a `Mono<DcbDomainEventStream<E>>` carrying the events, the observed position, and the consistency token for a conditional append.
- Kotlin decider extensions over the reactive DCB application service: `execute` returns `Mono<DcbAppendResult>` (empty on a no-op), `executeAndReturnDecision` returns `Mono<Decision>`, `executeAndReturnEvents` returns `Mono<List<E>>`.

Two scope and design notes:

- The query helper is built directly on the reactive `DcbEventStore` and a `CloudEventConverter`, not by wrapping a `DomainEventQueries` the way the blocking DSL does. There is no reactive `DomainEventQueries`, and building one is a general query-DSL concern, not DCB-specific, so it is out of scope here. The reactive helper therefore offers the DCB query methods only, not the general stream-query delegation the blocking one has.
- `executeAndReturnState` returns `Mono<S>` and so binds `S` to a non-null type, because a `Mono` cannot carry null. A decider whose folded state can be null (the common "does not exist yet" initial state) uses `executeAndReturnDecision` and reads its state, or `executeAndReturnEvents`. This is documented on the function.

The live `subscribeDcb` helper and DCB subscription metadata are deferred to the reactive DCB subscriptions phase, so this module has no subscription surface.

Tests cover the query helper (Flux and queryWithPosition with a usable token) and the decider extensions (append result, empty on no-op, returned decision and events). See ADR 36.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-dcb-appservice","parentHead":"80af566aa8d82cd1320bf169d1663b1c42912acd","parentPull":243,"trunk":"main"}
```
-->
