### PR TITLE
Raise the baseline to Java 21

### DIFF
--- a/.context/ORCHESTRATOR.md
+++ b/.context/ORCHESTRATOR.md
@@ -112,7 +112,7 @@ Subscription flow:
 ## Conventions And Patterns
 
 General:
-- Java 17 baseline; Kotlin JVM target follows Java 17.
+- Java 21 baseline; Kotlin JVM target follows Java 21.
 - Java and Kotlin coexist in most modules. Root Maven build-helper adds `src/main/kotlin` and `src/test/kotlin`.
 - Public APIs are small capability interfaces composed together rather than large monoliths.
 - Nullness uses JSpecify in newer APIs (`@NullMarked`, `@Nullable`) but not uniformly across old code.
@@ -188,9 +188,8 @@ Required shell workflow:
 - Before raw shell commands, explicitly consider whether `rtk` supports the command. Use raw commands only when unsupported or proven unsuitable.
 
 CI:
-- `.github/workflows/maven.yml` runs `mvn -B package --file pom.xml` on Temurin Java 17 and 21.
+- `.github/workflows/maven.yml` runs `mvn -B package --file pom.xml` on Temurin Java 21 and 25.
 - CI enables Testcontainers reuse by writing `$HOME/.testcontainers.properties`.
-- Qodana runs separately with `jetbrains/qodana-jvm-community:2025.2`, project JDK 17.
 
 Local focused Maven patterns:
 - Full package: `rtk mvn -B package --file pom.xml`
@@ -202,7 +201,7 @@ Local focused Maven patterns:
 
 Release scripts:
 - `mvn_local_snapshot.sh` runs release-profile local install with `-Drevision=...` and optional skip tests.
-- `mvn_release.sh` requires Java 17, uses `mvn deploy -Prelease`, GPG signing, source/javadoc jars, Sonatype Central publishing, and tags `occurrent-<version>`.
+- `mvn_release.sh` requires Java 21, uses `mvn deploy -Prelease`, GPG signing, source/javadoc jars, Sonatype Central publishing, and tags `occurrent-<version>`.
 
 ## Orchestrator Operating Notes
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ 17, 21 ]
+        java: [ 21, 25 ]
 
     steps:
       - uses: actions/checkout@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents, and human contributors, working in this repositor
 
 ## What this is
 
-Occurrent is a Maven multi-module JVM event-sourcing library built on CloudEvents. Java 17 baseline, Kotlin coexists in most modules (the root build adds `src/main/kotlin` and `src/test/kotlin`). It ships as small composable libraries rather than a framework: domain models stay independent of Occurrent.
+Occurrent is a Maven multi-module JVM event-sourcing library built on CloudEvents. Java 21 baseline, Kotlin coexists in most modules (the root build adds `src/main/kotlin` and `src/test/kotlin`). It ships as small composable libraries rather than a framework: domain models stay independent of Occurrent.
 
 ## Module layout
 
@@ -35,7 +35,7 @@ Unreleased changes go under the existing `### Changelog next version` heading, n
 
 ## Coding conventions
 
-- Java 17 and Kotlin coexist in most modules.
+- Java 21 and Kotlin coexist in most modules.
 - Public APIs are small capability interfaces composed together, not large monoliths.
 - Nullness uses JSpecify (`@NullMarked`, `@Nullable`) in newer APIs, not uniformly across older code.
 - Validate nulls and invalid arguments eagerly, with `Objects.requireNonNull` or `IllegalArgumentException`.
@@ -52,10 +52,10 @@ Unreleased changes go under the existing `### Changelog next version` heading, n
 
 ## Build and verification
 
-- Full build: `mvn -B package --file pom.xml` (CI runs this on Temurin Java 17 and 21).
+- Full build: `mvn -B package --file pom.xml` (CI runs this on Temurin Java 21 and 25).
 - Focused module test: `mvn -pl <module-path> -am test`.
 - Focused test class: `mvn -pl <module-path> -am -Dtest=<TestClass> -Dsurefire.failIfNoSpecifiedTests=false test`.
-- Release: `mvn_release.sh` (Java 17, `mvn deploy -Prelease`, GPG signing, Sonatype Central publishing).
+- Release: `mvn_release.sh` (Java 21, `mvn deploy -Prelease`, GPG signing, Sonatype Central publishing).
 
 ## Deeper context
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
 * Renamed the `SubscriptionPosition` type family to `Checkpoint` to stop overloading "position" for two different
   concepts: the ordering value (`position`) and the per-subscriber resume marker built from it. This is a breaking
   API change; there is no deprecated alias.

--- a/example/domain/uno/mongodb/common/pom.xml
+++ b/example/domain/uno/mongodb/common/pom.xml
@@ -26,8 +26,6 @@
     <artifactId>example-uno-es-mongodb-common</artifactId>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/example/domain/uno/mongodb/spring/blocking/pom.xml
+++ b/example/domain/uno/mongodb/spring/blocking/pom.xml
@@ -26,8 +26,6 @@
     <artifactId>example-uno-es-mongodb-spring-blocking</artifactId>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/example/domain/uno/mongodb/spring/pom.xml
+++ b/example/domain/uno/mongodb/spring/pom.xml
@@ -31,8 +31,6 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
 </project>

--- a/mvn_release.sh
+++ b/mvn_release.sh
@@ -45,7 +45,7 @@ if [ -z "${releaseVersion}" ]; then
     exit 1
 fi
 
-echo "!!!!!DON'T FORGET TO SWITCH TO JAVA 17!!!!!"
+echo "!!!!!DON'T FORGET TO SWITCH TO JAVA 21!!!!!"
 echo You may also need to disable "Stay invisible at the local network" in NordVPN, see nordvpn.md.
 echo
 read -r -p "Do you want to proceed (y/N)? " REPLY

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!--use '-Drevision=...' when invoking Maven to assign required version-->
         <revision>0.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <kotlin.compiler.jvmTarget>${maven.compiler.release}</kotlin.compiler.jvmTarget>
         <junit.version>5.11.3</junit.version>
         <test-containers.version>2.0.5</test-containers.version>
@@ -359,7 +359,7 @@
                     <version>${kotlin.version}</version>
 
                     <configuration>
-                        <jvmTarget>17</jvmTarget>
+                        <jvmTarget>21</jvmTarget>
                         <args>
                             <arg>-Xjsr305=strict</arg>
                         </args>


### PR DESCRIPTION
This raises the Occurrent baseline from Java 17 to Java 21. It is the standalone version bump with no code modernization, so the diff is just build config and docs. The modernization waves stack on top of this one.

## What changed

- `maven.compiler.release` and the Kotlin plugin `jvmTarget` move from 17 to 21. The `kotlin.compiler.jvmTarget` property already follows `maven.compiler.release`, so both move together.
- The CI matrix moves from `[17, 21]` to `[21, 25]`. Java 17 can no longer build a `release=21` artifact, so it is dropped. 21 stays as the baseline floor, and 25 is added so the build is also exercised on the newer LTS.
- The `mvn_release.sh` reminder and the `ORCHESTRATOR.md` / `AGENTS.md` notes move to 21. I also removed the stale Qodana line in `ORCHESTRATOR.md`, since Qodana is no longer in the repo.
- I dropped three redundant `maven.compiler.source/target=17` overrides in the uno MongoDB example poms. They only duplicated the root, so they now inherit `release=21`.
- I added a changelog note under `Changelog next version`, since raising the required JDK is a consumer-facing break.

## Data compatibility

Nothing here touches stored data. The bump is purely a build and runtime requirement, so an existing application only needs to move to Java 21 to upgrade.

## Verification

Full serial `mvn clean install` green on Temurin 21 across the whole reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
