### PR TITLE
Add reactive stream-subscription DSL

### DIFF
--- a/dsl/subscription-dsl/pom.xml
+++ b/dsl/subscription-dsl/pom.xml
@@ -29,5 +29,6 @@
     <modules>
         <module>common</module>
         <module>blocking</module>
+        <module>reactor</module>
     </modules>
 </project>

--- a/dsl/subscription-dsl/reactor/pom.xml
+++ b/dsl/subscription-dsl/reactor/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>subscription-dsl</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>subscription-dsl-reactor</artifactId>
+
+    <name>${mavenProjectName}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-dsl-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-api-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
+++ b/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.subscription.reactor
+
+import io.cloudevents.CloudEvent
+import org.occurrent.application.converter.CloudEventConverter
+import org.occurrent.application.converter.get
+import org.occurrent.condition.Condition
+import org.occurrent.dsl.subscription.EventMetadata
+import org.occurrent.filter.Filter
+import org.occurrent.subscription.OccurrentSubscriptionFilter
+import org.occurrent.subscription.StartAt
+import org.occurrent.subscription.api.reactor.Subscribable
+import org.occurrent.subscription.api.reactor.Subscription
+import reactor.core.publisher.Mono
+import java.util.function.BiFunction
+import java.util.function.Function
+import kotlin.reflect.KClass
+
+
+/**
+ * Subscription DSL entry-point. Usage example:
+ *
+ * ```
+ * val mySubscriptionModel = ..
+ * val myCloudEventConverter = ..
+ * streamSubscriptions(mySubscriptionModel, myCloudEventConverter) {
+ *      subscribe<MyEvent>("subscriptionId") { event ->
+ *          ...
+ *          Mono.empty()
+ *      }
+ * }
+ * ```
+ *
+ * This will create a subscription with id "subscriptionId" and subscribe to all events of type "MyEvent" (it uses the [cloudEventConverter] to derive the cloud event type from the domain event type).
+ */
+fun <E : Any> streamSubscriptions(subscriptionModel: Subscribable, cloudEventConverter: CloudEventConverter<E>, block: StreamSubscriptions<E>.() -> Unit) {
+    StreamSubscriptions(subscriptionModel, cloudEventConverter).apply(block)
+}
+
+class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, private val cloudEventConverter: CloudEventConverter<E>) {
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
+    }
+
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
+    }
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
+            @Suppress("UNCHECKED_CAST")
+            fn.apply(e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
+            @Suppress("UNCHECKED_CAST")
+            fn.apply(metadata, e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.apply(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.apply(metadata, e) }
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        val filter = subscriptionFilterFromEventTypes(eventTypes)
+        return subscribe(subscriptionId, filter, startAt, fn)
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        val filter = subscriptionFilterFromEventTypes(eventTypes)
+        return subscribe(subscriptionId, filter, startAt, fn)
+    }
+
+    fun subscribe(subscriptionId: String, filter: OccurrentSubscriptionFilter = OccurrentSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, filter, startAt) { _, e -> fn(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(
+        subscriptionId: String,
+        filter: OccurrentSubscriptionFilter = OccurrentSubscriptionFilter.filter(Filter.all()),
+        startAt: StartAt? = null,
+        fn: (EventMetadata, E) -> Mono<Void>
+    ): Subscription {
+        val action: (CloudEvent) -> Mono<Void> = { cloudEvent ->
+            val event = cloudEventConverter[cloudEvent]
+            val eventMetadata = EventMetadata.from(cloudEvent)
+            fn(eventMetadata, event)
+        }
+
+        return if (startAt == null) {
+            subscriptionModel.subscribe(subscriptionId, filter, action)
+        } else {
+            subscriptionModel.subscribe(subscriptionId, filter, startAt, action)
+        }
+    }
+
+    private fun subscriptionFilterFromEventTypes(eventTypes: Array<out KClass<out E>>): OccurrentSubscriptionFilter {
+        val condition = when {
+            eventTypes.isEmpty() -> null
+            eventTypes.size == 1 -> Condition.eq(cloudEventConverter[eventTypes[0]])
+            else -> Condition.or(eventTypes.map { e -> Condition.eq(cloudEventConverter[e]) })
+        }
+        val filter = OccurrentSubscriptionFilter.filter(if (condition == null) Filter.all() else Filter.type(condition))
+        return filter
+    }
+}


### PR DESCRIPTION
Part of adding a reactive Spring Boot starter. The reactive stack had no subscription DSL at all, only the blocking `StreamSubscriptions` existed, so a reactive app had nothing equivalent to the ergonomic `subscribe<MyEvent>("id") { ... }` surface. This adds the reactive counterpart in a new `subscription-dsl-reactor` module.

## What it does

`StreamSubscriptions` wraps a reactive `Subscribable` and a `CloudEventConverter`, mirroring the blocking DSL's overloads: reified single and dual event-type variants, `Class`/`KClass` lists, and an `OccurrentSubscriptionFilter` variant. It reuses the shared `subscription-dsl-common` `EventMetadata`, so the two DSLs stay in step.

The callback returns `Mono<Void>` instead of `Unit`, and the Java functional-interface overloads take `Function`/`BiFunction` rather than `Consumer`/`BiConsumer`.

## Two differences from the blocking DSL

The blocking DSL has a `waitUntilStarted: Boolean = true` parameter that blocks the calling thread. I dropped it. Blocking on a `Mono` inside a reactive DSL is the wrong default, so `subscribe(...)` returns the reactive `Subscription` and a caller who needs readiness awaits `subscription.waitUntilStarted()` itself.

I also left out the deprecated `Subscriptions` alias that the blocking module carries. That alias only exists there because `Subscriptions` was the original name before the `@StreamSubscription` rename. This module is new, so there is no released type to stay compatible with.

## Testing

Compiler-verified only for now. There is no reactive in-memory `Subscribable` to test against without a running MongoDB, so the DSL's runtime behavior is covered by the reactive starter integration tests later in this stack.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-starter-common-extraction","parentHead":"f53e5351e1d921e15cb5a1527a4bdda26c05b5d6","parentPull":256,"trunk":"main"}
```
-->
