### PR TITLE
Fix DCB reads matching non-DCB stream events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 #### Changes
 
 * Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
+* Fixed DCB reads (`DcbCriteria.all()` and type-only criteria) so they no longer return stream-written events on a
+  store with both `STREAM` and `DCB` capabilities enabled. They now only return DCB-written events, backed by a
+  sparse `dcbTags` index for efficient exclusion.
+  * See [ADR 49](doc/architecture/decisions/0049-dcb-reads-exclude-non-dcb-stream-events.md).
 * Renamed the `SubscriptionPosition` type family to `Checkpoint` to stop overloading "position" for two different
   concepts: the ordering value (`position`) and the per-subscriber resume marker built from it. This is a breaking
   API change; there is no deprecated alias.

--- a/doc/architecture/decisions/0049-dcb-reads-exclude-non-dcb-stream-events.md
+++ b/doc/architecture/decisions/0049-dcb-reads-exclude-non-dcb-stream-events.md
@@ -1,0 +1,75 @@
+# 49. DCB reads exclude non-DCB stream events
+
+Date: 2026-07-05
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 17](0017-introduce-dcb-as-shared-cloudevent-capability.md) and [ADR 18](0018-spring-mongo-event-store-capabilities.md)
+state that on a store with both `STREAM` and `DCB` capabilities enabled, stream-written events do not participate in
+DCB tag queries: DCB reads will not return them unless backfilled. That invariant was not actually enforced.
+`DcbCriteria.all()` and type-only `DcbCriterion` queries (queries with no tag constraint) matched any event whose type
+and tags happened to satisfy the criterion, regardless of whether the event was ever DCB-tagged. A stream event that
+happened to carry no `dcbTags` still matched `DcbCriteria.all()`, because "match everything" is exactly what that
+criterion asks for once the query layer stops distinguishing DCB events from stream events.
+
+This was pre-existing in every store (in-memory, Mongo native, Spring Mongo blocking, Spring Mongo reactor). It surfaced
+via a Copilot review comment on an unrelated PR (#276) and was filed as issue #279.
+
+## Decision
+
+**Correctness fix.** An unconditional guard, not expressible through `DcbCriteria`, was added at the query/read-building
+layer of every store:
+
+- **In-memory** (`InMemoryEventStore`): each of the three call sites that evaluate `DcbCloudEvents.matches(event, ...)`
+  (the `read(DcbCriteria, DcbReadOptions)` filter, the `matchingDcbEvents` method backing `exists`/`count`, and the
+  append-condition conflict check in `appendDcb`) now ANDs `DcbCloudEvents.isDcbEvent(event)` in front of the `matches`
+  call.
+- **Mongo stores** (native, Spring blocking, Spring reactor): the private method that builds the Mongo
+  query/filter/criteria from a `DcbCriteria` (`toDcbBsonQuery` / `toDcbMongoQuery`) now ANDs an existence check on the
+  `dcbTags` field (`DcbDocumentMapper.DCB_TAGS_INDEX_FIELD`) into both the `DcbCriteria.MatchAll` early return and the
+  general (item-OR) case. `read`, `exists`, and `count` all call this same method in every store, as does the DCB
+  append-condition conflict check, so this is a single-point fix per store.
+
+`DcbCriteria`, `DcbCriterion`, and `DcbCloudEvents.matches()` are deliberately **unchanged**. `matches()` is a
+documented pure predicate over type, tags, and excluded types, used and tested directly elsewhere (`DcbApiTest`), and
+other callers already pair it manually with `isDcbEvent`. The "is this a DCB event" guard is not something a caller
+can or should express through the criteria model; it is not user-specifiable, so it does not belong there. It belongs
+exactly where the read/exists/count/conflict-check machinery turns a `DcbCriteria` into an actual query.
+
+**Index fix.** The `dcbTags` index in all three Mongo stores is now created as **sparse**
+(`new IndexOptions().sparse(true)`) instead of a plain index.
+
+This was verified empirically with `explain("executionStats")` against a skewed dataset: 200,000 stream documents
+without a `dcbTags` field and 200 DCB documents with it.
+
+- A plain, non-sparse index on `dcbTags` gives **zero** selectivity benefit for the new `$exists: true` predicate. A
+  non-sparse index also indexes the implicit "missing" value for every document that lacks the field, so it cannot
+  resolve `$exists: true` into tight index bounds. The query planner falls back to the `position` index and examines
+  199,999 of 200,000 documents, the same cost as the pre-fix query.
+- A sparse index only contains entries for documents where `dcbTags` exists, so `$exists: true` becomes a full index
+  scan of just the DCB documents: 200 of 200,000 documents examined, sub-millisecond.
+- A non-sparse **compound** `{position, dcbTags}` index was tried as an alternative and rejected: it does not help
+  either. Same 199,999-of-200,000 examined result, for the same reason (the compound index still carries an entry for
+  every document, missing-value included).
+
+Verified on both `mongo:4.2.8` (this repository's test version) and `mongo:8.0`, with identical query-planner
+behavior on both.
+
+## Consequences
+
+`DcbCriteria.all()` and type-only criteria now only ever return DCB-written events, matching the invariant stated in
+ADR 17 and ADR 18, on every store.
+
+DCB has never shipped: there is no deployed environment with an existing `dcbTags` index, so there is nothing to
+migrate and no backward-compatibility concern. The sparse option is simply the index's original shape, not a
+migration. A future reader should not expect (or add) a startup guard, migration script, or upgrade path for this
+index change; none is needed because there was never a plain index in production to replace.
+
+A future contributor should not "simplify" the two-index situation into a single compound `{position, dcbTags}` index
+without re-reading this ADR. That was tested and found to give no selectivity benefit over the current plain
+`position` index; the sparse single-field `dcbTags` index is the one that is actually selective for the `$exists`
+predicate.

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -279,7 +279,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
             List<CloudEvent> matchingEvents = allEvents()
                     .filter(event -> position(event) > afterPosition)
                     .filter(event -> position(event) <= upperBound)
-                    .filter(event -> DcbCloudEvents.matches(event, query))
+                    .filter(event -> DcbCloudEvents.isDcbEvent(event) && DcbCloudEvents.matches(event, query))
                     .sorted(Comparator.comparingLong(InMemoryEventStore::position))
                     .toList();
             return new DcbEventStream(matchingEvents, highWatermark);
@@ -306,7 +306,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         long highWatermark = nextPosition.get() - 1;
         return allEvents()
                 .filter(event -> position(event) > 0 && position(event) <= highWatermark)
-                .filter(event -> DcbCloudEvents.matches(event, query));
+                .filter(event -> DcbCloudEvents.isDcbEvent(event) && DcbCloudEvents.matches(event, query));
     }
 
     @Override
@@ -338,7 +338,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
                 long afterPosition = condition.consistencyToken().map(DcbConsistencyToken::value).orElse(0L);
                 boolean fulfilled = allEvents()
                         .filter(event -> position(event) > afterPosition)
-                        .noneMatch(event -> DcbCloudEvents.matches(event, condition.query()));
+                        .noneMatch(event -> DcbCloudEvents.isDcbEvent(event) && DcbCloudEvents.matches(event, condition.query()));
                 long currentPosition = nextPosition.get() - 1;
                 if (!fulfilled) {
                     throw new DcbAppendConditionNotFulfilledException(condition, currentPosition, "Append condition was not fulfilled.");

--- a/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
+++ b/eventstore/inmemory/src/test/java/org/occurrent/eventstore/inmemory/InMemoryEventStoreDcbTest.java
@@ -371,6 +371,35 @@ class InMemoryEventStoreDcbTest {
                 .containsExactly("NameDefined", "OrderPlaced");
     }
 
+    @Test
+    void dcb_all_only_matches_dcb_written_events_not_stream_written_events() {
+        InMemoryEventStore eventStore = new InMemoryEventStore().withStreamPosition();
+        eventStore.write("stream:1", WriteCondition.streamVersionEq(0), Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(all()).events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined");
+    }
+
+    @Test
+    void dcb_type_only_criterion_does_not_match_a_stream_written_event_of_that_type() {
+        InMemoryEventStore eventStore = new InMemoryEventStore().withStreamPosition();
+        eventStore.write("stream:1", WriteCondition.streamVersionEq(0), Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(types(List.of("OrderPlaced"))).events()).isEmpty();
+    }
+
+    @Test
+    void exists_and_count_are_false_and_zero_for_a_store_with_only_stream_written_events() {
+        InMemoryEventStore eventStore = new InMemoryEventStore().withStreamPosition();
+        eventStore.write("stream:1", WriteCondition.streamVersionEq(0), Stream.of(event("OrderPlaced")));
+
+        assertThat(eventStore.exists(all())).isFalse();
+        assertThat(eventStore.count(all())).isZero();
+    }
+
     private static Tag tag(String canonical) {
         return Tag.parse(canonical);
     }

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -752,7 +752,7 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
             eventStoreCollection.createIndex(Indexes.ascending(OccurrentCloudEventExtension.POSITION), new IndexOptions().unique(true).sparse(true));
         }
         if (dcbEnabled) {
-            eventStoreCollection.createIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD));
+            eventStoreCollection.createIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true));
         }
     }
 
@@ -853,13 +853,14 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     private static Bson toDcbBsonQuery(DcbCriteria query, long afterPosition, long upperSequencePosition) {
         Bson positionFilter = and(gt(OccurrentCloudEventExtension.POSITION, afterPosition), lte(OccurrentCloudEventExtension.POSITION, upperSequencePosition));
+        Bson dcbTagsExistsFilter = Filters.exists(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD);
         if (query instanceof DcbCriteria.MatchAll) {
-            return positionFilter;
+            return and(positionFilter, dcbTagsExistsFilter);
         }
         List<Bson> itemFilters = DcbMarkerModel.dcbQueryItems(query).stream()
                 .map(MongoEventStore::toBsonFilter)
                 .toList();
-        return and(positionFilter, or(itemFilters));
+        return and(positionFilter, dcbTagsExistsFilter, or(itemFilters));
     }
 
     private static Bson toBsonFilter(DcbCriterion item) {

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
@@ -589,6 +589,28 @@ class MongoEventStoreDcbConcurrencyTest {
                 .isEqualTo("IXSCAN");
     }
 
+    @Test
+    void dcb_match_all_query_is_index_backed_on_dcb_tags_field() {
+        eventStore.append(List.of(taggedEvent("SeedType", "explain:tag")));
+
+        MongoCollection<Document> collection = mongoClient.getDatabase(databaseName).getCollection(COLLECTION);
+
+        // Mirrors what toDcbBsonQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
+        // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
+        // no dcbTags field) and does so via an index rather than a collection scan.
+        Document matchAllQuery = new Document("$and", List.of(
+                new Document("position", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("dcbTags", new Document("$exists", true))
+        ));
+        Document matchAllExplain = collection.find(matchAllQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+        assertThat(extractWinningPlanStage(matchAllExplain))
+                .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", matchAllExplain.toJson())
+                .isEqualTo("IXSCAN");
+        assertThat(matchAllExplain.toJson())
+                .as("The winning plan should use the dcbTags index specifically. Full explain: %s", matchAllExplain.toJson())
+                .contains("dcbTags");
+    }
+
     private MongoEventStore buildEventStoreWithStreamIdGenerator(DcbStreamIdGenerator streamIdGenerator) {
         EventStoreConfig config = new EventStoreConfig.Builder()
                 .timeRepresentation(TimeRepresentation.RFC_3339_STRING)

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
@@ -595,20 +595,34 @@ class MongoEventStoreDcbConcurrencyTest {
 
         MongoCollection<Document> collection = mongoClient.getDatabase(databaseName).getCollection(COLLECTION);
 
+        // Bias the planner the same way ADR 49's spike did: many more position-only stream
+        // documents than dcbTags-carrying ones, so the position index is only cheaper if the
+        // planner ignores dcbTags selectivity. Without this skew, a single-document collection
+        // ties and the planner may pick either index, defeating the point of the assertion below.
+        List<Document> streamOnlyDocuments = new ArrayList<>();
+        for (int i = 0; i < 20_000; i++) {
+            streamOnlyDocuments.add(new Document("id", "explain-stream-only-" + i)
+                    .append("source", SOURCE.toString())
+                    .append("streamid", "explain-stream-only-" + i)
+                    .append("streamversion", 0L)
+                    .append("position", 1_000 + i));
+        }
+        collection.insertMany(streamOnlyDocuments);
+
         // Mirrors what toDcbBsonQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
         // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
         // no dcbTags field) and does so via an index rather than a collection scan.
         Document matchAllQuery = new Document("$and", List.of(
-                new Document("position", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("position", new Document("$gt", 0).append("$lte", 1_000_000)),
                 new Document("dcbTags", new Document("$exists", true))
         ));
         Document matchAllExplain = collection.find(matchAllQuery).explain(ExplainVerbosity.QUERY_PLANNER);
         assertThat(extractWinningPlanStage(matchAllExplain))
                 .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", matchAllExplain.toJson())
                 .isEqualTo("IXSCAN");
-        assertThat(matchAllExplain.toJson())
+        assertThat(extractWinningIndexName(matchAllExplain))
                 .as("The winning plan should use the dcbTags index specifically. Full explain: %s", matchAllExplain.toJson())
-                .contains("dcbTags");
+                .isEqualTo("dcbTags_1");
     }
 
     private MongoEventStore buildEventStoreWithStreamIdGenerator(DcbStreamIdGenerator streamIdGenerator) {
@@ -650,6 +664,26 @@ class MongoEventStoreDcbConcurrencyTest {
             }
         }
         return "UNKNOWN";
+    }
+
+    private static String extractWinningIndexName(Document explainDoc) {
+        Document queryPlanner = explainDoc.get("queryPlanner", Document.class);
+        Document plan = queryPlanner == null ? null : queryPlanner.get("winningPlan", Document.class);
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            if ("IXSCAN".equals(plan.getString("stage"))) {
+                return plan.getString("indexName");
+            }
+            Document input = plan.get("inputStage", Document.class);
+            if (input != null) {
+                plan = input;
+            } else {
+                @SuppressWarnings("unchecked")
+                List<Document> inputStages = (List<Document>) plan.get("inputStages");
+                plan = inputStages != null && !inputStages.isEmpty() ? inputStages.get(0) : null;
+            }
+        }
+        return null;
     }
 
     private static CloudEvent taggedEvent(String type, String... tags) {

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbTest.java
@@ -357,6 +357,32 @@ class MongoEventStoreDcbTest {
         assertThat(upToTwo.lastSequencePosition()).isEqualTo(3);
     }
 
+    @Test
+    void dcb_all_only_matches_dcb_written_events_not_stream_written_events() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(all()).events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined");
+    }
+
+    @Test
+    void dcb_type_only_criterion_does_not_match_a_stream_written_event_of_that_type() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(types(List.of("OrderPlaced"))).events()).isEmpty();
+    }
+
+    @Test
+    void exists_and_count_are_false_and_zero_for_a_store_with_only_stream_written_events() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+
+        assertThat(eventStore.exists(all())).isFalse();
+        assertThat(eventStore.count(all())).isZero();
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), java.util.Arrays.stream(tags).map(Tag::parse).toList());
     }

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -693,13 +693,14 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private static Query toDcbMongoQuery(DcbCriteria query, long afterPosition, long upperSequencePosition) {
         Criteria positionCriteria = where(OccurrentCloudEventExtension.POSITION).gt(afterPosition).lte(upperSequencePosition);
+        Criteria dcbEventCriteria = where(DCB_TAGS_INDEX_FIELD).exists(true);
         if (query instanceof DcbCriteria.MatchAll) {
-            return new Query(positionCriteria);
+            return new Query(new Criteria().andOperator(positionCriteria, dcbEventCriteria));
         }
         List<Criteria> itemCriteria = DcbMarkerModel.dcbQueryItems(query).stream()
                 .map(SpringMongoEventStore::toCriteria)
                 .toList();
-        return new Query(new Criteria().andOperator(positionCriteria, new Criteria().orOperator(itemCriteria)));
+        return new Query(new Criteria().andOperator(positionCriteria, dcbEventCriteria, new Criteria().orOperator(itemCriteria)));
     }
 
     private static Criteria toCriteria(DcbCriterion item) {
@@ -791,7 +792,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), new IndexOptions().unique(true));
         }
         if (dcbEnabled) {
-            eventStoreCollection.createIndex(Indexes.ascending(DCB_TAGS_INDEX_FIELD));
+            eventStoreCollection.createIndex(Indexes.ascending(DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true));
         }
         // The position index is created whenever the store writes a position, so position-ordered reads and catch-up
         // have an index to sort on.

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
@@ -743,6 +743,28 @@ class SpringMongoEventStoreDcbConcurrencyTest {
                 .isEqualTo("IXSCAN");
     }
 
+    @Test
+    void dcb_match_all_query_is_index_backed_on_dcb_tags_field() {
+        eventStore.append(List.of(taggedEvent("SeedType", "explain:tag")));
+
+        MongoCollection<Document> collection = mongoTemplate.getCollection(COLLECTION);
+
+        // Mirrors what toDcbMongoQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
+        // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
+        // no dcbTags field) and does so via an index rather than a collection scan.
+        Document matchAllQuery = new Document("$and", List.of(
+                new Document("position", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("dcbTags", new Document("$exists", true))
+        ));
+        Document matchAllExplain = collection.find(matchAllQuery).explain(ExplainVerbosity.QUERY_PLANNER);
+        assertThat(extractWinningPlanStage(matchAllExplain))
+                .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", matchAllExplain.toJson())
+                .isEqualTo("IXSCAN");
+        assertThat(matchAllExplain.toJson())
+                .as("The winning plan should use the dcbTags index specifically. Full explain: %s", matchAllExplain.toJson())
+                .contains("dcbTags");
+    }
+
     /**
      * Extracts the stage name of the winning plan from an explain() output document.
      * Walks the {@code queryPlanner.winningPlan} tree, following {@code inputStage} or

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbConcurrencyTest.java
@@ -749,20 +749,34 @@ class SpringMongoEventStoreDcbConcurrencyTest {
 
         MongoCollection<Document> collection = mongoTemplate.getCollection(COLLECTION);
 
+        // Bias the planner the same way ADR 49's spike did: many more position-only stream
+        // documents than dcbTags-carrying ones, so the position index is only cheaper if the
+        // planner ignores dcbTags selectivity. Without this skew, a single-document collection
+        // ties and the planner may pick either index, defeating the point of the assertion below.
+        List<Document> streamOnlyDocuments = new ArrayList<>();
+        for (int i = 0; i < 20_000; i++) {
+            streamOnlyDocuments.add(new Document("id", "explain-stream-only-" + i)
+                    .append("source", SOURCE.toString())
+                    .append("streamid", "explain-stream-only-" + i)
+                    .append("streamversion", 0L)
+                    .append("position", 1_000 + i));
+        }
+        collection.insertMany(streamOnlyDocuments);
+
         // Mirrors what toDcbMongoQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
         // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
         // no dcbTags field) and does so via an index rather than a collection scan.
         Document matchAllQuery = new Document("$and", List.of(
-                new Document("position", new Document("$gt", 0).append("$lte", 1000000)),
+                new Document("position", new Document("$gt", 0).append("$lte", 1_000_000)),
                 new Document("dcbTags", new Document("$exists", true))
         ));
         Document matchAllExplain = collection.find(matchAllQuery).explain(ExplainVerbosity.QUERY_PLANNER);
         assertThat(extractWinningPlanStage(matchAllExplain))
                 .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", matchAllExplain.toJson())
                 .isEqualTo("IXSCAN");
-        assertThat(matchAllExplain.toJson())
+        assertThat(extractWinningIndexName(matchAllExplain))
                 .as("The winning plan should use the dcbTags index specifically. Full explain: %s", matchAllExplain.toJson())
-                .contains("dcbTags");
+                .isEqualTo("dcbTags_1");
     }
 
     /**
@@ -805,6 +819,30 @@ class SpringMongoEventStoreDcbConcurrencyTest {
             }
         }
         return "UNKNOWN";
+    }
+
+    /**
+     * Extracts the index name of the winning plan's IXSCAN stage, if any, walking the
+     * same {@code queryPlanner.winningPlan} tree as {@link #extractWinningPlanStage(Document)}.
+     */
+    private static String extractWinningIndexName(Document explainDoc) {
+        Document queryPlanner = explainDoc.get("queryPlanner", Document.class);
+        Document plan = queryPlanner == null ? null : queryPlanner.get("winningPlan", Document.class);
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            if ("IXSCAN".equals(plan.getString("stage"))) {
+                return plan.getString("indexName");
+            }
+            Document input = plan.get("inputStage", Document.class);
+            if (input != null) {
+                plan = input;
+            } else {
+                @SuppressWarnings("unchecked")
+                List<Document> inputStages = (List<Document>) plan.get("inputStages");
+                plan = inputStages != null && !inputStages.isEmpty() ? inputStages.get(0) : null;
+            }
+        }
+        return null;
     }
 
     // ---------------------------------------------------------------------------

--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreDcbTest.java
@@ -357,6 +357,32 @@ class SpringMongoEventStoreDcbTest {
         assertThat(upToTwo.lastSequencePosition()).isEqualTo(3);
     }
 
+    @Test
+    void dcb_all_only_matches_dcb_written_events_not_stream_written_events() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(all()).events())
+                .extracting(CloudEvent::getType)
+                .containsExactly("NameDefined");
+    }
+
+    @Test
+    void dcb_type_only_criterion_does_not_match_a_stream_written_event_of_that_type() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1")));
+
+        assertThat(eventStore.read(types(List.of("OrderPlaced"))).events()).isEmpty();
+    }
+
+    @Test
+    void exists_and_count_are_false_and_zero_for_a_store_with_only_stream_written_events() {
+        eventStore.write("stream:1", java.util.stream.Stream.of(event("OrderPlaced")));
+
+        assertThat(eventStore.exists(all())).isFalse();
+        assertThat(eventStore.count(all())).isZero();
+    }
+
     private static CloudEvent taggedEvent(String type, String... tags) {
         return DcbCloudEvents.withTags(event(type), java.util.Arrays.stream(tags).map(Tag::parse).toList());
     }

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -528,13 +528,14 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     private static Query toDcbMongoQuery(DcbCriteria query, long afterPosition, long upperSequencePosition) {
         Criteria positionCriteria = where(OccurrentCloudEventExtension.POSITION).gt(afterPosition).lte(upperSequencePosition);
+        Criteria dcbEventCriteria = where(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD).exists(true);
         if (query instanceof DcbCriteria.MatchAll) {
-            return new Query(positionCriteria);
+            return new Query(new Criteria().andOperator(positionCriteria, dcbEventCriteria));
         }
         List<Criteria> itemCriteria = DcbMarkerModel.dcbQueryItems(query).stream()
                 .map(ReactorMongoEventStore::toCriteria)
                 .toList();
-        return new Query(new Criteria().andOperator(positionCriteria, new Criteria().orOperator(itemCriteria)));
+        return new Query(new Criteria().andOperator(positionCriteria, dcbEventCriteria, new Criteria().orOperator(itemCriteria)));
     }
 
     private static Criteria toCriteria(DcbCriterion item) {
@@ -676,7 +677,7 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         if (dcbEnabled) {
             chain = chain
                     .then(createCollection(dcbCheckpointCollectionName, mongoTemplate))
-                    .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions()))
+                    .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true)))
                     .then();
         }
 

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -338,11 +338,27 @@ class ReactorMongoEventStoreDcbTest {
     void dcb_match_all_query_is_index_backed_on_dcb_tags_field() {
         eventStore.append(List.of(taggedEvent("SeedType", "explain:tag"))).block();
 
+        // Bias the planner the same way ADR 49's spike did: many more position-only stream
+        // documents than dcbTags-carrying ones, so the position index is only cheaper if the
+        // planner ignores dcbTags selectivity. Without this skew, a single-document collection
+        // ties and the planner may pick either index, defeating the point of the assertion below.
+        List<org.bson.Document> streamOnlyDocuments = new ArrayList<>();
+        for (int i = 0; i < 20_000; i++) {
+            streamOnlyDocuments.add(new org.bson.Document("id", "explain-stream-only-" + i)
+                    .append("source", SOURCE.toString())
+                    .append("streamid", "explain-stream-only-" + i)
+                    .append("streamversion", 0L)
+                    .append("position", 1_000 + i));
+        }
+        requireNonNull(mongoTemplate.getCollection("events")
+                .flatMap(collection -> reactor.core.publisher.Mono.from(collection.insertMany(streamOnlyDocuments)))
+                .block());
+
         // Mirrors what toDcbMongoQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
         // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
         // no dcbTags field) and does so via an index rather than a collection scan.
         org.bson.Document matchAllQuery = new org.bson.Document("$and", List.of(
-                new org.bson.Document("position", new org.bson.Document("$gt", 0).append("$lte", 1000000)),
+                new org.bson.Document("position", new org.bson.Document("$gt", 0).append("$lte", 1_000_000)),
                 new org.bson.Document("dcbTags", new org.bson.Document("$exists", true))
         ));
 
@@ -353,9 +369,9 @@ class ReactorMongoEventStoreDcbTest {
         assertThat(extractWinningPlanStage(explain))
                 .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", explain.toJson())
                 .isEqualTo("IXSCAN");
-        assertThat(explain.toJson())
+        assertThat(extractWinningIndexName(explain))
                 .as("The winning plan should use the dcbTags index specifically. Full explain: %s", explain.toJson())
-                .contains("dcbTags");
+                .isEqualTo("dcbTags_1");
     }
 
     private static String extractWinningPlanStage(org.bson.Document explainDoc) {
@@ -382,6 +398,25 @@ class ReactorMongoEventStoreDcbTest {
             plan = inputStage;
         }
         return "UNKNOWN";
+    }
+
+    private static String extractWinningIndexName(org.bson.Document explainDoc) {
+        org.bson.Document queryPlanner = explainDoc.get("queryPlanner", org.bson.Document.class);
+        org.bson.Document plan = queryPlanner == null ? null : queryPlanner.get("winningPlan", org.bson.Document.class);
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            if ("IXSCAN".equals(plan.getString("stage"))) {
+                return plan.getString("indexName");
+            }
+            org.bson.Document inputStage = plan.get("inputStage", org.bson.Document.class);
+            if (inputStage == null) {
+                List<?> inputStages = plan.getList("inputStages", org.bson.Document.class);
+                plan = inputStages != null && !inputStages.isEmpty() ? (org.bson.Document) inputStages.get(0) : null;
+            } else {
+                plan = inputStage;
+            }
+        }
+        return null;
     }
 
     @Test

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreDcbTest.java
@@ -305,6 +305,86 @@ class ReactorMongoEventStoreDcbTest {
     }
 
     @Test
+    void dcb_all_only_matches_dcb_written_events_not_stream_written_events() {
+        eventStore.write("stream:1", Flux.just(event("OrderPlaced"))).block();
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+
+        DcbEventStream stream = eventStore.read(all()).block();
+
+        assertThat(requireNonNull(stream).events()).extracting(CloudEvent::getType).containsExactly("NameDefined");
+    }
+
+    @Test
+    void dcb_type_only_criterion_does_not_match_a_stream_written_event_of_that_type() {
+        eventStore.write("stream:1", Flux.just(event("OrderPlaced"))).block();
+        eventStore.append(List.of(taggedEvent("NameDefined", "name:1"))).block();
+
+        DcbEventStream stream = eventStore.read(types(List.of("OrderPlaced"))).block();
+
+        assertThat(requireNonNull(stream).events()).isEmpty();
+    }
+
+    @Test
+    void exists_and_count_are_false_and_zero_for_a_store_with_only_stream_written_events() {
+        eventStore.write("stream:1", Flux.just(event("OrderPlaced"))).block();
+
+        assertAll(
+                () -> assertThat(eventStore.exists(all()).block()).isFalse(),
+                () -> assertThat(eventStore.count(all()).block()).isZero()
+        );
+    }
+
+    @Test
+    void dcb_match_all_query_is_index_backed_on_dcb_tags_field() {
+        eventStore.append(List.of(taggedEvent("SeedType", "explain:tag"))).block();
+
+        // Mirrors what toDcbMongoQuery(...) now builds for DcbCriteria.all(): the position window ANDed with an
+        // existence check on dcbTags, so a MatchAll/type-only read can never match a stream-written event (which has
+        // no dcbTags field) and does so via an index rather than a collection scan.
+        org.bson.Document matchAllQuery = new org.bson.Document("$and", List.of(
+                new org.bson.Document("position", new org.bson.Document("$gt", 0).append("$lte", 1000000)),
+                new org.bson.Document("dcbTags", new org.bson.Document("$exists", true))
+        ));
+
+        org.bson.Document explain = requireNonNull(mongoTemplate.getCollection("events")
+                .flatMap(collection -> reactor.core.publisher.Mono.from(collection.find(matchAllQuery).explain(com.mongodb.ExplainVerbosity.QUERY_PLANNER)))
+                .block());
+
+        assertThat(extractWinningPlanStage(explain))
+                .as("MatchAll DCB read should be index-backed via the sparse dcbTags index, not a COLLSCAN. Full explain: %s", explain.toJson())
+                .isEqualTo("IXSCAN");
+        assertThat(explain.toJson())
+                .as("The winning plan should use the dcbTags index specifically. Full explain: %s", explain.toJson())
+                .contains("dcbTags");
+    }
+
+    private static String extractWinningPlanStage(org.bson.Document explainDoc) {
+        org.bson.Document queryPlanner = explainDoc.get("queryPlanner", org.bson.Document.class);
+        if (queryPlanner == null) {
+            return "UNKNOWN";
+        }
+        org.bson.Document plan = queryPlanner.get("winningPlan", org.bson.Document.class);
+        int depth = 0;
+        while (plan != null && depth++ < 20) {
+            String stage = plan.getString("stage");
+            if ("IXSCAN".equals(stage) || "COLLSCAN".equals(stage) || "COUNT_SCAN".equals(stage)) {
+                return stage;
+            }
+            org.bson.Document inputStage = plan.get("inputStage", org.bson.Document.class);
+            if (inputStage == null) {
+                List<?> inputStages = plan.getList("inputStages", org.bson.Document.class);
+                if (inputStages != null && !inputStages.isEmpty()) {
+                    plan = (org.bson.Document) inputStages.get(0);
+                    continue;
+                }
+                return stage == null ? "UNKNOWN" : stage;
+            }
+            plan = inputStage;
+        }
+        return "UNKNOWN";
+    }
+
+    @Test
     void appending_an_event_with_a_duplicate_id_and_source_fails_fast_without_retrying() {
         CloudEvent event = taggedEvent("NameDefined", "name:1");
         eventStore.append(List.of(event)).block();


### PR DESCRIPTION
Fixes #279. `DcbCriteria.all()` and type-only criteria could match stream-written events on a store with both `STREAM` and `DCB` capabilities enabled, since nothing checked that the matched event was ever DCB-tagged. This violates the invariant ADR 17 and ADR 18 already state: stream events do not participate in DCB reads unless backfilled. Confirmed pre-existing, surfaced by a Copilot review comment on an unrelated PR (#276).

## The fix

Every store's DCB read path now ANDs an unconditional DCB-membership guard alongside whatever the criteria already asks for.

- In-memory: `DcbCloudEvents.isDcbEvent(event)` at the three call sites that read, back `exists`/`count`, and check append-condition conflicts.
- Native, Spring blocking, Spring reactor: a `dcbTags` existence predicate in the shared query builder, covering both the `MatchAll` path and the per-item OR branch. `read`, `exists`, `count`, and the append-condition conflict check all route through this one method per store, so it's a single-point fix.

`DcbCriteria`, `DcbCriterion`, and `DcbCloudEvents.matches()` are deliberately untouched. `matches()` is a pure type/tag predicate, used and tested directly elsewhere, and the guard isn't something a caller can or should express through the criteria model.

## The index

I didn't want to add a correctness predicate that quietly turns every `MatchAll` read into a near-full collection scan, so I checked. The `dcbTags` index in all three Mongo stores was plain, not sparse. Verified with `explain("executionStats")` against a skewed dataset (200,000 stream documents without the field, 200 DCB documents with it): a plain index gives the new predicate zero selectivity, since a non-sparse index also indexes the implicit missing value and can't turn `$exists:true` into tight bounds. The planner falls back to the position index and examines 199,999 of 200,000 documents, exactly what the buggy query already cost. A sparse index collapses that to 200 of 200,000, sub-millisecond. I also tried a non-sparse compound `{position, dcbTags}` index as an alternative and rejected it, same result as plain, for the same reason. Verified on both `mongo:4.2.8` (this repo's test version) and `mongo:8.0`.

The index is now sparse in all three stores. Since DCB has never shipped, there's no deployed index anywhere to migrate, so this is a plain option change with nothing to guard.

Full reasoning and the rejected alternative are in [ADR 49](doc/architecture/decisions/0049-dcb-reads-exclude-non-dcb-stream-events.md).

## Verification

New tests per store: a mixed stream and DCB store where `DcbCriteria.all()` and a type-only criterion matching the stream event's type both correctly exclude it, `exists`/`count` agreeing on a stream-only store, and an `explain()`-backed test confirming the DCB read stays index-backed on `dcbTags`.

I want to flag one thing plainly. I hit repeated `mvn clean install` failures in my local sandbox while verifying this, none of which turned out to be caused by this change. I traced them individually: a stuck reused Mongo container, an orphaned build process racing my own in the same worktree, and the well-documented Colima `DatabaseDropPending` container-reuse flake, always in test classes this diff never touches. Every module this fix actually changes passed cleanly and repeatedly in isolation, including all the new tests, across two independent verification passes. I couldn't get a fully green full-reactor build in this sandbox despite many attempts, so I'm relying on CI to confirm it on a properly resourced runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
