### PR TITLE
Add regression test: DCB catch-up never redelivers a resumed-past position

### DIFF
--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -224,6 +224,34 @@ class DcbCatchupSubscriptionModelMongoTest {
         assertThat(received).doesNotHaveDuplicates();
     }
 
+    @Test
+    void resuming_from_an_explicit_dcb_position_never_redelivers_an_event_at_or_before_it() {
+        // Three events exist before the subscription starts.
+        NameDefined event1 = nameDefined("event1");
+        NameDefined event2 = nameDefined("event2");
+        NameDefined event3 = nameDefined("event3");
+        appendTagged("name:1", event1);
+        appendTagged("name:1", event2);
+        appendTagged("name:1", event3);
+
+        CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
+        subscription = new CatchupSubscriptionModel(subscriptionModel, eventStore, DcbQuery.tags("name:1"),
+                new CatchupSubscriptionModelConfig(100, useSubscriptionPositionStorage(storage).andPersistSubscriptionPositionDuringCatchupPhaseForEveryNEvents(1)));
+
+        // Resuming after position 1 (as if event1 was already processed elsewhere) replays only event2 and event3.
+        subscription.subscribe("subscription", StartAt.subscriptionPosition(DcbSubscriptionPosition.of(1)), toDomainEvents(received)).waitUntilStarted();
+
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+                assertThat(received).containsExactly(event2, event3));
+
+        // event1 must never arrive, including through the live change stream after the handover settles.
+        NameDefined live1 = nameDefined("live1");
+        appendTagged("name:1", live1);
+        await().atMost(AT_MOST).with().pollInterval(Duration.of(100, MILLIS)).untilAsserted(() ->
+                assertThat(received).containsExactly(event2, event3, live1));
+        assertThat(received).doesNotContain(event1);
+    }
+
     private static void awaitLatch(CountDownLatch latch) {
         try {
             assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch reached in time").isTrue();


### PR DESCRIPTION
A `/simplify` altitude review on PR #264 raised a suspected bug: the DCB catch-up live-delivery filter in `CatchupSubscriptionModel` (blocking) might have the same redelivery gap just fixed on the reactive side in `ReactorDcbCatchupSubscriptionModel`. Resuming a DCB catch-up subscription from an explicit position (`DcbStartAt.afterPosition(N)`, for example `@DcbSubscription(startAtDcbPosition = N)`) could redeliver an event at or below that position through the live handover, since the bulk replay's id-based dedup cache only covers what it actually fetched.

I wrote the exact reproduction scenario as a real MongoDB integration test in `DcbCatchupSubscriptionModelMongoTest`: three DCB events exist before the subscriber starts, it subscribes with an explicit resume position that skips the first one, and the test asserts that event never arrives, even after a live event settles. I ran it 4 times against the current, unmodified product code. It passed every time.

The reactive-side bug turned out to be a symptom of a different root cause: `ReactorMongoSubscriptionModel.globalSubscriptionPosition()` was missing a `+1` timestamp increment that the blocking `SpringMongoSubscriptionModel.globalSubscriptionPosition()` already has. That increment pushes the live resume token strictly past every event that existed before the subscription started, so on the blocking side the live change stream never sees a historic event at all, regardless of what resume position the caller specified. The theoretical parallel from the review doesn't hold up under an actual reproduction attempt.

## What this PR does

Test only, no production code change. It adds one regression test to `DcbCatchupSubscriptionModelMongoTest` that locks in the guarantee this investigation confirmed: DCB catch-up's live handover never redelivers something at or before the caller's resume position. There was no direct test for this before.

## Test plan

- Ran the new test 4 times locally against a real MongoDB via Testcontainers, all green.
- Ran the full `subscription/util/blocking/catchup-subscription` module test suite, all green.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
