### PR TITLE
Make reactive durable and DCB catch-up models compose uniformly

### DIFF
--- a/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/EventForwarder.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/EventForwarder.java
@@ -25,10 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 public class EventForwarder {
@@ -38,7 +35,6 @@ public class EventForwarder {
     private final ReactorDurableSubscriptionModel subscriptionModel;
     private final CloudEventConverter<DomainEvent> domainEventConverter;
     private final ApplicationEventPublisher eventPublisher;
-    private final AtomicReference<Disposable> subscription;
 
     public EventForwarder(ReactorDurableSubscriptionModel subscriptionModel,
                           CloudEventConverter<DomainEvent> domainEventConverter,
@@ -46,24 +42,22 @@ public class EventForwarder {
         this.subscriptionModel = subscriptionModel;
         this.domainEventConverter = domainEventConverter;
         this.eventPublisher = eventPublisher;
-        this.subscription = new AtomicReference<>();
     }
 
     @PostConstruct
     void startEventStreaming() {
         log.info("Subscribing with id {}", SUBSCRIBER_ID);
-        Disposable disposable = subscriptionModel.subscribe(SUBSCRIBER_ID,
+        subscriptionModel.subscribe(SUBSCRIBER_ID,
                 cloudEvent -> Mono.just(cloudEvent)
                         .map(domainEventConverter::toDomainEvent)
                         .doOnNext(eventPublisher::publishEvent)
-                        .then())
-                .subscribe();
-        subscription.set(disposable);
+                        .then());
     }
 
     @PreDestroy
     void stopEventStreaming() {
         log.info("Unsubscribing");
-        subscription.get().dispose();
+        // Disposes the running subscription without deleting the stored position, so it resumes on restart.
+        subscriptionModel.shutdown();
     }
 }

--- a/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/EventForwarder.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/EventForwarder.java
@@ -57,7 +57,8 @@ public class EventForwarder {
     @PreDestroy
     void stopEventStreaming() {
         log.info("Unsubscribing");
-        // Disposes the running subscription without deleting the stored position, so it resumes on restart.
-        subscriptionModel.shutdown();
+        // Pause just this subscription: disposes it without deleting the stored position, so it resumes on restart,
+        // and without shutting down the (potentially shared) subscription model the way shutdown() would.
+        subscriptionModel.pauseSubscription(SUBSCRIBER_ID);
     }
 }

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -18,6 +18,7 @@ package org.occurrent.subscription.reactor.durable.catchup;
 
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
@@ -27,7 +28,8 @@ import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
-import org.occurrent.subscription.api.reactor.DcbSubscriptionModel;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.SubscriptionPosition;
 import org.occurrent.subscription.api.reactor.PositionAwareSubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -57,10 +59,16 @@ import static java.util.Objects.requireNonNull;
  * subscription fails loudly for the same reason, rather than replaying without a guaranteed handover to live.
  * <p>
  * This is the DCB path only. Stream time-based catch-up is not provided here, and this model does not persist
- * subscription positions, so layer a durable model on top if resume across restarts is needed.
+ * subscription positions, so layer a durable model on top (for example {@code ReactorDurableSubscriptionModel}) if
+ * resume across restarts is needed.
+ * <p>
+ * It implements {@link PositionAwareSubscriptionModel}, so it can sit as a plain (cold) subscription model underneath a
+ * durable model or be handed to the reactive DCB subscription DSL. Its generic {@link #subscribe(SubscriptionFilter, StartAt)}
+ * only understands a {@link DcbSubscriptionFilter} (or no filter, in which case a default {@link DcbQuery} supplied to the
+ * constructor is used), since catch-up is DCB-specific.
  */
 @NullMarked
-public class ReactorDcbCatchupSubscriptionModel {
+public class ReactorDcbCatchupSubscriptionModel implements PositionAwareSubscriptionModel {
 
     /**
      * Default number of DCB positions read per replay window.
@@ -73,16 +81,32 @@ public class ReactorDcbCatchupSubscriptionModel {
 
     private final PositionAwareSubscriptionModel subscriptionModel;
     private final DcbEventStore dcbEventStore;
+    private final @Nullable DcbQuery defaultQuery;
     private final long windowSize;
     private final int handoverCacheSize;
 
     public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore) {
-        this(subscriptionModel, dcbEventStore, DEFAULT_POSITION_WINDOW_SIZE, DEFAULT_HANDOVER_CACHE_SIZE);
+        this(subscriptionModel, dcbEventStore, null, DEFAULT_POSITION_WINDOW_SIZE, DEFAULT_HANDOVER_CACHE_SIZE);
     }
 
     public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, long windowSize, int handoverCacheSize) {
+        this(subscriptionModel, dcbEventStore, null, windowSize, handoverCacheSize);
+    }
+
+    /**
+     * Create a catch-up model with a default {@link DcbQuery} used by {@link #subscribe(SubscriptionFilter, StartAt)}
+     * when it is called without a filter. This mirrors the blocking {@code CatchupSubscriptionModel} constructor that
+     * takes a shared {@code DcbQuery.all()}, so the reactive starter can wire one model that every DCB subscription
+     * narrows with its own query in the consumer.
+     */
+    public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, @Nullable DcbQuery defaultQuery) {
+        this(subscriptionModel, dcbEventStore, defaultQuery, DEFAULT_POSITION_WINDOW_SIZE, DEFAULT_HANDOVER_CACHE_SIZE);
+    }
+
+    public ReactorDcbCatchupSubscriptionModel(PositionAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, @Nullable DcbQuery defaultQuery, long windowSize, int handoverCacheSize) {
         this.subscriptionModel = requireNonNull(subscriptionModel, PositionAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
         this.dcbEventStore = requireNonNull(dcbEventStore, DcbEventStore.class.getSimpleName() + " cannot be null");
+        this.defaultQuery = defaultQuery;
         if (windowSize <= 0) {
             throw new IllegalArgumentException("Window size must be greater than zero");
         }
@@ -94,6 +118,34 @@ public class ReactorDcbCatchupSubscriptionModel {
     }
 
     /**
+     * The generic (cold) subscription-model entry point. The {@code filter} must be a {@link DcbSubscriptionFilter}, or
+     * {@code null} to use the default {@link DcbQuery} supplied to the constructor. A {@code startAt} that resolves to a
+     * {@code dcbposition} replays history from that position and then goes live, anything else goes straight to live.
+     * This is how a durable model wrapping this catch-up model, and the reactive DCB subscription DSL, drive it.
+     */
+    @Override
+    public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+        requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
+        final DcbQuery query;
+        if (filter == null) {
+            if (defaultQuery == null) {
+                return Flux.error(new IllegalArgumentException("A " + DcbSubscriptionFilter.class.getSimpleName() + " is required unless a default " + DcbQuery.class.getSimpleName() + " was supplied to the constructor."));
+            }
+            query = defaultQuery;
+        } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
+            query = dcbSubscriptionFilter.query();
+        } else {
+            return Flux.error(new IllegalArgumentException(ReactorDcbCatchupSubscriptionModel.class.getSimpleName() + " only supports a " + DcbSubscriptionFilter.class.getSimpleName() + ", but got " + filter.getClass().getName()));
+        }
+        return subscribe(query, startAt);
+    }
+
+    @Override
+    public Mono<SubscriptionPosition> globalSubscriptionPosition() {
+        return subscriptionModel.globalSubscriptionPosition();
+    }
+
+    /**
      * Subscribe to DCB events matching {@code query}. A {@link DcbStartAt} that carries a {@code dcbposition} (for
      * example {@link DcbStartAt#beginning()} or {@link DcbStartAt#afterPosition(long)}) replays history from that
      * position and then goes live. Any other start (now or the subscription model default) goes straight to live.
@@ -101,11 +153,17 @@ public class ReactorDcbCatchupSubscriptionModel {
     public Flux<CloudEvent> subscribe(DcbQuery query, DcbStartAt startAt) {
         requireNonNull(query, "Query cannot be null");
         requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");
+        return subscribe(query, startAt.toStartAt());
+    }
 
-        StartAt resolved = startAt.toStartAt().get(new SubscriptionModelContext(ReactorDcbCatchupSubscriptionModel.class));
+    private Flux<CloudEvent> subscribe(DcbQuery query, StartAt startAt) {
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
+
+        StartAt resolved = startAt.get(new SubscriptionModelContext(ReactorDcbCatchupSubscriptionModel.class));
         if (!(resolved instanceof StartAt.StartAtSubscriptionPosition position) || !DcbSubscriptionPosition.isDcbSubscriptionPosition(position.subscriptionPosition)) {
-            // Not a DCB catch-up position, so go straight to live through the shared facade.
-            return DcbSubscriptionModel.from(subscriptionModel).subscribe(query, startAt);
+            // Not a DCB catch-up position, so go straight to live.
+            return subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), resolved == null ? startAt : resolved);
         }
 
         long startPosition = DcbSubscriptionPosition.dcbPositionOf(position.subscriptionPosition);

--- a/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -162,8 +162,11 @@ public class ReactorDcbCatchupSubscriptionModel implements PositionAwareSubscrip
 
         StartAt resolved = startAt.get(new SubscriptionModelContext(ReactorDcbCatchupSubscriptionModel.class));
         if (!(resolved instanceof StartAt.StartAtSubscriptionPosition position) || !DcbSubscriptionPosition.isDcbSubscriptionPosition(position.subscriptionPosition)) {
-            // Not a DCB catch-up position, so go straight to live.
-            return subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), resolved == null ? startAt : resolved);
+            // Not a DCB catch-up position, so go straight to live. Apply the same in-process DCB floor the replay-to-live
+            // path and the DcbSubscriptionModel adapter apply, so a backend that does not honor the filter server-side
+            // still only delivers events matching the query.
+            return subscriptionModel.subscribe(DcbSubscriptionFilter.filter(query), resolved == null ? startAt : resolved)
+                    .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query));
         }
 
         long startPosition = DcbSubscriptionPosition.dcbPositionOf(position.subscriptionPosition);

--- a/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/reactor/dcb-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModelTest.java
@@ -28,6 +28,8 @@ import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.DcbSubscriptionFilter;
+import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionPosition;
@@ -60,6 +62,40 @@ class ReactorDcbCatchupSubscriptionModelTest {
         // history. The fail-loud rule is scoped to replay starts only.
         StepVerifier.create(catchup.subscribe(DcbQuery.tags("name:1"), DcbStartAt.now()))
                 .verifyComplete();
+    }
+
+    @Test
+    void generic_subscribe_with_a_dcb_filter_goes_live_for_a_non_replay_start() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore());
+
+        StepVerifier.create(catchup.subscribe(DcbSubscriptionFilter.filter(DcbQuery.tags("name:1")), StartAt.now()))
+                .verifyComplete();
+    }
+
+    @Test
+    void generic_subscribe_uses_the_default_query_when_no_filter_is_given() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore(), DcbQuery.all());
+
+        StepVerifier.create(catchup.subscribe(null, StartAt.now()))
+                .verifyComplete();
+    }
+
+    @Test
+    void generic_subscribe_without_a_filter_or_default_query_fails() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore());
+
+        StepVerifier.create(catchup.subscribe(null, StartAt.now()))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+    }
+
+    @Test
+    void generic_subscribe_rejects_a_non_dcb_filter() {
+        ReactorDcbCatchupSubscriptionModel catchup = new ReactorDcbCatchupSubscriptionModel(new NoTokenSubscriptionModel(), new UnusedDcbEventStore());
+
+        StepVerifier.create(catchup.subscribe(OccurrentSubscriptionFilter.filter(org.occurrent.filter.Filter.all()), StartAt.now()))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     private static final class NoTokenSubscriptionModel implements PositionAwareSubscriptionModel {

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
@@ -37,6 +37,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
+import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -266,7 +267,9 @@ public class ReactorDurableSubscriptionModel implements PositionAwareSubscriptio
     public synchronized void stop() {
         if (!shutdown) {
             running = false;
-            runningSubscriptions.forEach((subscriptionId, __) -> pauseSubscription(subscriptionId));
+            // Snapshot the ids first: pauseSubscription mutates runningSubscriptions, and ConcurrentHashMap#forEach is
+            // only weakly consistent, so iterating it while removing could skip subscriptions.
+            new ArrayList<>(runningSubscriptions.keySet()).forEach(this::pauseSubscription);
         }
     }
 
@@ -275,7 +278,8 @@ public class ReactorDurableSubscriptionModel implements PositionAwareSubscriptio
         if (!shutdown) {
             running = true;
             if (resumeSubscriptionsAutomatically) {
-                pausedSubscriptions.forEach((subscriptionId, __) -> resumeSubscription(subscriptionId));
+                // Snapshot the ids first, for the same reason as stop(): resumeSubscription mutates pausedSubscriptions.
+                new ArrayList<>(pausedSubscriptions.keySet()).forEach(this::resumeSubscription);
             }
         }
     }

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
@@ -20,128 +20,314 @@ import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionPosition;
 import org.occurrent.subscription.api.reactor.PositionAwareSubscriptionModel;
+import org.occurrent.subscription.api.reactor.Subscribable;
+import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionModelLifeCycle;
 import org.occurrent.subscription.api.reactor.SubscriptionPositionStorage;
 import org.occurrent.subscription.util.predicate.EveryN;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 import static org.occurrent.subscription.PositionAwareCloudEvent.getSubscriptionPositionOrThrowIAE;
 
 /**
- * Wraps a {@link PositionAwareSubscriptionModel} and adds persistent subscription position support. It adds some convenience methods that stores the subscription position
- * after an "action" (the "function" in this method {@link ReactorDurableSubscriptionModel#subscribe(String, Function)}) has completed successfully.
- * It stores the subscription position in a {@link SubscriptionPositionStorage} implementation.
+ * Wraps a {@link PositionAwareSubscriptionModel} and adds persistent subscription position support, making a
+ * subscription durable: it resumes from the last stored position across restarts and stores the position after each
+ * successful {@code action}.
  * <p>
- * Note that this implementation stores the subscription position after _every_ action. If you have a lot of events and duplication is not
- * that much of a deal, consider changing this behavior by supplying an instance of {@link ReactorDurableSubscriptionModelConfig}.
+ * It is a transparent decorator that itself implements {@link Subscribable}, {@link PositionAwareSubscriptionModel},
+ * and {@link SubscriptionModelLifeCycle}, so a {@code Durable(delegate)} chain composes uniformly and can be handed to
+ * the reactive subscription DSLs and to lifecycle management, mirroring the blocking {@code DurableSubscriptionModel}.
+ * The named {@link #subscribe(String, SubscriptionFilter, StartAt, Function)} method reads events from the wrapped
+ * model's plain (cold) {@link PositionAwareSubscriptionModel#subscribe(SubscriptionFilter, StartAt)} primitive,
+ * resolving the start position from storage when the caller asks for the subscription-model default, and persisting the
+ * position after each event per {@link ReactorDurableSubscriptionModelConfig}.
+ * <p>
+ * Note that this implementation stores the subscription position after _every_ action by default. If you have a lot of
+ * events and duplication is not that much of a deal, consider changing this behavior by supplying an instance of
+ * {@link ReactorDurableSubscriptionModelConfig}.
  */
 @NullMarked
-public class ReactorDurableSubscriptionModel {
+public class ReactorDurableSubscriptionModel implements PositionAwareSubscriptionModel, Subscribable, SubscriptionModelLifeCycle {
     private static final Logger log = LoggerFactory.getLogger(ReactorDurableSubscriptionModel.class);
+
     private final PositionAwareSubscriptionModel subscription;
     private final SubscriptionPositionStorage storage;
     private final ReactorDurableSubscriptionModelConfig config;
+    private final ConcurrentMap<String, InternalSubscription> runningSubscriptions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InternalSubscription> pausedSubscriptions = new ConcurrentHashMap<>();
+
+    private volatile boolean shutdown = false;
+    private volatile boolean running = true;
 
     /**
-     * Create a subscription that combines a {@link ReactorDurableSubscriptionModel} with a {@link ReactorDurableSubscriptionModel} to automatically
-     * store the subscription after each successful call to <code>action</code> (The "consumer" in {@link #subscribe(String, Function)}).
+     * Create a durable subscription model that stores the subscription position after each successful call to the action.
      *
-     * @param subscription The subscription that will read events from the event store
-     * @param storage      The {@link ReactorDurableSubscriptionModel} that'll be used to persist the stream position
+     * @param subscription The subscription model that will read events from the event store
+     * @param storage      The {@link SubscriptionPositionStorage} that'll be used to persist the stream position
      */
     public ReactorDurableSubscriptionModel(PositionAwareSubscriptionModel subscription, SubscriptionPositionStorage storage) {
         this(subscription, storage, new ReactorDurableSubscriptionModelConfig(EveryN.everyEvent()));
     }
 
     /**
-     * Create a subscription that combines a {@link ReactorDurableSubscriptionModel} with a {@link ReactorDurableSubscriptionModel} to automatically
-     * store the subscription when the predicate defined in {@link ReactorDurableSubscriptionModelConfig#persistCloudEventPositionPredicate} is fulfilled.
+     * Create a durable subscription model that stores the subscription position when the predicate defined in
+     * {@link ReactorDurableSubscriptionModelConfig#persistCloudEventPositionPredicate} is fulfilled.
      *
-     * @param subscription The subscription that will read events from the event store
-     * @param storage      The {@link ReactorDurableSubscriptionModel} that'll be used to persist the stream position
+     * @param subscription The subscription model that will read events from the event store
+     * @param storage      The {@link SubscriptionPositionStorage} that'll be used to persist the stream position
+     * @param config       Configures when the subscription position is persisted
      */
     public ReactorDurableSubscriptionModel(PositionAwareSubscriptionModel subscription, SubscriptionPositionStorage storage,
                                            ReactorDurableSubscriptionModelConfig config) {
-        requireNonNull(subscription, PositionAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
-        requireNonNull(storage, SubscriptionPositionStorage.class.getSimpleName() + " cannot be null");
-        requireNonNull(config, ReactorDurableSubscriptionModelConfig.class.getSimpleName() + " cannot be null");
-        this.subscription = subscription;
-        this.storage = storage;
-        this.config = config;
+        this.subscription = requireNonNull(subscription, PositionAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
+        this.storage = requireNonNull(storage, SubscriptionPositionStorage.class.getSimpleName() + " cannot be null");
+        this.config = requireNonNull(config, ReactorDurableSubscriptionModelConfig.class.getSimpleName() + " cannot be null");
     }
 
     /**
-     * A convenience function that automatically starts from the latest persisted subscription position and saves the new position after each call to {@code action}
-     * has completed successfully. If you don't want to save the position after every event then don't use this method and instead save the position yourself by calling
-     * {@link SubscriptionPositionStorage#save(String, SubscriptionPosition)} when appropriate.
-     * <p>
-     * It's VERY important that side-effects take place within the <code>action</code> function
-     * because if you perform side-effects on the returned <code>Mono<Void></code> stream then the subscription position
-     * has already been stored in MongoDB and the <code>action</code> will not be re-run if side-effect fails.
-     * </p>
-     *
-     * @param subscriptionId The id of the subscription, must be unique!
-     * @param action         This action will be invoked for each cloud event that is stored in the EventStore.
-     * @return A stream of {@link CloudEvent}'s. The subscription position of the cloud event will already have been persisted when consumed by this stream so use <code>action</code> to perform side-effects.
+     * The plain (cold) subscription-model primitive. It is a straight pass-through to the wrapped model and does
+     * <em>not</em> persist the subscription position, since position storage is keyed by subscription id and this
+     * primitive has none. Use the named {@link #subscribe(String, SubscriptionFilter, StartAt, Function)} method for a
+     * durable subscription.
      */
-    public Mono<Void> subscribe(String subscriptionId, Function<CloudEvent, Mono<Void>> action) {
-        return subscribe(subscriptionId, null, action);
+    @Override
+    public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+        return subscription.subscribe(filter, startAt);
     }
 
-    /**
-     * A convenience function that automatically starts from the latest persisted subscription position and saves the new position after each call to {@code action}
-     * has completed successfully. If you don't want to save the position after every event then don't use this method and instead save the position yourself by calling
-     * {@link SubscriptionPositionStorage#save(String, SubscriptionPosition)} when appropriate.
-     *
-     * <p>
-     * It's VERY important that side-effects take place within the <code>action</code> function
-     * because if you perform side-effects on the returned <code>Mono<Void></code> stream then the subscription position
-     * has already been stored in MongoDB and the <code>action</code> will not be re-run if side-effect fails.
-     *
-     * @param subscriptionId The id of the subscription, must be unique!
-     * @param filter         The {@link SubscriptionFilter} to use to limit the events receive by the event store
-     * @param action         This action will be invoked for each cloud event that is stored in the EventStore.
-     * @return A stream of {@link CloudEvent}'s. The subscription position of the cloud event will already have been persisted when consumed by this stream so use <code>action</code> to perform side-effects.
-     */
-    public Mono<Void> subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, Function<CloudEvent, Mono<Void>> action) {
-        requireNonNull(subscriptionId, "Subscription id cannot be null");
-        return findStartAtForSubscription(subscriptionId)
-                .doOnNext(startAt -> log.info("Starting subscription {} from subscription position {}", subscriptionId, startAt))
-                .flatMapMany(startAt -> subscription.subscribe(filter, startAt))
-                .flatMap(cloudEventWithStreamPosition -> action.apply(cloudEventWithStreamPosition).thenReturn(cloudEventWithStreamPosition))
-                .filter(config.persistCloudEventPositionPredicate)
-                .flatMap(cloudEvent -> {
-                    SubscriptionPosition subscriptionPosition = getSubscriptionPositionOrThrowIAE(cloudEvent);
-                    return storage.save(subscriptionId, subscriptionPosition).thenReturn(cloudEvent);
+    @Override
+    public Mono<SubscriptionPosition> globalSubscriptionPosition() {
+        return subscription.globalSubscriptionPosition();
+    }
+
+    @Override
+    public synchronized Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        requireNonNull(subscriptionId, "subscriptionId cannot be null");
+        requireNonNull(action, "Action cannot be null");
+        requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
+
+        if (runningSubscriptions.containsKey(subscriptionId) || pausedSubscriptions.containsKey(subscriptionId)) {
+            throw new IllegalArgumentException("Subscription " + subscriptionId + " is already defined.");
+        }
+        if (shutdown) {
+            throw new IllegalStateException("Cannot start subscription because the subscription model is shutdown.");
+        }
+        return startInternalSubscription(subscriptionId, filter, new AtomicReference<>(startAt), action);
+    }
+
+    private Subscription startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Function<CloudEvent, Mono<Void>> action) {
+        if (!running) {
+            // The model is stopped: don't subscribe at all, so waitUntilStarted() doesn't complete for a subscription
+            // that won't deliver anything until start(true)/resumeSubscription actually starts it.
+            InternalSubscription internalSubscription = new InternalSubscription(Disposables.disposed(), currentStartAt, filter, action, Mono.never());
+            pausedSubscriptions.put(subscriptionId, internalSubscription);
+            return new ReactorDurableSubscription(subscriptionId, internalSubscription.started);
+        }
+        Sinks.Empty<Void> startedSink = Sinks.empty();
+        runningSubscriptions.put(subscriptionId, new InternalSubscription(Disposables.disposed(), currentStartAt, filter, action, startedSink.asMono()));
+        Disposable disposable = resolveStartAt(subscriptionId, currentStartAt.get())
+                .flatMapMany(resolvedStartAt -> {
+                    currentStartAt.set(resolvedStartAt);
+                    return source(subscriptionId, filter, resolvedStartAt, action, currentStartAt, true, startedSink);
                 })
-                .then();
+                // An empty resolveStartAt means a dynamic StartAt opted out of starting (its function returned null),
+                // so read from the original StartAt without durable position handling, mirroring the blocking model's
+                // "delegate to the wrapped model" branch.
+                .switchIfEmpty(Flux.defer(() -> source(subscriptionId, filter, currentStartAt.get(), action, currentStartAt, false, startedSink)))
+                .subscribe(unused -> {
+                        }, throwable -> {
+                            log.error("Subscription {} terminated with an unrecoverable error", subscriptionId, throwable);
+                            startedSink.tryEmitError(throwable);
+                            runningSubscriptions.remove(subscriptionId);
+                        });
+        InternalSubscription internalSubscription = new InternalSubscription(disposable, currentStartAt, filter, action, startedSink.asMono());
+        if (runningSubscriptions.replace(subscriptionId, internalSubscription) == null) {
+            // The placeholder was already removed by a synchronous error, so this subscription is already dead.
+            disposable.dispose();
+        }
+        return new ReactorDurableSubscription(subscriptionId, internalSubscription.started);
+    }
+
+    // Reads events from the wrapped model's cold primitive, applies the action, then persists the position after each
+    // event (per the config predicate) when persist is true. currentStartAt is advanced only after the action
+    // completes so that pause/resume continues from the last delivered event rather than replaying or skipping.
+    private Flux<Void> source(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action, AtomicReference<StartAt> currentStartAt, boolean persist, Sinks.Empty<Void> startedSink) {
+        return subscription.subscribe(filter, startAt)
+                .doOnSubscribe(__ -> startedSink.tryEmitEmpty())
+                .concatMap(cloudEvent -> action.apply(cloudEvent)
+                        .then(Mono.defer(() -> persist && config.persistCloudEventPositionPredicate.test(cloudEvent)
+                                ? storage.save(subscriptionId, getSubscriptionPositionOrThrowIAE(cloudEvent)).then()
+                                : Mono.empty()))
+                        .doOnSuccess(unused -> currentStartAt.set(StartAt.subscriptionPosition(getSubscriptionPositionOrThrowIAE(cloudEvent)))));
+    }
+
+    // Resolve the effective StartAt, mirroring the blocking DurableSubscriptionModel#generateStartAtPositionFrom:
+    // the subscription-model default reads the last stored position (initializing it from the global position when
+    // absent); a dynamic StartAt is resolved against this model's context and recursed, an empty result meaning "opt
+    // out"; any concrete StartAt passes through unchanged.
+    private Mono<StartAt> resolveStartAt(String subscriptionId, StartAt startAt) {
+        if (startAt.isDefault()) {
+            return storage.read(subscriptionId)
+                    .switchIfEmpty(Mono.defer(() -> subscription.globalSubscriptionPosition()
+                            .flatMap(globalSubscriptionPosition -> storage.save(subscriptionId, globalSubscriptionPosition))))
+                    .map(StartAt::subscriptionPosition)
+                    .switchIfEmpty(Mono.fromSupplier(StartAt::now));
+        } else if (startAt.isDynamic()) {
+            StartAt nextStartAt = startAt.get(new SubscriptionModelContext(ReactorDurableSubscriptionModel.class));
+            if (nextStartAt == null) {
+                return Mono.empty();
+            }
+            return resolveStartAt(subscriptionId, nextStartAt);
+        }
+        return Mono.just(startAt);
+    }
+
+    @Override
+    public synchronized void pauseSubscription(String subscriptionId) {
+        if (shutdown) {
+            throw new IllegalStateException(ReactorDurableSubscriptionModel.class.getSimpleName() + " is shutdown");
+        } else if (isPaused(subscriptionId)) {
+            throw new IllegalArgumentException("Subscription " + subscriptionId + " is already paused");
+        } else if (!isRunning(subscriptionId)) {
+            throw new IllegalArgumentException("Subscription " + subscriptionId + " is not running");
+        }
+
+        InternalSubscription internalSubscription = runningSubscriptions.remove(subscriptionId);
+        if (internalSubscription != null) {
+            internalSubscription.disposable.dispose();
+            pausedSubscriptions.put(subscriptionId, internalSubscription);
+        }
+    }
+
+    @Override
+    public synchronized Subscription resumeSubscription(String subscriptionId) {
+        if (shutdown) {
+            throw new IllegalStateException(ReactorDurableSubscriptionModel.class.getSimpleName() + " is shutdown");
+        } else if (isRunning(subscriptionId)) {
+            throw new IllegalArgumentException("Subscription " + subscriptionId + " is already running");
+        }
+
+        InternalSubscription internalSubscription = pausedSubscriptions.remove(subscriptionId);
+        if (internalSubscription == null) {
+            throw new IllegalArgumentException("Subscription " + subscriptionId + " isn't paused.");
+        }
+
+        running = true;
+        // Reuse the same currentStartAt reference so resume continues from the position of the last event delivered
+        // before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
+        return startInternalSubscription(subscriptionId, internalSubscription.filter, internalSubscription.currentStartAt, internalSubscription.action);
     }
 
     /**
-     * Find the calculate the current {@link StartAt} value for the {@code subscriptionId}. It creates the {@link StartAt} instance from the
-     * global subscription position (from {@link PositionAwareSubscriptionModel#globalSubscriptionPosition()}) if no
-     * {@code SubscriptionPosition} is found for the given subscription.
+     * Cancel a subscription. It'll no longer receive events, and its persisted subscription position is removed.
      *
-     * @param subscriptionId The id of the subscription whose position to find
-     * @return A Mono with the {@link SubscriptionPosition} data point for the supplied subscriptionId
+     * @param subscriptionId The subscription id to cancel
      */
-    public Mono<StartAt> findStartAtForSubscription(String subscriptionId) {
-        requireNonNull(subscriptionId, "Subscription id cannot be null");
-        return storage.read(subscriptionId)
-                .doOnNext(document -> log.info("Found subscription position: {}", document))
-                .switchIfEmpty(Mono.defer(() -> {
-                    log.info("No subscription position found for {}, will initialize a new one.", subscriptionId);
-                    return subscription.globalSubscriptionPosition()
-                            .flatMap(subscriptionPosition -> storage.save(subscriptionId, subscriptionPosition));
-                }))
-                .map(StartAt::subscriptionPosition)
-                .switchIfEmpty(Mono.defer(() -> Mono.just(StartAt.now())));
+    @Override
+    public synchronized void cancelSubscription(String subscriptionId) {
+        InternalSubscription internalSubscription = runningSubscriptions.remove(subscriptionId);
+        if (internalSubscription != null) {
+            internalSubscription.disposable.dispose();
+        }
+        pausedSubscriptions.remove(subscriptionId);
+        // Best-effort asynchronous cleanup of the stored position. cancelSubscription is void (fire-and-forget), so the
+        // delete runs on its own without blocking the caller.
+        storage.delete(subscriptionId).subscribe(unused -> {
+        }, throwable -> log.warn("Failed to delete stored subscription position for cancelled subscription {}", subscriptionId, throwable));
+    }
+
+    @Override
+    public synchronized void shutdown() {
+        shutdown = true;
+        running = false;
+        runningSubscriptions.values().forEach(internalSubscription -> internalSubscription.disposable.dispose());
+        runningSubscriptions.clear();
+        pausedSubscriptions.values().forEach(internalSubscription -> internalSubscription.disposable.dispose());
+        pausedSubscriptions.clear();
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (!shutdown) {
+            running = false;
+            runningSubscriptions.forEach((subscriptionId, __) -> pauseSubscription(subscriptionId));
+        }
+    }
+
+    @Override
+    public synchronized void start(boolean resumeSubscriptionsAutomatically) {
+        if (!shutdown) {
+            running = true;
+            if (resumeSubscriptionsAutomatically) {
+                pausedSubscriptions.forEach((subscriptionId, __) -> resumeSubscription(subscriptionId));
+            }
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public boolean isRunning(String subscriptionId) {
+        return !shutdown && runningSubscriptions.containsKey(subscriptionId);
+    }
+
+    @Override
+    public boolean isPaused(String subscriptionId) {
+        return !shutdown && pausedSubscriptions.containsKey(subscriptionId);
+    }
+
+    private static final class InternalSubscription {
+        final Disposable disposable;
+        final AtomicReference<StartAt> currentStartAt;
+        final @Nullable SubscriptionFilter filter;
+        final Function<CloudEvent, Mono<Void>> action;
+        final Mono<Void> started;
+
+        private InternalSubscription(Disposable disposable, AtomicReference<StartAt> currentStartAt, @Nullable SubscriptionFilter filter, Function<CloudEvent, Mono<Void>> action, Mono<Void> started) {
+            this.disposable = disposable;
+            this.currentStartAt = currentStartAt;
+            this.filter = filter;
+            this.action = action;
+            this.started = started;
+        }
+    }
+
+    private static final class ReactorDurableSubscription implements Subscription {
+        private final String subscriptionId;
+        private final Mono<Void> started;
+
+        private ReactorDurableSubscription(String subscriptionId, Mono<Void> started) {
+            this.subscriptionId = subscriptionId;
+            this.started = started;
+        }
+
+        @Override
+        public String id() {
+            return subscriptionId;
+        }
+
+        @Override
+        public Mono<Void> waitUntilStarted() {
+            return started;
+        }
     }
 }

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
@@ -46,7 +46,6 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
-import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -57,7 +56,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.MILLIS;
@@ -84,7 +82,7 @@ public class ReactorDurableSubscriptionModelTest {
     private ReactorDurableSubscriptionModel subscription;
     private ObjectMapper objectMapper;
     private ReactiveMongoTemplate reactiveMongoTemplate;
-    private CopyOnWriteArrayList<Disposable> disposables;
+    private SubscriptionPositionStorage storage;
 
     @RegisterExtension
     FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl()));
@@ -101,15 +99,16 @@ public class ReactorDurableSubscriptionModelTest {
         EventStoreConfig eventStoreConfig = new EventStoreConfig.Builder().eventStoreCollectionName("events").transactionConfig(reactiveMongoTransactionManager).timeRepresentation(TimeRepresentation.RFC_3339_STRING).build();
         mongoEventStore = new ReactorMongoEventStore(reactiveMongoTemplate, eventStoreConfig);
         springReactorSubscriptionForMongoDB = new ReactorMongoSubscriptionModel(reactiveMongoTemplate, "events", timeRepresentation);
-        SubscriptionPositionStorage storage = new ReactorSubscriptionPositionStorage(reactiveMongoTemplate, RESUME_TOKEN_COLLECTION);
+        storage = new ReactorSubscriptionPositionStorage(reactiveMongoTemplate, RESUME_TOKEN_COLLECTION);
         subscription = new ReactorDurableSubscriptionModel(springReactorSubscriptionForMongoDB, storage);
         objectMapper = new ObjectMapper();
-        disposables = new CopyOnWriteArrayList<>();
     }
 
     @AfterEach
     void dispose() {
-        disposables.forEach(Disposable::dispose);
+        if (subscription != null) {
+            subscription.shutdown();
+        }
         mongoClient.close();
     }
 
@@ -118,7 +117,7 @@ public class ReactorDurableSubscriptionModelTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
-        disposeAfterTest(subscription.subscribe("test", cloudEvent -> Mono.fromRunnable(() -> state.add(cloudEvent))).subscribe());
+        subscription.subscribe("test", cloudEvent -> Mono.fromRunnable(() -> state.add(cloudEvent)));
         Thread.sleep(200);
         NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
         NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
@@ -162,7 +161,7 @@ public class ReactorDurableSubscriptionModelTest {
             }
         };
         subscription = new ReactorDurableSubscriptionModel(springReactorSubscriptionForMongoDB, subscriptionPositionStorage);
-        disposeAfterTest(subscription.subscribe(UUID.randomUUID().toString(), e -> Mono.fromRunnable(() -> state.add(e))).subscribe());
+        subscription.subscribe(UUID.randomUUID().toString(), e -> Mono.fromRunnable(() -> state.add(e)));
 
         // When
         mongoEventStore.write("1", 0, serialize(nameDefined1)).block();
@@ -202,7 +201,7 @@ public class ReactorDurableSubscriptionModelTest {
             }
         };
         subscription = new ReactorDurableSubscriptionModel(springReactorSubscriptionForMongoDB, subscriptionPositionStorage, new ReactorDurableSubscriptionModelConfig(3));
-        disposeAfterTest(subscription.subscribe(UUID.randomUUID().toString(), e -> Mono.fromRunnable(() -> state.add(e))).subscribe());
+        subscription.subscribe(UUID.randomUUID().toString(), e -> Mono.fromRunnable(() -> state.add(e)));
 
         // When
         mongoEventStore.write("1", 0, serialize(nameDefined1)).block();
@@ -222,8 +221,7 @@ public class ReactorDurableSubscriptionModelTest {
         LocalDateTime now = LocalDateTime.now();
         CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
         String subscriberId = UUID.randomUUID().toString();
-        Function<CloudEvent, Mono<Void>> function = cloudEvents -> Mono.fromRunnable(() -> state.add(cloudEvents));
-        Disposable subscription1 = disposeAfterTest(subscription.subscribe(subscriberId, function).subscribe());
+        subscription.subscribe(subscriberId, cloudEvent -> Mono.fromRunnable(() -> state.add(cloudEvent)));
         Thread.sleep(200);
         NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
         NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
@@ -233,10 +231,13 @@ public class ReactorDurableSubscriptionModelTest {
         mongoEventStore.write("1", 0, serialize(nameDefined1)).block();
         // The subscription is async so we need to wait for it
         await().atMost(Durations.ONE_SECOND).until(not(state::isEmpty));
-        subscription1.dispose();
+        // Simulate a restart: shut the model down and start a fresh one sharing the same position storage so it resumes
+        // from the persisted position rather than from the original start.
+        subscription.shutdown();
         mongoEventStore.write("2", 0, serialize(nameDefined2)).block();
         mongoEventStore.write("1", 1, serialize(nameWasChanged1)).block();
-        disposeAfterTest(subscription.subscribe(subscriberId, function).subscribe());
+        subscription = new ReactorDurableSubscriptionModel(springReactorSubscriptionForMongoDB, storage);
+        subscription.subscribe(subscriberId, cloudEvent -> Mono.fromRunnable(() -> state.add(cloudEvent)));
 
         // Then
         await().atMost(Durations.TWO_SECONDS).with().pollInterval(Duration.of(20, MILLIS)).untilAsserted(() -> assertThat(state).hasSize(3));
@@ -258,7 +259,7 @@ public class ReactorDurableSubscriptionModelTest {
                 state.add(cloudEvent);
                 return Mono.empty();
             }
-        }).subscribe();
+        });
         stream.run();
         NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
         NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
@@ -268,6 +269,9 @@ public class ReactorDurableSubscriptionModelTest {
         mongoEventStore.write("1", 0, serialize(nameDefined1)).block();
         // The subscription is async so we need to wait for it
         await().atMost(Durations.ONE_SECOND).and().dontCatchUncaughtExceptions().untilAtomic(counter, equalTo(1));
+        // The failed subscription is removed asynchronously by the error handler, so wait until the id is free before
+        // re-subscribing with the same id.
+        await().atMost(Durations.ONE_SECOND).until(() -> !subscription.isRunning(subscriberId));
         // Since an exception occurred we need to run the stream again
         stream.run();
         mongoEventStore.write("2", 0, serialize(nameDefined2)).block();
@@ -287,10 +291,5 @@ public class ReactorDurableSubscriptionModelTest {
                 .withDataContentType("application/json")
                 .withData(unchecked(objectMapper::writeValueAsBytes).apply(e))
                 .build());
-    }
-
-    private Disposable disposeAfterTest(Disposable disposable) {
-        disposables.add(disposable);
-        return disposable;
     }
 }


### PR DESCRIPTION
Part of the reactive Spring Boot starter work. The reactive durable and DCB catch-up models could not compose the way the blocking ones do, which blocked wiring them into a starter or an annotation processor. This makes them compose.

## The problem

On the blocking side, `DurableSubscriptionModel` and `CatchupSubscriptionModel` implement the `SubscriptionModel` interface, so the starter builds one `Catchup(Durable(mongo))` object and hands it to the DSLs and the annotation processor. The reactive equivalents were standalone classes with their own bespoke `subscribe(...)` signatures, so nothing could compose them or hand them to the reactive DSLs.

## What changed

Both models now implement the reactive interfaces so a `Durable(Catchup(mongo))` chain composes into one object that is a `Subscribable`, a `PositionAwareSubscriptionModel`, and a `SubscriptionModelLifeCycle`.

The composition order differs from blocking on purpose. The reactive `PositionAwareSubscriptionModel` does not extend `Subscribable` or the lifecycle interface, so durable sits on the outside as the `Subscribable`/lifecycle authority and catch-up stays a plain `PositionAwareSubscriptionModel`. `ReactorDurableSubscriptionModel` self-manages named subscriptions with running and paused maps mirroring `ReactorMongoSubscriptionModel`, reads events from the wrapped model's cold `subscribe(filter, startAt)` primitive, resolves the start position from storage when the caller asks for the model default, and persists position after each action. Position advances only after the action completes, so pause and resume continue from the last delivered event rather than replaying or skipping.

`ReactorDcbCatchupSubscriptionModel` gains a generic `subscribe(filter, startAt)` that triggers dcbposition replay via the same `DcbSubscriptionPosition` marker the blocking catch-up already uses. The existing `subscribe(DcbQuery, DcbStartAt)` becomes a thin wrapper over it, so its tests pass unchanged, and a default-`DcbQuery` constructor lets the starter drive an all-matching catch-up.

## Breaking change

`ReactorDurableSubscriptionModel`'s cold `Mono<Void> subscribe(id, action)` API is replaced by the hot `Subscription`-returning `Subscribable` API plus the full lifecycle. The `mongodb-subscription-to-spring-event` example and the module tests are migrated. This is a deliberate reshape of the class added in the reactive lifecycle work, chosen so the reactive stack composes like the blocking one.

## Testing

Both `util/reactor` module test suites pass against a real MongoDB (durable 5, catch-up 6 unit plus 4 integration), and the example compiles against the new API. The full `Durable(Catchup(mongo))` composition is exercised end to end by the reactive starter integration tests later in this stack.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/reactive-stream-subscription-dsl","parentHead":"3047cccd3db7230a10df0ed439acdd1378352a7e","parentPull":257,"trunk":"main"}
```
-->
