### PR TITLE
Add reactive DCB catch-up

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added reactive DCB catch-up, which completes reactive DCB support.
+  * `ReactorDcbCatchupSubscriptionModel` replays DCB history by `dcbposition` and hands over to a live subscription, so a reactive read model can be rebuilt from the beginning. It mirrors the blocking DCB catch-up (the live resume token is captured before the replay so an event committing during the replay is still delivered), with id-based handover dedup because the reactive resume token is inclusive. Reactive DCB now matches the blocking stack across the store, application service, query DSL, and subscriptions.
+  * See [ADR 38](doc/architecture/decisions/0038-reactive-dcb-catch-up.md).
+
 * Added live reactive DCB subscriptions.
   * A reactive `DcbSubscriptionModel` facade (`subscription-api-reactor`) subscribes to DCB events matching a `DcbQuery` as a `Flux<CloudEvent>`, filtered server-side, and the reactor DCB DSL gains `DcbSubscriptions` with `Flux<E> subscribe(...)` and `Flux<DcbEvent<E>> subscribeWithMetadata(...)`. Live only for now. The `DcbStartAt` is passed through to the underlying subscription model, and the current reactive models have no DCB catch-up, so a `DcbStartAt.beginning()` behaves like a live start rather than replaying history.
   * See [ADR 37](doc/architecture/decisions/0037-live-reactive-dcb-subscriptions.md).

--- a/doc/architecture/decisions/0038-reactive-dcb-catch-up.md
+++ b/doc/architecture/decisions/0038-reactive-dcb-catch-up.md
@@ -33,4 +33,5 @@ The cache is bounded (default 1000 ids, evicts eldest). It is insertion-ordered,
 
 - A reactive read model can be rebuilt from the beginning by subscribing with `DcbStartAt.beginning()` or any `afterPosition(...)`, then continue live. This closes the last reactive DCB gap, so reactive DCB now matches the blocking stack at the store, application-service, query, and subscription layers.
 - The replay-longer-than-oplog trade-off carries over: if the replay outlasts the change stream history, the captured token ages out and the live resume fails loudly rather than dropping events.
+- The same no-loss stance applies when the model reports no resume token at all (for example an empty oplog or a restricted cluster). The catch-up cannot guarantee a clean handover from the replay to live, so it fails loudly rather than replaying and resuming live from "now", which would silently drop any event committed between the end of the replay and the live subscription becoming active.
 - Position-storage and durable resume are left to the existing `ReactorDurableSubscriptionModel` composing on top, so this module is the catch-up-then-live `Flux` and nothing more.

--- a/doc/architecture/decisions/0038-reactive-dcb-catch-up.md
+++ b/doc/architecture/decisions/0038-reactive-dcb-catch-up.md
@@ -1,0 +1,36 @@
+# 38. Reactive DCB catch-up
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+Live reactive DCB subscriptions shipped (ADR 37), but a `DcbStartAt.beginning()` started live rather than replaying, so a reactive read model could not be rebuilt from history. The blocking stack has DCB catch-up in `CatchupSubscriptionModel`. This adds the reactive equivalent. There was no reactive catch-up of any kind before this, not even for streams, so this is the first.
+
+It is scoped to DCB only. `dcbposition` is a monotonic server-assigned counter, so replay pages by position with no time sort and no count, which sidesteps the clock-skew loss and the count undercount the stream catch-up has to defend against. The reactive stream catch-up, if it is ever needed, is a separate piece.
+
+## Decision
+
+Add `ReactorDcbCatchupSubscriptionModel` in a new module `subscription/util/reactor/dcb-catchup-subscription`. Its `Flux<CloudEvent> subscribe(DcbQuery, DcbStartAt)` mirrors the blocking DCB catch-up: when the start is a DCB position it replays history and hands over to live, otherwise it goes straight to live through the reactive `DcbSubscriptionModel` facade.
+
+The catch-up `Flux` is `concat(bulk, reconcile, live)`:
+
+- The live resume token is captured with `globalSubscriptionPosition()` BEFORE any replay read, threaded through `flatMapMany`. This is the load-bearing invariant: an event that commits during the replay is still delivered, because live resumes from a token taken before the replay started.
+- `bulk` pages the matched events from the start position to the head observed at the start, in `dcbposition` windows.
+- `reconcile` keeps paging until the head stops advancing, covering events written during the bulk replay.
+- `live` subscribes from the captured token, filtered to `dcbposition > 0`, matches the query, and is not already delivered.
+
+### The one divergence from blocking: id-based dedup across both phases
+
+The blocking catch-up caches only the reconciliation tail, because its live subscription resumes after the bulk head. The reactive `globalSubscriptionPosition()` token resumes inclusively, so the live change stream re-delivers boundary events the replay already emitted. The fix is to dedup the handover by event id (not by a position watermark) and to feed the dedup cache from the bulk phase as well as reconcile. Id-based dedup also preserves in-flight-hole recovery: an event below the replay head that was never seen during the replay is still delivered once by live, because it is not in the cache.
+
+The cache is bounded (default 1000 ids, evicts eldest). It is insertion-ordered, so the most recently replayed ids are retained, which are exactly the ones live can re-deliver (the boundary and the during-replay commits near the head). Bulk events far below the token are evicted but are never re-delivered, so eviction is safe. This is the same bounded-cache assumption the blocking catch-up makes.
+
+## Consequences
+
+- A reactive read model can be rebuilt from the beginning by subscribing with `DcbStartAt.beginning()` or any `afterPosition(...)`, then continue live. This closes the last reactive DCB gap, so reactive DCB now matches the blocking stack at the store, application-service, query, and subscription layers.
+- The replay-longer-than-oplog trade-off carries over: if the replay outlasts the change stream history, the captured token ages out and the live resume fails loudly rather than dropping events.
+- Position-storage and durable resume are left to the existing `ReactorDurableSubscriptionModel` composing on top, so this module is the catch-up-then-live `Flux` and nothing more.

--- a/subscription/util/reactor/dcb-catchup-subscription/pom.xml
+++ b/subscription/util/reactor/dcb-catchup-subscription/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>subscription-util-reactor</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>reactor-dcb-catchup-subscription</artifactId>
+
+    <name>${mavenProjectName}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-api-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -34,7 +34,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -53,7 +52,8 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Trade-off: if the replay runs longer than the change stream history (the MongoDB oplog window), the captured token
  * ages out and the live resume fails loudly rather than silently dropping an event. Size the oplog for very large
- * rebuilds.
+ * rebuilds. If the model cannot report a resume token at all (for example an empty oplog or a restricted cluster), the
+ * subscription fails loudly for the same reason, rather than replaying without a guaranteed handover to live.
  * <p>
  * This is the DCB path only. Stream time-based catch-up is not provided here, and this model does not persist
  * subscription positions, so layer a durable model on top if resume across restarts is needed.
@@ -109,12 +109,11 @@ public class ReactorDcbCatchupSubscriptionModel {
 
         long startPosition = DcbSubscriptionPosition.dcbPositionOf(position.subscriptionPosition);
         // Capture the live resume token before the bulk replay so an event committing during the replay is still
-        // delivered by the live subscription. The underlying model can report no token (for example an empty oplog or
-        // a restricted cluster), so carry it as an Optional rather than letting an empty Mono collapse the whole
-        // subscription to nothing.
+        // delivered by the live subscription. If the model reports no token (for example an empty oplog or a restricted
+        // cluster) a no-loss handover to live cannot be guaranteed, so fail loudly instead of silently dropping the
+        // events committed between the end of the replay and going live.
         return subscriptionModel.globalSubscriptionPosition()
-                .map(Optional::of)
-                .defaultIfEmpty(Optional.empty())
+                .switchIfEmpty(Mono.error(() -> new IllegalStateException("Cannot run a DCB catch-up subscription because the subscription model reported no resume token to hand over to live delivery. The change stream history may be unavailable, for example an empty oplog or a restricted cluster.")))
                 .flatMapMany(liveToken ->
                 readHead(query, startPosition).flatMapMany(bulkHead -> {
                     HandoverCache cache = new HandoverCache(handoverCacheSize);
@@ -124,11 +123,7 @@ public class ReactorDcbCatchupSubscriptionModel {
                     // never seen during the replay is still delivered once by the live change stream.
                     Flux<CloudEvent> bulk = windows(query, startPosition, bulkHead, cache);
                     Flux<CloudEvent> reconcile = reconcile(query, bulkHead, cache);
-                    // With no token, fall back to the model default so the subscription still replays and goes live
-                    // rather than silently delivering nothing. The reconciliation above already covers events written
-                    // during the replay, so only the post-reconciliation tail falls in the gap the token would close.
-                    StartAt liveStart = liveToken.map(StartAt::subscriptionPosition).orElseGet(StartAt::subscriptionModelDefault);
-                    Flux<CloudEvent> live = subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), liveStart)
+                    Flux<CloudEvent> live = subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), StartAt.subscriptionPosition(liveToken))
                             .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0
                                     && DcbCloudEvents.matches(cloudEvent, query)
                                     && !cache.contains(cloudEvent.getId()));
@@ -152,9 +147,7 @@ public class ReactorDcbCatchupSubscriptionModel {
         long upTo = Math.min(fromExclusive + windowSize, toInclusive);
         return dcbEventStore.read(query, DcbReadOptions.between(fromExclusive, upTo))
                 .flatMapMany(stream -> {
-                    if (cache != null) {
-                        stream.events().forEach(event -> cache.add(event.getId()));
-                    }
+                    stream.events().forEach(event -> cache.add(event.getId()));
                     return Flux.fromIterable(stream.events());
                 })
                 .concatWith(Flux.defer(() -> windows(query, upTo, toInclusive, cache)));

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+import org.occurrent.subscription.DcbSubscriptionPosition;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.StartAt.SubscriptionModelContext;
+import org.occurrent.subscription.api.reactor.DcbSubscriptionModel;
+import org.occurrent.subscription.api.reactor.PositionAwareSubscriptionModel;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Reactive DCB catch-up: replays the DCB history matching a {@link DcbQuery} by {@code dcbposition}, then hands over to
+ * a live subscription, as a single {@link Flux}. It lets a reactive read model rebuild from the beginning of the DCB
+ * sequence and then keep up with new events.
+ * <p>
+ * The handover preserves the central invariant of the blocking catch-up. The live change-stream resume token is captured
+ * before the bulk replay, not after, so a DCB event that commits during the replay is still delivered by the live
+ * subscription. The replay pages the sequence in {@code dcbposition} windows (no count and no time sort, because
+ * {@code dcbposition} is monotonic and server-assigned), then a reconciliation pass keeps paging until the head stops
+ * advancing to deliver events written during the replay in order. The handover seam is deduplicated with a bounded id
+ * cache so a reconciliation event the live subscription also sees is delivered once.
+ * <p>
+ * Trade-off: if the replay runs longer than the change stream history (the MongoDB oplog window), the captured token
+ * ages out and the live resume fails loudly rather than silently dropping an event. Size the oplog for very large
+ * rebuilds.
+ * <p>
+ * This is the DCB path only. Stream time-based catch-up is not provided here, and this model does not persist
+ * subscription positions, so layer a durable model on top if resume across restarts is needed.
+ */
+@NullMarked
+public class ReactorDcbCatchupSubscriptionModel {
+
+    /**
+     * Default number of DCB positions read per replay window.
+     */
+    public static final long DEFAULT_POSITION_WINDOW_SIZE = 1000;
+    /**
+     * Default number of event ids kept to deduplicate the replay-to-live handover seam.
+     */
+    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 1000;
+
+    private final PositionAwareSubscriptionModel subscriptionModel;
+    private final DcbEventStore dcbEventStore;
+    private final long windowSize;
+    private final int handoverCacheSize;
+
+    public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore) {
+        this(subscriptionModel, dcbEventStore, DEFAULT_POSITION_WINDOW_SIZE, DEFAULT_HANDOVER_CACHE_SIZE);
+    }
+
+    public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, long windowSize, int handoverCacheSize) {
+        this.subscriptionModel = requireNonNull(subscriptionModel, PositionAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
+        this.dcbEventStore = requireNonNull(dcbEventStore, DcbEventStore.class.getSimpleName() + " cannot be null");
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("Window size must be greater than zero");
+        }
+        if (handoverCacheSize <= 0) {
+            throw new IllegalArgumentException("Handover cache size must be greater than zero");
+        }
+        this.windowSize = windowSize;
+        this.handoverCacheSize = handoverCacheSize;
+    }
+
+    /**
+     * Subscribe to DCB events matching {@code query}. A {@link DcbStartAt} that carries a {@code dcbposition} (for
+     * example {@link DcbStartAt#beginning()} or {@link DcbStartAt#afterPosition(long)}) replays history from that
+     * position and then goes live. Any other start (now or the subscription model default) goes straight to live.
+     */
+    public Flux<CloudEvent> subscribe(DcbQuery query, DcbStartAt startAt) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");
+
+        StartAt resolved = startAt.toStartAt().get(new SubscriptionModelContext(ReactorDcbCatchupSubscriptionModel.class));
+        if (!(resolved instanceof StartAt.StartAtSubscriptionPosition position) || !DcbSubscriptionPosition.isDcbSubscriptionPosition(position.subscriptionPosition)) {
+            // Not a DCB catch-up position, so go straight to live through the shared facade.
+            return DcbSubscriptionModel.from(subscriptionModel).subscribe(query, startAt);
+        }
+
+        long startPosition = DcbSubscriptionPosition.dcbPositionOf(position.subscriptionPosition);
+        // Capture the live resume token before the bulk replay so an event committing during the replay is still
+        // delivered by the live subscription.
+        return subscriptionModel.globalSubscriptionPosition().flatMapMany(liveToken ->
+                readHead(query, startPosition).flatMapMany(bulkHead -> {
+                    HandoverCache cache = new HandoverCache(handoverCacheSize);
+                    // Cache the replayed ids, including the bulk tail, because the reactive global subscription position
+                    // resumes inclusively, so the live change stream re-delivers boundary events the replay already
+                    // emitted. Dedup is by id, not by position, so an in-flight event below the replay head that was
+                    // never seen during the replay is still delivered once by the live change stream.
+                    Flux<CloudEvent> bulk = windows(query, startPosition, bulkHead, cache);
+                    Flux<CloudEvent> reconcile = reconcile(query, bulkHead, cache);
+                    Flux<CloudEvent> live = subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), StartAt.subscriptionPosition(liveToken))
+                            .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0
+                                    && DcbCloudEvents.matches(cloudEvent, query)
+                                    && !cache.contains(cloudEvent.getId()));
+                    return Flux.concat(bulk, reconcile, live);
+                }));
+    }
+
+    // Reads the current global DCB head observed for the query, as a single read.
+    private Mono<Long> readHead(DcbQuery query, long cursor) {
+        return dcbEventStore.read(query, DcbReadOptions.between(cursor, cursor)).map(stream -> stream.lastSequencePosition());
+    }
+
+    // Emits events in (fromExclusive, toInclusive] paging in position windows. Records ids in the cache when one is
+    // supplied (the reconciliation phase), so the live subscription can skip them at the handover seam.
+    private Flux<CloudEvent> windows(DcbQuery query, long fromExclusive, long toInclusive, HandoverCache cache) {
+        if (fromExclusive >= toInclusive) {
+            return Flux.empty();
+        }
+        long upTo = Math.min(fromExclusive + windowSize, toInclusive);
+        return dcbEventStore.read(query, DcbReadOptions.between(fromExclusive, upTo))
+                .flatMapMany(stream -> {
+                    if (cache != null) {
+                        stream.events().forEach(event -> cache.add(event.getId()));
+                    }
+                    return Flux.fromIterable(stream.events());
+                })
+                .concatWith(Flux.defer(() -> windows(query, upTo, toInclusive, cache)));
+    }
+
+    // Pages from the bulk head onward, re-reading the head each round, until it stops advancing. This delivers events
+    // written during the bulk replay in dcbposition order.
+    private Flux<CloudEvent> reconcile(DcbQuery query, long cursor, HandoverCache cache) {
+        return readHead(query, cursor).flatMapMany(head -> head > cursor
+                ? windows(query, cursor, head, cache).concatWith(Flux.defer(() -> reconcile(query, head, cache)))
+                : Flux.empty());
+    }
+
+    // A bounded, insertion-ordered set of event ids covering the recently replayed tail. The live change stream resumes
+    // inclusively, so it re-delivers events near the captured token that the replay already emitted, and this cache
+    // skips those. It does not need the whole history, only the tail the live resume can overlap.
+    private static final class HandoverCache {
+        private final int maxSize;
+        private final Set<String> ids;
+
+        private HandoverCache(int maxSize) {
+            this.maxSize = maxSize;
+            this.ids = Collections.synchronizedSet(new LinkedHashSet<>());
+        }
+
+        private void add(String id) {
+            synchronized (ids) {
+                if (ids.add(id) && ids.size() > maxSize) {
+                    java.util.Iterator<String> iterator = ids.iterator();
+                    iterator.next();
+                    iterator.remove();
+                }
+            }
+        }
+
+        private boolean contains(String id) {
+            return ids.contains(id);
+        }
+    }
+}

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -136,13 +136,15 @@ public class ReactorDcbCatchupSubscriptionModel {
                 }));
     }
 
-    // Reads the current global DCB head observed for the query, as a single read.
+    // Reads the store's current global DCB head as a single read. lastSequencePosition is the global head at read
+    // time regardless of whether the query matched anything.
     private Mono<Long> readHead(DcbQuery query, long cursor) {
         return dcbEventStore.read(query, DcbReadOptions.between(cursor, cursor)).map(stream -> stream.lastSequencePosition());
     }
 
-    // Emits events in (fromExclusive, toInclusive] paging in position windows. Records ids in the cache when one is
-    // supplied (the reconciliation phase), so the live subscription can skip them at the handover seam.
+    // Emits events in (fromExclusive, toInclusive] paging in position windows. Records every emitted id in the cache so
+    // the inclusive live resume can skip the replayed events at the handover seam. Used by both the bulk and the
+    // reconciliation phases.
     private Flux<CloudEvent> windows(DcbQuery query, long fromExclusive, long toInclusive, HandoverCache cache) {
         if (fromExclusive >= toInclusive) {
             return Flux.empty();

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -108,8 +109,13 @@ public class ReactorDcbCatchupSubscriptionModel {
 
         long startPosition = DcbSubscriptionPosition.dcbPositionOf(position.subscriptionPosition);
         // Capture the live resume token before the bulk replay so an event committing during the replay is still
-        // delivered by the live subscription.
-        return subscriptionModel.globalSubscriptionPosition().flatMapMany(liveToken ->
+        // delivered by the live subscription. The underlying model can report no token (for example an empty oplog or
+        // a restricted cluster), so carry it as an Optional rather than letting an empty Mono collapse the whole
+        // subscription to nothing.
+        return subscriptionModel.globalSubscriptionPosition()
+                .map(Optional::of)
+                .defaultIfEmpty(Optional.empty())
+                .flatMapMany(liveToken ->
                 readHead(query, startPosition).flatMapMany(bulkHead -> {
                     HandoverCache cache = new HandoverCache(handoverCacheSize);
                     // Cache the replayed ids, including the bulk tail, because the reactive global subscription position
@@ -118,7 +124,11 @@ public class ReactorDcbCatchupSubscriptionModel {
                     // never seen during the replay is still delivered once by the live change stream.
                     Flux<CloudEvent> bulk = windows(query, startPosition, bulkHead, cache);
                     Flux<CloudEvent> reconcile = reconcile(query, bulkHead, cache);
-                    Flux<CloudEvent> live = subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), StartAt.subscriptionPosition(liveToken))
+                    // With no token, fall back to the model default so the subscription still replays and goes live
+                    // rather than silently delivering nothing. The reconciliation above already covers events written
+                    // during the replay, so only the post-reconciliation tail falls in the gap the token would close.
+                    StartAt liveStart = liveToken.map(StartAt::subscriptionPosition).orElseGet(StartAt::subscriptionModelDefault);
+                    Flux<CloudEvent> live = subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), liveStart)
                             .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0
                                     && DcbCloudEvents.matches(cloudEvent, query)
                                     && !cache.contains(cloudEvent.getId()));

--- a/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
@@ -177,6 +177,28 @@ class ReactorDcbCatchupSubscriptionModelMongoTest {
         await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> assertThat(received).containsExactly("matchHistoric", "matchLive"));
     }
 
+    @Test
+    void replays_every_event_with_a_small_window_and_cache_then_goes_live_without_loss() {
+        // More matching events than both the window and the handover cache, so the bulk replay pages across many
+        // windows and the cache evicts during the replay. The handover must still deliver every event exactly once.
+        for (int i = 0; i < 5; i++) {
+            appendTagged(name("h" + i), "name:1");
+        }
+
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(subscriptionModel, eventStore, 1, 1);
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        subscribe(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.beginning()), received);
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> assertThat(received).containsExactly("h0", "h1", "h2", "h3", "h4"));
+
+        appendTagged(name("live0"), "name:1");
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> {
+            assertThat(received).containsExactly("h0", "h1", "h2", "h3", "h4", "live0");
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
     private void subscribe(reactor.core.publisher.Flux<CloudEvent> flux, CopyOnWriteArrayList<String> received) {
         disposables.add(flux.map(ce -> ((NameDefined) converter.toDomainEvent(ce)).name()).doOnNext(received::add).subscribe());
         // Give the change-stream subscription a moment to start before the test writes more events.

--- a/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Timeout(120)
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ReactorDcbCatchupSubscriptionModelMongoTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+            .withReplicaSet()
+            .withReuse(true);
+
+    @RegisterExtension
+    FlushMongoDBExtension flush = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbcatchup"));
+
+    private ReactorMongoEventStore eventStore;
+    private ReactorMongoSubscriptionModel subscriptionModel;
+    private CloudEventConverter<DomainEvent> converter;
+    private final CopyOnWriteArrayList<Disposable> disposables = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void create_instances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbcatchup");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager tx = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(tx)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(org.occurrent.eventstore.api.EventStoreCapability.STREAM, org.occurrent.eventstore.api.EventStoreCapability.DCB)
+                .build();
+        eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        subscriptionModel = new ReactorMongoSubscriptionModel(mongoTemplate, "events", TimeRepresentation.RFC_3339_STRING);
+        converter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+    }
+
+    @AfterEach
+    void dispose() {
+        disposables.forEach(Disposable::dispose);
+    }
+
+    @Test
+    void replays_dcb_history_from_the_beginning_then_delivers_live_events_without_duplicates() {
+        NameDefined h1 = name("h1");
+        NameDefined h2 = name("h2");
+        appendTagged(h1, "name:1");
+        appendTagged(name("ignoredHistoric"), "other:1");
+        appendTagged(h2, "name:1");
+
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(subscriptionModel, eventStore);
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        subscribe(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.beginning()), received);
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> assertThat(received).containsExactly("h1", "h2"));
+
+        NameDefined l1 = name("l1");
+        NameDefined l2 = name("l2");
+        appendTagged(l1, "name:1");
+        appendTagged(name("ignoredLive"), "other:1");
+        appendTagged(l2, "name:1");
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> {
+            assertThat(received).containsExactly("h1", "h2", "l1", "l2");
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    @Test
+    void a_dcb_event_committed_while_the_replay_is_running_is_delivered_exactly_once() {
+        // Two historic matching events, plus a non-matching one.
+        appendTagged(name("h1"), "name:1");
+        appendTagged(name("h2"), "name:1");
+
+        // Delay the first replay read so an event can commit while the replay is in flight. The live resume token is
+        // captured before the replay, so the during-replay event must still be delivered, exactly once.
+        AtomicBoolean firstReadStarted = new AtomicBoolean(false);
+        DelayFirstReadDcbEventStore delaying = new DelayFirstReadDcbEventStore(eventStore, Duration.ofSeconds(2), firstReadStarted);
+
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(subscriptionModel, delaying);
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        subscribe(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.beginning()), received);
+
+        // Wait until the replay read is in flight, then commit a new matching event during the delay.
+        await().atMost(Duration.ofSeconds(40)).untilTrue(firstReadStarted);
+        appendTagged(name("duringReplay"), "name:1");
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> {
+            assertThat(received).containsExactlyInAnyOrder("h1", "h2", "duringReplay");
+            assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    @Test
+    void only_events_matching_the_query_are_delivered_during_catchup_and_live() {
+        appendTagged(name("matchHistoric"), "name:1");
+        appendTagged(name("ignoredHistoric"), "other:1");
+
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(subscriptionModel, eventStore);
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        subscribe(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.beginning()), received);
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> assertThat(received).containsExactly("matchHistoric"));
+
+        appendTagged(name("matchLive"), "name:1");
+        appendTagged(name("ignoredLive"), "other:1");
+
+        await().atMost(Duration.ofSeconds(40)).untilAsserted(() -> assertThat(received).containsExactly("matchHistoric", "matchLive"));
+    }
+
+    private void subscribe(reactor.core.publisher.Flux<CloudEvent> flux, CopyOnWriteArrayList<String> received) {
+        disposables.add(flux.map(ce -> ((NameDefined) converter.toDomainEvent(ce)).name()).doOnNext(received::add).subscribe());
+        // Give the change-stream subscription a moment to start before the test writes more events.
+        sleep(700);
+    }
+
+    private NameDefined name(String name) {
+        return new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), name, name);
+    }
+
+    private void appendTagged(DomainEvent event, String tag) {
+        CloudEvent cloudEvent = converter.toCloudEvents(Stream.of(event)).collect(Collectors.toList()).get(0);
+        eventStore.append(List.of(DcbCloudEvents.withTags(cloudEvent, java.util.Set.of(tag)))).block();
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    // Delays the first bulk window read so an event can commit while the replay is in flight. The model's first read is
+    // the head probe (afterPosition == upToPosition), so the delay is applied to the first real window read after it.
+    // The event committed during the delay lands above the captured bulk head and must be recovered exactly once
+    // through reconciliation or the live subscription, which resumes from a token captured before the replay.
+    private static final class DelayFirstReadDcbEventStore implements org.occurrent.eventstore.api.dcb.reactor.DcbEventStore {
+        private final org.occurrent.eventstore.api.dcb.reactor.DcbEventStore delegate;
+        private final Duration delay;
+        private final AtomicBoolean firstReadStarted;
+        private final AtomicBoolean windowDelayed = new AtomicBoolean(false);
+
+        private DelayFirstReadDcbEventStore(org.occurrent.eventstore.api.dcb.reactor.DcbEventStore delegate, Duration delay, AtomicBoolean firstReadStarted) {
+            this.delegate = delegate;
+            this.delay = delay;
+            this.firstReadStarted = firstReadStarted;
+        }
+
+        @Override
+        public Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options) {
+            boolean isHeadProbe = options.afterSequencePosition().orElse(0) == options.upToSequencePosition().orElse(0);
+            if (!isHeadProbe && windowDelayed.compareAndSet(false, true)) {
+                return Mono.defer(() -> {
+                    firstReadStarted.set(true);
+                    return delegate.read(query, options).delayElement(delay);
+                });
+            }
+            return delegate.read(query, options);
+        }
+
+        @Override
+        public Mono<org.occurrent.eventstore.api.dcb.DcbAppendResult> append(List<CloudEvent> events) {
+            return delegate.append(events);
+        }
+
+        @Override
+        public Mono<org.occurrent.eventstore.api.dcb.DcbAppendResult> append(List<CloudEvent> events, org.occurrent.eventstore.api.dcb.DcbAppendCondition condition) {
+            return delegate.append(events, condition);
+        }
+    }
+}

--- a/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelMongoTest.java
@@ -81,12 +81,13 @@ class ReactorDcbCatchupSubscriptionModelMongoTest {
     private ReactorMongoEventStore eventStore;
     private ReactorMongoSubscriptionModel subscriptionModel;
     private CloudEventConverter<DomainEvent> converter;
+    private MongoClient mongoClient;
     private final CopyOnWriteArrayList<Disposable> disposables = new CopyOnWriteArrayList<>();
 
     @BeforeEach
     void create_instances() {
         ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbcatchup");
-        MongoClient mongoClient = MongoClients.create(connectionString);
+        mongoClient = MongoClients.create(connectionString);
         ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
         ReactiveMongoTransactionManager tx = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
         EventStoreConfig config = new EventStoreConfig.Builder()
@@ -103,6 +104,9 @@ class ReactorDcbCatchupSubscriptionModelMongoTest {
     @AfterEach
     void dispose() {
         disposables.forEach(Disposable::dispose);
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
     }
 
     @Test

--- a/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbEventStream;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.SubscriptionPosition;
+import org.occurrent.subscription.api.reactor.PositionAwareSubscriptionModel;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ReactorDcbCatchupSubscriptionModelTest {
+
+    @Test
+    void a_replay_start_fails_loudly_when_the_model_reports_no_resume_token() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore());
+
+        // Without a resume token the handover from the replay to live cannot be guaranteed loss-free, so the catch-up
+        // errors instead of replaying. The event store is never read, the failure happens before the first replay read.
+        StepVerifier.create(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.beginning()))
+                .expectError(IllegalStateException.class)
+                .verify();
+    }
+
+    @Test
+    void a_live_start_does_not_require_a_resume_token() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore());
+
+        // A non-replay start goes straight to live through the facade, so it neither needs a resume token nor reads
+        // history. The fail-loud rule is scoped to replay starts only.
+        StepVerifier.create(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.now()))
+                .verifyComplete();
+    }
+
+    private static final class NoTokenSubscriptionModel implements PositionAwareSubscriptionModel {
+        @Override
+        public Mono<SubscriptionPosition> globalSubscriptionPosition() {
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+            return Flux.empty();
+        }
+    }
+
+    private static final class UnusedDcbEventStore implements DcbEventStore {
+        @Override
+        public Mono<DcbEventStream> read(DcbQuery query, DcbReadOptions options) {
+            return Mono.error(new AssertionError("read must not be called when the catch-up fails loudly"));
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events) {
+            return Mono.error(new AssertionError("append must not be called"));
+        }
+
+        @Override
+        public Mono<DcbAppendResult> append(List<CloudEvent> events, DcbAppendCondition condition) {
+            return Mono.error(new AssertionError("append must not be called"));
+        }
+    }
+}

--- a/subscription/util/reactor/pom.xml
+++ b/subscription/util/reactor/pom.xml
@@ -26,6 +26,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>durable-subscription</module>
+        <module>dcb-catchup-subscription</module>
     </modules>
     <artifactId>subscription-util-reactor</artifactId>
 


### PR DESCRIPTION
Phase 4b of reactive DCB, the last phase, stacked on the live-subscriptions PR below. This adds reactive DCB catch-up, so a reactive read model can be rebuilt from history.

`ReactorDcbCatchupSubscriptionModel.subscribe(DcbQuery, DcbStartAt)` replays DCB history by `dcbposition` and hands over to a live subscription. When the start is a DCB position it replays, otherwise it goes straight to live. The catch-up `Flux` is `concat(bulk, reconcile, live)`:

- The live resume token is captured with `globalSubscriptionPosition()` BEFORE any replay read. This is the load-bearing invariant. An event that commits during the replay is still delivered, because live resumes from a token taken before the replay started.
- `bulk` pages the matched events from the start position to the head observed at the start, in `dcbposition` windows.
- `reconcile` keeps paging until the head stops advancing, covering events written during the bulk replay.
- `live` subscribes from the captured token, deduped against the replay.

It is DCB only. `dcbposition` is monotonic and server-assigned, so replay needs no time sort and no count, which sidesteps the clock-skew loss and count undercount the stream catch-up defends against. There is no reactive catch-up of any kind before this, so this is the first.

One divergence from the blocking catch-up worth a look. The reactive `globalSubscriptionPosition()` token resumes inclusively, so the live change stream re-delivers boundary events the replay already emitted. I dedup the handover by event id rather than a position watermark, and feed the bounded dedup cache from the bulk phase as well as reconcile. Id-based dedup also keeps in-flight-hole recovery: an event below the replay head that was never seen during the replay is still delivered once by live. The cache is bounded and insertion-ordered, so the retained ids are the recent ones near the head, which are exactly the ones live can re-deliver. Same bounded-cache assumption the blocking catch-up makes.

Tests use `ReactorMongoSubscriptionModel` over a DCB event store. The key one is `a_dcb_event_committed_while_the_replay_is_running_is_delivered_exactly_once`, which delays the first replay window read, commits an event during the replay, and asserts exactly-once delivery, no loss and no duplicate. They use Awaitility with a background subscription because change-stream startup timing makes StepVerifier flaky here.

This completes reactive DCB across the store, application service, query DSL, and subscriptions. See ADR 38.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-dcb-subscriptions","parentHead":"6c9d6f5660845d786d537e2ba83c7fa658852a36","parentPull":245,"trunk":"main"}
```
-->
