### PR TITLE
Add live reactive DCB subscriptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added live reactive DCB subscriptions.
+  * A reactive `DcbSubscriptionModel` facade (`subscription-api-reactor`) subscribes to DCB events matching a `DcbQuery` as a `Flux<CloudEvent>`, filtered server-side, and the reactor DCB DSL gains `DcbSubscriptions` with `Flux<E> subscribe(...)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`. Live only for now. History replay by `dcbposition` (catch-up) is not part of this, so a `DcbStartAt.beginning()` starts live rather than replaying.
+  * See [ADR 37](doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md).
+
 * Added a reactive DCB DSL (`dcb-dsl-reactor`).
   * Reactive `DcbDomainEventQueries` returns matched domain events as a `Flux` and a `Mono<DcbDomainEventStream>` with the consistency token for a conditional append, built directly on the reactive DCB event store. Kotlin decider extensions run a decider through the reactive DCB application service and return a `Mono`. The live `subscribeDcb` helper and DCB subscription metadata are not part of this and come with reactive DCB subscriptions.
   * See [ADR 36](doc/architecture/decisions/0036-reactive-dcb-dsl.md).

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 #### Changes
 
 * Added live reactive DCB subscriptions.
-  * A reactive `DcbSubscriptionModel` facade (`subscription-api-reactor`) subscribes to DCB events matching a `DcbQuery` as a `Flux<CloudEvent>`, filtered server-side, and the reactor DCB DSL gains `DcbSubscriptions` with `Flux<E> subscribe(...)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`. Live only for now. History replay by `dcbposition` (catch-up) is not part of this, so a `DcbStartAt.beginning()` starts live rather than replaying.
+  * A reactive `DcbSubscriptionModel` facade (`subscription-api-reactor`) subscribes to DCB events matching a `DcbQuery` as a `Flux<CloudEvent>`, filtered server-side, and the reactor DCB DSL gains `DcbSubscriptions` with `Flux<E> subscribe(...)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`. Live only for now. The `DcbStartAt` is passed through to the underlying subscription model, and the current reactive models have no DCB catch-up, so a `DcbStartAt.beginning()` behaves like a live start rather than replaying history.
   * See [ADR 37](doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md).
 
 * Added a reactive DCB DSL (`dcb-dsl-reactor`).

--- a/doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md
+++ b/doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md
@@ -22,11 +22,11 @@ A new `org.occurrent.subscription.api.reactor.DcbSubscriptionModel` shaped like 
 
 ### Reactive DcbSubscriptions DSL
 
-Added to the reactor DCB DSL module: `Flux<E> subscribe(DcbQuery, DcbStartAt)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`, where `DcbEvent<E>` carries the domain event and a `DcbEventMetadata`. The `Flux` is the subscription, so cancelling is disposing it. `DcbEventMetadata` is built directly from the `CloudEvent` (`dcbPosition`, `dcbTags`), because the reactive subscription stack has no generic `EventMetadata` wrapper, so reading the CloudEvent is simpler than mirroring the blocking wrapper.
+Added to the reactor DCB DSL module: `Flux<E> subscribe(DcbQuery, DcbStartAt)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`, where `DcbEvent<E>` carries the domain event and a `DcbEventMetadata`. The `Flux` is the subscription, so it is cancelled by cancelling the downstream subscription, for example disposing the `Disposable` returned by `subscribe()`. `DcbEventMetadata` is built directly from the `CloudEvent` (`dcbPosition`, `dcbTags`), because the reactive subscription stack has no generic `EventMetadata` wrapper, so reading the CloudEvent is simpler than mirroring the blocking wrapper.
 
 ### Live only, for now
 
-A `DcbStartAt.beginning()` or `afterPosition(...)` passes through to the live subscription and just starts live, because giving those start positions their replay meaning needs catch-up. This is documented on the facade and the DSL. Live subscriptions cover activity feeds and triggers. Rebuilding a projection from history needs the deferred catch-up phase.
+A `DcbStartAt` is passed through to the underlying `SubscriptionModel`, so whether a replay-oriented start such as `DcbStartAt.beginning()` or `afterPosition(...)` replays history depends on that model. The current reactive subscription models have no DCB catch-up, so such a start behaves like a live start today. This is documented on the facade and the DSL. Live subscriptions cover activity feeds and triggers. Rebuilding a projection from history needs the deferred catch-up phase.
 
 ## Consequences
 

--- a/doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md
+++ b/doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md
@@ -1,0 +1,35 @@
+# 37. Live reactive DCB subscriptions
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+The reactive stack gained a DCB event store (ADR 34), application service (ADR 35), and query DSL (ADR 36). It still had no way to subscribe to DCB events. The blocking stack has a `DcbSubscriptionModel` facade and a `DcbSubscriptions` DSL. This adds the live reactive equivalent.
+
+Most of the machinery is already shared and reactive-agnostic: `DcbSubscriptionFilter` and `DcbStartAt` live in `subscription-core`, `DcbSubscriptionFilterConverter` builds the change-stream `$match`, and `ReactorMongoSubscriptionModel` already applies a `DcbSubscriptionFilter` server-side. So the missing pieces are a reactive facade and a reactive DSL.
+
+## Decision
+
+Add live reactive DCB subscriptions. Live only. History replay by `dcbposition` (catch-up) is a separate, larger piece and is deferred.
+
+### Reactive DcbSubscriptionModel facade
+
+A new `org.occurrent.subscription.api.reactor.DcbSubscriptionModel` shaped like the reactive `SubscriptionModel`, not the blocking one. It is `Flux` based with no subscription id and no callback: `Flux<CloudEvent> subscribe(DcbQuery query, DcbStartAt startAt)` plus default overloads, and `from(SubscriptionModel delegate)`. The adapter subscribes the delegate with `DcbSubscriptionFilter.filter(query)` and `startAt.toStartAt()`, then keeps an in-process `dcbposition > 0 and matches(query)` floor so the subscription stays scoped to its own query even on a backend that does not honor the server-side filter. This mirrors the blocking adapter.
+
+### Reactive DcbSubscriptions DSL
+
+Added to the reactor DCB DSL module: `Flux<E> subscribe(DcbQuery, DcbStartAt)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`, where `DcbEvent<E>` carries the domain event and a `DcbEventMetadata`. The `Flux` is the subscription, so cancelling is disposing it. `DcbEventMetadata` is built directly from the `CloudEvent` (`dcbPosition`, `dcbTags`), because the reactive subscription stack has no generic `EventMetadata` wrapper, so reading the CloudEvent is simpler than mirroring the blocking wrapper.
+
+### Live only, for now
+
+A `DcbStartAt.beginning()` or `afterPosition(...)` passes through to the live subscription and just starts live, because giving those start positions their replay meaning needs catch-up. This is documented on the facade and the DSL. Live subscriptions cover activity feeds and triggers. Rebuilding a projection from history needs the deferred catch-up phase.
+
+## Consequences
+
+- Reactive callers can subscribe to live DCB events filtered by `DcbQuery`, server-side, and convert them to domain events with metadata, all as a `Flux`.
+- The reactive stack still cannot replay DCB history reactively. Reactive `dcbposition` catch-up is the remaining phase in `.context/reactive-dcb-plan.md`. There is no reactive catch-up for streams either, so that phase pioneers reactive catch-up rather than mirroring existing reactive code.
+- `DcbEventMetadata` now exists in a blocking and a reactive form, reading the same CloudEvent extensions.

--- a/dsl/dcb-dsl/reactor/pom.xml
+++ b/dsl/dcb-dsl/reactor/pom.xml
@@ -50,6 +50,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-api-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
@@ -67,6 +72,12 @@
         <!-- Test -->
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>subscription-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-spring-reactor</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -74,6 +85,11 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbEvent.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A domain event delivered by a DCB subscription together with its DCB metadata.
+ *
+ * @param metadata the DCB metadata of the delivered event
+ * @param event the converted domain event
+ * @param <E> the domain event type
+ */
+@NullMarked
+public record DcbEvent<E>(DcbEventMetadata metadata, E event) {
+
+    public DcbEvent {
+        requireNonNull(metadata, "metadata cannot be null");
+        requireNonNull(event, "event cannot be null");
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbEventMetadata.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbEventMetadata.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * DCB metadata of a delivered event, namely the DCB sequence position and the DCB tags.
+ * <p>
+ * Read straight from the {@link CloudEvent} extensions. The reactive subscription stack has no generic
+ * {@code EventMetadata} type, so unlike the blocking DCB DSL this reads the CloudEvent directly rather than wrapping a
+ * generic metadata object.
+ */
+@NullMarked
+public final class DcbEventMetadata {
+
+    private final CloudEvent cloudEvent;
+
+    public DcbEventMetadata(CloudEvent cloudEvent) {
+        this.cloudEvent = requireNonNull(cloudEvent, "CloudEvent cannot be null");
+    }
+
+    public static DcbEventMetadata from(CloudEvent cloudEvent) {
+        return new DcbEventMetadata(cloudEvent);
+    }
+
+    /**
+     * The DCB sequence position of the event, or empty when the event has no DCB position (for example a regular
+     * stream-written event).
+     */
+    public OptionalLong dcbPosition() {
+        long position = DcbCloudEvents.getPosition(cloudEvent);
+        return position > 0 ? OptionalLong.of(position) : OptionalLong.empty();
+    }
+
+    /**
+     * The canonical DCB tags of the event, or an empty set when the event has no DCB tags.
+     */
+    public Set<String> dcbTags() {
+        return DcbCloudEvents.getTags(cloudEvent);
+    }
+
+    /**
+     * The delivered {@link CloudEvent}, for any metadata not specific to DCB.
+     */
+    public CloudEvent cloudEvent() {
+        return cloudEvent;
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
@@ -31,11 +31,14 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * This wraps a reactive {@link SubscriptionModel} and a {@link CloudEventConverter}, mirroring how
  * {@link DcbDomainEventQueries} wraps its dependencies. Each {@code subscribe} returns a {@link Flux} that is the
- * subscription, so cancelling is disposing the {@link Flux}.
+ * subscription, so it is cancelled by cancelling the downstream subscription, for example disposing the
+ * {@link reactor.core.Disposable} returned by {@code subscribe()}.
  * <p>
- * Delivery is live and the events are post-filtered by the {@link DcbQuery} server-side where the backend supports it.
- * A {@link DcbStartAt} that asks to replay history is passed through to the live subscription, which starts live,
- * because reactive DCB catch-up is not implemented yet.
+ * Delivery is live. Events are filtered by the {@link DcbQuery} server-side where the backend supports it, with an
+ * in-process scoping filter as a correctness floor. A {@link DcbStartAt} is passed through to the underlying
+ * {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()} replays history
+ * depends on that model. The current reactive subscription models have no DCB catch-up, so such a start behaves like a
+ * live start today.
  *
  * @param <E> the domain event type
  */

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.api.reactor.DcbSubscriptionModel;
+import org.occurrent.subscription.api.reactor.SubscriptionModel;
+import reactor.core.publisher.Flux;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Subscribes to live DCB-tagged events reactively without passing the {@link CloudEventConverter} on every call.
+ * <p>
+ * This wraps a reactive {@link SubscriptionModel} and a {@link CloudEventConverter}, mirroring how
+ * {@link DcbDomainEventQueries} wraps its dependencies. Each {@code subscribe} returns a {@link Flux} that is the
+ * subscription, so cancelling is disposing the {@link Flux}.
+ * <p>
+ * Delivery is live and the events are post-filtered by the {@link DcbQuery} server-side where the backend supports it.
+ * A {@link DcbStartAt} that asks to replay history is passed through to the live subscription, which starts live,
+ * because reactive DCB catch-up is not implemented yet.
+ *
+ * @param <E> the domain event type
+ */
+@NullMarked
+public final class DcbSubscriptions<E> {
+
+    private final DcbSubscriptionModel subscriptionModel;
+    private final CloudEventConverter<E> cloudEventConverter;
+
+    public DcbSubscriptions(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+        this.subscriptionModel = DcbSubscriptionModel.from(requireNonNull(subscriptionModel, SubscriptionModel.class.getSimpleName() + " cannot be null"));
+        this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, converting each to a domain event.
+     */
+    public Flux<E> subscribe(DcbQuery query) {
+        return subscribe(query, DcbStartAt.subscriptionModelDefault());
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt}, converting each to a domain
+     * event.
+     */
+    public Flux<E> subscribe(DcbQuery query, DcbStartAt startAt) {
+        return subscriptionModel.subscribe(query, startAt).map(cloudEventConverter::toDomainEvent);
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, delivering each domain event together with its DCB
+     * metadata.
+     */
+    public Flux<DcbEvent<E>> subscribeWithMetadata(DcbQuery query) {
+        return subscribeWithMetadata(query, DcbStartAt.subscriptionModelDefault());
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt}, delivering each domain event
+     * together with its DCB metadata.
+     */
+    public Flux<DcbEvent<E>> subscribeWithMetadata(DcbQuery query, DcbStartAt startAt) {
+        return subscriptionModel.subscribe(query, startAt)
+                .map(cloudEvent -> new DcbEvent<>(DcbEventMetadata.from(cloudEvent), cloudEventConverter.toDomainEvent(cloudEvent)));
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorSubscriptionsTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorSubscriptionsTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.ConnectionString
+import com.mongodb.reactivestreams.client.MongoClients
+import io.cloudevents.CloudEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.awaitility.Durations.FIVE_SECONDS
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayNameGeneration
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.occurrent.application.converter.CloudEventConverter
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter
+import org.occurrent.domain.DomainEvent
+import org.occurrent.domain.NameDefined
+import org.occurrent.eventstore.api.EventStoreCapability.DCB
+import org.occurrent.eventstore.api.EventStoreCapability.STREAM
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents
+import org.occurrent.eventstore.api.dcb.DcbQuery
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation
+import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.mongodb.MongoDBContainer
+import reactor.core.Disposable
+import java.net.URI
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Timeout(30)
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores::class)
+class DcbReactorSubscriptionsTest {
+
+    private lateinit var eventStore: ReactorMongoEventStore
+    private lateinit var subscriptionModel: ReactorMongoSubscriptionModel
+    private lateinit var converter: CloudEventConverter<DomainEvent>
+    private lateinit var dcbSubscriptions: DcbSubscriptions<DomainEvent>
+    private lateinit var time: LocalDateTime
+    private val disposables = CopyOnWriteArrayList<Disposable>()
+
+    @RegisterExtension
+    val flush = FlushMongoDBExtension(ConnectionString(mongoDBContainer.replicaSetUrl + ".dcbreactorsub"))
+
+    @BeforeEach
+    fun create_instances() {
+        val connectionString = ConnectionString(mongoDBContainer.replicaSetUrl + ".dcbreactorsub")
+        val mongoClient = MongoClients.create(connectionString)
+        val mongoTemplate = ReactiveMongoTemplate(mongoClient, connectionString.database!!)
+        val transactionManager = ReactiveMongoTransactionManager(SimpleReactiveMongoDatabaseFactory(mongoClient, connectionString.database!!))
+        val config = EventStoreConfig.Builder()
+            .eventStoreCollectionName("events")
+            .transactionConfig(transactionManager)
+            .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+            .eventStoreCapabilities(STREAM, DCB)
+            .build()
+        eventStore = ReactorMongoEventStore(mongoTemplate, config)
+        subscriptionModel = ReactorMongoSubscriptionModel(mongoTemplate, "events", TimeRepresentation.RFC_3339_STRING)
+        converter = JacksonCloudEventConverter.Builder<DomainEvent>(ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build()
+        dcbSubscriptions = DcbSubscriptions(subscriptionModel, converter)
+        time = LocalDateTime.now()
+    }
+
+    @AfterEach
+    fun dispose() {
+        disposables.forEach(Disposable::dispose)
+    }
+
+    @Test
+    fun delivers_only_events_matching_the_query() {
+        val received = CopyOnWriteArrayList<DomainEvent>()
+        disposables.add(dcbSubscriptions.subscribe(DcbQuery.tags("entity:alice")).doOnNext(received::add).subscribe())
+        Thread.sleep(500)
+
+        appendTagged(NameDefined(UUID.randomUUID().toString(), time, "alice", "Alice"), "entity:alice")
+        appendTagged(NameDefined(UUID.randomUUID().toString(), time, "bob", "Bob"), "entity:bob")
+
+        await().atMost(FIVE_SECONDS).untilAsserted {
+            assertThat(received).extracting<String> { (it as NameDefined).name }.containsExactly("Alice")
+        }
+    }
+
+    @Test
+    fun exposes_dcb_metadata() {
+        val received = CopyOnWriteArrayList<DcbEvent<DomainEvent>>()
+        disposables.add(dcbSubscriptions.subscribeWithMetadata(DcbQuery.tags("entity:carol")).doOnNext(received::add).subscribe())
+        Thread.sleep(500)
+
+        appendTagged(NameDefined(UUID.randomUUID().toString(), time, "carol", "Carol"), "entity:carol")
+
+        await().atMost(FIVE_SECONDS).untilAsserted {
+            assertThat(received).hasSize(1)
+            val delivered = received[0]
+            assertThat((delivered.event as NameDefined).name).isEqualTo("Carol")
+            assertThat(delivered.metadata.dcbPosition().isPresent).isTrue()
+            assertThat(delivered.metadata.dcbPosition().asLong).isGreaterThan(0)
+            assertThat(delivered.metadata.dcbTags()).containsExactly("entity:carol")
+        }
+    }
+
+    private fun appendTagged(event: DomainEvent, tag: String) {
+        val cloudEvent: CloudEvent = converter.toCloudEvents(java.util.stream.Stream.of(event)).toList()[0]
+        eventStore.append(listOf(DcbCloudEvents.withTags(cloudEvent, setOf(tag)))).block()
+    }
+
+    companion object {
+        @Container
+        @JvmStatic
+        val mongoDBContainer = MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+            .withReplicaSet()
+            .withReuse(true)
+    }
+}

--- a/subscription/api/reactor/pom.xml
+++ b/subscription/api/reactor/pom.xml
@@ -48,5 +48,25 @@
             <artifactId>jspecify</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/subscription/api/reactor/pom.xml
+++ b/subscription/api/reactor/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
@@ -26,9 +26,10 @@ import reactor.core.publisher.Flux;
  * A typed reactive view over a {@link SubscriptionModel} that subscribes to DCB events selected by a {@link DcbQuery}.
  * <p>
  * It is the DCB counterpart to the reactive {@link SubscriptionModel}, accepting a {@link DcbQuery} and a
- * {@link DcbStartAt} rather than a stream filter and a generic start position. Delivery is live. A {@link DcbStartAt}
- * that asks to replay history (such as {@link DcbStartAt#beginning()} or {@link DcbStartAt#afterPosition(long)}) is
- * passed through to the live subscription, which starts live, because reactive DCB catch-up is not implemented yet.
+ * {@link DcbStartAt} rather than a stream filter and a generic start position. The {@link DcbStartAt} is passed through
+ * to the underlying {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()}
+ * or {@link DcbStartAt#afterPosition(long)} replays history depends on that model. The current reactive subscription
+ * models have no DCB catch-up, so such a start behaves like a live start today.
  */
 @NullMarked
 public interface DcbSubscriptionModel {

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import reactor.core.publisher.Flux;
+
+/**
+ * A typed reactive view over a {@link SubscriptionModel} that subscribes to DCB events selected by a {@link DcbQuery}.
+ * <p>
+ * It is the DCB counterpart to the reactive {@link SubscriptionModel}, accepting a {@link DcbQuery} and a
+ * {@link DcbStartAt} rather than a stream filter and a generic start position. Delivery is live. A {@link DcbStartAt}
+ * that asks to replay history (such as {@link DcbStartAt#beginning()} or {@link DcbStartAt#afterPosition(long)}) is
+ * passed through to the live subscription, which starts live, because reactive DCB catch-up is not implemented yet.
+ */
+@NullMarked
+public interface DcbSubscriptionModel {
+
+    /**
+     * Subscribe to DCB events matching {@code query}, starting at {@code startAt}.
+     *
+     * @return a {@link Flux} of the matching cloud events.
+     */
+    Flux<CloudEvent> subscribe(DcbQuery query, DcbStartAt startAt);
+
+    /**
+     * Subscribe to DCB events matching {@code query} at the subscription model default position.
+     */
+    default Flux<CloudEvent> subscribe(DcbQuery query) {
+        return subscribe(query, DcbStartAt.subscriptionModelDefault());
+    }
+
+    /**
+     * Subscribe to every DCB event at the subscription model default position.
+     */
+    default Flux<CloudEvent> subscribe() {
+        return subscribe(DcbQuery.all());
+    }
+
+    /**
+     * Create a DCB view over an existing reactive {@link SubscriptionModel}.
+     */
+    static DcbSubscriptionModel from(SubscriptionModel delegate) {
+        return new DcbSubscriptionModelAdapter(delegate);
+    }
+}

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+import reactor.core.publisher.Flux;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Translates {@link DcbSubscriptionModel} calls into the shared reactive {@link SubscriptionModel}, building a
+ * {@link DcbSubscriptionFilter} from the query and converting the {@link DcbStartAt} to a generic start position.
+ */
+@NullMarked
+final class DcbSubscriptionModelAdapter implements DcbSubscriptionModel {
+
+    private final SubscriptionModel delegate;
+
+    DcbSubscriptionModelAdapter(SubscriptionModel delegate) {
+        this.delegate = requireNonNull(delegate, SubscriptionModel.class.getSimpleName() + " cannot be null");
+    }
+
+    @Override
+    public Flux<CloudEvent> subscribe(DcbQuery query, DcbStartAt startAt) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");
+        // The DcbSubscriptionFilter is honored server-side for live delivery. The in-process check keeps the
+        // subscription scoped to its own query for any backend that does not honor the filter, matching the blocking
+        // adapter.
+        return delegate.subscribe(DcbSubscriptionFilter.filter(query), startAt.toStartAt())
+                .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query));
+    }
+}

--- a/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
+++ b/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.api.reactor;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+import org.occurrent.subscription.DcbSubscriptionPosition;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.SubscriptionFilter;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbSubscriptionModelAdapterTest {
+
+    @Test
+    void delivers_only_dcb_events_matching_the_query_and_passes_the_start_position_through() {
+        CloudEvent matching = dcbEvent("NameDefined", 1, "name:1");
+        CloudEvent withoutPosition = DcbCloudEvents.withTags(event("NameDefined"), Set.of("name:1"));
+        CloudEvent otherBoundary = dcbEvent("OrderPlaced", 2, "order:1");
+
+        RecordingSubscriptionModel delegate = new RecordingSubscriptionModel(Flux.just(matching, withoutPosition, otherBoundary));
+        DcbSubscriptionModel adapter = DcbSubscriptionModel.from(delegate);
+
+        StepVerifier.create(adapter.subscribe(DcbQuery.tags("name:1"), DcbStartAt.afterPosition(5)))
+                .expectNext(matching)
+                .verifyComplete();
+
+        // The in-process floor drops the event with no dcbposition and the one whose tags do not match the query, so
+        // the subscription stays scoped to its own query even if a backend ignores the server-side filter.
+        assertThat(delegate.capturedFilter).isInstanceOf(DcbSubscriptionFilter.class);
+        // The DcbStartAt is converted to a generic StartAt and passed straight to the delegate.
+        assertThat(delegate.capturedStartAt).isInstanceOfSatisfying(StartAt.StartAtSubscriptionPosition.class,
+                start -> assertThat(start.subscriptionPosition).isEqualTo(DcbSubscriptionPosition.of(5)));
+    }
+
+    private static CloudEvent dcbEvent(String type, long position, String... tags) {
+        return DcbCloudEvents.withPosition(DcbCloudEvents.withTags(event(type), Set.of(tags)), position);
+    }
+
+    private static CloudEvent event(String type) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("urn:test"))
+                .withType(type)
+                .build();
+    }
+
+    private static final class RecordingSubscriptionModel implements SubscriptionModel {
+        private final Flux<CloudEvent> events;
+        @Nullable
+        private SubscriptionFilter capturedFilter;
+        @Nullable
+        private StartAt capturedStartAt;
+
+        private RecordingSubscriptionModel(Flux<CloudEvent> events) {
+            this.events = events;
+        }
+
+        @Override
+        public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+            this.capturedFilter = filter;
+            this.capturedStartAt = startAt;
+            return events;
+        }
+    }
+}


### PR DESCRIPTION
Phase 4a of reactive DCB, stacked on the reactive DSL PR below. This adds live reactive DCB subscriptions.

Most of the machinery was already shared and reactive-agnostic. `DcbSubscriptionFilter` and `DcbStartAt` are in `subscription-core`, and `ReactorMongoSubscriptionModel` already applies a `DcbSubscriptionFilter` server-side on the change stream. So this PR is the missing facade and DSL on top of that.

- A reactive `DcbSubscriptionModel` in `subscription-api-reactor`, shaped like the reactive `SubscriptionModel` (Flux based, no subscription id or callback): `Flux<CloudEvent> subscribe(DcbQuery, DcbStartAt)` plus `from(SubscriptionModel)`. The adapter subscribes the delegate with a `DcbSubscriptionFilter` and keeps an in-process `dcbposition > 0 and matches` floor so the subscription stays scoped to its query even on a backend that does not honor the server-side filter, the same as the blocking adapter.
- A reactive `DcbSubscriptions` DSL: `Flux<E> subscribe(...)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`, with `DcbEventMetadata` read from the CloudEvent.

Scope is live only. A `DcbStartAt.beginning()` or `afterPosition(...)` passes through and starts live rather than replaying, because giving those their replay meaning needs `dcbposition` catch-up, which is the next phase. There is no reactive catch-up anywhere in the repo yet, not even for streams, so that phase is its own larger effort. The live-only limitation is documented on the facade and the DSL.

Tests subscribe over `ReactorMongoSubscriptionModel` against a DCB event store and confirm server-side plus in-process filtering (a matching event is delivered, a non-matching one is not) and that metadata is exposed. They use Awaitility with a background subscription, the proven pattern in the existing reactor subscription tests, because change-stream startup timing makes StepVerifier flaky here.

See ADR 37.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-dcb-dsl","parentHead":"3838fb2bd57817648f10220fe4ccdbd5d453bada","parentPull":244,"trunk":"main"}
```
-->
