### PR TITLE
Add a reactive stream application service (parity with blocking)

### DIFF
--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ApplicationService.java
@@ -1,5 +1,7 @@
 package org.occurrent.application.service.blocking;
 
+import org.occurrent.application.service.ExecuteFilter;
+
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
@@ -16,6 +16,8 @@
  */
 
 package org.occurrent.application.service.blocking;
+
+import org.occurrent.application.service.ExecuteFilter;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.StreamReadFilter;
 

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/GenericApplicationService.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/GenericApplicationService.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.service.blocking.ApplicationService;
-import org.occurrent.application.service.blocking.ExecuteFilter;
+import org.occurrent.application.service.ExecuteFilter;
 import org.occurrent.application.service.blocking.ExecuteOptions;
 import org.occurrent.eventstore.api.StreamReadFilter;
 import org.occurrent.eventstore.api.WriteConditionNotFulfilledException;

--- a/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
+++ b/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ApplicationServiceExtensions.kt
@@ -16,6 +16,8 @@
 
 package org.occurrent.application.service.blocking
 
+import org.occurrent.application.service.ExecuteFilter
+
 import org.occurrent.eventstore.api.WriteResult
 import java.util.UUID
 import java.util.function.Function

--- a/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ExecuteFilterExtensions.kt
+++ b/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ExecuteFilterExtensions.kt
@@ -1,5 +1,7 @@
 package org.occurrent.application.service.blocking
 
+import org.occurrent.application.service.ExecuteFilter
+
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 

--- a/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ExecuteOptionsExtensions.kt
+++ b/application/service/blocking/src/main/kotlin/org/occurrent/application/service/blocking/ExecuteOptionsExtensions.kt
@@ -1,5 +1,7 @@
 package org.occurrent.application.service.blocking
 
+import org.occurrent.application.service.ExecuteFilter
+
 import org.occurrent.eventstore.api.StreamReadFilter
 import java.util.function.Consumer
 import java.util.stream.Stream

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteFilterTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteFilterTest.java
@@ -1,5 +1,7 @@
 package org.occurrent.application.service.blocking;
 
+import org.occurrent.application.service.ExecuteFilter;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteOptionsTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteOptionsTest.java
@@ -1,5 +1,7 @@
 package org.occurrent.application.service.blocking;
 
+import org.occurrent.application.service.ExecuteFilter;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/generic/GenericApplicationServiceTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/generic/GenericApplicationServiceTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.generic.GenericCloudEventConverter;
 import org.occurrent.application.service.blocking.ApplicationService;
-import org.occurrent.application.service.blocking.ExecuteFilter;
+import org.occurrent.application.service.ExecuteFilter;
 import org.occurrent.application.service.blocking.PolicySideEffect;
 import org.occurrent.application.service.blocking.generic.support.CountNumberOfNamesDefinedPolicy;
 import org.occurrent.application.service.blocking.generic.support.WhenNameDefinedThenCountAverageSizeOfNamePolicy;

--- a/application/service/common/pom.xml
+++ b/application/service/common/pom.xml
@@ -30,6 +30,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-type-mapper-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>filter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>

--- a/application/service/common/src/main/java/org/occurrent/application/service/ExecuteFilter.java
+++ b/application/service/common/src/main/java/org/occurrent/application/service/ExecuteFilter.java
@@ -1,5 +1,22 @@
-package org.occurrent.application.service.blocking;
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.occurrent.application.service;
+
+import org.jspecify.annotations.NullMarked;
 import org.occurrent.application.converter.typemapper.CloudEventTypeGetter;
 import org.occurrent.condition.Condition;
 import org.occurrent.eventstore.api.StreamReadFilter;
@@ -14,29 +31,13 @@ import java.util.stream.Stream;
  * through a {@link CloudEventTypeGetter} at execution time.
  * <p>
  * This type exists to keep {@link StreamReadFilter} independent from application service concerns while
- * still allowing fluent filters based on domain event classes such as {@code type(MyEvent.class)}.
- * <p>
- * Typical usage is to pass an {@link ExecuteFilter} to {@link ExecuteOptions} or directly to
- * {@link ApplicationService}:
- * <pre>{@code
- * applicationService.execute(
- *         streamId,
- *         ExecuteOptions.<DomainEvent>options()
- *                 .filter(ExecuteFilter.type(NameDefined.class))
- *                 .sideEffect(newEvents -> newEvents.forEach(this::publish)),
- *         domainFn
- * );
- *
- * applicationService.execute(
- *         streamId,
- *         ExecuteFilter.excludeTypes(NameWasChanged.class, NameDefined.class),
- *         domainFn
- * );
- * }</pre>
+ * still allowing fluent filters based on domain event classes such as {@code type(MyEvent.class)}. It is shared
+ * by both the blocking and the reactive application services.
  *
  * @param <E> The application service event type.
  */
 @FunctionalInterface
+@NullMarked
 public interface ExecuteFilter<E> {
 
     /**

--- a/application/service/reactor/pom.xml
+++ b/application/service/reactor/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>eventstore-api-dcb-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -47,6 +52,11 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jspecify</groupId>
@@ -88,6 +98,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-generic</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
@@ -98,4 +119,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ApplicationService.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ApplicationService.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.application.service.ExecuteFilter;
+import org.occurrent.eventstore.api.WriteResult;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * The reactive counterpart of the blocking {@code ApplicationService}. It loads the events for a stream, applies them to
+ * a pure domain function, writes the new events with optimistic concurrency, and runs an optional side-effect after the
+ * write, all as a {@link Mono}.
+ *
+ * @param <E> The type of the event to store. Normally this would be your custom "DomainEvent" class but it could also be {@link CloudEvent}.
+ */
+@NullMarked
+public interface ApplicationService<E> {
+
+    /**
+     * Execute a function that loads events from the event store and applies them to the domain model using
+     * {@link ExecuteOptions}.
+     *
+     * @param streamId                     The id of the stream to load events from and also write the events returned from {@code functionThatCallsDomainModel} to.
+     * @param executeOptions               Options that control stream read filtering and an optional reactive side-effect.
+     * @param functionThatCallsDomainModel A <i>pure</i> function that calls the domain model.
+     * @return A {@link Mono} of the write result.
+     */
+    Mono<WriteResult> execute(String streamId, ExecuteOptions<E> executeOptions, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel);
+
+    /**
+     * Execute a function using an {@link ExecuteFilter} that resolves domain event classes to CloudEvent types when reading.
+     */
+    default Mono<WriteResult> execute(String streamId, ExecuteFilter<? extends E> executeFilter, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        Objects.requireNonNull(executeFilter, "ExecuteFilter cannot be null");
+        Objects.requireNonNull(functionThatCallsDomainModel, "functionThatCallsDomainModel cannot be null");
+        return execute(streamId, ExecuteOptions.<E>options().filter(executeFilter), functionThatCallsDomainModel);
+    }
+
+    /**
+     * Execute a function with no read filter and no side-effect.
+     */
+    default Mono<WriteResult> execute(String streamId, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        return execute(streamId, ExecuteOptions.empty(), functionThatCallsDomainModel);
+    }
+
+    /**
+     * Convenience overload that accepts a {@link UUID} stream id.
+     */
+    default Mono<WriteResult> execute(UUID streamId, ExecuteOptions<E> executeOptions, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), executeOptions, functionThatCallsDomainModel);
+    }
+
+    /**
+     * Convenience overload that accepts a {@link UUID} stream id and an {@link ExecuteFilter}.
+     */
+    default Mono<WriteResult> execute(UUID streamId, ExecuteFilter<? extends E> executeFilter, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), executeFilter, functionThatCallsDomainModel);
+    }
+
+    /**
+     * Convenience overload that accepts a {@link UUID} stream id.
+     */
+    default Mono<WriteResult> execute(UUID streamId, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        return execute(streamId.toString(), functionThatCallsDomainModel);
+    }
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ExecuteOptions.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ExecuteOptions.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.service.ExecuteFilter;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Options used when executing a command through a reactive {@link ApplicationService}.
+ * <p>
+ * It carries an optional {@link StreamReadFilter} (or an {@link ExecuteFilter} resolved at execution time) that limits
+ * which events are read, and an optional reactive side-effect that is invoked after the events have been written. The
+ * side-effect returns a {@link Mono} so it can do non-blocking work, and it runs once on success, outside the retry.
+ *
+ * @param <E> The application service event type.
+ */
+@NullMarked
+public final class ExecuteOptions<E> {
+    private final @Nullable StreamReadFilter filter;
+    private final @Nullable ExecuteFilter<? extends E> executeFilter;
+    private final @Nullable Function<Stream<E>, Mono<Void>> sideEffect;
+
+    private ExecuteOptions(@Nullable StreamReadFilter filter, @Nullable ExecuteFilter<? extends E> executeFilter, @Nullable Function<Stream<E>, Mono<Void>> sideEffect) {
+        this.filter = filter;
+        this.executeFilter = executeFilter;
+        this.sideEffect = sideEffect;
+    }
+
+    /**
+     * Create empty options, i.e. no read filter and no side-effect.
+     */
+    public static <E> ExecuteOptions<E> empty() {
+        return new ExecuteOptions<>(null, null, null);
+    }
+
+    /**
+     * Alias for {@link #empty()} intended to read naturally in fluent call sites.
+     */
+    public static <E> ExecuteOptions<E> options() {
+        return empty();
+    }
+
+    /**
+     * Create options that contain only the supplied {@link ExecuteFilter}.
+     */
+    public static <E> ExecuteOptions<E> withExecuteFilter(ExecuteFilter<? extends E> executeFilter) {
+        return new ExecuteOptions<>(null, Objects.requireNonNull(executeFilter, "executeFilter cannot be null"), null);
+    }
+
+    /**
+     * Set the stream read filter.
+     */
+    public ExecuteOptions<E> filter(StreamReadFilter filter) {
+        return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null, null);
+    }
+
+    /**
+     * Set an application-service-level execute filter that resolves domain event classes to CloudEvent types at
+     * execution time.
+     */
+    public ExecuteOptions<E> filter(ExecuteFilter<? extends E> executeFilter) {
+        return withExecuteFilter(executeFilter);
+    }
+
+    /**
+     * Set the reactive side-effect to invoke after a successful write. It receives the events produced by the current
+     * execution and returns a {@link Mono} that completes when the side-effect is done.
+     */
+    @SuppressWarnings("unchecked")
+    public <E_SPECIFIC extends E> ExecuteOptions<E_SPECIFIC> sideEffect(Function<Stream<E_SPECIFIC>, Mono<Void>> sideEffect) {
+        return new ExecuteOptions<>(filter, (ExecuteFilter<? extends E_SPECIFIC>) executeFilter, Objects.requireNonNull(sideEffect, "sideEffect cannot be null"));
+    }
+
+    /**
+     * Return the configured stream read filter, or {@code null} if none has been configured.
+     */
+    public @Nullable StreamReadFilter filter() {
+        return filter;
+    }
+
+    /**
+     * Return the configured application-service execute filter, or {@code null} if none has been configured.
+     */
+    public @Nullable ExecuteFilter<? extends E> executeFilter() {
+        return executeFilter;
+    }
+
+    /**
+     * Return the configured post-write side-effect, or {@code null} if none has been configured.
+     */
+    public @Nullable Function<Stream<E>, Mono<Void>> sideEffect() {
+        return sideEffect;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ExecuteOptions<?> that = (ExecuteOptions<?>) obj;
+        return Objects.equals(this.filter, that.filter) &&
+                Objects.equals(this.executeFilter, that.executeFilter) &&
+                Objects.equals(this.sideEffect, that.sideEffect);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filter, executeFilter, sideEffect);
+    }
+
+    @Override
+    public String toString() {
+        return "ExecuteOptions[" +
+                "filter=" + filter + ", " +
+                "executeFilter=" + executeFilter + ", " +
+                "sideEffect=" + sideEffect + ']';
+    }
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/PolicySideEffect.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/PolicySideEffect.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * A reactive utility that makes it easier to run policies (a.k.a. triggers) as side-effects after events are written to
+ * the event store. A policy takes a single domain event of a specific type and returns a {@code Mono<Void>} that
+ * completes when the policy is done. This is the reactive counterpart of the blocking {@code PolicySideEffect}.
+ *
+ * @param <E> The type of your domain event.
+ */
+@NullMarked
+public interface PolicySideEffect<E> extends Function<Stream<E>, Mono<Void>> {
+
+    /**
+     * Run a single policy for every event of {@code eventType} produced by the command, in order. Events that are not
+     * assignable to {@code eventType} are ignored.
+     */
+    static <E, E_SPECIFIC extends E> PolicySideEffect<E> executePolicy(Class<E_SPECIFIC> eventType, Function<E_SPECIFIC, Mono<Void>> policy) {
+        Objects.requireNonNull(eventType, "Event type cannot be null");
+        Objects.requireNonNull(policy, "Policy cannot be null");
+        return stream -> Flux.fromStream(stream)
+                .filter(e -> eventType.isAssignableFrom(e.getClass()))
+                .map(eventType::cast)
+                .concatMap(policy::apply)
+                .then();
+    }
+
+    /**
+     * Compose this policy with another one, running them in order against the same produced events.
+     */
+    default <E_SPECIFIC extends E> PolicySideEffect<E> andThenExecuteAnotherPolicy(Class<E_SPECIFIC> eventType, Function<E_SPECIFIC, Mono<Void>> policy) {
+        PolicySideEffect<E> first = this;
+        PolicySideEffect<E> second = executePolicy(eventType, policy);
+        return stream -> {
+            List<E> events = stream.toList();
+            return first.apply(events.stream()).then(second.apply(events.stream()));
+        };
+    }
+}

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/generic/GenericApplicationService.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/generic/GenericApplicationService.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.generic;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.service.ExecuteFilter;
+import org.occurrent.application.service.reactor.ApplicationService;
+import org.occurrent.application.service.reactor.ExecuteOptions;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import org.occurrent.eventstore.api.WriteConditionNotFulfilledException;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.api.reactor.EventStore;
+import org.occurrent.eventstore.api.reactor.ReadEventStreamWithFilter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * The reactive counterpart of the blocking {@code GenericApplicationService}. It reads a stream, applies the events to a
+ * pure domain function, writes the produced events with optimistic concurrency, and runs an optional reactive
+ * side-effect after the write, retrying from a fresh read on a {@link WriteConditionNotFulfilledException}.
+ *
+ * @param <E> The type of the event to store. Normally this would be your custom "DomainEvent" class but it could also be {@link CloudEvent}.
+ */
+@NullMarked
+public class GenericApplicationService<E> implements ApplicationService<E> {
+
+    private final EventStore eventStore;
+    private final CloudEventConverter<E> cloudEventConverter;
+    private final Retry retry;
+
+    /**
+     * Create a service with the default retry policy for optimistic concurrency conflicts.
+     */
+    public GenericApplicationService(EventStore eventStore, CloudEventConverter<E> cloudEventConverter) {
+        this(eventStore, cloudEventConverter, defaultRetry());
+    }
+
+    /**
+     * Create a service with explicit collaborators and a retry policy applied when a {@link WriteConditionNotFulfilledException}
+     * is caught.
+     */
+    public GenericApplicationService(EventStore eventStore, CloudEventConverter<E> cloudEventConverter, Retry retry) {
+        if (eventStore == null) throw new IllegalArgumentException(EventStore.class.getSimpleName() + " cannot be null");
+        if (cloudEventConverter == null) throw new IllegalArgumentException(CloudEventConverter.class.getSimpleName() + " cannot be null");
+        if (retry == null) throw new IllegalArgumentException(Retry.class.getSimpleName() + " cannot be null");
+
+        this.eventStore = eventStore;
+        this.cloudEventConverter = cloudEventConverter;
+        this.retry = retry;
+    }
+
+    @Override
+    public Mono<WriteResult> execute(String streamId, ExecuteOptions<E> executeOptions, Function<Stream<E>, Stream<E>> functionThatCallsDomainModel) {
+        Objects.requireNonNull(streamId, "Stream id cannot be null");
+        Objects.requireNonNull(executeOptions, "ExecuteOptions cannot be null");
+        Objects.requireNonNull(functionThatCallsDomainModel, "Function that calls domain model cannot be null");
+
+        @Nullable StreamReadFilter filter = resolveFilter(executeOptions);
+        if (filter != null && !(eventStore instanceof ReadEventStreamWithFilter)) {
+            throw new UnsupportedOperationException("The provided EventStore implementation does not support reading with a StreamReadFilter. EventStore must implement ReadEventStreamWithFilter in order to use filters when reading.");
+        }
+        @Nullable Function<Stream<E>, Mono<Void>> sideEffect = executeOptions.sideEffect();
+
+        // The read, decide, and write run as one unit and retry from a fresh read on an optimistic-concurrency
+        // conflict, so the decision always runs against the current events. The side-effect is composed after the
+        // retry so it runs once on success, not per attempt.
+        Mono<Result<E>> readDecideWrite = Mono.defer(() -> read(streamId, filter).flatMap(eventStream ->
+                eventStream.events().collectList().flatMap(currentCloudEvents -> {
+                    Stream<E> domainEvents = cloudEventConverter.toDomainEvents(currentCloudEvents.stream());
+                    List<E> newDomainEvents = emptyStreamIfNull(functionThatCallsDomainModel.apply(domainEvents)).toList();
+                    List<CloudEvent> newCloudEvents = cloudEventConverter.toCloudEvents(newDomainEvents.stream()).toList();
+                    return eventStore.write(streamId, eventStream.version(), Flux.fromIterable(newCloudEvents))
+                            .map(writeResult -> new Result<>(writeResult, newDomainEvents));
+                }))).retryWhen(retry);
+
+        return readDecideWrite.flatMap(result -> {
+            if (sideEffect == null) {
+                return Mono.just(result.writeResult());
+            }
+            return sideEffect.apply(result.newDomainEvents().stream()).thenReturn(result.writeResult());
+        });
+    }
+
+    private Mono<org.occurrent.eventstore.api.reactor.EventStream<CloudEvent>> read(String streamId, @Nullable StreamReadFilter filter) {
+        if (filter == null) {
+            return eventStore.read(streamId);
+        }
+        return ((ReadEventStreamWithFilter) eventStore).read(streamId, filter);
+    }
+
+    private @Nullable StreamReadFilter resolveFilter(ExecuteOptions<E> executeOptions) {
+        ExecuteFilter<? extends E> executeFilter = executeOptions.executeFilter();
+        if (executeFilter != null) {
+            return executeFilter.resolve(cloudEventConverter::getCloudEventType);
+        }
+        return executeOptions.filter();
+    }
+
+    private static <T> Stream<T> emptyStreamIfNull(@Nullable Stream<T> stream) {
+        return stream == null ? Stream.empty() : stream;
+    }
+
+    /**
+     * Returns the default reactive retry policy for optimistic concurrency conflicts. It retries a
+     * {@link WriteConditionNotFulfilledException} up to five times with exponential backoff and rethrows the original
+     * failure when the attempts are exhausted.
+     */
+    public static Retry defaultRetry() {
+        return Retry.backoff(5, Duration.ofMillis(100))
+                .maxBackoff(Duration.ofSeconds(2))
+                .filter(WriteConditionNotFulfilledException.class::isInstance)
+                .onRetryExhaustedThrow((spec, signal) -> signal.failure());
+    }
+
+    private record Result<E>(WriteResult writeResult, List<E> newDomainEvents) {
+    }
+}

--- a/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ApplicationServiceExtensions.kt
+++ b/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ApplicationServiceExtensions.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor
+
+import org.occurrent.application.service.ExecuteFilter
+import org.occurrent.eventstore.api.WriteResult
+import reactor.core.publisher.Mono
+import java.util.UUID
+import java.util.function.Function
+import java.util.stream.Stream
+import kotlin.streams.asSequence
+import kotlin.streams.asStream
+
+/** Execute a domain function over a Kotlin [Sequence], returning a [Mono] of the write result. */
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: String, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    executeSequence(streamId, ExecuteOptions.empty<E>(), functionThatCallsDomainModel)
+
+/** [executeSequence] variant accepting a [UUID] stream id. */
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: UUID, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    executeSequence(streamId.toString(), functionThatCallsDomainModel)
+
+/** Execute a domain function over a Kotlin [Sequence] with [ExecuteOptions]. */
+@Suppress("UNCHECKED_CAST")
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: String, options: ExecuteOptions<*>, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    execute(streamId, options as ExecuteOptions<E>) { streamOfEvents -> functionThatCallsDomainModel(streamOfEvents.asSequence()).asStream() }
+
+/** Execute a domain function over a Kotlin [Sequence] with an [ExecuteFilter]. */
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: String, executeFilter: ExecuteFilter<out E>, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    execute(streamId, executeFilter) { streamOfEvents -> functionThatCallsDomainModel(streamOfEvents.asSequence()).asStream() }
+
+/** [executeSequence] variant accepting a [UUID] stream id and [ExecuteOptions]. */
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: UUID, options: ExecuteOptions<*>, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    executeSequence(streamId.toString(), options, functionThatCallsDomainModel)
+
+/** [executeSequence] variant accepting a [UUID] stream id and an [ExecuteFilter]. */
+fun <E : Any> ApplicationService<E>.executeSequence(streamId: UUID, executeFilter: ExecuteFilter<out E>, functionThatCallsDomainModel: (Sequence<E>) -> Sequence<E>): Mono<WriteResult> =
+    executeSequence(streamId.toString(), executeFilter, functionThatCallsDomainModel)
+
+/** Execute a domain function over a Kotlin [List], returning a [Mono] of the write result. */
+fun <E : Any> ApplicationService<E>.executeList(streamId: String, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> =
+    executeList(streamId, ExecuteOptions.empty<E>(), functionThatCallsDomainModel)
+
+/** [executeList] variant accepting a [UUID] stream id. */
+fun <E : Any> ApplicationService<E>.executeList(streamId: UUID, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> =
+    executeList(streamId.toString(), functionThatCallsDomainModel)
+
+/** Execute a domain function over a Kotlin [List] with [ExecuteOptions]. */
+@Suppress("UNCHECKED_CAST")
+fun <E : Any> ApplicationService<E>.executeList(streamId: String, options: ExecuteOptions<*>, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> {
+    val f = Function<Stream<E>, Stream<E>> { eventStream -> functionThatCallsDomainModel(eventStream.toList()).stream() }
+    return execute(streamId, options as ExecuteOptions<E>, f)
+}
+
+/** Execute a domain function over a Kotlin [List] with an [ExecuteFilter]. */
+fun <E : Any> ApplicationService<E>.executeList(streamId: String, executeFilter: ExecuteFilter<out E>, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> {
+    val f = Function<Stream<E>, Stream<E>> { eventStream -> functionThatCallsDomainModel(eventStream.toList()).stream() }
+    return execute(streamId, executeFilter, f)
+}
+
+/** [executeList] variant accepting a [UUID] stream id and [ExecuteOptions]. */
+fun <E : Any> ApplicationService<E>.executeList(streamId: UUID, options: ExecuteOptions<*>, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> =
+    executeList(streamId.toString(), options, functionThatCallsDomainModel)
+
+/** [executeList] variant accepting a [UUID] stream id and an [ExecuteFilter]. */
+fun <E : Any> ApplicationService<E>.executeList(streamId: UUID, executeFilter: ExecuteFilter<out E>, functionThatCallsDomainModel: (List<E>) -> List<E>): Mono<WriteResult> =
+    executeList(streamId.toString(), executeFilter, functionThatCallsDomainModel)

--- a/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ExecuteFilterExtensions.kt
+++ b/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ExecuteFilterExtensions.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor
+
+import org.occurrent.application.service.ExecuteFilter
+import kotlin.reflect.KClass
+
+/**
+ * Kotlin namespace for application-service-level typed execute filters for the reactive application service.
+ * Java callers should use the static factory methods on [ExecuteFilter].
+ */
+object ExecuteFilters {
+
+    /** Create an [ExecuteFilter] that includes events of the reified domain event type [E]. */
+    inline fun <reified E : Any> type(): ExecuteFilter<E> = ExecuteFilter.type(E::class.java)
+
+    /** Create an [ExecuteFilter] that includes events whose domain event type matches any of [eventTypes]. */
+    fun <E : Any> includeTypes(vararg eventTypes: KClass<out E>): ExecuteFilter<E> {
+        require(eventTypes.isNotEmpty()) { "At least one event type must be supplied" }
+        val first = eventTypes.first().java
+        val remaining = eventTypes.drop(1).map { it.java }.toTypedArray()
+        return ExecuteFilter.includeTypes(first, *remaining)
+    }
+
+    /** Create an [ExecuteFilter] that excludes events whose domain event type matches any of [eventTypes]. */
+    fun <E : Any> excludeTypes(vararg eventTypes: KClass<out E>): ExecuteFilter<E> {
+        require(eventTypes.isNotEmpty()) { "At least one event type must be supplied" }
+        val first = eventTypes.first().java
+        val remaining = eventTypes.drop(1).map { it.java }.toTypedArray()
+        return ExecuteFilter.excludeTypes(first, *remaining)
+    }
+}

--- a/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ExecuteOptionsExtensions.kt
+++ b/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/ExecuteOptionsExtensions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor
+
+import org.occurrent.application.service.ExecuteFilter
+import org.occurrent.eventstore.api.StreamReadFilter
+
+/** Create empty reactive [ExecuteOptions] for Kotlin call sites. */
+fun options(): ExecuteOptions<Any> = ExecuteOptions.options()
+
+/** Create reactive [ExecuteOptions] containing the supplied [StreamReadFilter]. */
+fun filter(filter: StreamReadFilter): ExecuteOptions<Any> = options().filter(filter)
+
+/** Create reactive [ExecuteOptions] containing the supplied [ExecuteFilter]. */
+fun <E : Any> filter(filter: ExecuteFilter<out E>): ExecuteOptions<E> = ExecuteOptions.withExecuteFilter(filter)

--- a/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/PolicySideEffectExtensions.kt
+++ b/application/service/reactor/src/main/kotlin/org/occurrent/application/service/reactor/PolicySideEffectExtensions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor
+
+import reactor.core.publisher.Mono
+import java.util.function.Function
+import java.util.stream.Stream
+
+/**
+ * Build a reactive side-effect that runs [policy] for every produced event of the reified type [E]. The result can be
+ * passed to [ExecuteOptions.sideEffect].
+ */
+inline fun <T : Any, reified E : T> executePolicy(noinline policy: (E) -> Mono<Void>): Function<Stream<T>, Mono<Void>> =
+    PolicySideEffect.executePolicy(E::class.java, Function { event: E -> policy(event) })

--- a/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/generic/GenericApplicationServiceTest.java
+++ b/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/generic/GenericApplicationServiceTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.application.service.reactor.generic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.generic.GenericCloudEventConverter;
+import org.occurrent.application.service.ExecuteFilter;
+import org.occurrent.application.service.reactor.ApplicationService;
+import org.occurrent.application.service.reactor.ExecuteOptions;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.api.WriteCondition;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.api.reactor.EventStore;
+import org.occurrent.eventstore.api.reactor.EventStream;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.application.service.reactor.ExecuteOptions.options;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GenericApplicationServiceTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true);
+
+    @RegisterExtension
+    FlushMongoDBExtension flush = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".appservice"));
+
+    private ReactorMongoEventStore eventStore;
+    private CloudEventConverter<DomainEvent> converter;
+    private ApplicationService<DomainEvent> applicationService;
+
+    @BeforeEach
+    void create_instances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".appservice");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager tx = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(tx)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM)
+                .build();
+        eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        converter = customCloudEventConverter();
+        applicationService = new GenericApplicationService<>(eventStore, converter);
+    }
+
+    @Test
+    void writes_decider_produced_events_and_returns_the_write_result() {
+        String streamId = UUID.randomUUID().toString();
+
+        WriteResult result = applicationService.execute(streamId, options(),
+                events -> Stream.of(new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Johan"))).block();
+
+        assertThat(requireNonNull(result).streamId()).isEqualTo(streamId);
+        assertThat(result.newStreamVersion()).isEqualTo(1L);
+        assertThat(readNames(streamId)).containsExactly("Johan");
+    }
+
+    @Test
+    void supports_a_read_filter_and_a_reactive_side_effect() {
+        String streamId = UUID.randomUUID().toString();
+        write(streamId,
+                new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Johan"),
+                new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Mattias"));
+        AtomicReference<String> sideEffectPayload = new AtomicReference<>("not-called");
+        AtomicReference<Long> typesSeenByDomain = new AtomicReference<>(0L);
+
+        WriteResult result = applicationService.execute(streamId,
+                ExecuteOptions.<DomainEvent>options().filter(ExecuteFilter.type(NameDefined.class))
+                        .sideEffect(events -> Mono.fromRunnable(() -> sideEffectPayload.set(events.findFirst().map(DomainEvent::name).orElse("empty")))),
+                events -> {
+                    typesSeenByDomain.set(events.count());
+                    return Stream.of(new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "New Name"));
+                }).block();
+
+        // The read was filtered to NameDefined, so the domain function only saw that one event. The write still appends
+        // to the full stream (version 2 -> 3), and the reactive side-effect ran once with the new event.
+        assertThat(typesSeenByDomain.get()).isEqualTo(1L);
+        assertThat(requireNonNull(result).newStreamVersion()).isEqualTo(3L);
+        assertThat(sideEffectPayload.get()).isEqualTo("New Name");
+    }
+
+    @Test
+    void supports_execute_filter_as_a_direct_argument() {
+        String streamId = UUID.randomUUID().toString();
+        write(streamId,
+                new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Johan"),
+                new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Mattias"));
+
+        WriteResult result = applicationService.execute(streamId, ExecuteFilter.type(NameDefined.class),
+                events -> Stream.of(new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "New Name"))).block();
+
+        assertThat(requireNonNull(result).newStreamVersion()).isEqualTo(3L);
+    }
+
+    @Test
+    void runs_the_side_effect_after_execute_even_when_no_events_are_produced() {
+        // Parity with the blocking GenericApplicationService: the side-effect runs once after a successful execute,
+        // with the new events (an empty stream here), regardless of whether the domain function produced any.
+        String streamId = UUID.randomUUID().toString();
+        AtomicInteger sideEffectInvocations = new AtomicInteger();
+
+        applicationService.execute(streamId,
+                options().sideEffect(events -> Mono.fromRunnable(sideEffectInvocations::incrementAndGet)),
+                events -> Stream.empty()).block();
+
+        assertThat(sideEffectInvocations).hasValue(1);
+        assertThat(readNames(streamId)).isEmpty();
+    }
+
+    @Test
+    void retries_from_a_fresh_read_when_the_write_condition_is_not_fulfilled() {
+        String streamId = UUID.randomUUID().toString();
+        write(streamId, new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Johan"));
+        CloudEvent interloper = converter.toCloudEvent(new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "Interloper"));
+        ApplicationService<DomainEvent> service = new GenericApplicationService<>(new ConflictingOnceEventStore(eventStore, interloper), converter);
+        AtomicInteger attempts = new AtomicInteger();
+
+        WriteResult result = service.execute(streamId, options(),
+                events -> {
+                    attempts.incrementAndGet();
+                    return Stream.of(new NameWasChanged(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "New Name"));
+                }).block();
+
+        // The first write conflicts because the interloper bumped the stream version, the retry reads the fresh stream
+        // and writes successfully.
+        assertThat(attempts).hasValue(2);
+        assertThat(requireNonNull(result)).isNotNull();
+        assertThat(readNames(streamId)).containsExactly("Johan", "Interloper", "New Name");
+    }
+
+    private void write(String streamId, DomainEvent... events) {
+        eventStore.write(streamId, Flux.fromIterable(converter.toCloudEvents(Stream.of(events)).toList())).block();
+    }
+
+    private List<String> readNames(String streamId) {
+        return requireNonNull(eventStore.read(streamId).flatMapMany(EventStream::events).map(converter::toDomainEvent).map(DomainEvent::name).collectList().block());
+    }
+
+    private static CloudEventConverter<DomainEvent> customCloudEventConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return new GenericCloudEventConverter<DomainEvent>(
+                cloudEvent -> {
+                    try {
+                        return switch (cloudEvent.getType()) {
+                            case "name-defined-v1" -> objectMapper.readValue(requireNonNull(cloudEvent.getData()).toBytes(), NameDefined.class);
+                            case "name-was-changed-v1" -> objectMapper.readValue(requireNonNull(cloudEvent.getData()).toBytes(), NameWasChanged.class);
+                            default -> throw new IllegalArgumentException("Unsupported event type " + cloudEvent.getType());
+                        };
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                event -> {
+                    try {
+                        return CloudEventBuilder.v1()
+                                .withId(event.eventId())
+                                .withSource(URI.create("http://name"))
+                                .withType(customCloudEventType(event.getClass()))
+                                .withTime(event.timestamp().toInstant().atOffset(ZoneOffset.UTC))
+                                .withSubject(event.name())
+                                .withDataContentType("application/json")
+                                .withData(objectMapper.writeValueAsBytes(event))
+                                .build();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                GenericApplicationServiceTest::customCloudEventType
+        );
+    }
+
+    private static String customCloudEventType(Class<? extends DomainEvent> type) {
+        if (type.equals(NameDefined.class)) {
+            return "name-defined-v1";
+        } else if (type.equals(NameWasChanged.class)) {
+            return "name-was-changed-v1";
+        }
+        throw new IllegalArgumentException("Unsupported event type " + type.getName());
+    }
+
+    /**
+     * A reactive event store that, on the first conditional write, first commits a conflicting event so the carried
+     * stream version is stale and the write fails once, then delegates normally on later attempts.
+     */
+    private static final class ConflictingOnceEventStore implements EventStore {
+        private final EventStore delegate;
+        private final CloudEvent conflictingEvent;
+        private final AtomicBoolean conflictInserted = new AtomicBoolean();
+
+        private ConflictingOnceEventStore(EventStore delegate, CloudEvent conflictingEvent) {
+            this.delegate = delegate;
+            this.conflictingEvent = conflictingEvent;
+        }
+
+        @Override
+        public Mono<EventStream<CloudEvent>> read(String streamId, int skip, int limit) {
+            return delegate.read(streamId, skip, limit);
+        }
+
+        @Override
+        public Mono<WriteResult> write(String streamId, WriteCondition writeCondition, Flux<CloudEvent> events) {
+            if (conflictInserted.compareAndSet(false, true)) {
+                return delegate.write(streamId, Flux.just(conflictingEvent)).then(delegate.write(streamId, writeCondition, events));
+            }
+            return delegate.write(streamId, writeCondition, events);
+        }
+
+        @Override
+        public Mono<WriteResult> write(String streamId, Flux<CloudEvent> events) {
+            return delegate.write(streamId, events);
+        }
+
+        @Override
+        public Mono<Boolean> exists(String streamId) {
+            return delegate.exists(streamId);
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,11 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added a reactive stream application service, so the reactive stack has the same application-service ergonomics as the blocking one.
+  * `ApplicationService` in `application-service-reactor` runs the read, decide, and write cycle against the reactive event store and returns a `Mono<WriteResult>`, retrying from a fresh read on a `WriteConditionNotFulfilledException`. The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, the side-effect is reactive (`Function<Stream<E>, Mono<Void>>`), and it mirrors the blocking surface including the `ExecuteFilter` read filter and the Kotlin extensions.
+  * `ExecuteFilter` moved to the shared `application-service-common` module (package `org.occurrent.application.service`) so both stacks share one copy. This is a breaking change, the old `org.occurrent.application.service.blocking.ExecuteFilter` is gone, so update the import to `org.occurrent.application.service.ExecuteFilter`.
+  * See [ADR 39](doc/architecture/decisions/0039-reactive-stream-application-service.md).
+
 * Added reactive DCB catch-up, which completes reactive DCB support.
   * `ReactorDcbCatchupSubscriptionModel` replays DCB history by `dcbposition` and hands over to a live subscription, so a reactive read model can be rebuilt from the beginning. It mirrors the blocking DCB catch-up (the live resume token is captured before the replay so an event committing during the replay is still delivered), with id-based handover dedup because the reactive resume token is inclusive. Reactive DCB now matches the blocking stack across the store, application service, query DSL, and subscriptions.
   * See [ADR 38](doc/architecture/decisions/0038-reactive-dcb-catch-up.md).

--- a/doc/architecture/decisions/0039-reactive-stream-application-service.md
+++ b/doc/architecture/decisions/0039-reactive-stream-application-service.md
@@ -1,0 +1,29 @@
+# 39. Reactive stream application service
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+Occurrent had a blocking stream-based `ApplicationService` (`application-service-blocking`) from the start, but the only reactive application service was the DCB one added in ADR 35. A caller using the reactive Spring MongoDB event store for ordinary stream-per-aggregate work had no application service and had to hand-write the read, decide, write, and retry loop. The reactive event store API (`eventstore-api-reactor`) already exposes everything needed (`read` returning a `Mono<EventStream>`, conditional `write` returning a `Mono<WriteResult>`, and `ReadEventStreamWithFilter`), so the gap was only the service layer.
+
+## Decision
+
+Add a reactive stream `ApplicationService` in `application-service-reactor`, package `org.occurrent.application.service.reactor`, mirroring the blocking one with reactive return types.
+
+- `ApplicationService<E>` returns `Mono<WriteResult>` from `execute(streamId, ExecuteOptions<E>, Function<Stream<E>, Stream<E>>)`, plus the same `String`/`UUID`/`ExecuteFilter` convenience overloads as the blocking interface. The already-deprecated `Consumer`-side-effect overloads are not carried over.
+- `generic.GenericApplicationService<E>` runs read, decide, and write as one unit with `Mono.defer(...).retryWhen(...)`, retrying from a fresh read on a `WriteConditionNotFulfilledException` (default five attempts with exponential backoff, rethrowing the original failure when exhausted), exactly like the blocking service and the reactive DCB service. The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, and the post-write side-effect is reactive (`Function<Stream<E>, Mono<Void>>`), composed after the retry so it runs once on success.
+- `ExecuteOptions<E>` carries a read filter (a raw `StreamReadFilter` or an `ExecuteFilter`) and the reactive side-effect. A reactive `PolicySideEffect` and Kotlin extension functions mirror the blocking ergonomics.
+
+### ExecuteFilter moved to a shared module
+
+`ExecuteFilter` resolves domain event classes to a `StreamReadFilter` and has nothing blocking about it, but it lived in `application-service-blocking`. It moved to the shared `application-service-common` module (package `org.occurrent.application.service`) so the blocking and reactive services use one copy. This is a breaking change for callers that imported `org.occurrent.application.service.blocking.ExecuteFilter`.
+
+## Consequences
+
+- Reactive callers get the same application-service ergonomics as blocking callers: read filtering, optimistic-concurrency retry, and a post-write side-effect, all as a `Mono`. This closes the application-service parity gap between the blocking and reactive stacks.
+- `ExecuteFilter` now lives in `org.occurrent.application.service`. The old `org.occurrent.application.service.blocking.ExecuteFilter` import must be updated.
+- `ExecuteOptions` and the `ApplicationService` interface stay separate per stack because their side-effect and return types differ (synchronous `Consumer`/`WriteResult` versus reactive `Function<…, Mono<Void>>`/`Mono<WriteResult>`), which Java cannot unify without an abstraction that costs more than the duplication.


### PR DESCRIPTION
Occurrent had a blocking stream `ApplicationService` from the start, but the only reactive application service was the DCB one. A caller using the reactive Spring MongoDB event store for ordinary stream-per-aggregate work had to hand-write the read, decide, write, and retry loop. This closes that gap.

`application-service-reactor` gains a stream `ApplicationService` mirroring the blocking one with reactive types:

- `Mono<WriteResult> execute(streamId, ExecuteOptions<E>, Function<Stream<E>, Stream<E>>)` plus the same `String`/`UUID`/`ExecuteFilter` convenience overloads (the already-deprecated `Consumer`-side-effect ones are dropped).
- `GenericApplicationService` runs read, decide, and write as one unit and retries from a fresh read on a `WriteConditionNotFulfilledException` (five attempts, exponential backoff, rethrowing the original on exhaustion), the same policy as the blocking service and the reactive DCB service.
- The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`. The post-write side-effect is reactive (`Function<Stream<E>, Mono<Void>>`), composed after the retry so it runs once on success.
- A reactive `ExecuteOptions`, a reactive `PolicySideEffect`, and Kotlin extensions mirror the blocking ergonomics.

**Breaking:** `ExecuteFilter` resolves domain event classes to a read filter and has nothing blocking about it, so it moved to the shared `application-service-common` module. `org.occurrent.application.service.blocking.ExecuteFilter` moved to `org.occurrent.application.service.ExecuteFilter`. I updated every consumer in this repo. `ExecuteOptions` and the `ApplicationService` interface stay per-stack because their side-effect and return types differ (sync vs reactive), which Java cannot unify cheaply.

Verification: `mvn clean install` compiles the whole project, the new reactive `GenericApplicationServiceTest` passes on the Mongo harness (round trip and write result, read filter plus reactive side-effect, `ExecuteFilter` as a direct argument, side-effect-after-execute, and retry-from-a-fresh-read on a conflict), and the blocking application-service tests still pass after the `ExecuteFilter` move.

See [ADR 39](doc/architecture/decisions/0039-reactive-stream-application-service.md).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
