### PR TITLE
Extract shared starter code into autoconfigure-common

### DIFF
--- a/framework/spring-boot-autoconfigure-mongodb-common/pom.xml
+++ b/framework/spring-boot-autoconfigure-mongodb-common/pom.xml
@@ -62,6 +62,35 @@
             <artifactId>cloudevent-converter-jackson3</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>subscription-dsl-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>dcb-dsl-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>application-service-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <!-- Jackson 3 still relies on com.fasterxml.jackson annotations -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/DcbApplicationServiceRegistrar.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/DcbApplicationServiceRegistrar.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  Copyright 2026 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.common;
+
+import org.occurrent.application.service.dcb.TagGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+import java.util.function.Function;
+
+/**
+ * Builds the {@link BeanFactoryPostProcessor} that registers a {@code DcbApplicationService} bean when the DCB
+ * event-store capability is enabled and a {@link TagGenerator} bean exists. Shared by the blocking and reactive
+ * starters, which differ only in the concrete {@code DcbApplicationService} type they register and how the instance is
+ * built, so the bean-name lookup, the TagGenerator-presence check, the warn-log message, and the bean-definition wiring
+ * live here once.
+ */
+public final class DcbApplicationServiceRegistrar {
+
+    private static final Logger log = LoggerFactory.getLogger(DcbApplicationServiceRegistrar.class);
+
+    private DcbApplicationServiceRegistrar() {
+    }
+
+    /**
+     * @param dcbApplicationServiceType the concrete {@code DcbApplicationService} type to register (blocking or reactive)
+     * @param beanName                  the name to register the bean under
+     * @param factory                   builds the {@code DcbApplicationService} instance from the bean factory
+     */
+    public static BeanFactoryPostProcessor registrar(Class<?> dcbApplicationServiceType, String beanName, Function<ConfigurableListableBeanFactory, Object> factory) {
+        return beanFactory -> {
+            if (!(beanFactory instanceof BeanDefinitionRegistry registry)) {
+                return;
+            }
+            boolean hasDcbApplicationService = beanFactory.getBeanNamesForType(dcbApplicationServiceType, false, false).length > 0;
+            boolean hasTagGenerator = beanFactory.getBeanNamesForType(TagGenerator.class, false, false).length > 0;
+            if (hasDcbApplicationService) {
+                return;
+            }
+            if (!hasTagGenerator) {
+                log.warn("Occurrent DCB event-store capability is enabled but no {} bean was found, so a {} is not auto-configured. " +
+                                "Define a {} bean (it derives the DCB tags written with each event) to enable auto-configuration, or provide your own {} bean.",
+                        TagGenerator.class.getName(), dcbApplicationServiceType.getName(), TagGenerator.class.getSimpleName(), dcbApplicationServiceType.getSimpleName());
+                return;
+            }
+            RootBeanDefinition beanDefinition = new RootBeanDefinition(dcbApplicationServiceType);
+            beanDefinition.setInstanceSupplier(() -> factory.apply(beanFactory));
+            registry.registerBeanDefinition(beanName, beanDefinition);
+        };
+    }
+}

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/DcbApplicationServiceRegistrar.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/DcbApplicationServiceRegistrar.java
@@ -46,7 +46,7 @@ public final class DcbApplicationServiceRegistrar {
      * @param beanName                  the name to register the bean under
      * @param factory                   builds the {@code DcbApplicationService} instance from the bean factory
      */
-    public static BeanFactoryPostProcessor registrar(Class<?> dcbApplicationServiceType, String beanName, Function<ConfigurableListableBeanFactory, Object> factory) {
+    public static <T> BeanFactoryPostProcessor registrar(Class<T> dcbApplicationServiceType, String beanName, Function<ConfigurableListableBeanFactory, ? extends T> factory) {
         return beanFactory -> {
             if (!(beanFactory instanceof BeanDefinitionRegistry registry)) {
                 return;

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
@@ -1,0 +1,163 @@
+/*
+ *
+ *  Copyright 2024 Johan Haleby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.common;
+
+import org.jspecify.annotations.NonNull;
+import org.occurrent.annotation.StreamSubscription;
+import org.occurrent.annotation.StreamSubscription.ResumeBehavior;
+import org.occurrent.annotation.StreamSubscription.StartPosition;
+import org.occurrent.annotation.StreamSubscription.StartupMode;
+import org.occurrent.annotation.Subscription;
+import org.occurrent.dsl.dcb.DcbEventMetadata;
+import org.occurrent.dsl.subscription.EventMetadata;
+import org.occurrent.eventstore.api.dcb.DcbQuery;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static java.util.function.Predicate.not;
+
+/**
+ * Stack-neutral helpers for processing the {@link StreamSubscription} and {@link DcbSubscription} annotations, and the
+ * deprecated {@link Subscription} alias. Shared by the blocking and reactive annotation {@code BeanPostProcessor}s so the
+ * reflection and event-type resolution logic lives in one place and cannot drift. The stack-specific parts (how the
+ * consumer is invoked, how the start position is resolved, and which subscription DSL is used) stay in each processor.
+ */
+public final class SubscriptionAnnotations {
+
+    private SubscriptionAnnotations() {
+    }
+
+    /**
+     * The normalized form of a stream subscription declaration, built from either the {@link StreamSubscription}
+     * annotation or the deprecated {@link Subscription} alias. The deprecated annotation's enums are mapped to the
+     * canonical {@link StreamSubscription} enums by name, since the constants are identical.
+     */
+    public record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
+                                               long startAtTimeEpochMillis, StartPosition startAt,
+                                               ResumeBehavior resumeBehavior, StartupMode startupMode, String annotationName) {
+
+        public static StreamSubscriptionDefinition from(StreamSubscription subscription) {
+            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
+                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode(), "@StreamSubscription");
+        }
+
+        @SuppressWarnings("deprecation")
+        public static StreamSubscriptionDefinition from(Subscription subscription) {
+            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
+                    subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
+                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()), "@Subscription");
+        }
+    }
+
+    public static boolean isStreamMetadataParameter(Class<?> parameterType) {
+        return EventMetadata.class.isAssignableFrom(parameterType);
+    }
+
+    public static boolean isDcbMetadataParameter(Class<?> parameterType) {
+        return EventMetadata.class.isAssignableFrom(parameterType) || DcbEventMetadata.class.isAssignableFrom(parameterType);
+    }
+
+    public static List<Class<?>> analyzeParameters(Method method, Predicate<Class<?>> isMetadataParameter) {
+        List<Class<?>> parameterTypes = new ArrayList<>();
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            if (isMetadataParameter.test(parameterType)) {
+                if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
+                    throw new IllegalArgumentException("A subscription method may declare at most one metadata parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                }
+                parameterTypes.add(parameterType);
+            } else {
+                if (parameterTypes.isEmpty()) {
+                    parameterTypes.add(parameterType);
+                } else if (parameterTypes.size() == 2) {
+                    throw new IllegalArgumentException("A subscription method may declare an event parameter and at most one metadata parameter, but %s#%s declares more.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                } else if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
+                    parameterTypes.add(parameterType);
+                } else {
+                    throw new IllegalArgumentException("A subscription method may declare only one event parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
+                }
+            }
+        }
+        return parameterTypes;
+    }
+
+    public static Class<?> eventTypeOf(List<Class<?>> parameterTypes, Predicate<Class<?>> isMetadataParameter) {
+        return parameterTypes.stream().filter(not(isMetadataParameter)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("You need to declare an event type"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> List<Class<E>> resolveDomainEventTypes(String id, Object bean, Method method, Class<E> specifiedEventType, Class<?>[] eventTypesSpecifiedInAnnotation, String annotationName) {
+        if (eventTypesSpecifiedInAnnotation.length == 0) {
+            return getConcreteEventTypes(id, specifiedEventType);
+        }
+        return Arrays.stream(eventTypesSpecifiedInAnnotation)
+                .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
+                .peek(e -> {
+                    if (!specifiedEventType.isAssignableFrom(e)) {
+                        throw new IllegalStateException("Event type %s specified in the %s annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), annotationName, id, bean.getClass().getName(), method.getName()));
+                    }
+                })
+                .toList();
+    }
+
+    public static DcbQuery buildDcbQuery(List<String> cloudEventTypes, List<String> tagsAllOf) {
+        boolean hasTypes = !cloudEventTypes.isEmpty();
+        boolean hasTags = !tagsAllOf.isEmpty();
+        if (!hasTypes && !hasTags) {
+            return DcbQuery.all();
+        } else if (hasTypes && hasTags) {
+            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new)).tags(tagsAllOf);
+        } else if (hasTypes) {
+            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new));
+        } else {
+            return DcbQuery.tags(tagsAllOf.get(0), tagsAllOf.stream().skip(1).toArray(String[]::new));
+        }
+    }
+
+    public static Object[] bindArguments(List<Class<?>> parameterTypes, Object event, Object metadata, Predicate<Class<?>> isMetadataParameter) {
+        if (parameterTypes.size() == 1) {
+            return new Object[]{event};
+        }
+        // Place each argument by which declared parameter slot is the metadata type, not by runtime assignability. A
+        // broad event parameter (for example Object) is assignable from the metadata value too, so an isInstance check
+        // would misplace it, this keys off the declared types instead and honors a metadata-first parameter order.
+        Object first = isMetadataParameter.test(parameterTypes.get(0)) ? metadata : event;
+        Object second = first == metadata ? event : metadata;
+        return new Object[]{first, second};
+    }
+
+    public static <E> @NonNull List<Class<E>> getConcreteEventTypes(String subscriptionId, Class<E> specifiedEventType) {
+        final List<Class<E>> domainEventTypesToSubscribeTo;
+        if (specifiedEventType.isSealed()) {
+            //noinspection unchecked
+            Class<E>[] permittedSubclasses = (Class<E>[]) specifiedEventType.getPermittedSubclasses();
+            domainEventTypesToSubscribeTo = Arrays.stream(permittedSubclasses).flatMap(c -> getConcreteEventTypes(subscriptionId, c).stream()).toList();
+        } else if (specifiedEventType.isInterface() || specifiedEventType.isArray() || Modifier.isAbstract(specifiedEventType.getModifiers())) {
+            String msg = "You cannot subscribe to a non-sealed interface, abstract type, or array (problem is with %s for subscription '%s'). A concrete or sealed event type is required, or list the event types explicitly with the annotation's eventTypes attribute (for example eventTypes = {MyEvent1.class, MyEvent2.class}).";
+            throw new IllegalArgumentException(msg.formatted(specifiedEventType.getName(), subscriptionId));
+        } else {
+            domainEventTypesToSubscribeTo = List.of(specifiedEventType);
+        }
+        return domainEventTypesToSubscribeTo;
+    }
+}

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
@@ -18,6 +18,7 @@
 package org.occurrent.springboot.mongo.common;
 
 import org.jspecify.annotations.NonNull;
+import org.occurrent.annotation.DcbSubscription;
 import org.occurrent.annotation.StreamSubscription;
 import org.occurrent.annotation.StreamSubscription.ResumeBehavior;
 import org.occurrent.annotation.StreamSubscription.StartPosition;
@@ -146,7 +147,7 @@ public final class SubscriptionAnnotations {
         return new Object[]{first, second};
     }
 
-    public static <E> @NonNull List<Class<E>> getConcreteEventTypes(String subscriptionId, Class<E> specifiedEventType) {
+    private static <E> @NonNull List<Class<E>> getConcreteEventTypes(String subscriptionId, Class<E> specifiedEventType) {
         final List<Class<E>> domainEventTypesToSubscribeTo;
         if (specifiedEventType.isSealed()) {
             //noinspection unchecked

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -21,7 +21,6 @@ import kotlin.jvm.functions.Function2;
 import org.jspecify.annotations.NonNull;
 import org.occurrent.annotation.DcbSubscription;
 import org.occurrent.annotation.StreamSubscription;
-import org.occurrent.annotation.StreamSubscription.ResumeBehavior;
 import org.occurrent.annotation.StreamSubscription.StartPosition;
 import org.occurrent.annotation.StreamSubscription.StartupMode;
 import org.occurrent.annotation.Subscription;
@@ -32,6 +31,8 @@ import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.dsl.subscription.reactor.StreamSubscriptions;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.filter.Filter;
+import org.occurrent.springboot.mongo.common.SubscriptionAnnotations;
+import org.occurrent.springboot.mongo.common.SubscriptionAnnotations.StreamSubscriptionDefinition;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.SubscriptionPositionStorage;
@@ -46,23 +47,19 @@ import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static java.util.function.Predicate.not;
 import static org.occurrent.filter.Filter.CompositionOperator.OR;
 import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
  * Reactive counterpart of the blocking {@code OccurrentAnnotationBeanPostProcessor}. It supports the
  * {@link StreamSubscription} and {@link DcbSubscription} annotations, and the deprecated {@link Subscription} alias,
- * for the reactive (Project Reactor) stack.
+ * for the reactive (Project Reactor) stack. The stack-neutral reflection and event-type resolution is shared with the
+ * blocking processor through {@link SubscriptionAnnotations}.
  * <p>
  * The reactive stack has no stream (non-DCB) catch-up model, so a {@link StreamSubscription} that asks to replay
  * history (a start time, or {@code BEGINNING_OF_TIME}) fails loud. Only {@code NOW} and {@code DEFAULT} are supported
@@ -100,28 +97,6 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         return bean;
     }
 
-    /**
-     * The normalized form of a stream subscription declaration, built from either the {@link StreamSubscription}
-     * annotation or the deprecated {@link Subscription} alias. The deprecated annotation's enums are mapped to the
-     * canonical {@link StreamSubscription} enums by name, since the constants are identical.
-     */
-    private record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
-                                                long startAtTimeEpochMillis, StartPosition startAt,
-                                                ResumeBehavior resumeBehavior, StartupMode startupMode, String annotationName) {
-
-        static StreamSubscriptionDefinition from(StreamSubscription subscription) {
-            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode(), "@StreamSubscription");
-        }
-
-        @SuppressWarnings("deprecation")
-        static StreamSubscriptionDefinition from(Subscription subscription) {
-            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
-                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()), "@Subscription");
-        }
-    }
-
     @SuppressWarnings("unchecked")
     private <E> void processSubscribeAnnotation(Object bean, Method method, StreamSubscriptionDefinition subscription) {
         String id = subscription.id();
@@ -129,9 +104,9 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         final List<Class<?>> parameterTypes;
         if (method.getParameterCount() >= 1) {
             CloudEventConverter<E> cloudEventConverter = applicationContext.getBean(CloudEventConverter.class);
-            parameterTypes = analyzeParameters(method, OccurrentReactiveAnnotationBeanPostProcessor::isStreamMetadataParameter);
-            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentReactiveAnnotationBeanPostProcessor::isStreamMetadataParameter);
-            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, subscription.eventTypes(), subscription.annotationName());
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isStreamMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isStreamMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, subscription.eventTypes(), subscription.annotationName());
 
             if (domainEventTypesToSubscribeTo.size() == 1) {
                 filter = Filter.type(cloudEventConverter.getCloudEventType(domainEventTypesToSubscribeTo.get(0)));
@@ -149,7 +124,7 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         StartAt startAt = generateStreamStartAt(subscription);
 
         Function2<EventMetadata, E, Mono<Void>> consumer = (metadata, event) ->
-                invokeMono(method, bean, bindArguments(parameterTypes, event, metadata, OccurrentReactiveAnnotationBeanPostProcessor::isStreamMetadataParameter));
+                invokeMono(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadata, SubscriptionAnnotations::isStreamMetadataParameter));
 
         boolean shouldWaitUntilStarted = shouldWaitUntilStarted(subscription.startupMode());
         StreamSubscriptions<E> streamSubscriptions = applicationContext.getBean(StreamSubscriptions.class);
@@ -169,18 +144,18 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         final List<Class<?>> parameterTypes;
         if (method.getParameterCount() >= 1) {
             CloudEventConverter<E> cloudEventConverter = applicationContext.getBean(CloudEventConverter.class);
-            parameterTypes = analyzeParameters(method, OccurrentReactiveAnnotationBeanPostProcessor::isDcbMetadataParameter);
-            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentReactiveAnnotationBeanPostProcessor::isDcbMetadataParameter);
-            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@DcbSubscription");
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isDcbMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isDcbMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@DcbSubscription");
             List<String> cloudEventTypes = domainEventTypesToSubscribeTo.stream().map(cloudEventConverter::getCloudEventType).toList();
-            query = buildDcbQuery(cloudEventTypes, List.of(annotation.tagsAllOf()));
+            query = SubscriptionAnnotations.buildDcbQuery(cloudEventTypes, List.of(annotation.tagsAllOf()));
         } else {
             throw new IllegalArgumentException("A @DcbSubscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
         }
 
         BiFunction<DcbEventMetadata, E, Mono<Void>> consumer = (dcbMetadata, event) -> {
             Object metadataArgument = parameterTypes.contains(DcbEventMetadata.class) ? dcbMetadata : dcbMetadata.eventMetadata();
-            return invokeMono(method, bean, bindArguments(parameterTypes, event, metadataArgument, OccurrentReactiveAnnotationBeanPostProcessor::isDcbMetadataParameter));
+            return invokeMono(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadataArgument, SubscriptionAnnotations::isDcbMetadataParameter));
         };
 
         long startAtDcbPosition = annotation.startAtDcbPosition();
@@ -198,83 +173,6 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         if (shouldWaitUntilStarted) {
             subscription.waitUntilStarted().block();
         }
-    }
-
-    private static boolean isStreamMetadataParameter(Class<?> parameterType) {
-        return EventMetadata.class.isAssignableFrom(parameterType);
-    }
-
-    private static boolean isDcbMetadataParameter(Class<?> parameterType) {
-        return EventMetadata.class.isAssignableFrom(parameterType) || DcbEventMetadata.class.isAssignableFrom(parameterType);
-    }
-
-    private static List<Class<?>> analyzeParameters(Method method, Predicate<Class<?>> isMetadataParameter) {
-        List<Class<?>> parameterTypes = new ArrayList<>();
-        for (Class<?> parameterType : method.getParameterTypes()) {
-            if (isMetadataParameter.test(parameterType)) {
-                if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
-                    throw new IllegalArgumentException("A subscription method may declare at most one metadata parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                }
-                parameterTypes.add(parameterType);
-            } else {
-                if (parameterTypes.isEmpty()) {
-                    parameterTypes.add(parameterType);
-                } else if (parameterTypes.size() == 2) {
-                    throw new IllegalArgumentException("A subscription method may declare an event parameter and at most one metadata parameter, but %s#%s declares more.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                } else if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
-                    parameterTypes.add(parameterType);
-                } else {
-                    throw new IllegalArgumentException("A subscription method may declare only one event parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                }
-            }
-        }
-        return parameterTypes;
-    }
-
-    private static Class<?> eventTypeOf(List<Class<?>> parameterTypes, Predicate<Class<?>> isMetadataParameter) {
-        return parameterTypes.stream().filter(not(isMetadataParameter)).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("You need to declare an event type"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <E> List<Class<E>> resolveDomainEventTypes(String id, Object bean, Method method, Class<E> specifiedEventType, Class<?>[] eventTypesSpecifiedInAnnotation, String annotationName) {
-        if (eventTypesSpecifiedInAnnotation.length == 0) {
-            return getConcreteEventTypes(id, specifiedEventType);
-        }
-        return Arrays.stream(eventTypesSpecifiedInAnnotation)
-                .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
-                .peek(e -> {
-                    if (!specifiedEventType.isAssignableFrom(e)) {
-                        throw new IllegalStateException("Event type %s specified in the %s annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), annotationName, id, bean.getClass().getName(), method.getName()));
-                    }
-                })
-                .toList();
-    }
-
-    private static DcbQuery buildDcbQuery(List<String> cloudEventTypes, List<String> tagsAllOf) {
-        boolean hasTypes = !cloudEventTypes.isEmpty();
-        boolean hasTags = !tagsAllOf.isEmpty();
-        if (!hasTypes && !hasTags) {
-            return DcbQuery.all();
-        } else if (hasTypes && hasTags) {
-            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new)).tags(tagsAllOf);
-        } else if (hasTypes) {
-            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new));
-        } else {
-            return DcbQuery.tags(tagsAllOf.get(0), tagsAllOf.stream().skip(1).toArray(String[]::new));
-        }
-    }
-
-    private static Object[] bindArguments(List<Class<?>> parameterTypes, Object event, Object metadata, Predicate<Class<?>> isMetadataParameter) {
-        if (parameterTypes.size() == 1) {
-            return new Object[]{event};
-        }
-        // Place each argument by which declared parameter slot is the metadata type, not by runtime assignability. A
-        // broad event parameter (for example Object) is assignable from the metadata value too, so an isInstance check
-        // would misplace it, this keys off the declared types instead and honors a metadata-first parameter order.
-        Object first = isMetadataParameter.test(parameterTypes.get(0)) ? metadata : event;
-        Object second = first == metadata ? event : metadata;
-        return new Object[]{first, second};
     }
 
     // Invokes the annotated method for a delivered event. The method is expected to return a Mono<Void> (a null or
@@ -365,20 +263,5 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
                 return storage.read(subscriptionId).blockOptional().isPresent() ? DcbStartAt.subscriptionModelDefault() : replayStart;
             });
         };
-    }
-
-    private static <E> @NonNull List<Class<E>> getConcreteEventTypes(String subscriptionId, Class<E> specifiedEventType) {
-        final List<Class<E>> domainEventTypesToSubscribeTo;
-        if (specifiedEventType.isSealed()) {
-            //noinspection unchecked
-            Class<E>[] permittedSubclasses = (Class<E>[]) specifiedEventType.getPermittedSubclasses();
-            domainEventTypesToSubscribeTo = Arrays.stream(permittedSubclasses).flatMap(c -> getConcreteEventTypes(subscriptionId, c).stream()).toList();
-        } else if (specifiedEventType.isInterface() || specifiedEventType.isArray() || Modifier.isAbstract(specifiedEventType.getModifiers())) {
-            String msg = "You cannot subscribe to a non-sealed interface, abstract type, or array (problem is with %s for subscription '%s'). A concrete or sealed event type is required, or list the event types explicitly with the annotation's eventTypes attribute (for example eventTypes = {MyEvent1.class, MyEvent2.class}).";
-            throw new IllegalArgumentException(msg.formatted(specifiedEventType.getName(), subscriptionId));
-        } else {
-            domainEventTypesToSubscribeTo = List.of(specifiedEventType);
-        }
-        return domainEventTypesToSubscribeTo;
     }
 }

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.occurrent.eventstore.api.reactor.EventStore;
 import org.occurrent.eventstore.api.reactor.EventStoreQueries;
 import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.springboot.mongo.common.DcbApplicationServiceRegistrar;
 import org.occurrent.springboot.mongo.common.Jackson3CloudEventConverterConfiguration;
 import org.occurrent.springboot.mongo.common.OccurrentProperties;
 import org.occurrent.springboot.mongo.common.OccurrentProperties.EventStoreProperties;
@@ -52,13 +53,9 @@ import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptio
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorSubscriptionPositionStorage;
 import org.occurrent.subscription.reactor.durable.ReactorDurableSubscriptionModel;
 import org.occurrent.subscription.reactor.durable.catchup.ReactorDcbCatchupSubscriptionModel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -88,8 +85,6 @@ import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
 @EnableConfigurationProperties(OccurrentProperties.class)
 @Import(Jackson3CloudEventConverterConfiguration.class)
 public class OccurrentReactiveMongoAutoConfiguration<E> {
-
-    private static final Logger log = LoggerFactory.getLogger(OccurrentReactiveMongoAutoConfiguration.class);
 
     @Bean
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
@@ -214,25 +209,7 @@ public class OccurrentReactiveMongoAutoConfiguration<E> {
     @Conditional(OnDcbEventStoreCapabilityCondition.class)
     @ConditionalOnProperty(name = {"occurrent.event-store.enabled", "occurrent.application-service.enabled"}, havingValue = "true", matchIfMissing = true)
     static BeanFactoryPostProcessor occurrentReactiveDcbApplicationServiceRegistrar() {
-        return beanFactory -> {
-            if (!(beanFactory instanceof BeanDefinitionRegistry registry)) {
-                return;
-            }
-            boolean hasDcbApplicationService = beanFactory.getBeanNamesForType(DcbApplicationService.class, false, false).length > 0;
-            boolean hasTagGenerator = beanFactory.getBeanNamesForType(TagGenerator.class, false, false).length > 0;
-            if (hasDcbApplicationService) {
-                return;
-            }
-            if (!hasTagGenerator) {
-                log.warn("Occurrent DCB event-store capability is enabled but no {} bean was found, so a {} is not auto-configured. " +
-                                "Define a {} bean (it derives the DCB tags written with each event) to enable auto-configuration, or provide your own {} bean.",
-                        TagGenerator.class.getName(), DcbApplicationService.class.getName(), TagGenerator.class.getSimpleName(), DcbApplicationService.class.getSimpleName());
-                return;
-            }
-            RootBeanDefinition beanDefinition = new RootBeanDefinition(DcbApplicationService.class);
-            beanDefinition.setInstanceSupplier(() -> createDcbApplicationService(beanFactory));
-            registry.registerBeanDefinition("occurrentDcbApplicationService", beanDefinition);
-        };
+        return DcbApplicationServiceRegistrar.registrar(DcbApplicationService.class, "occurrentDcbApplicationService", OccurrentReactiveMongoAutoConfiguration::createDcbApplicationService);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentAnnotationBeanPostProcessor.java
@@ -33,6 +33,8 @@ import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.dsl.subscription.blocking.StreamSubscriptions;
 import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.filter.Filter;
+import org.occurrent.springboot.mongo.common.SubscriptionAnnotations;
+import org.occurrent.springboot.mongo.common.SubscriptionAnnotations.StreamSubscriptionDefinition;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.SubscriptionPositionStorage;
@@ -49,30 +51,26 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-import static java.util.function.Predicate.not;
 import static org.occurrent.filter.Filter.CompositionOperator.OR;
 import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
  * Implements support for the {@link StreamSubscription} and {@link DcbSubscription} annotations, and the deprecated
- * {@link Subscription} alias, in Spring Boot.
+ * {@link Subscription} alias, in Spring Boot. The stack-neutral reflection and event-type resolution is shared with the
+ * reactive processor through {@link SubscriptionAnnotations}.
  */
 class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
 
@@ -105,28 +103,6 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         return bean;
     }
 
-    /**
-     * The normalized form of a stream subscription declaration, built from either the {@link StreamSubscription}
-     * annotation or the deprecated {@link Subscription} alias. The deprecated annotation's enums are mapped to the
-     * canonical {@link StreamSubscription} enums by name, since the constants are identical.
-     */
-    private record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
-                                                long startAtTimeEpochMillis, StartPosition startAt,
-                                                ResumeBehavior resumeBehavior, StartupMode startupMode, String annotationName) {
-
-        static StreamSubscriptionDefinition from(StreamSubscription subscription) {
-            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode(), "@StreamSubscription");
-        }
-
-        @SuppressWarnings("deprecation")
-        static StreamSubscriptionDefinition from(Subscription subscription) {
-            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
-                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()), "@Subscription");
-        }
-    }
-
     @SuppressWarnings("unchecked")
     private <E> void processSubscribeAnnotation(Object bean, Method method, StreamSubscriptionDefinition subscription) {
         String id = subscription.id();
@@ -134,9 +110,9 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         final List<Class<?>> parameterTypes;
         if (method.getParameterCount() >= 1) {
             CloudEventConverter<E> cloudEventTypeMapper = applicationContext.getBean(CloudEventConverter.class);
-            parameterTypes = analyzeParameters(method, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter);
-            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter);
-            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, subscription.eventTypes(), subscription.annotationName());
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isStreamMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isStreamMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, subscription.eventTypes(), subscription.annotationName());
 
             if (domainEventTypesToSubscribeTo.size() == 1) {
                 filter = Filter.type(cloudEventTypeMapper.getCloudEventType(domainEventTypesToSubscribeTo.get(0)));
@@ -152,7 +128,7 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         }
 
         Function2<EventMetadata, E, Unit> consumer = (metadata, event) -> {
-            invoke(method, bean, bindArguments(parameterTypes, event, metadata, OccurrentAnnotationBeanPostProcessor::isStreamMetadataParameter));
+            invoke(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadata, SubscriptionAnnotations::isStreamMetadataParameter));
             return Unit.INSTANCE;
         };
 
@@ -175,18 +151,18 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         final List<Class<?>> parameterTypes;
         if (method.getParameterCount() >= 1) {
             CloudEventConverter<E> cloudEventConverter = applicationContext.getBean(CloudEventConverter.class);
-            parameterTypes = analyzeParameters(method, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter);
-            Class<E> specifiedEventType = (Class<E>) eventTypeOf(parameterTypes, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter);
-            List<Class<E>> domainEventTypesToSubscribeTo = resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@DcbSubscription");
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isDcbMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isDcbMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@DcbSubscription");
             List<String> cloudEventTypes = domainEventTypesToSubscribeTo.stream().map(cloudEventConverter::getCloudEventType).toList();
-            query = buildDcbQuery(cloudEventTypes, List.of(annotation.tagsAllOf()));
+            query = SubscriptionAnnotations.buildDcbQuery(cloudEventTypes, List.of(annotation.tagsAllOf()));
         } else {
             throw new IllegalArgumentException("A @DcbSubscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
         }
 
         BiConsumer<DcbEventMetadata, E> consumer = (dcbMetadata, event) -> {
             Object metadataArgument = parameterTypes.contains(DcbEventMetadata.class) ? dcbMetadata : dcbMetadata.eventMetadata();
-            invoke(method, bean, bindArguments(parameterTypes, event, metadataArgument, OccurrentAnnotationBeanPostProcessor::isDcbMetadataParameter));
+            invoke(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadataArgument, SubscriptionAnnotations::isDcbMetadataParameter));
         };
 
         long startAtDcbPosition = annotation.startAtDcbPosition();
@@ -204,83 +180,6 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
         if (shouldWaitUntilStarted) {
             subscription.waitUntilStarted();
         }
-    }
-
-    private static boolean isStreamMetadataParameter(Class<?> parameterType) {
-        return EventMetadata.class.isAssignableFrom(parameterType);
-    }
-
-    private static boolean isDcbMetadataParameter(Class<?> parameterType) {
-        return EventMetadata.class.isAssignableFrom(parameterType) || DcbEventMetadata.class.isAssignableFrom(parameterType);
-    }
-
-    private static List<Class<?>> analyzeParameters(Method method, Predicate<Class<?>> isMetadataParameter) {
-        List<Class<?>> parameterTypes = new ArrayList<>();
-        for (Class<?> parameterType : method.getParameterTypes()) {
-            if (isMetadataParameter.test(parameterType)) {
-                if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
-                    throw new IllegalArgumentException("A subscription method may declare at most one metadata parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                }
-                parameterTypes.add(parameterType);
-            } else {
-                if (parameterTypes.isEmpty()) {
-                    parameterTypes.add(parameterType);
-                } else if (parameterTypes.size() == 2) {
-                    throw new IllegalArgumentException("A subscription method may declare an event parameter and at most one metadata parameter, but %s#%s declares more.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                } else if (parameterTypes.stream().anyMatch(isMetadataParameter)) {
-                    parameterTypes.add(parameterType);
-                } else {
-                    throw new IllegalArgumentException("A subscription method may declare only one event parameter, but %s#%s declares more than one.".formatted(method.getDeclaringClass().getName(), method.getName()));
-                }
-            }
-        }
-        return parameterTypes;
-    }
-
-    private static Class<?> eventTypeOf(List<Class<?>> parameterTypes, Predicate<Class<?>> isMetadataParameter) {
-        return parameterTypes.stream().filter(not(isMetadataParameter)).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("You need to declare an event type"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <E> List<Class<E>> resolveDomainEventTypes(String id, Object bean, Method method, Class<E> specifiedEventType, Class<?>[] eventTypesSpecifiedInAnnotation, String annotationName) {
-        if (eventTypesSpecifiedInAnnotation.length == 0) {
-            return getConcreteEventTypes(id, specifiedEventType);
-        }
-        return Arrays.stream(eventTypesSpecifiedInAnnotation)
-                .flatMap(e -> getConcreteEventTypes(id, (Class<E>) e).stream())
-                .peek(e -> {
-                    if (!specifiedEventType.isAssignableFrom(e)) {
-                        throw new IllegalStateException("Event type %s specified in the %s annotation with id %s is not assignable from the event type specified in %s#%s(..).".formatted(e.getName(), annotationName, id, bean.getClass().getName(), method.getName()));
-                    }
-                })
-                .toList();
-    }
-
-    private static DcbQuery buildDcbQuery(List<String> cloudEventTypes, List<String> tagsAllOf) {
-        boolean hasTypes = !cloudEventTypes.isEmpty();
-        boolean hasTags = !tagsAllOf.isEmpty();
-        if (!hasTypes && !hasTags) {
-            return DcbQuery.all();
-        } else if (hasTypes && hasTags) {
-            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new)).tags(tagsAllOf);
-        } else if (hasTypes) {
-            return DcbQuery.types(cloudEventTypes.get(0), cloudEventTypes.stream().skip(1).toArray(String[]::new));
-        } else {
-            return DcbQuery.tags(tagsAllOf.get(0), tagsAllOf.stream().skip(1).toArray(String[]::new));
-        }
-    }
-
-    private static Object[] bindArguments(List<Class<?>> parameterTypes, Object event, Object metadata, Predicate<Class<?>> isMetadataParameter) {
-        if (parameterTypes.size() == 1) {
-            return new Object[]{event};
-        }
-        // Place each argument by which declared parameter slot is the metadata type, not by runtime assignability. A
-        // broad event parameter (for example Object) is assignable from the metadata value too, so an isInstance check
-        // would misplace it, this keys off the declared types instead and honors a metadata-first parameter order.
-        Object first = isMetadataParameter.test(parameterTypes.get(0)) ? metadata : event;
-        Object second = first == metadata ? event : metadata;
-        return new Object[]{first, second};
     }
 
     private static void invoke(Method method, Object bean, Object[] arguments) {
@@ -521,20 +420,5 @@ class OccurrentAnnotationBeanPostProcessor implements BeanPostProcessor, Applica
 
         record StartAtStartPosition(StartPosition startPosition) implements StartPositionToUse {
         }
-    }
-
-    private static <E> @NonNull List<Class<E>> getConcreteEventTypes(String subscriptionId, Class<E> specifiedEventType) {
-        final List<Class<E>> domainEventTypesToSubscribeTo;
-        if (specifiedEventType.isSealed()) {
-            //noinspection unchecked
-            Class<E>[] permittedSubclasses = (Class<E>[]) specifiedEventType.getPermittedSubclasses();
-            domainEventTypesToSubscribeTo = Arrays.stream(permittedSubclasses).flatMap(c -> getConcreteEventTypes(subscriptionId, c).stream()).toList();
-        } else if (specifiedEventType.isInterface() || specifiedEventType.isArray() || Modifier.isAbstract(specifiedEventType.getModifiers())) {
-            String msg = "You cannot subscribe to a non-sealed interface, abstract type, or array (problem is with %s for subscription '%s'). A concrete or sealed event type is required, or list the event types explicitly with the annotation's eventTypes attribute (for example eventTypes = {MyEvent1.class, MyEvent2.class}).";
-            throw new IllegalArgumentException(msg.formatted(specifiedEventType.getName(), subscriptionId));
-        } else {
-            domainEventTypesToSubscribeTo = List.of(specifiedEventType);
-        }
-        return domainEventTypesToSubscribeTo;
     }
 }

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -21,8 +21,6 @@ import com.mongodb.ReadConcern;
 import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
 import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
@@ -43,6 +41,7 @@ import org.occurrent.eventstore.api.dcb.DcbQuery;
 import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.retry.RetryStrategy;
+import org.occurrent.springboot.mongo.common.DcbApplicationServiceRegistrar;
 import org.occurrent.springboot.mongo.common.Jackson3CloudEventConverterConfiguration;
 import org.occurrent.springboot.mongo.common.OccurrentProperties;
 import org.occurrent.springboot.mongo.common.OccurrentProperties.EventStoreProperties;
@@ -64,8 +63,6 @@ import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptio
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -96,8 +93,6 @@ import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubs
 @EnableConfigurationProperties(OccurrentProperties.class)
 @Import(Jackson3CloudEventConverterConfiguration.class)
 public class OccurrentMongoAutoConfiguration<E> {
-
-    private static final Logger log = LoggerFactory.getLogger(OccurrentMongoAutoConfiguration.class);
 
     @Bean
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
@@ -246,25 +241,7 @@ public class OccurrentMongoAutoConfiguration<E> {
     @Conditional(OnDcbEventStoreCapabilityCondition.class)
     @ConditionalOnProperty(name = {"occurrent.event-store.enabled", "occurrent.application-service.enabled"}, havingValue = "true", matchIfMissing = true)
     static BeanFactoryPostProcessor occurrentDcbApplicationServiceRegistrar() {
-        return beanFactory -> {
-            if (!(beanFactory instanceof BeanDefinitionRegistry registry)) {
-                return;
-            }
-            boolean hasDcbApplicationService = beanFactory.getBeanNamesForType(DcbApplicationService.class, false, false).length > 0;
-            boolean hasTagGenerator = beanFactory.getBeanNamesForType(TagGenerator.class, false, false).length > 0;
-            if (hasDcbApplicationService) {
-                return;
-            }
-            if (!hasTagGenerator) {
-                log.warn("Occurrent DCB event-store capability is enabled but no {} bean was found, so a {} is not auto-configured. " +
-                                "Define a {} bean (it derives the DCB tags written with each event) to enable auto-configuration, or provide your own {} bean.",
-                        TagGenerator.class.getName(), DcbApplicationService.class.getName(), TagGenerator.class.getSimpleName(), DcbApplicationService.class.getSimpleName());
-                return;
-            }
-            RootBeanDefinition beanDefinition = new RootBeanDefinition(DcbApplicationService.class);
-            beanDefinition.setInstanceSupplier(() -> createDcbApplicationService(beanFactory));
-            registry.registerBeanDefinition("occurrentDcbApplicationService", beanDefinition);
-        };
+        return DcbApplicationServiceRegistrar.registrar(DcbApplicationService.class, "occurrentDcbApplicationService", OccurrentMongoAutoConfiguration::createDcbApplicationService);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
When the reactive starter was added it mirrored the blocking one, which left two chunks of stack-neutral code duplicated between the two BeanPostProcessors and the two auto-configs. This pulls them into the shared `spring-boot-autoconfigure-mongodb-common` module so both starters call one copy and a future fix cannot drift.

## What moved

`SubscriptionAnnotations` holds the annotation-parsing helpers that were byte-for-byte identical in both BeanPostProcessors: the `StreamSubscriptionDefinition` record and its `from(...)` factories, the metadata-parameter predicates, `analyzeParameters`, `eventTypeOf`, `resolveDomainEventTypes`/`getConcreteEventTypes` (the sealed-type walk), `buildDcbQuery`, and `bindArguments`.

`DcbApplicationServiceRegistrar` holds the `BeanFactoryPostProcessor` that registers a `DcbApplicationService` when the DCB capability is on and a `TagGenerator` exists. It is parameterized by the concrete service type and an instance factory, so the bean-name lookup, the `TagGenerator` check, the warn-log message, and the bean-definition wiring live in one place. Each starter keeps its own `createDcbApplicationService` (blocking uses `RetryStrategy.none()`, reactive uses `Retry.max(0)`), passed in as the factory.

## What stayed put

The stack-specific parts stay in each starter: the `Mono`-returning vs `void` consumer bodies, `invoke` vs `invokeMono`, `applyStartupWorkarounds`, and all start-position, catch-up, and resume-behavior logic. I also left the annotation dispatch loop inline in each BeanPostProcessor. It dispatches to the stack-specific DSLs, so sharing it would need a callback indirection that costs more than the dozen lines it saves.

`common` gains only stack-neutral dependencies (`annotations`, `subscription-dsl-common`, `dcb-dsl-common`, `eventstore-api-dcb`, `application-service-common`, `slf4j-api`), no blocking or reactive module.

## Testing

Both starters build, and their annotation and auto-config-wiring suites pass (21 blocking, 8 reactive) against a real MongoDB.

## Note

This depends on the reactive starter, so it is stacked on that PR rather than opened off main.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
