### PR TITLE
Add named, lifecycle-managed subscribe to the reactive DCB DSL

### DIFF
--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
@@ -47,8 +47,8 @@ import static java.util.Objects.requireNonNull;
  * Delivery is live. Events are filtered by the {@link DcbQuery} server-side where the backend supports it, with an
  * in-process scoping filter as a correctness floor. A {@link DcbStartAt} is passed through to the underlying
  * {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()} replays history
- * depends on that model. The current reactive subscription models have no DCB catch-up, so such a start behaves like a
- * live start today.
+ * depends on that model. A plain model has no DCB catch-up and treats such a start as live, whereas a model composed
+ * with {@code ReactorDcbCatchupSubscriptionModel} replays history from that position before going live.
  * <p>
  * The {@link #subscribe(String, DcbQuery, Function)} and {@link #subscribeWithMetadata(String, DcbQuery, BiFunction)}
  * methods below are the named, lifecycle-managed counterpart to the {@link Flux}-returning methods above, mirroring

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
@@ -16,15 +16,23 @@
 
 package org.occurrent.dsl.dcb.reactor;
 
+import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.dcb.DcbEventMetadata;
 import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.api.reactor.DcbSubscriptionModel;
+import org.occurrent.subscription.api.reactor.Subscribable;
+import org.occurrent.subscription.api.reactor.Subscription;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +49,12 @@ import static java.util.Objects.requireNonNull;
  * {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()} replays history
  * depends on that model. The current reactive subscription models have no DCB catch-up, so such a start behaves like a
  * live start today.
+ * <p>
+ * The {@link #subscribe(String, DcbQuery, Function)} and {@link #subscribeWithMetadata(String, DcbQuery, BiFunction)}
+ * methods below are the named, lifecycle-managed counterpart to the {@link Flux}-returning methods above, mirroring
+ * {@link Subscribable}: they return a {@link Subscription} tracked by id, which can be cancelled with
+ * {@link #cancel(String)}. Like {@link Subscribable}, they return without waiting for the subscription to start; call
+ * {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before you continue.
  *
  * @param <E> the domain event type
  */
@@ -85,5 +99,63 @@ public final class DcbSubscriptions<E> {
     public Flux<DcbEvent<E>> subscribeWithMetadata(DcbQuery query, DcbStartAt startAt) {
         return subscriptionModel.subscribe(query, startAt)
                 .map(cloudEvent -> new DcbEvent<>(DcbEventMetadata.from(EventMetadata.from(cloudEvent)), cloudEventConverter.toDomainEvent(cloudEvent)));
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, tracked by {@code subscriptionId}.
+     */
+    public Subscription subscribe(String subscriptionId, DcbQuery query, Function<E, Mono<Void>> fn) {
+        return subscribe(subscriptionId, query, null, fn);
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt}, tracked by
+     * {@code subscriptionId}.
+     */
+    public Subscription subscribe(String subscriptionId, DcbQuery query, @Nullable DcbStartAt startAt, Function<E, Mono<Void>> fn) {
+        requireNonNull(fn, "Subscription function cannot be null");
+        return subscribeWithMetadata(subscriptionId, query, startAt, (metadata, event) -> fn.apply(event));
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, tracked by {@code subscriptionId}, exposing DCB metadata
+     * to the callback.
+     * <p>
+     * This is a distinct method rather than an overload of {@link #subscribe} so that a method reference stays
+     * unambiguous on the {@link Function} overloads.
+     */
+    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
+        return subscribeWithMetadata(subscriptionId, query, null, fn);
+    }
+
+    /**
+     * Subscribes to live DCB events that match {@code query}, starting at {@code startAt} and tracked by
+     * {@code subscriptionId}, exposing DCB metadata to the callback. Returns without waiting for the subscription to
+     * start.
+     */
+    public Subscription subscribeWithMetadata(String subscriptionId, DcbQuery query, @Nullable DcbStartAt startAt, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(fn, "Subscription function cannot be null");
+
+        // The DcbSubscriptionModel scopes delivery to the query (server-side where the backend supports it, and an
+        // in-process floor in the typed adapter otherwise), so this callback only converts and dispatches.
+        Function<CloudEvent, Mono<Void>> action = cloudEvent -> {
+            E event = cloudEventConverter.toDomainEvent(cloudEvent);
+            return fn.apply(DcbEventMetadata.from(EventMetadata.from(cloudEvent)), event);
+        };
+
+        DcbStartAt startAtToUse = startAt == null ? DcbStartAt.subscriptionModelDefault() : startAt;
+        return subscriptionModel.subscribe(subscriptionId, query, startAtToUse, action);
+    }
+
+    /**
+     * Cancels and removes the subscription with the given id, stopping further delivery to its callback. Cancelling an
+     * unknown or already cancelled subscription id is a no-op. This is the natural teardown for a per-connection
+     * subscription, such as an SSE activity feed that subscribes when a client connects and cancels when it disconnects.
+     */
+    public void cancel(String subscriptionId) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        subscriptionModel.cancelSubscription(subscriptionId);
     }
 }

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
@@ -31,8 +31,9 @@ import java.util.function.Function;
  * It is the DCB counterpart to the reactive {@link SubscriptionModel}, accepting a {@link DcbQuery} and a
  * {@link DcbStartAt} rather than a stream filter and a generic start position. The {@link DcbStartAt} is passed through
  * to the underlying {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()}
- * or {@link DcbStartAt#afterPosition(long)} replays history depends on that model. The current reactive subscription
- * models have no DCB catch-up, so such a start behaves like a live start today.
+ * or {@link DcbStartAt#afterPosition(long)} replays history depends on that model. A plain model such as
+ * {@code ReactorMongoSubscriptionModel} has no DCB catch-up and treats such a start as live, whereas a model composed
+ * with {@code ReactorDcbCatchupSubscriptionModel} replays history from that position before going live.
  * <p>
  * The {@code subscribe(query)}/{@code subscribe(query, startAt)} methods above return a bare {@link Flux}: the
  * subscription lives as long as something is subscribed to the {@code Flux} and is cancelled by disposing that

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
@@ -21,6 +21,9 @@ import org.jspecify.annotations.NullMarked;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.subscription.DcbStartAt;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
 
 /**
  * A typed reactive view over a {@link SubscriptionModel} that subscribes to DCB events selected by a {@link DcbQuery}.
@@ -30,6 +33,13 @@ import reactor.core.publisher.Flux;
  * to the underlying {@link SubscriptionModel}, so whether a replay-oriented start such as {@link DcbStartAt#beginning()}
  * or {@link DcbStartAt#afterPosition(long)} replays history depends on that model. The current reactive subscription
  * models have no DCB catch-up, so such a start behaves like a live start today.
+ * <p>
+ * The {@code subscribe(query)}/{@code subscribe(query, startAt)} methods above return a bare {@link Flux}: the
+ * subscription lives as long as something is subscribed to the {@code Flux} and is cancelled by disposing that
+ * subscription. The named {@link #subscribe(String, DcbQuery, DcbStartAt, Function)} methods below are the
+ * lifecycle-managed counterpart, mirroring {@link Subscribable}: they track the subscription by id so it can be
+ * cancelled through {@link #cancelSubscription(String)}, which is what a durable, catch-up-capable DCB subscription
+ * (such as the {@code @DcbSubscription} annotation) needs.
  */
 @NullMarked
 public interface DcbSubscriptionModel {
@@ -56,7 +66,39 @@ public interface DcbSubscriptionModel {
     }
 
     /**
-     * Create a DCB view over an existing reactive {@link SubscriptionModel}.
+     * Subscribe to DCB events matching {@code query}, starting at {@code startAt}, tracked by {@code subscriptionId}
+     * so it can be cancelled with {@link #cancelSubscription(String)}. Unlike the {@link Flux}-returning
+     * {@code subscribe} methods above, this requires the underlying {@link SubscriptionModel} to also support named,
+     * lifecycle-managed subscriptions.
+     *
+     * @param subscriptionId The id of the subscription, must be unique!
+     * @param action         This action will be invoked for each cloud event matching {@code query}. The next event
+     *                       is not processed until the returned {@link Mono} completes.
+     */
+    Subscription subscribe(String subscriptionId, DcbQuery query, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action);
+
+    /**
+     * Subscribe to DCB events matching {@code query} at the subscription model default position, tracked by
+     * {@code subscriptionId}.
+     *
+     * @see #subscribe(String, DcbQuery, DcbStartAt, Function)
+     */
+    default Subscription subscribe(String subscriptionId, DcbQuery query, Function<CloudEvent, Mono<Void>> action) {
+        return subscribe(subscriptionId, query, DcbStartAt.subscriptionModelDefault(), action);
+    }
+
+    /**
+     * Cancel a named DCB subscription started with {@link #subscribe(String, DcbQuery, DcbStartAt, Function)} and
+     * forget it. Cancelling a subscription id that is unknown or already cancelled is a no-op.
+     */
+    void cancelSubscription(String subscriptionId);
+
+    /**
+     * Create a DCB view over an existing reactive {@link SubscriptionModel}. The named
+     * {@link #subscribe(String, DcbQuery, DcbStartAt, Function)} and {@link #cancelSubscription(String)} methods
+     * additionally require {@code delegate} to implement {@link Subscribable} and {@link SubscriptionModelLifeCycle}
+     * respectively; this is only checked when one of those methods is called, not eagerly here, since a delegate
+     * that only ever uses the {@link Flux}-returning {@code subscribe} methods need not support named subscriptions.
      */
     static DcbSubscriptionModel from(SubscriptionModel delegate) {
         return new DcbSubscriptionModelAdapter(delegate);

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
@@ -23,12 +23,20 @@ import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Translates {@link DcbSubscriptionModel} calls into the shared reactive {@link SubscriptionModel}, building a
  * {@link DcbSubscriptionFilter} from the query and converting the {@link DcbStartAt} to a generic start position.
+ * <p>
+ * The named, lifecycle-managed {@code subscribe} methods additionally require the {@code delegate} to implement
+ * {@link Subscribable} and {@link SubscriptionModelLifeCycle}, since a bare {@link SubscriptionModel} has no notion
+ * of a named subscription that can be cancelled by id. The composed durable subscription model and
+ * {@code ReactorMongoSubscriptionModel} both satisfy this.
  */
 @NullMarked
 final class DcbSubscriptionModelAdapter implements DcbSubscriptionModel {
@@ -48,5 +56,37 @@ final class DcbSubscriptionModelAdapter implements DcbSubscriptionModel {
         // adapter.
         return delegate.subscribe(DcbSubscriptionFilter.filter(query), startAt.toStartAt())
                 .filter(cloudEvent -> DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query));
+    }
+
+    @Override
+    public Subscription subscribe(String subscriptionId, DcbQuery query, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        requireNonNull(query, "Query cannot be null");
+        requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");
+        requireNonNull(action, "Subscription action cannot be null");
+        if (!(delegate instanceof Subscribable subscribable)) {
+            throw new IllegalStateException("Named DCB subscriptions require the underlying " + SubscriptionModel.class.getSimpleName() +
+                    " to also implement " + Subscribable.class.getSimpleName() + ", but " + delegate.getClass().getName() + " does not.");
+        }
+        // The DcbSubscriptionFilter is honored server-side for live delivery, but a DCB catch-up replays by the
+        // model-level query, so an in-process check keeps the subscription scoped to its own query during catch-up too
+        // (and stays correct for any backend that does not honor the filter), matching the blocking adapter.
+        Function<CloudEvent, Mono<Void>> scopedToQuery = cloudEvent -> {
+            if (DcbCloudEvents.getPosition(cloudEvent) > 0 && DcbCloudEvents.matches(cloudEvent, query)) {
+                return action.apply(cloudEvent);
+            }
+            return Mono.empty();
+        };
+        return subscribable.subscribe(subscriptionId, DcbSubscriptionFilter.filter(query), startAt.toStartAt(), scopedToQuery);
+    }
+
+    @Override
+    public void cancelSubscription(String subscriptionId) {
+        requireNonNull(subscriptionId, "Subscription id cannot be null");
+        if (!(delegate instanceof SubscriptionModelLifeCycle lifeCycle)) {
+            throw new IllegalStateException("Cancelling named DCB subscriptions requires the underlying " + SubscriptionModel.class.getSimpleName() +
+                    " to also implement " + SubscriptionModelLifeCycle.class.getSimpleName() + ", but " + delegate.getClass().getName() + " does not.");
+        }
+        lifeCycle.cancelSubscription(subscriptionId);
     }
 }

--- a/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
+++ b/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
@@ -30,13 +30,18 @@ import org.occurrent.subscription.DcbSubscriptionPosition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class DcbSubscriptionModelAdapterTest {
@@ -60,6 +65,56 @@ class DcbSubscriptionModelAdapterTest {
         // The DcbStartAt is converted to a generic StartAt and passed straight to the delegate.
         assertThat(delegate.capturedStartAt).isInstanceOfSatisfying(StartAt.StartAtSubscriptionPosition.class,
                 start -> assertThat(start.subscriptionPosition).isEqualTo(DcbSubscriptionPosition.of(5)));
+    }
+
+    @Test
+    void named_subscribe_scopes_delivery_to_the_query_and_cancel_delegates_to_the_lifecycle() {
+        CloudEvent matching = dcbEvent("NameDefined", 1, "name:1");
+        CloudEvent otherBoundary = dcbEvent("OrderPlaced", 2, "order:1");
+
+        RecordingSubscribableSubscriptionModel delegate = new RecordingSubscribableSubscriptionModel();
+        DcbSubscriptionModel adapter = DcbSubscriptionModel.from(delegate);
+
+        List<CloudEvent> delivered = new ArrayList<>();
+        Function<CloudEvent, Mono<Void>> action = cloudEvent -> {
+            delivered.add(cloudEvent);
+            return Mono.empty();
+        };
+
+        Subscription subscription = adapter.subscribe("sub-1", DcbQuery.tags("name:1"), DcbStartAt.afterPosition(5), action);
+
+        assertThat(subscription.id()).isEqualTo("sub-1");
+        assertThat(delegate.capturedFilter).isInstanceOf(DcbSubscriptionFilter.class);
+        assertThat(delegate.capturedStartAt).isInstanceOfSatisfying(StartAt.StartAtSubscriptionPosition.class,
+                start -> assertThat(start.subscriptionPosition).isEqualTo(DcbSubscriptionPosition.of(5)));
+
+        // The in-process floor scopes delivery to the query, matching the boundary case for the plain Flux subscribe.
+        delegate.capturedAction.apply(matching).block();
+        delegate.capturedAction.apply(otherBoundary).block();
+        assertThat(delivered).containsExactly(matching);
+
+        adapter.cancelSubscription("sub-1");
+        assertThat(delegate.cancelledSubscriptionIds).containsExactly("sub-1");
+    }
+
+    @Test
+    void named_subscribe_throws_if_the_delegate_does_not_support_named_subscriptions() {
+        RecordingSubscriptionModel delegate = new RecordingSubscriptionModel(Flux.empty());
+        DcbSubscriptionModel adapter = DcbSubscriptionModel.from(delegate);
+
+        assertThatThrownBy(() -> adapter.subscribe("sub-1", DcbQuery.tags("name:1"), DcbStartAt.afterPosition(5), cloudEvent -> Mono.empty()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(Subscribable.class.getSimpleName());
+    }
+
+    @Test
+    void cancel_subscription_throws_if_the_delegate_does_not_support_lifecycle_management() {
+        RecordingSubscriptionModel delegate = new RecordingSubscriptionModel(Flux.empty());
+        DcbSubscriptionModel adapter = DcbSubscriptionModel.from(delegate);
+
+        assertThatThrownBy(() -> adapter.cancelSubscription("sub-1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(SubscriptionModelLifeCycle.class.getSimpleName());
     }
 
     private static CloudEvent dcbEvent(String type, long position, String... tags) {
@@ -90,6 +145,76 @@ class DcbSubscriptionModelAdapterTest {
             this.capturedFilter = filter;
             this.capturedStartAt = startAt;
             return events;
+        }
+    }
+
+    private static final class RecordingSubscribableSubscriptionModel implements SubscriptionModel, Subscribable, SubscriptionModelLifeCycle {
+        @Nullable
+        private SubscriptionFilter capturedFilter;
+        @Nullable
+        private StartAt capturedStartAt;
+        @Nullable
+        private Function<CloudEvent, Mono<Void>> capturedAction;
+        private final List<String> cancelledSubscriptionIds = new ArrayList<>();
+
+        @Override
+        public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+
+        @Override
+        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+            this.capturedFilter = filter;
+            this.capturedStartAt = startAt;
+            this.capturedAction = action;
+            return new Subscription() {
+                @Override
+                public String id() {
+                    return subscriptionId;
+                }
+
+                @Override
+                public Mono<Void> waitUntilStarted() {
+                    return Mono.empty();
+                }
+            };
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public void start(boolean resumeSubscriptionsAutomatically) {
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public boolean isRunning(String subscriptionId) {
+            return true;
+        }
+
+        @Override
+        public boolean isPaused(String subscriptionId) {
+            return false;
+        }
+
+        @Override
+        public Subscription resumeSubscription(String subscriptionId) {
+            throw new UnsupportedOperationException("Not used by this test");
+        }
+
+        @Override
+        public void pauseSubscription(String subscriptionId) {
+        }
+
+        @Override
+        public void cancelSubscription(String subscriptionId) {
+            cancelledSubscriptionIds.add(subscriptionId);
         }
     }
 }


### PR DESCRIPTION
Part of the reactive Spring Boot starter work. A reactive `@DcbSubscription` annotation needs a named, durable, catch-up-capable DCB subscription, but the reactive DCB API only had Flux-returning `subscribe(query)` with no id and no lifecycle. This adds the named counterpart, mirroring the blocking `DcbSubscriptions`.

## What changed

`DcbSubscriptionModel` gains `subscribe(id, query, startAt, action)` returning a `Subscription`, a default overload without `startAt`, and `cancelSubscription(id)`. The adapter implements them over the wrapped `SubscriptionModel`, requiring it to also be a `Subscribable` (and `SubscriptionModelLifeCycle` for cancel). That requirement is checked lazily on the first named call rather than in `from(...)`, so a delegate that only ever uses the Flux methods does not need to support named subscriptions. The named path applies the same in-process DCB query floor the Flux path already uses.

`DcbSubscriptions` gains `subscribe(id, query[, startAt], fn)` and `subscribeWithMetadata(id, query[, startAt], fn)` with `Mono<Void>` callbacks, plus `cancel(id)`. Each converts the cloud event and builds the DCB metadata exactly as the blocking DSL does. Consistent with the reactive stream DSL, there is no `waitUntilStarted` flag: callers await `Subscription.waitUntilStarted()` themselves.

## Testing

The adapter carries the load-bearing logic and is unit-tested (named subscribe scopes delivery, cancel delegates to the lifecycle, and both fail loud with a clear message when the delegate lacks the required interface). The DSL methods are thin pass-throughs and are exercised end to end by the reactive starter integration tests later in this stack.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
