### PR TITLE
Restart native subscription model on change-stream errors and resume gap-free

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,12 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Hardened `NativeMongoSubscriptionModel` against the MongoDB operational failures `SpringMongoSubscriptionModel` already survives in production: replica-set failovers, transient network errors, and change-stream history loss.
+  * A change-stream error (a failover, a transient network error, or anything else the driver itself does not resume) now restarts the subscription with the existing `RetryStrategy` backoff instead of silently dying, resuming from the position of the last event actually delivered so recovery is gap-free rather than a replay or a skipped window.
+  * `MongoCommandException`s with error code 286 (`ChangeStreamHistoryLost`) restart from `StartAt.now()` only when configured to via the new `NativeMongoSubscriptionModelConfig.restartSubscriptionsOnChangeStreamHistoryLost(true)` (default `false`, matching the Spring default); otherwise the subscription stops and logs an error, same as `SpringMongoSubscriptionModel`.
+  * `resumeSubscription` now continues from the position of the last event delivered before the pause instead of the subscription's original `StartAt`, so pausing and resuming neither replays events nor drops events written while paused.
+  * See [ADR 41](doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md).
+
 * Added a reactive query DSL, so the reactive stack has the same typed-query ergonomics as the blocking one, and the reactive DCB DSL's domain event queries now delegate to it.
   * `DomainEventQueries` in `query-dsl-reactor` wraps a reactive `EventStoreQueries` and a `CloudEventConverter`, returning `Flux<E>` from its query methods and `Mono<E>` from `queryOne`, with the same `Class`/`Filter`/`SortBy` overloads and Kotlin `KClass` extensions as the blocking version.
   * `DcbDomainEventQueries` in `dcb-dsl-reactor` now wraps a `DomainEventQueries<E>` and delegates every plain stream-query method to it, exactly like the blocking version, instead of only exposing the DCB query family. This is a breaking change to its constructor: `new DcbDomainEventQueries(DcbEventStore, CloudEventConverter)` no longer compiles, build a `DomainEventQueries<E>` first and pass that instead.

--- a/changelog.md
+++ b/changelog.md
@@ -11,9 +11,9 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 #### Changes
 
 * Hardened `NativeMongoSubscriptionModel` against the MongoDB operational failures `SpringMongoSubscriptionModel` already survives in production: replica-set failovers, transient network errors, and change-stream history loss.
-  * A change-stream error (a failover, a transient network error, or anything else the driver itself does not resume) now restarts the subscription with the existing `RetryStrategy` backoff instead of silently dying, resuming from the position of the last event actually delivered so recovery is gap-free rather than a replay or a skipped window.
+  * A change-stream error (a failover, a transient network error, or anything else the driver itself does not resume) now restarts the subscription with the existing `RetryStrategy` backoff instead of silently dying, resuming from the position of the last change-stream document read so recovery is gap-free rather than a replay or a skipped window.
   * `MongoCommandException`s with error code 286 (`ChangeStreamHistoryLost`) restart from `StartAt.now()` only when configured to via the new `NativeMongoSubscriptionModelConfig.restartSubscriptionsOnChangeStreamHistoryLost(true)` (default `false`, matching the Spring default); otherwise the subscription stops and logs an error, same as `SpringMongoSubscriptionModel`.
-  * `resumeSubscription` now continues from the position of the last event delivered before the pause instead of the subscription's original `StartAt`, so pausing and resuming neither replays events nor drops events written while paused.
+  * `resumeSubscription` now continues from the position of the last change-stream document read before the pause instead of the subscription's original `StartAt`, so pausing and resuming neither replays events nor drops events written while paused.
   * See [ADR 41](doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md).
 
 * Added a reactive query DSL, so the reactive stack has the same typed-query ergonomics as the blocking one, and the reactive DCB DSL's domain event queries now delegate to it.

--- a/doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md
+++ b/doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md
@@ -1,0 +1,40 @@
+# 41. Native MongoDB subscription model restart-on-error
+
+Date: 2026-07-01
+
+## Status
+
+Accepted
+
+## Context
+
+`SpringMongoSubscriptionModel` is the production-hardened MongoDB change-stream subscription model: it survives replica-set primary elections/failovers, transient network errors, and change-stream history loss by classifying the underlying error and restarting the subscription rather than letting it die. `NativeMongoSubscriptionModel`, the equivalent built on the plain MongoDB driver, had none of this. Its change-stream consumption loop caught `MongoException` and `IllegalStateException` and only ever logged them at DEBUG and let the subscription's thread end, silently, with no restart. Any operational MongoDB event that the driver itself could not transparently resume (a longer failover, a killed cursor, a non-resumable error) permanently killed the subscription with no visible signal beyond a debug log line.
+
+The native model already had per-event action retry (`RetryStrategy`), a running/paused subscription lifecycle, and `waitUntilStarted`, all wired through `executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy)` in `startSubscription`. That existing retry wrapper was already being triggered by accident for any exception type it didn't explicitly catch (i.e. anything other than `MongoException`/`IllegalStateException`), always restarting from the subscription's original `StartAt`. The fix is to route the errors that matter through that same wrapper deliberately, with the right classification and the right restart position, rather than swallowing them.
+
+Also, `resumeSubscription` reused the subscription's original `StartAt` verbatim. For a subscription started at a fixed position, this replays every event since that position on every resume. For one started at `StartAt.now()`/`StartAt.subscriptionModelDefault()` (which the shared `MongoCommons.applyStartPosition` resolves as "no explicit position, let the driver default to the current time when the cursor opens"), reusing the original marker on resume instead skips every event written while the subscription was paused, since the newly opened cursor starts from "now" at resume time. Either way, resume did not continue from where the subscription actually left off.
+
+## Decision
+
+Track the position of the last event actually delivered from the change stream in an `AtomicReference<StartAt>` (`currentStartAt`), shared between the `Runnable` passed to `executeWithRetry` and every subsequent invocation it makes of `newInternalSubscription`. It starts at the caller-supplied `StartAt` and is updated to `StartAt.subscriptionPosition(new MongoResumeTokenSubscriptionPosition(...))` after each document is read from the cursor, matched or not.
+
+Widen the try block in `newInternalSubscription` to cover opening the cursor (`eventCollection.watch(...)` and `.cursor()`), not just iterating it, since a change-stream error can surface at either point. In the catch block, classify the throwable and decide, in order:
+
+1. The subscription was intentionally closed (a new `intentionallyClosed` flag on `InternalSubscription`, set before `cursor.close()`) or the exception matches the pre-existing "cursor is not longer open" heuristic: benign, log at DEBUG, do not restart. This is the pause/cancel/shutdown path.
+2. `MongoCommandException` with error code 286 (`ChangeStreamHistoryLost`, via the existing `MongoCommons.CHANGE_STREAM_HISTORY_LOST_ERROR_CODE` constant): if `NativeMongoSubscriptionModelConfig.restartSubscriptionsOnChangeStreamHistoryLost` is `true` (default `false`, matching the Spring default), set `currentStartAt` to `StartAt.now()` and rethrow; otherwise log at ERROR and do not restart.
+3. The model itself is shutting down: benign, log at DEBUG, do not restart.
+4. Anything else: log at WARN and rethrow.
+
+A rethrow is caught by the already-installed `executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy)` wrapper in `startSubscription`, which retries with the configured backoff and re-invokes `newInternalSubscription`, which reads the now-updated `currentStartAt`. No new threading or restart mechanism was needed; the existing retry-Runnable already does exactly what a restart needs, once the classification stops swallowing the exceptions that reach it.
+
+`resumeSubscription` now reuses the same `currentStartAt` reference the paused `InternalSubscription` was tracking, instead of a fixed original `StartAt`, so resume continues from the position of the last event delivered before the pause.
+
+Add `NativeMongoSubscriptionModelConfig`, mirroring `SpringMongoSubscriptionModelConfig`'s builder shape, carrying `retryStrategy` (default: exponential backoff 100ms to 2s, matching the existing default) and `restartSubscriptionsOnChangeStreamHistoryLost` (default `false`). It does not bundle the collection name or time representation the way the Spring config does, since the native constructors already take those positionally; the new config only adds the two new toggles, via a new constructor overload alongside the existing ones.
+
+## Consequences
+
+- `NativeMongoSubscriptionModel` survives the same class of MongoDB operational disruption `SpringMongoSubscriptionModel` does: failovers, transient network errors, and (opt-in) change-stream history loss, recovering gap-free from the position of the last event it actually delivered rather than replaying or skipping.
+- `resumeSubscription` no longer replays (fixed `StartAt`) or drops events written during the pause window (`StartAt.now()`/default); it continues from where the subscription left off.
+- The restart-on-error behavior reuses the model's existing per-event `RetryStrategy` and backoff rather than introducing a second retry mechanism, keeping the change small and avoiding a parallel "restart in a new thread" scheme like the one `SpringMongoSubscriptionModel` needs (native does not need it, since its retry wrapper already runs on a dedicated per-subscription thread).
+- Existing constructors are unchanged; the config-object constructor is additive.
+- Verified against real MongoDB (a replica-set Testcontainer) by injecting the exact exception types a failover, a transient socket error, and a 286 history-lost response would surface, rather than orchestrating a live replica-set election. `SpringMongoSubscriptionModelTest`, the reference this behavior mirrors, uses the identical injection technique; a live multi-node failover test was considered and rejected as disproportionate infrastructure for the coverage it would add over the deterministic injection tests.

--- a/doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md
+++ b/doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md
@@ -33,7 +33,7 @@ Add `NativeMongoSubscriptionModelConfig`, mirroring `SpringMongoSubscriptionMode
 
 ## Consequences
 
-- `NativeMongoSubscriptionModel` survives the same class of MongoDB operational disruption `SpringMongoSubscriptionModel` does: failovers, transient network errors, and (opt-in) change-stream history loss, recovering gap-free from the position of the last event it actually delivered rather than replaying or skipping.
+- `NativeMongoSubscriptionModel` survives the same class of MongoDB operational disruption `SpringMongoSubscriptionModel` does: failovers, transient network errors, and (opt-in) change-stream history loss, recovering gap-free from the position of the last change-stream document it read rather than replaying or skipping.
 - `resumeSubscription` no longer replays (fixed `StartAt`) or drops events written during the pause window (`StartAt.now()`/default); it continues from where the subscription left off.
 - The restart-on-error behavior reuses the model's existing per-event `RetryStrategy` and backoff rather than introducing a second retry mechanism, keeping the change small and avoiding a parallel "restart in a new thread" scheme like the one `SpringMongoSubscriptionModel` needs (native does not need it, since its retry wrapper already runs on a dedicated per-subscription thread).
 - Existing constructors are unchanged; the config-object constructor is additive.

--- a/subscription/mongodb/native/blocking/pom.xml
+++ b/subscription/mongodb/native/blocking/pom.xml
@@ -124,5 +124,10 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscription.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscription.java
@@ -32,6 +32,11 @@ public record NativeMongoSubscription(String subscriptionId, CountDownLatch subs
         return subscriptionId;
     }
 
+    /**
+     * Note that this only signals that the change stream cursor has been acquired, not that MongoDB has confirmed
+     * the cursor is healthy; a failure right after this returns is still possible and will trigger the subscription
+     * model's own restart-on-error handling.
+     */
     @Override
     public boolean waitUntilStarted(Duration timeout) {
         Timeout safeTimeout = DurationToTimeoutConverter.convertDurationToTimeout(timeout);

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -166,7 +166,7 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         requireNonNull(database, MongoDatabase.class.getSimpleName() + " cannot be null");
         requireNonNull(eventCollection, "Event collection cannot be null");
         requireNonNull(timeRepresentation, "Time representation cannot be null");
-        requireNonNull(subscriptionExecutor, "CloudEventDispatcher cannot  be null");
+        requireNonNull(subscriptionExecutor, "subscriptionExecutor cannot be null");
         requireNonNull(config, NativeMongoSubscriptionModelConfig.class.getSimpleName() + " cannot be null");
         this.database = database;
         this.retryStrategy = config.retryStrategy;
@@ -204,9 +204,10 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         cloudEventDispatcher.execute(executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy));
     }
 
-    // currentStartAt tracks the position of the last event actually delivered from the change stream (updated below),
-    // shared with the outer executeWithRetry(internalSubscription, ...) wrapper in startSubscription so that a restart
-    // (rethrown below) or a resume (see resumeSubscription) continues gap-free from there instead of the original StartAt.
+    // currentStartAt tracks the position of the last change-stream document read (updated below, whether or not it
+    // produced a delivered CloudEvent), shared with the outer executeWithRetry(internalSubscription, ...) wrapper in
+    // startSubscription so that a restart (rethrown below) or a resume (see resumeSubscription) continues gap-free
+    // from there instead of the original StartAt.
     // The try block spans opening the cursor too, not just iterating it, since a change-stream error (e.g. history lost,
     // a failover) can just as well surface when the cursor is (re-)opened as while iterating it.
     private void newInternalSubscription(String subscriptionId, SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Consumer<CloudEvent> action, CountDownLatch subscriptionStartedLatch) {
@@ -244,6 +245,8 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
                     throw e;
                 } else {
                     log.error("There was not enough oplog to resume subscription {}, will not restart subscription! Consider removing the subscription from the durable storage or use a catch-up subscription to get up to speed if needed.", subscriptionId, e);
+                    runningSubscriptions.remove(subscriptionId);
+                    pausedSubscriptions.remove(subscriptionId);
                 }
             } else if (shutdown) {
                 log.debug("Subscription {} is shutting down, ignoring {}.", subscriptionId, e.getClass().getName(), e);
@@ -385,8 +388,8 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         running = true;
 
         CountDownLatch startedLatch = new CountDownLatch(1);
-        // Reuses the same currentStartAt reference so a resume continues from the position of the last event
-        // delivered before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
+        // Reuses the same currentStartAt reference so a resume continues from the position of the last change-stream
+        // document read before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
         Runnable newSubscription = () -> newInternalSubscription(subscriptionId, internalSubscription.filter,
                 internalSubscription.currentStartAt, internalSubscription.action, startedLatch);
         startSubscription(newSubscription);

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -18,7 +18,6 @@ package org.occurrent.subscription.mongodb.nativedriver.blocking;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
-import com.mongodb.MongoException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoCollection;
@@ -58,6 +57,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -87,6 +88,7 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
     private final TimeRepresentation timeRepresentation;
     private final ExecutorService cloudEventDispatcher;
     private final RetryStrategy retryStrategy;
+    private final boolean restartSubscriptionsOnChangeStreamHistoryLost;
     private final MongoDatabase database;
 
     private volatile boolean shutdown = false;
@@ -133,13 +135,42 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
      */
     public NativeMongoSubscriptionModel(MongoDatabase database, MongoCollection<Document> eventCollection, TimeRepresentation timeRepresentation,
                                         ExecutorService subscriptionExecutor, RetryStrategy retryStrategy) {
+        this(database, eventCollection, timeRepresentation, subscriptionExecutor, NativeMongoSubscriptionModelConfig.withConfig().retryStrategy(retryStrategy));
+    }
+
+    /**
+     * Create a subscription using the native MongoDB sync driver.
+     *
+     * @param database             The MongoDB database to use
+     * @param eventCollectionName  The name of the collection that contains the events
+     * @param timeRepresentation   How time is represented in the database, must be the same as what's specified for the EventStore that stores the events.
+     * @param subscriptionExecutor The executor that will be used for the subscription. Typically a dedicated thread will be required per subscription.
+     * @param config               Configure how the subscription model should behave, for example retries and how to handle change stream history lost errors.
+     */
+    public NativeMongoSubscriptionModel(MongoDatabase database, String eventCollectionName, TimeRepresentation timeRepresentation,
+                                        ExecutorService subscriptionExecutor, NativeMongoSubscriptionModelConfig config) {
+        this(database, database.getCollection(requireNonNull(eventCollectionName, "Event collection cannot be null")), timeRepresentation, subscriptionExecutor, config);
+    }
+
+    /**
+     * Create a subscription using the native MongoDB sync driver.
+     *
+     * @param database             The MongoDB database to use
+     * @param eventCollection      The collection that contains the events
+     * @param timeRepresentation   How time is represented in the database, must be the same as what's specified for the EventStore that stores the events.
+     * @param subscriptionExecutor The executor that will be used for the subscription. Typically a dedicated thread will be required per subscription.
+     * @param config               Configure how the subscription model should behave, for example retries and how to handle change stream history lost errors.
+     */
+    public NativeMongoSubscriptionModel(MongoDatabase database, MongoCollection<Document> eventCollection, TimeRepresentation timeRepresentation,
+                                        ExecutorService subscriptionExecutor, NativeMongoSubscriptionModelConfig config) {
         requireNonNull(database, MongoDatabase.class.getSimpleName() + " cannot be null");
         requireNonNull(eventCollection, "Event collection cannot be null");
         requireNonNull(timeRepresentation, "Time representation cannot be null");
         requireNonNull(subscriptionExecutor, "CloudEventDispatcher cannot  be null");
-        requireNonNull(retryStrategy, "RetryStrategy cannot be null");
+        requireNonNull(config, NativeMongoSubscriptionModelConfig.class.getSimpleName() + " cannot be null");
         this.database = database;
-        this.retryStrategy = retryStrategy;
+        this.retryStrategy = config.retryStrategy;
+        this.restartSubscriptionsOnChangeStreamHistoryLost = config.restartSubscriptionsOnChangeStreamHistoryLost;
         this.cloudEventDispatcher = subscriptionExecutor;
         this.timeRepresentation = timeRepresentation;
         this.eventCollection = eventCollection;
@@ -158,8 +189,9 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         }
 
         CountDownLatch subscriptionStartedLatch = new CountDownLatch(1);
+        AtomicReference<StartAt> currentStartAt = new AtomicReference<>(startAt);
 
-        Runnable internalSubscription = () -> newInternalSubscription(subscriptionId, filter, startAt, action, subscriptionStartedLatch);
+        Runnable internalSubscription = () -> newInternalSubscription(subscriptionId, filter, currentStartAt, action, subscriptionStartedLatch);
 
         if (shutdown || cloudEventDispatcher.isShutdown() || cloudEventDispatcher.isTerminated()) {
             throw new IllegalStateException("Cannot start subscription because the executor is shutdown or terminated.");
@@ -172,34 +204,66 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         cloudEventDispatcher.execute(executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy));
     }
 
-    private void newInternalSubscription(String subscriptionId, SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, CountDownLatch subscriptionStartedLatch) {
-        List<Bson> pipeline = createPipeline(timeRepresentation, filter);
-        ChangeStreamIterable<Document> changeStreamDocuments = eventCollection.watch(pipeline, Document.class);
-        SubscriptionModelContext subscriptionModelContext = new SubscriptionModelContext(NativeMongoSubscriptionModel.class);
-        ChangeStreamIterable<Document> changeStreamDocumentsAtPosition = MongoCommons.applyStartPosition(changeStreamDocuments, ChangeStreamIterable::startAfter, ChangeStreamIterable::startAtOperationTime, startAt.get(subscriptionModelContext), subscriptionModelContext);
-        MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = changeStreamDocumentsAtPosition.cursor();
-
-        InternalSubscription internalSubscription = new InternalSubscription(cursor, startAt, action, filter, subscriptionStartedLatch);
-
-        if (running) {
-            runningSubscriptions.put(subscriptionId, internalSubscription);
-        } else {
-            pausedSubscriptions.put(subscriptionId, internalSubscription);
-        }
-
-        internalSubscription.started();
-
+    // currentStartAt tracks the position of the last event actually delivered from the change stream (updated below),
+    // shared with the outer executeWithRetry(internalSubscription, ...) wrapper in startSubscription so that a restart
+    // (rethrown below) or a resume (see resumeSubscription) continues gap-free from there instead of the original StartAt.
+    // The try block spans opening the cursor too, not just iterating it, since a change-stream error (e.g. history lost,
+    // a failover) can just as well surface when the cursor is (re-)opened as while iterating it.
+    private void newInternalSubscription(String subscriptionId, SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Consumer<CloudEvent> action, CountDownLatch subscriptionStartedLatch) {
+        InternalSubscription internalSubscription = null;
         try {
-            cursor.forEachRemaining(changeStreamDocument -> MongoCloudEventsToJsonDeserializer.deserializeToCloudEvent(changeStreamDocument, timeRepresentation)
-                    .map(cloudEvent -> new PositionAwareCloudEvent(cloudEvent, new MongoResumeTokenSubscriptionPosition(changeStreamDocument.getResumeToken())))
-                    .ifPresent(executeWithRetry(action, NOT_SHUTDOWN, retryStrategy)));
-        } catch (MongoException e) {
-            log.debug("Caught {} (code={}, message={}), this might happen when cursor is shutdown.", e.getClass().getName(), e.getCode(), e.getMessage(), e);
-        } catch (IllegalStateException e) {
-            log.debug("Caught {} (message={}), this might happen when cursor is shutdown.", e.getClass().getName(), e.getMessage(), e);
+            List<Bson> pipeline = createPipeline(timeRepresentation, filter);
+            ChangeStreamIterable<Document> changeStreamDocuments = eventCollection.watch(pipeline, Document.class);
+            SubscriptionModelContext subscriptionModelContext = new SubscriptionModelContext(NativeMongoSubscriptionModel.class);
+            ChangeStreamIterable<Document> changeStreamDocumentsAtPosition = MongoCommons.applyStartPosition(changeStreamDocuments, ChangeStreamIterable::startAfter, ChangeStreamIterable::startAtOperationTime, currentStartAt.get().get(subscriptionModelContext), subscriptionModelContext);
+            MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = changeStreamDocumentsAtPosition.cursor();
+
+            internalSubscription = new InternalSubscription(cursor, currentStartAt, action, filter, subscriptionStartedLatch);
+
+            if (running) {
+                runningSubscriptions.put(subscriptionId, internalSubscription);
+            } else {
+                pausedSubscriptions.put(subscriptionId, internalSubscription);
+            }
+
+            internalSubscription.started();
+
+            cursor.forEachRemaining(changeStreamDocument -> {
+                MongoCloudEventsToJsonDeserializer.deserializeToCloudEvent(changeStreamDocument, timeRepresentation)
+                        .map(cloudEvent -> new PositionAwareCloudEvent(cloudEvent, new MongoResumeTokenSubscriptionPosition(changeStreamDocument.getResumeToken())))
+                        .ifPresent(executeWithRetry(action, NOT_SHUTDOWN, retryStrategy));
+                currentStartAt.set(StartAt.subscriptionPosition(new MongoResumeTokenSubscriptionPosition(changeStreamDocument.getResumeToken())));
+            });
+        } catch (RuntimeException e) {
+            if ((internalSubscription != null && internalSubscription.isIntentionallyClosed()) || isCursorNoLongerOpen(e)) {
+                log.debug("Caught {} (message={}) for subscription {}, this might happen when a subscription is paused or cancelled.", e.getClass().getName(), e.getMessage(), subscriptionId, e);
+            } else if (isChangeStreamHistoryLost(e)) {
+                if (restartSubscriptionsOnChangeStreamHistoryLost) {
+                    log.warn("There was not enough oplog to resume subscription {}, will restart subscription from current time.", subscriptionId, e);
+                    currentStartAt.set(StartAt.now());
+                    throw e;
+                } else {
+                    log.error("There was not enough oplog to resume subscription {}, will not restart subscription! Consider removing the subscription from the durable storage or use a catch-up subscription to get up to speed if needed.", subscriptionId, e);
+                }
+            } else if (shutdown) {
+                log.debug("Subscription {} is shutting down, ignoring {}.", subscriptionId, e.getClass().getName(), e);
+            } else {
+                log.warn("Error caught for subscription {}: {} {}. Will restart!", subscriptionId, e.getClass().getName(), e.getMessage(), e);
+                throw e;
+            }
         } finally {
-            internalSubscription.stopped();
+            if (internalSubscription != null) {
+                internalSubscription.stopped();
+            }
         }
+    }
+
+    private static boolean isCursorNoLongerOpen(Throwable throwable) {
+        return throwable instanceof IllegalStateException && throwable.getMessage() != null && throwable.getMessage().startsWith("Cursor") && throwable.getMessage().endsWith("is not longer open.");
+    }
+
+    private static boolean isChangeStreamHistoryLost(Throwable throwable) {
+        return throwable instanceof MongoCommandException mongoCommandException && mongoCommandException.getErrorCode() == MongoCommons.CHANGE_STREAM_HISTORY_LOST_ERROR_CODE;
     }
 
     private static List<Bson> createPipeline(TimeRepresentation timeRepresentation, @Nullable SubscriptionFilter filter) {
@@ -321,8 +385,10 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         running = true;
 
         CountDownLatch startedLatch = new CountDownLatch(1);
+        // Reuses the same currentStartAt reference so a resume continues from the position of the last event
+        // delivered before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
         Runnable newSubscription = () -> newInternalSubscription(subscriptionId, internalSubscription.filter,
-                internalSubscription.startAt, internalSubscription.action, startedLatch);
+                internalSubscription.currentStartAt, internalSubscription.action, startedLatch);
         startSubscription(newSubscription);
 
         return new NativeMongoSubscription(subscriptionId, startedLatch);
@@ -353,14 +419,15 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         final CountDownLatch startedLatch;
         final CountDownLatch stoppedLatch;
         final MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor;
-        final StartAt startAt;
+        final AtomicReference<StartAt> currentStartAt;
         final Consumer<CloudEvent> action;
+        private final AtomicBoolean intentionallyClosed = new AtomicBoolean(false);
 
-        private InternalSubscription(MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor, StartAt startAtSupplier, Consumer<CloudEvent> action, SubscriptionFilter filter, CountDownLatch startedLatch) {
+        private InternalSubscription(MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor, AtomicReference<StartAt> currentStartAt, Consumer<CloudEvent> action, SubscriptionFilter filter, CountDownLatch startedLatch) {
             this.filter = filter;
             this.startedLatch = startedLatch;
             this.cursor = cursor;
-            this.startAt = startAtSupplier;
+            this.currentStartAt = currentStartAt;
             this.action = action;
             this.stoppedLatch = new CountDownLatch(1);
         }
@@ -370,12 +437,12 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
             if (this == o) return true;
             if (!(o instanceof InternalSubscription)) return false;
             InternalSubscription that = (InternalSubscription) o;
-            return Objects.equals(filter, that.filter) && Objects.equals(startedLatch, that.startedLatch) && Objects.equals(stoppedLatch, that.stoppedLatch) && Objects.equals(cursor, that.cursor) && Objects.equals(startAt, that.startAt) && Objects.equals(action, that.action);
+            return Objects.equals(filter, that.filter) && Objects.equals(startedLatch, that.startedLatch) && Objects.equals(stoppedLatch, that.stoppedLatch) && Objects.equals(cursor, that.cursor) && Objects.equals(currentStartAt, that.currentStartAt) && Objects.equals(action, that.action);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(filter, startedLatch, stoppedLatch, cursor, startAt, action);
+            return Objects.hash(filter, startedLatch, stoppedLatch, cursor, currentStartAt, action);
         }
 
         void started() {
@@ -386,6 +453,10 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
             stoppedLatch.countDown();
         }
 
+        boolean isIntentionallyClosed() {
+            return intentionallyClosed.get();
+        }
+
         public boolean waitUntilStopped(Duration duration) {
             try {
                 return stoppedLatch.await(duration.toMillis(), MILLISECONDS);
@@ -394,7 +465,10 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
             }
         }
 
+        // Marked before closing so the change-stream error this deliberately triggers is recognized as benign
+        // (pause/cancel/shutdown) rather than an unexpected failure that should restart the subscription.
         public void close() {
+            intentionallyClosed.set(true);
             try {
                 cursor.close();
             } catch (Exception e) {

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -257,12 +257,17 @@ public class NativeMongoSubscriptionModel implements PositionAwareSubscriptionMo
         } finally {
             if (internalSubscription != null) {
                 internalSubscription.stopped();
+                try {
+                    internalSubscription.cursor.close();
+                } catch (Exception closeException) {
+                    log.debug("Failed to close cursor for subscription {}, this can happen if the connection was already closed.", subscriptionId, closeException);
+                }
             }
         }
     }
 
     private static boolean isCursorNoLongerOpen(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getMessage() != null && throwable.getMessage().startsWith("Cursor") && throwable.getMessage().endsWith("is not longer open.");
+        return throwable instanceof IllegalStateException && throwable.getMessage() != null && throwable.getMessage().startsWith("Cursor") && throwable.getMessage().contains("is not longer open");
     }
 
     private static boolean isChangeStreamHistoryLost(Throwable throwable) {

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelConfig.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.nativedriver.blocking;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.retry.RetryStrategy;
+
+import java.time.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Configuration for the {@code NativeMongoSubscriptionModel}.
+ */
+@NullMarked
+public class NativeMongoSubscriptionModelConfig {
+
+    final RetryStrategy retryStrategy;
+    final boolean restartSubscriptionsOnChangeStreamHistoryLost;
+
+    /**
+     * Create a new instance of {@link NativeMongoSubscriptionModelConfig} with default settings.
+     * It will by default use a {@link RetryStrategy} with exponential backoff starting with 100 ms and progressively go up to max 2 seconds wait time between each retry.
+     */
+    public NativeMongoSubscriptionModelConfig() {
+        this(RetryStrategy.exponentialBackoff(Duration.ofMillis(100), Duration.ofSeconds(2), 2.0f), false);
+    }
+
+    private NativeMongoSubscriptionModelConfig(RetryStrategy retryStrategy, boolean restartSubscriptionsOnChangeStreamHistoryLost) {
+        requireNonNull(retryStrategy, RetryStrategy.class.getSimpleName() + " cannot be null");
+        this.retryStrategy = retryStrategy;
+        this.restartSubscriptionsOnChangeStreamHistoryLost = restartSubscriptionsOnChangeStreamHistoryLost;
+    }
+
+    /**
+     * Create a new {@code NativeMongoSubscriptionModelConfig} by using this static method instead of calling the {@link #NativeMongoSubscriptionModelConfig()} constructor.
+     * Behaves the same as calling the constructor so this is just syntactic sugar.
+     *
+     * @return A new instance of {@code NativeMongoSubscriptionModelConfig}
+     */
+    public static NativeMongoSubscriptionModelConfig withConfig() {
+        return new NativeMongoSubscriptionModelConfig();
+    }
+
+    /**
+     * If there’s not enough history available in the MongoDB oplog to resume a subscription created from a {@code NativeMongoSubscriptionModel}, you can configure it to restart the subscription from the current time automatically.
+     * This is only of concern when an application is restarted, and the subscriptions are configured to start from a position in the oplog that is no longer available. It’s disabled by default since it might not be 100% safe
+     * (meaning that you can miss some events when the subscription is restarted). It’s not 100% safe if you run subscriptions in a different process than the event store, and you have lots of writes happening to the event store.
+     * It’s safe if you run the subscription in the same process as the writes to the event store if you make sure that the subscription is started before you accept writes to the event store on startup. To enable automatic restart, you can do like this:
+     *
+     * <pre>
+     * var subscriptionModel = new NativeMongoSubscriptionModel(database, "events", TimeRepresentation.RFC_3339_STRING, executor, NativeMongoSubscriptionModelConfig.withConfig().restartSubscriptionsOnChangeStreamHistoryLost(true));
+     * </pre>
+     *
+     * @param restartSubscriptionsOnChangeStreamHistoryLost Whether or not to automatically restart a subscription, whose change stream history is lost.
+     * @return A new instance of {@code NativeMongoSubscriptionModelConfig}
+     */
+    public NativeMongoSubscriptionModelConfig restartSubscriptionsOnChangeStreamHistoryLost(boolean restartSubscriptionsOnChangeStreamHistoryLost) {
+        return new NativeMongoSubscriptionModelConfig(retryStrategy, restartSubscriptionsOnChangeStreamHistoryLost);
+    }
+
+    /**
+     * Specify the retry strategy to use. This is used both when retrying the action supplied to a subscription if it throws an exception,
+     * and to back off between attempts when the subscription model automatically restarts a subscription after a change stream error.
+     *
+     * @param retryStrategy A custom retry strategy to use
+     * @return A new instance of {@code NativeMongoSubscriptionModelConfig}
+     */
+    public NativeMongoSubscriptionModelConfig retryStrategy(RetryStrategy retryStrategy) {
+        return new NativeMongoSubscriptionModelConfig(retryStrategy, restartSubscriptionsOnChangeStreamHistoryLost);
+    }
+}

--- a/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelResilienceTest.java
+++ b/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelResilienceTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.nativedriver.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoSocketReadException;
+import com.mongodb.ConnectionString;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.BsonDocument;
+import org.bson.BsonElement;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.mongodb.nativedriver.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.internal.ExecutorShutdown;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.FIVE_SECONDS;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.occurrent.functional.CheckedFunction.unchecked;
+import static org.occurrent.retry.RetryStrategy.exponentialBackoff;
+import static org.occurrent.time.TimeConversion.toLocalDateTime;
+
+/**
+ * Tests that {@link NativeMongoSubscriptionModel} survives the same class of MongoDB operational failures
+ * (leader elections/failovers, transient network errors, change stream history lost) that
+ * {@code SpringMongoSubscriptionModel} has been hardened against in production, and that it recovers gap-free.
+ */
+@Testcontainers
+@Timeout(20)
+public class NativeMongoSubscriptionModelResilienceTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"))
+                    .withReuse(true)
+                    .withReplicaSet();
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".resilience"));
+
+    private MongoEventStore mongoEventStore;
+    private ObjectMapper objectMapper;
+    private MongoClient mongoClient;
+    private ExecutorService subscriptionExecutor;
+    private MongoDatabase database;
+    private MongoCollection<Document> realEventCollection;
+    private NativeMongoSubscriptionModel subscriptionModel;
+
+    @BeforeEach
+    void createEventStore() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".resilience");
+        this.mongoClient = MongoClients.create(connectionString);
+        TimeRepresentation timeRepresentation = TimeRepresentation.RFC_3339_STRING;
+        EventStoreConfig config = new EventStoreConfig(timeRepresentation);
+        database = mongoClient.getDatabase(requireNonNull(connectionString.getDatabase()));
+        realEventCollection = database.getCollection(requireNonNull(connectionString.getCollection()));
+        mongoEventStore = new MongoEventStore(mongoClient, connectionString.getDatabase(), connectionString.getCollection(), config);
+        subscriptionExecutor = Executors.newCachedThreadPool();
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void shutdown() {
+        if (subscriptionModel != null) {
+            subscriptionModel.shutdown();
+        }
+        ExecutorShutdown.shutdownSafely(subscriptionExecutor, 10, TimeUnit.SECONDS);
+        mongoClient.close();
+    }
+
+    /**
+     * Wraps {@code realEventCollection} so that the very first {@code watch(...)} call throws {@code exception},
+     * simulating a change-stream disruption (a failover, a transient network error, history lost, ...), while every
+     * subsequent call behaves exactly like the real collection. Mirrors how {@code SpringMongoSubscriptionModelTest}
+     * injects the same class of failure.
+     */
+    @SuppressWarnings("unchecked")
+    private MongoCollection<Document> collectionThatFailsOnce(RuntimeException exception) {
+        MongoCollection<Document> throwingCollection = mock(MongoCollection.class);
+        when(throwingCollection.watch(anyList(), eq(Document.class)))
+                .thenThrow(exception)
+                .thenAnswer(invocation -> realEventCollection.watch((List<? extends Bson>) invocation.getArgument(0), Document.class));
+        return throwingCollection;
+    }
+
+    private static MongoCommandException changeStreamHistoryLostException() {
+        List<BsonElement> elements = new ArrayList<>();
+        elements.add(new BsonElement("code", new BsonInt32(286)));
+        elements.add(new BsonElement("codeName", new BsonString("ChangeStreamHistoryLost")));
+        return new MongoCommandException(new BsonDocument(elements), new ServerAddress());
+    }
+
+    /**
+     * Simulates the class of error a driver surfaces during a replica-set primary election/failover: the change
+     * stream cursor becomes unusable and a socket-level read fails until a new primary is elected.
+     */
+    private static MongoSocketReadException failoverLikeException() {
+        return new MongoSocketReadException("expected: simulated primary election/failover", new ServerAddress(), new java.io.IOException("Connection reset by peer"));
+    }
+
+    @Nested
+    @DisplayName("ChangeStreamHistoryLost")
+    class ChangeStreamHistoryLostTest {
+
+        @Test
+        void restarts_subscription_from_now_when_configured_to_do_so() {
+            // Given
+            MongoCollection<Document> throwingCollection = collectionThatFailsOnce(changeStreamHistoryLostException());
+            subscriptionModel = new NativeMongoSubscriptionModel(database, throwingCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
+                    NativeMongoSubscriptionModelConfig.withConfig().restartSubscriptionsOnChangeStreamHistoryLost(true).retryStrategy(exponentialBackoff(Duration.of(20, MILLIS), Duration.of(200, MILLIS), 2)));
+
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            subscriptionModel.subscribe(UUID.randomUUID().toString(), state::add).waitUntilStarted(Duration.ofSeconds(10));
+
+            // When
+            mongoEventStore.write("1", 0, serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
+
+            // Then
+            await().atMost(10, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
+        }
+
+        @Test
+        void does_not_restart_subscription_when_not_configured_to_do_so() throws InterruptedException {
+            // Given
+            MongoCollection<Document> throwingCollection = collectionThatFailsOnce(changeStreamHistoryLostException());
+            subscriptionModel = new NativeMongoSubscriptionModel(database, throwingCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
+                    NativeMongoSubscriptionModelConfig.withConfig().retryStrategy(exponentialBackoff(Duration.of(20, MILLIS), Duration.of(200, MILLIS), 2)));
+
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriptionId = UUID.randomUUID().toString();
+            boolean started = subscriptionModel.subscribe(subscriptionId, state::add).waitUntilStarted(Duration.ofSeconds(2));
+
+            // When
+            mongoEventStore.write("1", 0, serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
+            Thread.sleep(500);
+
+            // Then
+            assertThat(started).isFalse();
+            assertThat(state).isEmpty();
+            assertThat(subscriptionModel.isRunning(subscriptionId)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Failover / transient errors")
+    class FailoverTest {
+
+        @Test
+        void restarts_and_resumes_gap_free_after_a_failover_like_error() {
+            // Given
+            MongoCollection<Document> throwingCollection = collectionThatFailsOnce(failoverLikeException());
+            subscriptionModel = new NativeMongoSubscriptionModel(database, throwingCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
+                    NativeMongoSubscriptionModelConfig.withConfig().retryStrategy(exponentialBackoff(Duration.of(20, MILLIS), Duration.of(200, MILLIS), 2)));
+
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            subscriptionModel.subscribe(UUID.randomUUID().toString(), state::add).waitUntilStarted(Duration.ofSeconds(10));
+
+            // When
+            mongoEventStore.write("1", 0, serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
+
+            // Then
+            await().atMost(10, SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("Pause/resume")
+    class PauseResumeTest {
+
+        @Test
+        void resume_continues_from_last_delivered_position_instead_of_replaying_from_the_original_start_at() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            subscriptionModel = new NativeMongoSubscriptionModel(database, realEventCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
+                    NativeMongoSubscriptionModelConfig.withConfig().retryStrategy(exponentialBackoff(Duration.of(20, MILLIS), Duration.of(200, MILLIS), 2)));
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriptionId = UUID.randomUUID().toString();
+            // StartAt.now() is the scenario the Spring "supplier" fix targets: reusing a stale position on resume
+            // must not replay (or skip) events relative to where the subscription actually left off.
+            subscriptionModel.subscribe(subscriptionId, StartAt.now(), state::add).waitUntilStarted(Duration.ofSeconds(10));
+
+            mongoEventStore.write("1", 0, serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
+            await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(1));
+
+            // When
+            subscriptionModel.pauseSubscription(subscriptionId);
+            mongoEventStore.write("1", 1, serialize(new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(1), "name", "name2")));
+            subscriptionModel.resumeSubscription(subscriptionId).waitUntilStarted(Duration.ofSeconds(10));
+
+            // Then: the event written while paused is delivered exactly once after resume, and the first event is
+            // not redelivered.
+            await().atMost(FIVE_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(2));
+            assertThat(state).extracting(CloudEvent::getType).containsExactly(NameDefined.class.getName(), NameWasChanged.class.getName());
+        }
+    }
+
+    private Stream<CloudEvent> serialize(DomainEvent e) {
+        return Stream.of(CloudEventBuilder.v1()
+                .withId(e.eventId())
+                .withSource(URI.create("http://name"))
+                .withType(e.getClass().getName())
+                .withTime(toLocalDateTime(e.timestamp()).atOffset(UTC))
+                .withSubject(e.name())
+                .withDataContentType("application/json")
+                .withData(unchecked(objectMapper::writeValueAsBytes).apply(e))
+                .build());
+    }
+}

--- a/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelResilienceTest.java
+++ b/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelResilienceTest.java
@@ -21,10 +21,13 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSocketReadException;
 import com.mongodb.ConnectionString;
 import com.mongodb.ServerAddress;
+import com.mongodb.client.ChangeStreamIterable;
+import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import org.bson.BsonDocument;
@@ -72,8 +75,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.occurrent.functional.CheckedFunction.unchecked;
@@ -143,6 +148,22 @@ public class NativeMongoSubscriptionModelResilienceTest {
         return throwingCollection;
     }
 
+    /**
+     * Wraps {@code realEventCollection} so that {@code watch(...)} succeeds (registering the subscription normally),
+     * but the cursor throws {@code exception} as soon as it is iterated, simulating a change-stream disruption that
+     * happens mid-subscription rather than at cursor-open time.
+     */
+    @SuppressWarnings("unchecked")
+    private MongoCollection<Document> collectionThatFailsDuringIteration(RuntimeException exception) {
+        MongoChangeStreamCursor<ChangeStreamDocument<Document>> throwingCursor = mock(MongoChangeStreamCursor.class);
+        doThrow(exception).when(throwingCursor).forEachRemaining(any());
+        ChangeStreamIterable<Document> throwingIterable = mock(ChangeStreamIterable.class);
+        when(throwingIterable.cursor()).thenReturn(throwingCursor);
+        MongoCollection<Document> throwingCollection = mock(MongoCollection.class);
+        when(throwingCollection.watch(anyList(), eq(Document.class))).thenReturn(throwingIterable);
+        return throwingCollection;
+    }
+
     private static MongoCommandException changeStreamHistoryLostException() {
         List<BsonElement> elements = new ArrayList<>();
         elements.add(new BsonElement("code", new BsonInt32(286)));
@@ -181,7 +202,29 @@ public class NativeMongoSubscriptionModelResilienceTest {
         }
 
         @Test
-        void does_not_restart_subscription_when_not_configured_to_do_so() throws InterruptedException {
+        void removes_the_subscription_entry_when_history_is_lost_mid_subscription_and_not_configured_to_restart() {
+            // Given: unlike collectionThatFailsOnce, the failure happens once the cursor is already registered in
+            // runningSubscriptions, proving the entry isn't leaked once the subscription gives up.
+            MongoCollection<Document> throwingCollection = collectionThatFailsDuringIteration(changeStreamHistoryLostException());
+            subscriptionModel = new NativeMongoSubscriptionModel(database, throwingCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
+                    NativeMongoSubscriptionModelConfig.withConfig().retryStrategy(exponentialBackoff(Duration.of(20, MILLIS), Duration.of(200, MILLIS), 2)));
+            String subscriptionId = UUID.randomUUID().toString();
+
+            // When
+            subscriptionModel.subscribe(subscriptionId, __ -> {}).waitUntilStarted(Duration.ofSeconds(2));
+
+            // Then
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                assertThat(subscriptionModel.isRunning(subscriptionId)).isFalse();
+                assertThat(subscriptionModel.isPaused(subscriptionId)).isFalse();
+            });
+            // The strongest proof the entry isn't leaked: the id is free to reuse. If it were still in either map,
+            // this would throw IllegalArgumentException("Subscription ... is already defined.").
+            subscriptionModel.subscribe(subscriptionId, __ -> {}).waitUntilStarted(Duration.ofSeconds(2));
+        }
+
+        @Test
+        void does_not_restart_subscription_when_not_configured_to_do_so() {
             // Given
             MongoCollection<Document> throwingCollection = collectionThatFailsOnce(changeStreamHistoryLostException());
             subscriptionModel = new NativeMongoSubscriptionModel(database, throwingCollection, TimeRepresentation.RFC_3339_STRING, subscriptionExecutor,
@@ -194,11 +237,10 @@ public class NativeMongoSubscriptionModelResilienceTest {
 
             // When
             mongoEventStore.write("1", 0, serialize(new NameDefined(UUID.randomUUID().toString(), now, "name", "name1")));
-            Thread.sleep(500);
 
             // Then
             assertThat(started).isFalse();
-            assertThat(state).isEmpty();
+            await().atMost(Duration.ofSeconds(1)).during(Duration.ofMillis(500)).untilAsserted(() -> assertThat(state).isEmpty());
             assertThat(subscriptionModel.isRunning(subscriptionId)).isFalse();
         }
     }


### PR DESCRIPTION
`NativeMongoSubscriptionModel` used to die silently on any change-stream error. Its consumption loop caught `MongoException` and `IllegalStateException` and only ever logged them at DEBUG, then let the subscription's thread end with no restart. A replica-set failover, a transient network error, or `ChangeStreamHistoryLost` (error code 286) would all permanently kill a subscription with nothing but a debug line to show for it. `SpringMongoSubscriptionModel` has been hardened against exactly this in production for years. This PR brings the native driver model to the same level.

## What changed

`newInternalSubscription` now tracks the resume token of the last event it actually delivered in an `AtomicReference<StartAt>`, shared across retries. The try block now spans opening the cursor too, not just iterating it, since a change-stream error can happen at either point. On catch, the error is classified:

- Intentionally closed (pause, cancel, shutdown) or the pre-existing "cursor is not longer open" pattern: benign, logged at DEBUG, no restart.
- `MongoCommandException` with code 286: restarts from `StartAt.now()` only when `NativeMongoSubscriptionModelConfig.restartSubscriptionsOnChangeStreamHistoryLost(true)` is set (default `false`, matching Spring's default). Otherwise it logs at ERROR and stops, same as Spring.
- Anything else (a failover, a socket error, whatever the driver itself couldn't resume): logged at WARN and rethrown.

A rethrow is caught by the `executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy)` wrapper already installed in `startSubscription`, the same one used for per-event action retries. It retries with the configured backoff and re-invokes `newInternalSubscription`, which reads the now-updated position. No new restart-in-a-new-thread mechanism was needed, the existing retry `Runnable` already does the job once the classification stops swallowing the exceptions that reach it.

I also fixed `resumeSubscription`, which used to reuse the subscription's original `StartAt` verbatim. For a fixed position that replayed every event on every resume. For `StartAt.now()`/the default (which resolve to "let the driver default to the current time when the cursor opens") it instead dropped every event written while paused. It now resumes from the same tracked position the restart logic uses, so pause and resume neither replay nor drop events.

Added `NativeMongoSubscriptionModelConfig`, mirroring `SpringMongoSubscriptionModelConfig`'s builder shape, with `retryStrategy` and `restartSubscriptionsOnChangeStreamHistoryLost`. It doesn't bundle the collection name or time representation the way the Spring config does, since the native constructors already take those positionally. This only adds a new constructor overload, existing ones are untouched.

## Tests

`NativeMongoSubscriptionModelResilienceTest` injects a `MongoCommandException` with code 286 (flag on and off) and a `MongoSocketReadException` simulating a failover-like disruption, and asserts the subscription recovers and keeps delivering. A separate test proves pause and resume continue from the last delivered position rather than replaying.

I verified this against a real replica-set Testcontainer, injecting the exact exception types a failover or a 286 response would surface, rather than orchestrating a live multi-node election. `SpringMongoSubscriptionModelTest`, the reference this mirrors, uses the same injection technique. I considered building a live failover test and decided against it, the added coverage over the deterministic injection tests didn't justify the extra infrastructure.

The full existing native subscription model, native event store, and Spring Boot MongoDB starter test suites stay green, no test edits.

See [ADR 41](doc/architecture/decisions/0041-native-mongodb-subscription-model-restart-on-error.md) for the full design writeup.

## Compatibility

Backward compatible, no changes to the API consumers are required. The new behavior is additive, and `restartSubscriptionsOnChangeStreamHistoryLost` defaults to `false`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
