### PR TITLE
Use SequencedCollection getFirst/getLast in the event stores

### DIFF
--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbQuery.java
@@ -143,7 +143,7 @@ public sealed interface DcbQuery permits DcbQuery.MatchAll, DcbQuery.Items, DcbQ
                 items.addAll(existing.items());
             }
         }
-        return items.size() == 1 ? items.get(0) : new Items(items);
+        return items.size() == 1 ? items.getFirst() : new Items(items);
     }
 
     /**

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -201,7 +201,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         final long oldStreamVersion = currentStreamVersionContainer.get();
         if (addedEvents != null && !addedEvents.isEmpty()) {
             listener.accept(addedEvents.stream());
-            CloudEvent cloudEvent = addedEvents.get(addedEvents.size() - 1);
+            CloudEvent cloudEvent = addedEvents.getLast();
             long newStreamVersion = OccurrentExtensionGetter.getStreamVersion(cloudEvent);
             writeResult = new WriteResult(streamId, oldStreamVersion, newStreamVersion);
         } else {
@@ -215,7 +215,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         Map<String, List<CloudEvent>> eventsById = events.stream().collect(groupingBy(c -> c.getId() + c.getSource().toString()));
         eventsById.forEach((key, cloudEvents) -> {
             if (cloudEvents.size() > 1) {
-                CloudEvent cloudEvent = cloudEvents.get(0);
+                CloudEvent cloudEvent = cloudEvents.getFirst();
                 throw new DuplicateCloudEventException(cloudEvent.getId(), cloudEvent.getSource());
             }
         });
@@ -357,8 +357,8 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
             assignInsertionOrder(addedEvents);
             state.put(streamId, new CopyOnWriteArrayList<>(eventList));
             nextPosition.addAndGet(addedEvents.size());
-            long firstPosition = position(addedEvents.get(0));
-            long lastPosition = position(addedEvents.get(addedEvents.size() - 1));
+            long firstPosition = position(addedEvents.getFirst());
+            long lastPosition = position(addedEvents.getLast());
             result = new DcbAppendResult(firstPosition, lastPosition, addedEvents.size());
         }
 
@@ -651,7 +651,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         if (events == null || events.isEmpty()) {
             return 0;
         }
-        return (long) events.get(events.size() - 1).getExtension(STREAM_VERSION);
+        return (long) events.getLast().getExtension(STREAM_VERSION);
     }
 
     @Nullable

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -287,7 +287,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
                         } catch (MongoException e) {
                             throw translateException(new WriteContext(streamId, currentStreamVersion, writeCondition), e);
                         }
-                        final long newStreamVersion = cloudEventDocuments.get(cloudEventDocuments.size() - 1).getLong(STREAM_VERSION);
+                        final long newStreamVersion = cloudEventDocuments.getLast().getLong(STREAM_VERSION);
                         return StreamVersionDiff.of(currentStreamVersion, newStreamVersion);
                     }
                 }, transactionOptions);

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -192,7 +192,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
                     }
                 }
                 insertAll(streamId, currentStreamVersion, writeCondition, cloudEventDocuments);
-                newStreamVersion = cloudEventDocuments.get(cloudEventDocuments.size() - 1).getLong(STREAM_VERSION);
+                newStreamVersion = cloudEventDocuments.getLast().getLong(STREAM_VERSION);
             } else {
                 newStreamVersion = currentStreamVersion;
             }

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -180,7 +180,7 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
                                 if (stampedDocuments.isEmpty()) {
                                     newStreamVersion = currentStreamVersion;
                                 } else {
-                                    newStreamVersion = stampedDocuments.get(stampedDocuments.size() - 1).getLong(STREAM_VERSION);
+                                    newStreamVersion = stampedDocuments.getLast().getLong(STREAM_VERSION);
                                 }
                                 return insertAll(streamId, currentStreamVersion, writeCondition, stampedDocuments)
                                         .then(Mono.just(StreamVersionDiff.of(currentStreamVersion, newStreamVersion)));


### PR DESCRIPTION
Third wave of the Java 21 work, stacked on #274. Now that the baseline is 21, this uses the `SequencedCollection` accessors in the event stores.

## What changed

Nine call sites move from `list.get(0)` / `list.get(list.size() - 1)` to `getFirst()` / `getLast()`, across `InMemoryEventStore`, the native and Spring blocking/reactor Mongo stores, and `DcbQuery`. The clearest of these is `InMemoryEventStore`, where a `firstPosition` / `lastPosition` pair now reads directly as `getFirst()` / `getLast()` instead of an index and a `size() - 1`. Every site is on a `List` that is non-empty by an enclosing guard (an `isEmpty()` check or a `size()` branch), so behavior is unchanged.

## What I left alone

I deliberately kept this small. The test call sites (around 40 `get(0)` in the core-module tests) are already clear, since they assert on a known element, and some `get(...)` calls elsewhere are `Map` lookups rather than positional access, where the accessor does not apply. Converting those would be churn without a readability gain, so this stays limited to the main event-store code where `get(size() - 1)` is genuinely noisier than `getLast()`.

## Verification

Full serial `mvn clean install` green on Temurin 21. No behavior change, all existing tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/java21-w2-classifier","parentHead":"fb5446e3cc97852b78cfe543fc0c35db4478fb7e","parentPull":274,"trunk":"main"}
```
-->
