### PR TITLE
Add a reactive query DSL

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -359,6 +359,11 @@
             </dependency>
             <dependency>
                 <groupId>org.occurrent</groupId>
+                <artifactId>query-dsl-reactor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.occurrent</groupId>
                 <artifactId>decider</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dsl/query-dsl/pom.xml
+++ b/dsl/query-dsl/pom.xml
@@ -28,6 +28,7 @@
     <artifactId>query-dsl</artifactId>
     <modules>
         <module>blocking</module>
+        <module>reactor</module>
     </modules>
 
 </project>

--- a/dsl/query-dsl/reactor/pom.xml
+++ b/dsl/query-dsl/reactor/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>query-dsl</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>query-dsl-reactor</artifactId>
+
+    <name>${mavenProjectName}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-spring-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>application-service-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>command-composition</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- See https://github.com/Kotlin/dokka#using-the-maven-plugin for more examples-->
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <version>${dokka.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>javadocJar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dokkaPlugins>
+                                <plugin>
+                                    <groupId>org.jetbrains.dokka</groupId>
+                                    <artifactId>kotlin-as-java-plugin</artifactId>
+                                    <version>${dokka.version}</version>
+                                </plugin>
+                            </dokkaPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/DomainEventQueries.java
+++ b/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/DomainEventQueries.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.query.reactor;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.reactor.EventStoreQueries;
+import org.occurrent.filter.Filter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * A wrapper around a reactive {@link EventStoreQueries} that maps the result of a query into your domain event type
+ * using a {@link CloudEventConverter}. This is the reactive counterpart of the blocking {@code DomainEventQueries}.
+ *
+ * @param <T> The type of your event
+ */
+@NullMarked
+public class DomainEventQueries<T> {
+
+    private final EventStoreQueries eventStoreQueries;
+    private final CloudEventConverter<T> cloudEventConverter;
+
+    /**
+     * Creates an instance of {@code DomainEventQueries}
+     */
+    public DomainEventQueries(EventStoreQueries eventStoreQueries, CloudEventConverter<T> cloudEventConverter) {
+        Objects.requireNonNull(eventStoreQueries, EventStoreQueries.class.getSimpleName() + " cannot be null");
+        Objects.requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
+        this.eventStoreQueries = eventStoreQueries;
+        this.cloudEventConverter = cloudEventConverter;
+    }
+
+    /**
+     * The underlying {@link EventStoreQueries} this instance reads from. Useful for capabilities layered on top of
+     * the event store, such as DCB queries when the store also implements the reactive {@code DcbEventStore}.
+     */
+    public EventStoreQueries eventStoreQueries() {
+        return eventStoreQueries;
+    }
+
+    /**
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return The first cloud event matching the specified filter, or an empty {@link Mono} if none match.
+     */
+    public <E extends T> Mono<E> queryOne(Filter filter) {
+        return this.<E>toDomainEvents(eventStoreQueries.query(filter, 0, 1)).next();
+    }
+
+    /**
+     * Query for the first event of the given type.
+     *
+     * @return The domain event matching the specified type, or an empty {@link Mono} if none match.
+     */
+    public <E extends T> Mono<E> queryOne(Class<E> type) {
+        return query(type, 0, 1).next();
+    }
+
+    /**
+     * Query for the first event of the given type sorting by {@code sortBy}.
+     *
+     * @return The domain event matching the specified type, or an empty {@link Mono} if none match.
+     */
+    public <E extends T> Mono<E> queryOne(Class<E> type, SortBy sortBy) {
+        return queryOne(type, 0, 1, sortBy);
+    }
+
+    /**
+     * Query for the first event of the given type using {@code skip} and {@code limit}.
+     *
+     * @return The domain event matching the specified type, or an empty {@link Mono} if none match.
+     */
+    public <E extends T> Mono<E> queryOne(Class<E> type, int skip, int limit) {
+        return queryOne(type, skip, limit, SortBy.unsorted());
+    }
+
+    /**
+     * Query for the first event of the given using {@code skip}, {@code limit} and {@code sortBy}.
+     *
+     * @return The domain event matching the specified type, or an empty {@link Mono} if none match.
+     */
+    public <E extends T> Mono<E> queryOne(Class<E> type, int skip, int limit, SortBy sortBy) {
+        Objects.requireNonNull(type, "type cannot be null");
+        return this.<E>toDomainEvents(eventStoreQueries.query(Filter.type(cloudEventConverter.getCloudEventType(type)), skip, limit, sortBy)).next();
+    }
+
+    /**
+     * Query by event type (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type.
+     */
+    public <E extends T> Flux<E> query(Class<E> type) {
+        return this.toDomainEvents(eventStoreQueries.query(Filter.type(cloudEventConverter.getCloudEventType(type))));
+    }
+
+    /**
+     * Query by event type (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code skip} and {@code limit}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip and limit.
+     */
+    public <E extends T> Flux<E> query(Class<E> type, int skip, int limit) {
+        return this.toDomainEvents(eventStoreQueries.query(Filter.type(cloudEventConverter.getCloudEventType(type)), skip, limit));
+    }
+
+    /**
+     * Query by event type (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code skip}, {@code limit} and {@code sortBy}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit and sort by <code>sortBy</code>.
+     */
+    public <E extends T> Flux<E> query(Class<E> type, int skip, int limit, SortBy sortBy) {
+        return this.toDomainEvents(eventStoreQueries.query(Filter.type(cloudEventConverter.getCloudEventType(type)), skip, limit, sortBy));
+    }
+
+    /**
+     * Query by event type (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also including sorting .
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, sorted by <code>sortBy</code>.
+     */
+    public <E extends T> Flux<E> query(Class<E> type, SortBy sortBy) {
+        return this.toDomainEvents(eventStoreQueries.query(Filter.type(cloudEventConverter.getCloudEventType(type)), sortBy));
+    }
+
+    /**
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified filter, skip, limit and sort by <code>sortBy</code>.
+     */
+    public <E extends T> Flux<E> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        return toDomainEvents(eventStoreQueries.query(filter, skip, limit, sortBy));
+    }
+
+    /**
+     * Query by event types (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code skip}, {@code limit} and {@code sortBy}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit and sort by <code>sortBy</code>.
+     */
+    public Flux<T> query(Collection<Class<? extends T>> types, int skip, int limit, SortBy sortBy) {
+        final Filter filterToUse = createFilterFrom(types);
+        if (filterToUse == null) {
+            return Flux.empty();
+        }
+
+        return this.toDomainEvents(eventStoreQueries.query(filterToUse, skip, limit, sortBy));
+    }
+
+    /**
+     * Query by event types (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code skip}, {@code limit}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit.
+     */
+    public Flux<T> query(Collection<Class<? extends T>> types, int skip, int limit) {
+        final Filter filterToUse = createFilterFrom(types);
+        if (filterToUse == null) {
+            return Flux.empty();
+        }
+
+        return this.toDomainEvents(eventStoreQueries.query(filterToUse, skip, limit));
+    }
+
+    /**
+     * Query by event types (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code sortBy}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit.
+     */
+    public Flux<T> query(Collection<Class<? extends T>> types, SortBy sortBy) {
+        final Filter filterToUse = createFilterFrom(types);
+        if (filterToUse == null) {
+            return Flux.empty();
+        }
+
+        return this.toDomainEvents(eventStoreQueries.query(filterToUse, sortBy));
+    }
+
+    /**
+     * Query by event types (will use the supplied {@link CloudEventConverter} to get the cloud event type from the class..
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit.
+     */
+    public Flux<T> query(Collection<Class<? extends T>> types) {
+        final Filter filterToUse = createFilterFrom(types);
+        if (filterToUse == null) {
+            return Flux.empty();
+        }
+
+        return this.toDomainEvents(eventStoreQueries.query(filterToUse));
+    }
+
+    /**
+     * Query by event types (will use the supplied {@link CloudEventConverter}) to get the cloud event type from the class, also include {@code sortBy}.
+     * <p>
+     * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
+     *
+     * @return All cloud events matching the specified type, skip, limit.
+     */
+    @SuppressWarnings("unchecked")
+    @SafeVarargs
+    public final Flux<T> query(Class<? extends T> type, @Nullable Class<? extends T>... types) {
+        final List<T> list = new ArrayList<>();
+        list.add((T) type);
+        if (types != null && types.length > 0) {
+            list.addAll(Arrays.stream(types).map(t -> (T) t).toList());
+        }
+        return query((Collection<Class<? extends T>>) list);
+    }
+
+    /**
+     * Count specific events in the event store that matches the supplied {@code filter}.
+     *
+     * @return The number of events in the event store matching the {@code filter}.
+     */
+    public Mono<Long> count(Filter filter) {
+        return eventStoreQueries.count(filter);
+    }
+
+    /**
+     * Count all events in the event store
+     *
+     * @return The number of events in the event store
+     */
+    public Mono<Long> count() {
+        return count(Filter.all());
+    }
+
+    /**
+     * Check if any events exists that matches the given {@code filter}.
+     *
+     * @return A {@link Mono} of <code>true</code> if any events exists that are matching the {@code filter}, <code>false</code> otherwise.
+     */
+    public Mono<Boolean> exists(Filter filter) {
+        return eventStoreQueries.exists(filter);
+    }
+
+    /**
+     * @return All cloud events matching the specified filter sorted by <code>sortBy</code>.
+     */
+    public <E extends T> Flux<E> query(Filter filter, SortBy sortBy) {
+        return toDomainEvents(eventStoreQueries.query(filter, sortBy));
+    }
+
+    /**
+     * @return All cloud events matching the specified filter
+     */
+    public <E extends T> Flux<E> query(Filter filter, int skip, int limit) {
+        return toDomainEvents(eventStoreQueries.query(filter, skip, limit));
+    }
+
+    /**
+     * @return All cloud events in insertion order
+     */
+    public Flux<T> all(int skip, int limit, SortBy sortBy) {
+        return eventStoreQueries.all(skip, limit, sortBy).map(cloudEventConverter::toDomainEvent);
+    }
+
+    /**
+     * @return All cloud events sorted by <code>sortBy</code>
+     */
+    public Flux<T> all(SortBy sortBy) {
+        return eventStoreQueries.all(sortBy).map(cloudEventConverter::toDomainEvent);
+    }
+
+    /**
+     * @return All cloud events in insertion order
+     */
+    public Flux<T> all(int skip, int limit) {
+        return eventStoreQueries.all(skip, limit).map(cloudEventConverter::toDomainEvent);
+    }
+
+    /**
+     * @return All cloud events in an unspecified order (most likely insertion order but this is not guaranteed and it is database/implementation specific)
+     */
+    public Flux<T> all() {
+        return eventStoreQueries.all().map(cloudEventConverter::toDomainEvent);
+    }
+
+    /**
+     * @return All cloud events matching the specified filter
+     */
+    public <E extends T> Flux<E> query(Filter filter) {
+        return toDomainEvents(eventStoreQueries.query(filter));
+    }
+
+    /**
+     * Convert a {@link Flux} of {@link CloudEvent}s into domain events using the configured {@link CloudEventConverter}.
+     * Useful when you already have CloudEvents and want them as domain events.
+     */
+    @SuppressWarnings("unchecked")
+    public <E extends T> Flux<E> toDomainEvents(Flux<CloudEvent> flux) {
+        Objects.requireNonNull(flux, "Flux cannot be null");
+        return flux.map(cloudEventConverter::toDomainEvent).map(t -> (E) t);
+    }
+
+    private @Nullable Filter createFilterFrom(Collection<Class<? extends T>> types) {
+        return (types == null ? Stream.<Class<? extends T>>empty() : types.stream())
+                .map(type -> Filter.type(cloudEventConverter.getCloudEventType(type)))
+                .reduce(Filter::or)
+                .orElse(null);
+    }
+}

--- a/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/DomainEventQueries.java
+++ b/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/DomainEventQueries.java
@@ -66,7 +66,7 @@ public class DomainEventQueries<T> {
     /**
      * Note that it's recommended to create an index the fields you're sorting on in order to make them efficient.
      *
-     * @return The first cloud event matching the specified filter, or an empty {@link Mono} if none match.
+     * @return The first domain event matching the specified filter, or an empty {@link Mono} if none match.
      */
     public <E extends T> Mono<E> queryOne(Filter filter) {
         return this.<E>toDomainEvents(eventStoreQueries.query(filter, 0, 1)).next();
@@ -233,15 +233,14 @@ public class DomainEventQueries<T> {
      *
      * @return All cloud events matching the specified type, skip, limit.
      */
-    @SuppressWarnings("unchecked")
     @SafeVarargs
     public final Flux<T> query(Class<? extends T> type, @Nullable Class<? extends T>... types) {
-        final List<T> list = new ArrayList<>();
-        list.add((T) type);
+        final List<Class<? extends T>> list = new ArrayList<>();
+        list.add(type);
         if (types != null && types.length > 0) {
-            list.addAll(Arrays.stream(types).map(t -> (T) t).toList());
+            list.addAll(Arrays.asList(types));
         }
-        return query((Collection<Class<? extends T>>) list);
+        return query(list);
     }
 
     /**

--- a/dsl/query-dsl/reactor/src/main/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesExtensions.kt
+++ b/dsl/query-dsl/reactor/src/main/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesExtensions.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.query.reactor
+
+import org.occurrent.eventstore.api.SortBy
+import org.occurrent.filter.Filter
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import kotlin.reflect.KClass
+
+/**
+ * Query by type of domain event ([T]).
+ *
+ * @see DomainEventQueries.query
+ */
+fun <T : Any> DomainEventQueries<in T>.query(
+    type: KClass<T>,
+    skip: Int = 0,
+    limit: Int = Int.MAX_VALUE,
+    sortBy: SortBy = SortBy.unsorted()
+): Flux<T> = query(type.java, skip, limit, sortBy)
+
+/**
+ * Query by type of domain event ([T]).
+ * @see DomainEventQueries.query
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> DomainEventQueries<T>.query(
+    type: KClass<out T>,
+    vararg additionalTypes: KClass<out T>,
+    skip: Int = 0,
+    limit: Int = Int.MAX_VALUE,
+    sortBy: SortBy = SortBy.unsorted()
+): Flux<T> = (if (additionalTypes.isEmpty()) {
+    query(type.java, skip, limit, sortBy)
+} else {
+    val typeList = mutableListOf(type.java, *additionalTypes.map { it.java }.toTypedArray())
+    query(typeList, skip, limit, sortBy)
+}) as Flux<T>
+
+/**
+ * Query for a single event (Kotlin equivalent to [DomainEventQueries.queryOne]).
+ */
+inline fun <reified T : Any> DomainEventQueries<in T>.queryOne(
+    skip: Int = 0,
+    limit: Int = Int.MAX_VALUE,
+    sortBy: SortBy = SortBy.unsorted()
+): Mono<T> = queryOne(T::class.java, skip, limit, sortBy)
+
+/**
+ * Query for a single event (Kotlin equivalent to [DomainEventQueries.queryOne]).
+ */
+fun <T : Any> DomainEventQueries<in T>.queryOne(
+    type: KClass<T>,
+    skip: Int = 0,
+    limit: Int = Int.MAX_VALUE,
+    sortBy: SortBy = SortBy.unsorted()
+): Mono<T> = queryOne(type.java, skip, limit, sortBy)
+
+/**
+ * Query that collects the matching domain events into a [Mono] of a [List].
+ *
+ * The [query] family already returns a [Flux], which is the idiomatic reactive shape, so this is only a
+ * convenience for callers that want the whole result as one list.
+ *
+ * @see DomainEventQueries.query
+ */
+fun <T : Any> DomainEventQueries<in T>.queryForList(
+    filter: Filter = Filter.all(),
+    sortBy: SortBy = SortBy.unsorted()
+): Mono<List<T>> =
+    query<T>(filter, sortBy)
+        .map { it as T }
+        .collectList()
+
+/**
+ * Query that collects the matching domain events into a [Mono] of a [List].
+ * @see DomainEventQueries.query
+ */
+fun <T : Any> DomainEventQueries<in T>.queryForList(
+    filter: Filter = Filter.all(),
+    skip: Int = 0,
+    limit: Int = Int.MAX_VALUE,
+    sortBy: SortBy = SortBy.unsorted()
+): Mono<List<T>> =
+    query<T>(filter, skip, limit, sortBy)
+        .map { it as T }
+        .collectList()

--- a/dsl/query-dsl/reactor/src/test/java/org/occurrent/dsl/query/reactor/DomainEventQueriesTest.java
+++ b/dsl/query-dsl/reactor/src/test/java/org/occurrent/dsl/query/reactor/DomainEventQueriesTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.query.reactor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.reactor.ApplicationService;
+import org.occurrent.application.service.reactor.generic.GenericApplicationService;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.Name;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Flux;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.occurrent.application.composition.command.CommandConversion.toStreamCommand;
+import static org.occurrent.application.composition.command.ListCommandComposition.composeCommands;
+import static org.occurrent.application.composition.command.partial.PartialFunctionApplication.partial;
+import static org.occurrent.eventstore.api.SortBy.SortDirection.DESCENDING;
+import static org.occurrent.filter.Filter.type;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DomainEventQueriesTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true);
+
+    @RegisterExtension
+    FlushMongoDBExtension flush = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".querydsl"));
+
+    private ApplicationService<DomainEvent> applicationService;
+    private DomainEventQueries<DomainEvent> domainEventQueries;
+
+    @BeforeEach
+    void createInstances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".querydsl");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager tx = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(tx)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .build();
+        ReactorMongoEventStore eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        CloudEventConverter<DomainEvent> cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
+        domainEventQueries = new DomainEventQueries<>(eventStore, cloudEventConverter);
+    }
+
+    @Test
+    void all() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe")
+                )
+        )).block();
+
+        // When
+        List<DomainEvent> events = domainEventQueries.all().collectList().block();
+
+        // Then
+        assertAll(
+                () -> assertThat(events).hasSize(2),
+                () -> assertThat(events).element(0).isEqualTo(new NameDefined("eventId1", time, "name", "Some Doe")),
+                () -> assertThat(events).element(1).isEqualTo(new NameWasChanged("eventId2", time, "name", "Jane Doe"))
+        );
+    }
+
+    @Test
+    void query_based_on_type() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe")
+                )
+        )).block();
+
+        // When
+        List<NameDefined> events = domainEventQueries.<NameDefined>query(type(NameDefined.class.getName())).collectList().block();
+
+        // Then
+        assertAll(
+                () -> assertThat(events).hasSize(1),
+                () -> assertThat(events).element(0).isEqualTo(new NameDefined("eventId1", time, "name", "Some Doe"))
+        );
+    }
+
+    @Test
+    void query_one() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe")
+                )
+        )).block();
+
+        // When
+        NameDefined event = domainEventQueries.<NameDefined>queryOne(type(NameDefined.class.getName())).block();
+
+        // Then
+        assertThat(event).isEqualTo(new NameDefined("eventId1", time, "name", "Some Doe"));
+    }
+
+    @Test
+    void query_one_when_no_events_match_then_mono_is_empty() {
+        // When
+        NameDefined event = domainEventQueries.<NameDefined>queryOne(type(NameDefined.class.getName())).block();
+
+        // Then
+        assertThat(event).isNull();
+    }
+
+    @Test
+    void query_based_on_class_type() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe")
+                )
+        )).block();
+
+        // When
+        List<NameDefined> events = domainEventQueries.query(NameDefined.class).collectList().block();
+
+        // Then
+        assertAll(
+                () -> assertThat(events).hasSize(1),
+                () -> assertThat(events).element(0).isEqualTo(new NameDefined("eventId1", time, "name", "Some Doe"))
+        );
+    }
+
+    @Test
+    void query_one_based_on_class_type() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe"),
+                        partial(Name::changeName, "eventId3", time, "name", "Jane Doe2")
+                )
+        )).block();
+
+        // When
+        NameWasChanged event = domainEventQueries.queryOne(NameWasChanged.class).block();
+
+        // Then
+        assertThat(event).isEqualTo(new NameWasChanged("eventId2", time, "name", "Jane Doe"));
+    }
+
+    @Test
+    void query_based_on_var_arg_class_type() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe"),
+                        partial(Name::changeName, "eventId3", time, "name", "Jane Doe2")
+                )
+        )).block();
+
+        // When
+        List<DomainEvent> events = domainEventQueries.query(NameWasChanged.class, NameDefined.class).collectList().block();
+
+        // Then
+        assertAll(
+                () -> assertThat(events).hasSize(3),
+                () -> assertThat(events).extracting(DomainEvent::eventId).containsOnly("eventId1", "eventId2", "eventId3")
+        );
+    }
+
+    @Test
+    void query_based_on_collection_class_type() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe"),
+                        partial(Name::changeName, "eventId3", time, "name", "Jane Doe2")
+                )
+        )).block();
+
+        // When
+        List<DomainEvent> events = domainEventQueries.query(Arrays.asList(NameWasChanged.class, NameDefined.class)).collectList().block();
+
+        // Then
+        assertAll(
+                () -> assertThat(events).hasSize(3),
+                () -> assertThat(events).extracting(DomainEvent::eventId).containsOnly("eventId1", "eventId2", "eventId3")
+        );
+    }
+
+    @Test
+    void query_one_based_on_class_type_and_sort_by() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe"),
+                        partial(Name::changeName, "eventId3", time, "name", "Jane Doe2")
+                )
+        )).block();
+
+        // When
+        NameWasChanged event = domainEventQueries.queryOne(NameWasChanged.class, SortBy.natural(DESCENDING)).block();
+
+        // Then
+        assertThat(event).isEqualTo(new NameWasChanged("eventId3", time, "name", "Jane Doe2"));
+    }
+
+    @Test
+    void count_and_exists() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                composeCommands(
+                        partial(Name::defineName, "eventId1", time, "name", "Some Doe"),
+                        partial(Name::changeName, "eventId2", time, "name", "Jane Doe")
+                )
+        )).block();
+
+        // When
+        Long count = domainEventQueries.count().block();
+        Boolean exists = domainEventQueries.exists(type(NameDefined.class.getName())).block();
+
+        // Then
+        assertAll(
+                () -> assertThat(count).isEqualTo(2L),
+                () -> assertThat(exists).isTrue()
+        );
+    }
+
+    @Test
+    void toDomainEvents_converts_an_existing_flux_of_cloud_events() {
+        // Given
+        LocalDateTime time = LocalDateTime.now();
+        applicationService.execute("stream", toStreamCommand(
+                partial(Name::defineName, "eventId1", time, "name", "Some Doe")
+        )).block();
+        Flux<CloudEvent> cloudEvents = domainEventQueries.eventStoreQueries().all();
+
+        // When
+        List<DomainEvent> events = domainEventQueries.<DomainEvent>toDomainEvents(cloudEvents).collectList().block();
+
+        // Then
+        assertThat(events).containsExactly(new NameDefined("eventId1", time, "name", "Some Doe"));
+    }
+}

--- a/dsl/query-dsl/reactor/src/test/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesKotlinTest.kt
+++ b/dsl/query-dsl/reactor/src/test/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesKotlinTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.query.reactor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.ConnectionString
+import com.mongodb.reactivestreams.client.MongoClients
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.occurrent.application.composition.command.composeCommands
+import org.occurrent.application.composition.command.partial
+import org.occurrent.application.converter.CloudEventConverter
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter
+import org.occurrent.application.service.reactor.ApplicationService
+import org.occurrent.application.service.reactor.executeList
+import org.occurrent.application.service.reactor.generic.GenericApplicationService
+import org.occurrent.domain.DomainEvent
+import org.occurrent.domain.Name
+import org.occurrent.domain.NameDefined
+import org.occurrent.domain.NameWasChanged
+import org.occurrent.eventstore.api.SortBy
+import org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING
+import org.occurrent.eventstore.api.SortBy.SortDirection.DESCENDING
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore
+import org.occurrent.filter.Filter
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.mongodb.MongoDBContainer
+import java.net.URI
+import java.time.LocalDateTime
+
+@Testcontainers
+@DisplayNameGeneration(DisplayNameGenerator.Simple::class)
+class DomainEventQueriesKotlinTest {
+
+    private lateinit var applicationService: ApplicationService<DomainEvent>
+    private lateinit var domainEventQueries: DomainEventQueries<DomainEvent>
+
+    @RegisterExtension
+    val flush = FlushMongoDBExtension(ConnectionString(mongoDBContainer.replicaSetUrl + ".querydslkotlin"))
+
+    @BeforeEach
+    fun createInstances() {
+        val connectionString = ConnectionString(mongoDBContainer.replicaSetUrl + ".querydslkotlin")
+        val mongoClient = MongoClients.create(connectionString)
+        val mongoTemplate = ReactiveMongoTemplate(mongoClient, connectionString.database!!)
+        val tx = ReactiveMongoTransactionManager(SimpleReactiveMongoDatabaseFactory(mongoClient, connectionString.database!!))
+        val config = EventStoreConfig.Builder()
+            .eventStoreCollectionName("events")
+            .transactionConfig(tx)
+            .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+            .build()
+        val eventStore = ReactorMongoEventStore(mongoTemplate, config)
+        val cloudEventConverter: CloudEventConverter<DomainEvent> = JacksonCloudEventConverter.Builder<DomainEvent>(ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build()
+        applicationService = GenericApplicationService(eventStore, cloudEventConverter)
+        domainEventQueries = DomainEventQueries(eventStore, cloudEventConverter)
+    }
+
+    @Test
+    fun queryForList() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val events = domainEventQueries.queryForList(skip = 1).block()
+
+        // Then
+        assertAll(
+            { assertThat(events).hasSize(1) },
+            { assertThat(events!!.first()).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe")) }
+        )
+    }
+
+    @Test
+    fun queryForListWithFilterAndSortBy() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val events = domainEventQueries.queryForList(Filter.type(NameWasChanged::class.qualifiedName), SortBy.natural(ASCENDING)).block()
+
+        // Then
+        assertAll(
+            { assertThat(events).hasSize(1) },
+            { assertThat(events!!.first()).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe")) }
+        )
+    }
+
+    @Test
+    fun querySingleWithSpecificReifiedKClassType() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val event = domainEventQueries.queryOne<NameWasChanged>().block()
+
+        // Then
+        assertThat(event).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe"))
+    }
+
+    @Test
+    fun querySingleWithSpecificKClassType() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val event = domainEventQueries.queryOne(NameWasChanged::class).block()
+
+        // Then
+        assertThat(event).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe"))
+    }
+
+    @Test
+    fun queryWithKClassType() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val events = domainEventQueries.query(NameWasChanged::class).collectList().block()
+
+        // Then
+        assertAll(
+            { assertThat(events).hasSize(1) },
+            { assertThat(events!!.first()).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe")) }
+        )
+    }
+
+    @Test
+    fun queryWithMultipleKClassType() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe")
+            )
+        ).block()
+
+        // When
+        val events: List<DomainEvent> = domainEventQueries.query(NameDefined::class, NameWasChanged::class).collectList().block()!!
+
+        // Then
+        assertAll(
+            { assertThat(events).hasSize(2) },
+            { assertThat(events.map { it.eventId() }).containsOnly("eventId1", "eventId2") }
+        )
+    }
+
+    @Test
+    fun queryOneBasedOnReifiedClassTypeAndSortBy() {
+        // Given
+        val time = LocalDateTime.now()
+        applicationService.executeList(
+            "stream", composeCommands(
+                Name::defineName.partial("eventId1", time, "name", "Some Doe"),
+                Name::changeName.partial("eventId2", time, "name", "Jane Doe"),
+                Name::changeName.partial("eventId3", time, "name", "Jane Doe2"),
+            )
+        ).block()
+
+        // When
+        val nameWasChanged = domainEventQueries.queryOne<NameWasChanged>(sortBy = SortBy.natural(DESCENDING)).block()
+
+        // Then
+        assertThat(nameWasChanged).isEqualTo(NameWasChanged("eventId3", time, "name", "Jane Doe2"))
+    }
+
+    companion object {
+        @Container
+        @JvmStatic
+        private val mongoDBContainer = MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true)
+    }
+}


### PR DESCRIPTION
The reactive stack had no counterpart to the blocking `DomainEventQueries`, so a reactive caller doing an ordinary filtered or typed query had to hand-write the CloudEvent-to-domain-event mapping instead of getting it for free.

This adds a `query-dsl-reactor` module with a reactive `DomainEventQueries` that wraps `org.occurrent.eventstore.api.reactor.EventStoreQueries` and mirrors the blocking `DomainEventQueries` method for method: `Flux` instead of `Stream`, `Mono` instead of a nullable or plain return, and `count()`/`exists()` returning `Mono`. Kotlin extensions add the same `KClass` overloads as the blocking version plus a `queryForList` convenience that collects a `Flux` into `Mono<List<T>>`.

This is a standalone addition with no breaking changes. It's also the foundation for a follow-up PR that makes the reactive `DcbDomainEventQueries` delegate to it, closing a gap its own Javadoc calls out today.

Tested against `ReactorMongoEventStore` through Testcontainers, 18 tests across the Java and Kotlin test classes.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
