### PR TITLE
Make reactive DcbDomainEventQueries delegate to DomainEventQueries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,11 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Added a reactive query DSL, so the reactive stack has the same typed-query ergonomics as the blocking one, and the reactive DCB DSL's domain event queries now delegate to it.
+  * `DomainEventQueries` in `query-dsl-reactor` wraps a reactive `EventStoreQueries` and a `CloudEventConverter`, returning `Flux<E>` from its query methods and `Mono<E>` from `queryOne`, with the same `Class`/`Filter`/`SortBy` overloads and Kotlin `KClass` extensions as the blocking version.
+  * `DcbDomainEventQueries` in `dcb-dsl-reactor` now wraps a `DomainEventQueries<E>` and delegates every plain stream-query method to it, exactly like the blocking version, instead of only exposing the DCB query family. This is a breaking change to its constructor: `new DcbDomainEventQueries(DcbEventStore, CloudEventConverter)` no longer compiles, build a `DomainEventQueries<E>` first and pass that instead.
+  * See [ADR 40](doc/architecture/decisions/0040-reactive-query-dsl-and-dcb-domain-event-queries-delegation.md).
+
 * Added a reactive stream application service, so the reactive stack has the same application-service ergonomics as the blocking one.
   * `ApplicationService` in `application-service-reactor` runs the read, decide, and write cycle against the reactive event store and returns a `Mono<WriteResult>`, retrying from a fresh read on a `WriteConditionNotFulfilledException`. The domain function stays a synchronous `Function<Stream<E>, Stream<E>>`, the side-effect is reactive (`Function<Stream<E>, Mono<Void>>`), and it mirrors the blocking surface including the `ExecuteFilter` read filter and the Kotlin extensions.
   * `ExecuteFilter` moved to the shared `application-service-common` module (package `org.occurrent.application.service`) so both stacks share one copy. This is a breaking change, the old `org.occurrent.application.service.blocking.ExecuteFilter` is gone, so update the import to `org.occurrent.application.service.ExecuteFilter`.

--- a/doc/architecture/decisions/0040-reactive-query-dsl-and-dcb-domain-event-queries-delegation.md
+++ b/doc/architecture/decisions/0040-reactive-query-dsl-and-dcb-domain-event-queries-delegation.md
@@ -1,0 +1,45 @@
+# 40. Reactive query DSL and DCB domain event queries delegation
+
+Date: 2026-07-01
+
+## Status
+
+Accepted
+
+## Context
+
+`dsl/query-dsl` had only a `blocking` module. Its `DomainEventQueries<T>` wraps a blocking `EventStoreQueries` and a `CloudEventConverter<T>` to give callers typed, converted queries (`query(Filter)`, `query(Class)`, `queryOne(...)`, `count()`, `exists()`, `all()`) instead of a raw `Stream<CloudEvent>`. The reactive event store API (`eventstore-api-reactor`) already exposes the same `EventStoreQueries` capability, returning `Flux`/`Mono` instead of `Stream`/plain values, and `ReactorMongoEventStore` already implements it. There was no reactive counterpart to the blocking `DomainEventQueries`, so a reactive caller doing ordinary filtered or typed queries had to hand-write the CloudEvent-to-domain-event mapping.
+
+The gap showed up concretely in `dcb-dsl-reactor`. The blocking `DcbDomainEventQueries` wraps a blocking `DomainEventQueries<E>`: it owns the DCB query family (`query(DcbQuery)`, `queryWithPosition(...)`) and delegates every plain stream-oriented query method to the wrapped `DomainEventQueries`, so one object serves both query styles. The reactive `DcbDomainEventQueries` could not do the same, because there was no reactive `DomainEventQueries` to wrap. Its Javadoc said so directly: "The reactive side has no general `DomainEventQueries` to wrap, so the stream-oriented query delegation of the blocking version is intentionally absent." It only exposed the DCB query family, built directly on the reactive `DcbEventStore` and a `CloudEventConverter`.
+
+## Decision
+
+Add `query-dsl-reactor`, a reactive `DomainEventQueries<T>` in package `org.occurrent.dsl.query.reactor`, mirroring the blocking one method-for-method:
+
+- Wraps a reactive `EventStoreQueries` and a `CloudEventConverter<T>`.
+- Query methods return `Flux<E>` (the idiomatic reactive shape for a lazily-consumed collection).
+- `queryOne(...)` returns `Mono<E>`, empty when nothing matches, instead of a nullable value.
+- `count()` and `exists(Filter)` return `Mono<Long>`/`Mono<Boolean>`, matching the reactive `EventStoreQueries` signatures.
+- Exposes `eventStoreQueries()` so capabilities layered on top of the event store, such as DCB, can check whether the underlying store also implements the reactive `DcbEventStore`.
+- Exposes `toDomainEvents(Flux<CloudEvent>)` so callers that already have a `Flux<CloudEvent>` from elsewhere can convert it without reaching into the `CloudEventConverter` directly.
+- A Kotlin extensions file mirrors the blocking one's `KClass`-based overloads for `query`/`queryOne`. It replaces the blocking file's `queryForSequence` family with nothing, since `Flux` is already the idiomatic reactive return type in Kotlin, and keeps a `queryForList` convenience that collects a `Flux` into `Mono<List<T>>` for callers that want the whole result as one value.
+
+`DcbDomainEventQueries` in `dcb-dsl-reactor` now wraps a `DomainEventQueries<E>` instead of a raw `DcbEventStore` and `CloudEventConverter<E>`, exactly like the blocking version:
+
+```java
+public DcbDomainEventQueries(DomainEventQueries<E> domainEventQueries) {
+    this.domainEventQueries = requireNonNull(domainEventQueries, ...);
+    this.dcbEventStore = requireDcbEventStore(domainEventQueries);
+}
+```
+
+The constructor validates that the wrapped `DomainEventQueries`'s `eventStoreQueries()` also implements the reactive `DcbEventStore`, the same check the blocking version performs, and throws `IllegalArgumentException` otherwise. Every plain stream-query method delegates to the wrapped `DomainEventQueries`; the DCB query family converts CloudEvents by wrapping the DCB read's materialized event list in a `Flux` and passing it through `domainEventQueries.toDomainEvents(...)`, instead of calling the `CloudEventConverter` directly.
+
+This is a breaking change to `DcbDomainEventQueries`'s constructor. Nothing outside `dcb-dsl-reactor` constructed it directly (no example app uses the reactive DCB DSL's query type yet), so the blast radius is the class itself, its Kotlin extensions, and its own test.
+
+## Consequences
+
+- Reactive callers doing ordinary filtered or typed queries get the same ergonomics blocking callers already had: typed results, `Flux`/`Mono` instead of raw CloudEvents, and Kotlin `KClass` overloads.
+- `DcbDomainEventQueries` in `dcb-dsl-reactor` reaches full structural parity with the blocking version: both wrap a `DomainEventQueries<E>`, both derive DCB capability via an `instanceof` check on the wrapped store, both delegate the same method set.
+- `new DcbDomainEventQueries(DcbEventStore, CloudEventConverter)` no longer compiles. Callers must build a `DomainEventQueries<E>` first and pass that instead.
+- The reactive `DomainEventQueries` and the blocking one stay separate classes rather than a shared generic abstraction, because their return types differ throughout (`Flux`/`Mono` versus `Stream`/plain values) and the method-for-method mirroring costs less than a unifying abstraction would.

--- a/dsl/dcb-dsl/reactor/pom.xml
+++ b/dsl/dcb-dsl/reactor/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>query-dsl-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>eventstore-api-dcb-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
@@ -17,36 +17,53 @@
 package org.occurrent.dsl.dcb.reactor;
 
 import org.jspecify.annotations.NullMarked;
-import org.occurrent.application.converter.CloudEventConverter;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.dsl.dcb.DcbDomainEventStream;
+import org.occurrent.dsl.query.reactor.DomainEventQueries;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.reactor.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.filter.Filter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Collection;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Queries a reactive DCB event store and converts the matched CloudEvents into your domain event type.
+ * Queries a reactive DCB-capable event store and converts the matched CloudEvents into your domain event type.
  *
- * <p>This is the reactive counterpart to the blocking {@code DcbDomainEventQueries}. It is built directly on a
- * reactive {@link DcbEventStore} and a {@link CloudEventConverter}, and exposes only the DCB query methods. The
- * reactive side has no general {@code DomainEventQueries} to wrap, so the stream-oriented query delegation of the
- * blocking version is intentionally absent.</p>
+ * <p>This wraps a {@link DomainEventQueries} so a DCB application can use a single object for both DCB queries
+ * (the {@link #query(DcbQuery)} family) and the regular stream-oriented queries (which are delegated to the
+ * wrapped {@link DomainEventQueries} unchanged). This is the reactive counterpart to the blocking
+ * {@code DcbDomainEventQueries}. The wrapped instance must be backed by an event store that also implements the
+ * reactive {@link DcbEventStore} (for example the Spring MongoDB event store with the DCB capability enabled);
+ * otherwise the constructor throws.</p>
  *
  * @param <E> the domain event type
  */
 @NullMarked
 public class DcbDomainEventQueries<E> {
 
+    private final DomainEventQueries<E> domainEventQueries;
     private final DcbEventStore dcbEventStore;
-    private final CloudEventConverter<E> cloudEventConverter;
 
-    public DcbDomainEventQueries(DcbEventStore dcbEventStore, CloudEventConverter<E> cloudEventConverter) {
-        this.dcbEventStore = requireNonNull(dcbEventStore, DcbEventStore.class.getSimpleName() + " cannot be null");
-        this.cloudEventConverter = requireNonNull(cloudEventConverter, CloudEventConverter.class.getSimpleName() + " cannot be null");
+    /**
+     * Wraps a {@link DomainEventQueries} backed by a reactive DCB-capable event store.
+     *
+     * @throws IllegalArgumentException if the wrapped {@link DomainEventQueries} is not backed by a reactive {@link DcbEventStore}
+     */
+    public DcbDomainEventQueries(DomainEventQueries<E> domainEventQueries) {
+        this.domainEventQueries = requireNonNull(domainEventQueries, DomainEventQueries.class.getSimpleName() + " cannot be null");
+        this.dcbEventStore = requireDcbEventStore(domainEventQueries);
     }
+
+    // ------------------------------------------------------------------------------------------------------
+    // DCB queries
+    // ------------------------------------------------------------------------------------------------------
 
     /**
      * Queries matching DCB events from the beginning of the DCB sequence.
@@ -61,7 +78,7 @@ public class DcbDomainEventQueries<E> {
     public Flux<E> query(DcbQuery query, DcbReadOptions options) {
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
-        return dcbEventStore.read(query, options).flatMapMany(eventStream -> Flux.fromStream(cloudEventConverter.toDomainEvents(eventStream.stream())));
+        return dcbEventStore.read(query, options).flatMapMany(eventStream -> domainEventQueries.toDomainEvents(Flux.fromStream(eventStream.stream())));
     }
 
     /**
@@ -78,7 +95,122 @@ public class DcbDomainEventQueries<E> {
     public Mono<DcbDomainEventStream<E>> queryWithPosition(DcbQuery query, DcbReadOptions options) {
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
-        return dcbEventStore.read(query, options).map(eventStream ->
-                new DcbDomainEventStream<>(cloudEventConverter.toDomainEvents(eventStream.stream()).toList(), eventStream.lastSequencePosition(), eventStream.consistencyToken()));
+        return dcbEventStore.read(query, options).flatMap(eventStream ->
+                domainEventQueries.<E>toDomainEvents(Flux.fromStream(eventStream.stream())).collectList()
+                        .map(events -> new DcbDomainEventStream<>(events, eventStream.lastSequencePosition(), eventStream.consistencyToken())));
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Stream queries delegated to the wrapped DomainEventQueries
+    // ------------------------------------------------------------------------------------------------------
+
+    public <E1 extends E> Mono<E1> queryOne(Filter filter) {
+        return domainEventQueries.queryOne(filter);
+    }
+
+    public <E1 extends E> Mono<E1> queryOne(Class<E1> type) {
+        return domainEventQueries.queryOne(type);
+    }
+
+    public <E1 extends E> Mono<E1> queryOne(Class<E1> type, SortBy sortBy) {
+        return domainEventQueries.queryOne(type, sortBy);
+    }
+
+    public <E1 extends E> Mono<E1> queryOne(Class<E1> type, int skip, int limit) {
+        return domainEventQueries.queryOne(type, skip, limit);
+    }
+
+    public <E1 extends E> Mono<E1> queryOne(Class<E1> type, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.queryOne(type, skip, limit, sortBy);
+    }
+
+    public <E1 extends E> Flux<E1> query(Class<E1> type) {
+        return domainEventQueries.query(type);
+    }
+
+    public <E1 extends E> Flux<E1> query(Class<E1> type, int skip, int limit) {
+        return domainEventQueries.query(type, skip, limit);
+    }
+
+    public <E1 extends E> Flux<E1> query(Class<E1> type, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(type, skip, limit, sortBy);
+    }
+
+    public <E1 extends E> Flux<E1> query(Class<E1> type, SortBy sortBy) {
+        return domainEventQueries.query(type, sortBy);
+    }
+
+    public <E1 extends E> Flux<E1> query(Filter filter, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(filter, skip, limit, sortBy);
+    }
+
+    public Flux<E> query(Collection<Class<? extends E>> types, int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.query(types, skip, limit, sortBy);
+    }
+
+    public Flux<E> query(Collection<Class<? extends E>> types, int skip, int limit) {
+        return domainEventQueries.query(types, skip, limit);
+    }
+
+    public Flux<E> query(Collection<Class<? extends E>> types, SortBy sortBy) {
+        return domainEventQueries.query(types, sortBy);
+    }
+
+    public Flux<E> query(Collection<Class<? extends E>> types) {
+        return domainEventQueries.query(types);
+    }
+
+    @SafeVarargs
+    public final Flux<E> query(Class<? extends E> type, @Nullable Class<? extends E>... types) {
+        return domainEventQueries.query(type, types);
+    }
+
+    public Mono<Long> count(Filter filter) {
+        return domainEventQueries.count(filter);
+    }
+
+    public Mono<Long> count() {
+        return domainEventQueries.count();
+    }
+
+    public Mono<Boolean> exists(Filter filter) {
+        return domainEventQueries.exists(filter);
+    }
+
+    public <E1 extends E> Flux<E1> query(Filter filter, SortBy sortBy) {
+        return domainEventQueries.query(filter, sortBy);
+    }
+
+    public <E1 extends E> Flux<E1> query(Filter filter, int skip, int limit) {
+        return domainEventQueries.query(filter, skip, limit);
+    }
+
+    public Flux<E> all(int skip, int limit, SortBy sortBy) {
+        return domainEventQueries.all(skip, limit, sortBy);
+    }
+
+    public Flux<E> all(SortBy sortBy) {
+        return domainEventQueries.all(sortBy);
+    }
+
+    public Flux<E> all(int skip, int limit) {
+        return domainEventQueries.all(skip, limit);
+    }
+
+    public Flux<E> all() {
+        return domainEventQueries.all();
+    }
+
+    public <E1 extends E> Flux<E1> query(Filter filter) {
+        return domainEventQueries.query(filter);
+    }
+
+    private static DcbEventStore requireDcbEventStore(DomainEventQueries<?> domainEventQueries) {
+        EventStoreQueries eventStoreQueries = domainEventQueries.eventStoreQueries();
+        if (!(eventStoreQueries instanceof DcbEventStore dcbEventStore)) {
+            throw new IllegalArgumentException("DCB queries require the " + DomainEventQueries.class.getSimpleName() + " to be backed by a reactive "
+                    + DcbEventStore.class.getSimpleName() + ", but was " + eventStoreQueries.getClass().getName());
+        }
+        return dcbEventStore;
     }
 }

--- a/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.dsl.dcb.DcbDomainEventStream;
+import org.occurrent.dsl.query.reactor.DomainEventQueries;
+import org.occurrent.eventstore.api.EventStoreCapability;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.dcb.DcbAppendCondition;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbConsistencyToken;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.reactor.EventStoreQueries;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.filter.Filter;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DcbDomainEventQueriesTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true);
+
+    @RegisterExtension
+    FlushMongoDBExtension flush = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbquerydsl"));
+
+    private ReactorMongoEventStore eventStore;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private DcbDomainEventQueries<DomainEvent> dcbQueries;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void createInstances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbquerydsl");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager tx = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(tx)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(EventStoreCapability.STREAM, EventStoreCapability.DCB)
+                .build();
+        eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        dcbQueries = new DcbDomainEventQueries<>(new DomainEventQueries<>(eventStore, cloudEventConverter));
+        time = LocalDateTime.now();
+    }
+
+    @Test
+    void query_converts_matching_dcb_events_to_domain_events() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", nameDefined, nameWasChanged);
+
+        List<DomainEvent> events = dcbQueries.query(DcbQuery.tags("name:1")).collectList().block();
+
+        assertThat(events).containsExactly(nameDefined, nameWasChanged);
+    }
+
+    @Test
+    void query_honors_read_options_after_sequence_position() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", nameDefined);
+        append("name:1", nameWasChanged);
+
+        List<DomainEvent> events = dcbQueries.query(DcbQuery.tags("name:1"), DcbReadOptions.afterSequencePosition(1)).collectList().block();
+
+        assertThat(events).containsExactly(nameWasChanged);
+    }
+
+    @Test
+    void query_with_position_preserves_last_sequence_position() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        append("name:1", nameDefined);
+        append("other:1", new NameWasChanged("eventId2", time, "name", "Jane Doe"));
+
+        DcbDomainEventStream<DomainEvent> eventStream = dcbQueries.queryWithPosition(DcbQuery.tags("name:1")).block();
+
+        assertThat(eventStream.events()).containsExactly(nameDefined);
+        assertThat(eventStream.stream()).containsExactly(nameDefined);
+        assertThat(eventStream.lastSequencePosition()).isEqualTo(2);
+    }
+
+    @Test
+    void query_with_position_exposes_a_usable_consistency_token() {
+        append("name:1", new NameDefined("eventId1", time, "name", "Some Doe"));
+
+        DcbDomainEventStream<DomainEvent> eventStream = dcbQueries.queryWithPosition(DcbQuery.tags("name:1")).block();
+        DcbConsistencyToken token = eventStream.consistencyToken();
+        assertThat(token).isNotNull();
+
+        // A matching event committed after the DSL read invalidates the token, so a conditional append carrying it back
+        // to the store is correctly rejected. This proves the token flows through the DSL projection, not just the position.
+        append("name:1", new NameWasChanged("eventId2", time, "name", "Jane Doe"));
+        List<CloudEvent> newEvents = cloudEventConverter.toCloudEvents(Stream.of(new NameWasChanged("eventId3", time, "name", "Joe Doe")))
+                .map(event -> DcbCloudEvents.withTags(event, List.of("name:1")))
+                .toList();
+
+        assertThatThrownBy(() -> eventStore.append(newEvents, DcbAppendCondition.failIfEventsMatch(DcbQuery.tags("name:1"), token)).block())
+                .isInstanceOf(DcbAppendConditionNotFulfilledException.class);
+    }
+
+    @Test
+    void delegates_plain_filter_and_type_queries_to_the_wrapped_domain_event_queries() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", nameDefined, nameWasChanged);
+
+        List<NameWasChanged> byType = dcbQueries.query(NameWasChanged.class).collectList().block();
+        List<DomainEvent> byFilter = dcbQueries.<DomainEvent>query(Filter.all()).collectList().block();
+        NameDefined one = dcbQueries.queryOne(NameDefined.class).block();
+
+        assertThat(byType).containsExactly(nameWasChanged);
+        assertThat(byFilter).containsExactly(nameDefined, nameWasChanged);
+        assertThat(one).isEqualTo(nameDefined);
+    }
+
+    @Test
+    void delegates_count_and_exists_to_the_wrapped_domain_event_queries() {
+        append("name:1", new NameDefined("eventId1", time, "name", "Some Doe"));
+
+        Long count = dcbQueries.count().block();
+        Boolean exists = dcbQueries.exists(Filter.type(NameDefined.class.getName())).block();
+
+        assertThat(count).isEqualTo(1L);
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void constructor_rejects_a_domain_event_queries_not_backed_by_a_reactive_dcb_event_store() {
+        DomainEventQueries<DomainEvent> wrapped = new DomainEventQueries<>(new StreamOnlyEventStoreQueries(), cloudEventConverter);
+
+        assertThatThrownBy(() -> new DcbDomainEventQueries<>(wrapped))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("DCB queries require");
+    }
+
+    private static final class StreamOnlyEventStoreQueries implements EventStoreQueries {
+        @Override
+        public Flux<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+            return Flux.empty();
+        }
+
+        @Override
+        public Mono<Long> count(Filter filter) {
+            return Mono.just(0L);
+        }
+
+        @Override
+        public Mono<Boolean> exists(Filter filter) {
+            return Mono.just(false);
+        }
+    }
+
+    private void append(String tag, DomainEvent... events) {
+        List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
+                .map(event -> DcbCloudEvents.withTags(event, List.of(tag)))
+                .toList();
+        eventStore.append(cloudEvents).block();
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
@@ -35,6 +35,7 @@ import org.occurrent.domain.NameDefined
 import org.occurrent.domain.NameWasChanged
 import org.occurrent.dsl.decider.Decider
 import org.occurrent.dsl.decider.decider
+import org.occurrent.dsl.query.reactor.DomainEventQueries
 import org.occurrent.eventstore.api.EventStoreCapability.DCB
 import org.occurrent.eventstore.api.EventStoreCapability.STREAM
 import org.occurrent.eventstore.api.dcb.DcbAppendCondition
@@ -86,7 +87,7 @@ class DcbReactorDslTest {
         eventStore = ReactorMongoEventStore(mongoTemplate, config)
         converter = JacksonCloudEventConverter.Builder<DomainEvent>(ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build()
         applicationService = GenericDcbApplicationService(eventStore, converter, { event -> setOf(tagFor(event)) }, GenericDcbApplicationService.defaultRetry())
-        queries = DcbDomainEventQueries(eventStore, converter)
+        queries = DcbDomainEventQueries(DomainEventQueries(eventStore, converter))
         time = LocalDateTime.now()
     }
 


### PR DESCRIPTION
Builds on the reactive query DSL PR.

`DcbDomainEventQueries` in `dcb-dsl-reactor` now wraps a `DomainEventQueries<E>` instead of a raw `DcbEventStore` and `CloudEventConverter`, and delegates every plain stream-query method (`query(Filter)`, `query(Class)`, `queryOne`, `count`, `exists`, `all`) to it. That's exactly what the blocking `DcbDomainEventQueries` already does, so both stacks now use one object for the DCB query family and ordinary stream queries.

The constructor validates that the wrapped store also implements the reactive `DcbEventStore` via `instanceof`, throwing `IllegalArgumentException` otherwise, matching the blocking version.

This is a breaking change to the constructor: `new DcbDomainEventQueries(DcbEventStore, CloudEventConverter)` no longer compiles. Build a `DomainEventQueries<E>` first and pass that instead. Nothing outside `dcb-dsl-reactor` constructed it directly, so the blast radius is the class itself, its Kotlin test, and a new Java test.

Added [ADR 40](doc/architecture/decisions/0040-reactive-query-dsl-and-dcb-domain-event-queries-delegation.md), covering both this PR and the prior one, plus a changelog entry.

`DcbDomainEventQueriesTest.java` is new. It covers the DCB query family (already tested before, just moved onto `ReactorMongoEventStore`), the newly delegated plain queries, and the constructor rejecting a store that isn't DCB-capable. All green against `ReactorMongoEventStore` through Testcontainers.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-query-dsl","parentHead":"6e83f7bbbae01d2a7bde7c69524fbecbbe98514f","parentPull":251,"trunk":"main"}
```
-->
