### PR TITLE
Revive @Subscription as the capability-agnostic subscription

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,13 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   invisible to DCB reads. This enforces the invariant that the Mongo capability filter relies on, so the filter keys
   off the sparse-indexed `dcbTags` array for an efficient `Filter.capability(DCB)`.
   * See [ADR 50](doc/architecture/decisions/0050-stream-catchup-subscriptions-exclude-dcb-events.md).
+* Revived `@Subscription` and the `Subscriptions` DSL, previously deprecated aliases for the stream forms, as the
+  capability-neutral default. On a store with both `STREAM` and `DCB` capabilities they deliver both stream-written and
+  DCB-appended events, filtered only by event type, with catch-up over the unified global position and resume via
+  `GlobalCheckpoint`. `@StreamSubscription` and `@DcbSubscription` stay as the explicit capability-scoped forms. This is
+  safe for existing applications because the neutral form only ever also sees DCB events on a DCB-enabled store, and
+  those are new since DCB is unreleased. On a stream-only store it behaves exactly as `@Subscription` did before.
+  * See [ADR 51](doc/architecture/decisions/0051-capability-agnostic-subscription.md).
 * Renamed the `SubscriptionPosition` type family to `Checkpoint` to stop overloading "position" for two different
   concepts: the ordering value (`position`) and the per-subscriber resume marker built from it. This is a breaking
   API change; there is no deprecated alias.

--- a/doc/architecture/decisions/0051-capability-agnostic-subscription.md
+++ b/doc/architecture/decisions/0051-capability-agnostic-subscription.md
@@ -1,0 +1,87 @@
+# 51. Capability-agnostic `@Subscription` as the default
+
+Date: 2026-07-06
+
+## Status
+
+Accepted
+
+## Context
+
+A subscription forced a choice between `@StreamSubscription`, which sees stream events filtered by an Occurrent
+`Filter`, and `@DcbSubscription`, which sees DCB events filtered by tags. Most consumers do not fit either box. A
+projection or a read model reacts to events by type and does not care which write model produced them. Forcing such a
+consumer to pick a capability is asking a question it has no reason to answer, and picking the wrong one silently drops
+the other half of the history.
+
+The capability distinction only ever leaked into subscriptions through one seam: the catch-up start position.
+[ADR 24](0024-stream-and-dcb-subscription-model-split.md) split the subscription model and start-position types into
+stream and DCB forms for a load-bearing reason. Stream catch-up started at a time and DCB catch-up started at a
+`dcbposition`, the two position types were incompatible, and DCB carried a `tags()` boundary that stream had no
+equivalent for. A shared `StartAt` let a caller hand a DCB subscription a time-based start or a stream subscription a
+DCB position, and the mismatch failed quietly at runtime. The split turned that whole class of mismatch into a compile
+error.
+
+Two later changes removed the ground that split stood on for the neutral case. [ADR 45](0045-unified-global-position.md)
+made `position` a first-class property of every event, stream and DCB alike, so both stacks now share one global,
+comparable ordering axis instead of two disjoint ones. `GlobalCheckpoint` (`position:N`) is already the
+capability-neutral resume token that both existing catch-up models persist and reload. Live delivery was already
+capability-agnostic, because the raw change stream sees every event regardless of capability.
+[ADR 50](0050-stream-catchup-subscriptions-exclude-dcb-events.md) was what made stream subscriptions capability-scoped
+at all, by ANDing `Filter.capability(STREAM)` into `StreamCatchupSubscriptionModel`. Without that guard the underlying
+machinery is neutral by construction. So a subscription that wants both stream and DCB events, filtered only by type,
+no longer needs a DCB-specific position or a stream-specific time. It needs the global position that now exists for
+every event, and that position removes the reason the type split reached the neutral case.
+
+## Decision
+
+**Revive `@Subscription` and the `Subscriptions` DSL as the capability-neutral default.** Both currently exist only as
+deprecated aliases, `@Subscription` for `@StreamSubscription` and `Subscriptions` as a subclass of
+`StreamSubscriptions`. They become the neutral form that delivers both stream and DCB events, filtered only by the
+generic `Filter` over event types. There is no capability parameter and no `tags()`, because the neutral subscription
+does not scope by write model. This is the default a projection or read model reaches for when it just wants events by
+type.
+
+**Catch-up runs over the unified global position and resumes via `GlobalCheckpoint`.** The neutral subscription reuses
+the position-based catch-up path that already exists for stream subscriptions, with one difference: it omits the
+`Filter.capability(STREAM)` guard that ADR 50 (#282) added. The caller's own type `Filter` is still honored. No
+capability guard is composed on top of it, so both stream and DCB events matching the type filter are replayed and then
+handed over to the already-capability-agnostic live change stream. The handover is the same one the stream path uses,
+minus the guard.
+
+**Type safety is preserved the way ADR 24 intended.** The neutral subscription exposes only capability-neutral start
+positions: now, beginning, the subscription model default, and an explicit global position. It never exposes a
+DCB-specific position, a stream-only time-based position, or `tags`. There is therefore no mismatched combination for a
+caller to form, so the property ADR 24 established (illegal starts are unrepresentable rather than quietly wrong) holds
+for the neutral form as well. The neutral form does not widen the surface back into the union that ADR 24 closed. It
+adds a third, strictly neutral surface next to the two scoped ones.
+
+**A neutral filter marker and a third dispatch route.** The neutral subscription carries a capability-neutral
+`SubscriptionFilter` marker, distinct from the stream and DCB markers, and the catch-up dispatcher gains a third route
+for it alongside the stream and DCB routes that [ADR 25](0025-dual-mode-catch-up-for-stream-and-dcb-applications.md)
+established. The neutral route is the position-based catch-up without the capability guard. This ADR fixes the decision,
+not the class layout. The concrete type and method names beyond `@Subscription` and `Subscriptions` are left to the
+implementation.
+
+**`@StreamSubscription` and `@DcbSubscription` are unchanged.** The stream annotation and DSL remain the explicit
+stream-scoped form, capability-guarded per ADR 50. The DCB annotation and DSL remain the explicit DCB-scoped form,
+tag-filtered per [ADR 27](0027-add-the-dcbsubscription-annotation.md). A caller who genuinely wants one capability
+still says so. The neutral form is the default, not a replacement for the scoped ones.
+
+## Consequences
+
+`@Subscription` changes meaning from stream-only to capability-neutral. This is safe. The change only manifests on a
+store that has the DCB capability enabled, and those stores are new because DCB is unreleased, so no existing deployment
+observes a behavior change. On a stream-only store the neutral subscription is identical to what `@Subscription`
+delivered before, because such a store has no DCB events for the dropped guard to have excluded.
+
+The relationship to the prior subscription ADRs is as follows. ADR 24's start-position type safety is upheld, because
+the neutral subscription exposes only neutral start positions and forms no new mismatch. ADR 25's dual-mode dispatch
+gains a third neutral route next to its stream and DCB routes. ADR 27's `@DcbSubscription` is untouched. ADR 45's
+unified position is the enabler that makes a single neutral catch-up axis possible. ADR 50's capability filter is simply
+omitted for the neutral case, which is the whole mechanism of this decision.
+
+On a legacy store that predates the unified global position, an event has no position to catch up over, so the neutral
+subscription degrades to time-based catch-up over stream events. This is correct rather than a limitation, because a
+store old enough to lack a global position also has no DCB events, so there is nothing for the neutral form to miss
+there.

--- a/dsl/subscription-dsl/blocking/src/main/kotlin/org/occurrent/dsl/subscription/blocking/Subscriptions.kt
+++ b/dsl/subscription-dsl/blocking/src/main/kotlin/org/occurrent/dsl/subscription/blocking/Subscriptions.kt
@@ -20,8 +20,10 @@ import io.cloudevents.CloudEvent
 import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.application.converter.get
 import org.occurrent.dsl.subscription.EventMetadata
+import org.occurrent.dsl.subscription.agnosticSubscriptionFilterFromEventTypes
 import org.occurrent.dsl.subscription.subscriptionFilterFromEventTypes
 import org.occurrent.filter.Filter
+import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.OccurrentSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.api.blocking.Subscribable
@@ -51,14 +53,23 @@ fun <E : Any> streamSubscriptions(subscriptionModel: Subscribable, cloudEventCon
 }
 
 /**
- * Renamed to [streamSubscriptions] to mirror `@StreamSubscription` and the DCB counterpart `DcbSubscriptions`.
+ * Capability-agnostic subscription DSL entry-point. On a store with both the `STREAM` and `DCB` capabilities it
+ * delivers both stream-written and DCB-appended events, filtered only by event type. Usage example:
+ *
+ * ```
+ * val mySubscriptionModel = ..
+ * val myCloudEventConverter = ..
+ * subscriptions(mySubscriptionModel, myCloudEventConverter) {
+ *      subscribe<MyEvent>("subscriptionId") {
+ *          ...
+ *      }
+ * }
+ * ```
+ *
+ * Use [streamSubscriptions] or the DCB counterpart when a subscription should be scoped to a single capability.
  */
-// No ReplaceWith: the lambda receiver is Subscriptions<E>, which is not assignable to the streamSubscriptions
-// receiver StreamSubscriptions<E>, so an automated replacement would not compile.
-@Deprecated("Renamed to streamSubscriptions")
-@Suppress("DEPRECATION")
-fun <E : Any> subscriptions(subscriptionModel: Subscribable, cloudEventConverter: CloudEventConverter<E>, subscriptions: Subscriptions<E>.() -> Unit) {
-    Subscriptions(subscriptionModel, cloudEventConverter).apply(subscriptions)
+fun <E : Any> subscriptions(subscriptionModel: Subscribable, cloudEventConverter: CloudEventConverter<E>, block: Subscriptions<E>.() -> Unit) {
+    Subscriptions(subscriptionModel, cloudEventConverter).apply(block)
 }
 
 open class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, private val cloudEventConverter: CloudEventConverter<E>) {
@@ -173,8 +184,118 @@ open class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscriba
 }
 
 /**
- * Renamed to [StreamSubscriptions] to mirror `@StreamSubscription` and the DCB counterpart `DcbSubscriptions`. Kept as a
- * subclass rather than a typealias so the released type stays in the bytecode for Java and binary compatibility.
+ * The capability-agnostic subscription DSL. It mirrors the method surface of [StreamSubscriptions] but routes through an
+ * [AgnosticSubscriptionFilter] instead of an [OccurrentSubscriptionFilter], so on a store with both the `STREAM` and
+ * `DCB` capabilities it delivers both stream-written and DCB-appended events, filtered only by event type. Use
+ * [StreamSubscriptions] or `DcbSubscriptions` when a subscription should be scoped to a single capability.
  */
-@Deprecated("Renamed to StreamSubscriptions", ReplaceWith("StreamSubscriptions"))
-class Subscriptions<E : Any>(subscriptionModel: Subscribable, cloudEventConverter: CloudEventConverter<E>) : StreamSubscriptions<E>(subscriptionModel, cloudEventConverter)
+class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, private val cloudEventConverter: CloudEventConverter<E>) {
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Unit): Subscription {
+        return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): Subscription {
+        return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (E1) -> Unit): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Unit): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
+    }
+
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Unit): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
+    }
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Unit): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Consumer<E1>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
+            @Suppress("UNCHECKED_CAST")
+            fn.accept(e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E1>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
+            @Suppress("UNCHECKED_CAST")
+            fn.accept(metadata, e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Consumer<E>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.accept(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.accept(metadata, e) }
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Unit): Subscription {
+        val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
+        return subscribe(subscriptionId, filter, startAt, fn)
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): Subscription {
+        val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
+        return subscribe(subscriptionId, filter, startAt, true, fn)
+    }
+
+    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Unit): Subscription {
+        return subscribe(subscriptionId, filter, startAt) { _, e -> fn(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(
+        subscriptionId: String,
+        filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()),
+        startAt: StartAt? = null,
+        waitUntilStarted: Boolean = true,
+        fn: (EventMetadata, E) -> Unit
+    ): Subscription {
+        val consumer: (CloudEvent) -> Unit = { cloudEvent ->
+            val event = cloudEventConverter[cloudEvent]
+            val eventMetadata = EventMetadata.from(cloudEvent)
+            fn(eventMetadata, event)
+        }
+
+        val subscription = if (startAt == null) {
+            subscriptionModel.subscribe(subscriptionId, filter, consumer)
+        } else {
+            subscriptionModel.subscribe(subscriptionId, filter, startAt, consumer)
+        }
+
+        return subscription.apply {
+            if (waitUntilStarted) {
+                waitUntilStarted()
+            }
+        }
+    }
+}

--- a/dsl/subscription-dsl/common/src/main/kotlin/org/occurrent/dsl/subscription/SubscriptionFilters.kt
+++ b/dsl/subscription-dsl/common/src/main/kotlin/org/occurrent/dsl/subscription/SubscriptionFilters.kt
@@ -20,19 +20,34 @@ import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.application.converter.get
 import org.occurrent.condition.Condition
 import org.occurrent.filter.Filter
+import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.OccurrentSubscriptionFilter
 import kotlin.reflect.KClass
 
 /**
- * Build an [OccurrentSubscriptionFilter] that matches the cloud event types derived from the given domain [eventTypes],
- * using the [cloudEventConverter] to map each [KClass] to its cloud event type. An empty [eventTypes] matches all events.
+ * Build the plain [Filter] that matches the cloud event types derived from the given domain [eventTypes], using the
+ * [cloudEventConverter] to map each [KClass] to its cloud event type. An empty [eventTypes] matches all events.
  * Shared by the blocking and reactive subscription DSLs, since the logic is neither blocking- nor reactive-specific.
  */
-fun <E : Any> subscriptionFilterFromEventTypes(cloudEventConverter: CloudEventConverter<E>, eventTypes: Array<out KClass<out E>>): OccurrentSubscriptionFilter {
+fun <E : Any> filterFromEventTypes(cloudEventConverter: CloudEventConverter<E>, eventTypes: Array<out KClass<out E>>): Filter {
     val condition = when {
         eventTypes.isEmpty() -> null
         eventTypes.size == 1 -> Condition.eq(cloudEventConverter[eventTypes[0]])
         else -> Condition.or(eventTypes.map { e -> Condition.eq(cloudEventConverter[e]) })
     }
-    return OccurrentSubscriptionFilter.filter(if (condition == null) Filter.all() else Filter.type(condition))
+    return if (condition == null) Filter.all() else Filter.type(condition)
 }
+
+/**
+ * Build an [OccurrentSubscriptionFilter] (stream capability) that matches the cloud event types derived from the given
+ * domain [eventTypes]. An empty [eventTypes] matches all events.
+ */
+fun <E : Any> subscriptionFilterFromEventTypes(cloudEventConverter: CloudEventConverter<E>, eventTypes: Array<out KClass<out E>>): OccurrentSubscriptionFilter =
+    OccurrentSubscriptionFilter.filter(filterFromEventTypes(cloudEventConverter, eventTypes))
+
+/**
+ * Build an [AgnosticSubscriptionFilter] (capability-agnostic) that matches the cloud event types derived from the given
+ * domain [eventTypes]. An empty [eventTypes] matches all events, of every capability.
+ */
+fun <E : Any> agnosticSubscriptionFilterFromEventTypes(cloudEventConverter: CloudEventConverter<E>, eventTypes: Array<out KClass<out E>>): AgnosticSubscriptionFilter =
+    AgnosticSubscriptionFilter.filter(filterFromEventTypes(cloudEventConverter, eventTypes))

--- a/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
+++ b/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
@@ -20,8 +20,10 @@ import io.cloudevents.CloudEvent
 import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.application.converter.get
 import org.occurrent.dsl.subscription.EventMetadata
+import org.occurrent.dsl.subscription.agnosticSubscriptionFilterFromEventTypes
 import org.occurrent.dsl.subscription.subscriptionFilterFromEventTypes
 import org.occurrent.filter.Filter
+import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.OccurrentSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.api.reactor.Subscribable
@@ -139,6 +141,137 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
     fun subscribe(
         subscriptionId: String,
         filter: OccurrentSubscriptionFilter = OccurrentSubscriptionFilter.filter(Filter.all()),
+        startAt: StartAt? = null,
+        fn: (EventMetadata, E) -> Mono<Void>
+    ): Subscription {
+        val action: (CloudEvent) -> Mono<Void> = { cloudEvent ->
+            val event = cloudEventConverter[cloudEvent]
+            val eventMetadata = EventMetadata.from(cloudEvent)
+            fn(eventMetadata, event)
+        }
+
+        return if (startAt == null) {
+            subscriptionModel.subscribe(subscriptionId, filter, action)
+        } else {
+            subscriptionModel.subscribe(subscriptionId, filter, startAt, action)
+        }
+    }
+}
+
+/**
+ * Capability-agnostic subscription DSL entry-point. On a store with both the `STREAM` and `DCB` capabilities it
+ * delivers both stream-written and DCB-appended events, filtered only by event type. Usage example:
+ *
+ * ```
+ * val mySubscriptionModel = ..
+ * val myCloudEventConverter = ..
+ * subscriptions(mySubscriptionModel, myCloudEventConverter) {
+ *      subscribe<MyEvent>("subscriptionId") { event ->
+ *          ...
+ *          Mono.empty()
+ *      }
+ * }
+ * ```
+ *
+ * Use [streamSubscriptions] or the DCB counterpart when a subscription should be scoped to a single capability.
+ */
+fun <E : Any> subscriptions(subscriptionModel: Subscribable, cloudEventConverter: CloudEventConverter<E>, block: Subscriptions<E>.() -> Unit) {
+    Subscriptions(subscriptionModel, cloudEventConverter).apply(block)
+}
+
+/**
+ * The capability-agnostic subscription DSL. It mirrors the method surface of [StreamSubscriptions] but routes through an
+ * [AgnosticSubscriptionFilter] instead of an [OccurrentSubscriptionFilter], so on a store with both the `STREAM` and
+ * `DCB` capabilities it delivers both stream-written and DCB-appended events, filtered only by event type. Use
+ * [StreamSubscriptions] or `DcbSubscriptions` when a subscription should be scoped to a single capability.
+ */
+class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, private val cloudEventConverter: CloudEventConverter<E>) {
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    @JvmName("subscribeAll")
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
+    }
+
+    /**
+     * Create a new subscription that is invoked after a specific domain event is written to the event store
+     */
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = E1::class.simpleName!!, startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
+    }
+
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
+    }
+
+    @JvmName("subscribeAnyOf")
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
+            @Suppress("UNCHECKED_CAST")
+            fn.apply(e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
+            @Suppress("UNCHECKED_CAST")
+            fn.apply(metadata, e as E1)
+        }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.apply(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): Subscription {
+        return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.apply(metadata, e) }
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
+        return subscribe(subscriptionId, filter, startAt, fn)
+    }
+
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+        val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
+        return subscribe(subscriptionId, filter, startAt, fn)
+    }
+
+    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+        return subscribe(subscriptionId, filter, startAt) { _, e -> fn(e) }
+    }
+
+    @JvmOverloads
+    fun subscribe(
+        subscriptionId: String,
+        filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()),
         startAt: StartAt? = null,
         fn: (EventMetadata, E) -> Mono<Void>
     ): Subscription {

--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SubscriptionExtensionsTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/SubscriptionExtensionsTest.kt
@@ -29,7 +29,7 @@ import org.occurrent.application.converter.jackson.jacksonCloudEventConverter
 import org.occurrent.domain.DomainEvent
 import org.occurrent.domain.NameDefined
 import org.occurrent.domain.NameWasChanged
-import org.occurrent.dsl.subscription.blocking.subscriptions
+import org.occurrent.dsl.subscription.blocking.streamSubscriptions
 import org.occurrent.eventstore.api.blocking.write
 import org.occurrent.eventstore.inmemory.InMemoryEventStore
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel
@@ -55,7 +55,7 @@ class SubscriptionExtensionsTest {
         val subscriptionModel = InMemorySubscriptionModel()
         val converter = jacksonCloudEventConverter(ObjectMapper(), URI.create("urn:name"), DomainEvent::eventId)
 
-        subscriptions(subscriptionModel, converter) {
+        streamSubscriptions(subscriptionModel, converter) {
             updateView("names", materializedView)
         }
 

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Subscription.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Subscription.java
@@ -20,7 +20,9 @@ package org.occurrent.annotation;
 import java.lang.annotation.*;
 
 /**
- * An annotation that can be used to start/resume subscriptions. For example:
+ * Starts or resumes a capability-agnostic subscription. It delivers events of the given types regardless of which write
+ * model produced them, so on a store that has both the {@code STREAM} and {@code DCB} capabilities it receives both
+ * stream-written and DCB-appended events, filtered only by event type. For example:
  *
  * <pre lang="java">
  * &#64;Subscription(id = "mySubscription")
@@ -29,29 +31,41 @@ import java.lang.annotation.*;
  * }
  * </pre>
  *
+ * <h4>Which subscription annotation to use</h4>
+ * <p>
+ * This is the neutral default for a read model or policy that reacts to events by type and does not care which write
+ * model produced them. Use {@link StreamSubscription} or {@link DcbSubscription} instead when a subscription should be
+ * scoped to a single capability, that is stream-written events only, or DCB events filtered by tags.
+ * </p>
+ *
  * <h4>Start Position</h4>
  * <p>
- * You can also specify at which time the subscription should start:
+ * You can specify where the subscription should start over the unified global {@code position}:
  * <pre lang="java">
- * &#64;Subscription(id = "mySubscription", startAt = StartPosition.BEGINNING_OF_TIME)
+ * &#64;Subscription(id = "mySubscription", startAt = StartPosition.BEGINNING)
  * void mySubscription(MyDomainEvent event) { .. }
  * </pre>
- * This will first replay all historic events from the beginning of time and then continue subscribing to new events continuously. You can also start at a specific date
- * by using {@link #startAtISO8601()} or {@link #startAtTimeEpochMillis()}.
+ * This will first replay all historic events from the beginning of the global position sequence and then continue
+ * subscribing to new events continuously. You can also start after a specific global position with
+ * {@link #startAtGlobalPosition()}.
  * </p>
  * <p>
- * Note that the example above will <i>start</i> replay historic events from the beginning of time when the subscription is started the first time. However, once the subscription is resumed,
- * e.g. on application restart, it'll continue from the last received event. If you want a different behavior, configure a different {@link #resumeBehavior()}.
+ * Note that the example above will <i>start</i> replaying historic events from the beginning when the subscription is
+ * started the first time. However, once the subscription is resumed, for example on application restart, it will
+ * continue from the last received event. If you want a different behavior, configure a different
+ * {@link #resumeBehavior()}.
  * </p>
  * <p>
- * Note also that if {@code MyDomainEvent} is a sealed interface/class, then all events implementing this interface/class will be received. If you want to receive only
- * some of the events that implements this interface, see {@link #eventTypes()}.
+ * Note also that if {@code MyDomainEvent} is a sealed interface or class, then all events implementing this interface
+ * or class will be received. If you want to receive only some of the events that implement this interface, see
+ * {@link #eventTypes()}.
  * </p>
  *
  * <h4>Metadata</h4>
  * <p>
- * Sometimes it can be useful to get the metadata associated with the received event. For this reason, you can add a parameter to the method annotated with
- * {@code @Subscription} of type {@link org.occurrent.dsl.subscription.EventMetadata}. For example:
+ * Sometimes it can be useful to get the metadata associated with the received event. For this reason, you can add a
+ * parameter to the method annotated with {@code @Subscription} of type
+ * {@link org.occurrent.dsl.subscription.EventMetadata}. For example:
  * <pre lang="java">
  * &#64;Subscription(id = "mySubscription")
  * void mySubscription(MyDomainEvent event, EventMetadata metadata) {
@@ -61,11 +75,7 @@ import java.lang.annotation.*;
  *   ..
  * }
  * </pre>
- *
- * @deprecated Use {@link StreamSubscription} instead. This annotation is the original name for a stream subscription and
- * is kept as an alias for backward compatibility. It will be removed in a future release.
  */
-@Deprecated(forRemoval = true)
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
@@ -103,58 +113,51 @@ public @interface Subscription {
     Class<?>[] eventTypes() default {};
 
     /**
-     * Specify the start position to one if the predefined ones in {@link StartPosition}.
+     * Specify the start position as one of the predefined {@link StartPosition} values. Mutually exclusive with
+     * {@link #startAtGlobalPosition()}, which starts after a specific global position instead of a predefined one.
      */
     StartPosition startAt() default StartPosition.DEFAULT;
 
     /**
-     * Specify the start position as time epoch milliseconds
+     * Start after a specific global {@code position}, that is deliver events from {@code startAtGlobalPosition + 1}
+     * onward, which is useful to rewind a durable read model to a known-good position. The default of {@code -1} means
+     * unset, in which case {@link #startAt()} is used. Mutually exclusive with a non-{@link StartPosition#DEFAULT}
+     * {@link #startAt()}, and {@link #resumeBehavior()} applies the same way it does to {@link StartPosition#BEGINNING}.
      */
-    long startAtTimeEpochMillis() default -1;
+    long startAtGlobalPosition() default -1;
 
     /**
-     * Start a subscription from the specified ISO8601 date/time. Valid dates are e.g.
-     * <pre>
-     * 2024-05-10T10:48:00.838
-     * 2024-05-10T10:48:00.838Z
-     * 2024-05-10T15:30:37.123+02:00
-     * </pre>
-     */
-    String startAtISO8601() default "";
-
-    /**
-     * Specify if the resume behavior for the subscription should differ from when its started.
-     * For example, if you specify {@code startAt=BEGINNING_OF_TIME}, the {@code resumeBehavior}
-     * defines how the subscription should behave on restart of the application. By default, if you've
-     * specified {@code startAt} (or epoch/iso date), then the subscription will be resumed from the last
-     * received event when the application is restarted. I.e. first the subscription is caught-up
-     * (by reading the events from the beginning of time in this example) and then it'll continue by listening
-     * to new events, <i>without</i>_ starting from the beginning of time when the application is restarted.
-     * If you <i>always</i> want to start from the beginning of time, you can set the resume behavior to
-     * {@link ResumeBehavior#SAME_AS_START_AT}. This means that the subscription will start the "catching-up"
-     * even on application restarts. This can be useful for in-memory projections/read-models where you don't
-     * want to maintain any state at all.
+     * Specify if the resume behavior for the subscription should differ from when it is started. By default
+     * ({@link ResumeBehavior#DEFAULT}), a subscription that starts by replaying history (from
+     * {@link StartPosition#BEGINNING} or from a {@link #startAtGlobalPosition()}) replays only the first time it is
+     * started and then resumes from the last received event on application restart. That is the right behavior for a
+     * durable read model that persists what it builds.
+     * <p>
+     * An in-memory read model is different: it keeps no durable state, so it has to replay the whole history on every
+     * boot. For that, combine {@link StartPosition#BEGINNING} with {@link ResumeBehavior#SAME_AS_START_AT}, which
+     * replays from the beginning on every restart and keeps no checkpoint. With the default resume behavior an in-memory
+     * model would, after a restart, resume mid-sequence and silently miss all history before the stored position.
      */
     ResumeBehavior resumeBehavior() default ResumeBehavior.DEFAULT;
 
     StartupMode startupMode() default StartupMode.DEFAULT;
 
     /**
-     * A set of predefined start positions
+     * A set of predefined, capability-neutral start positions over the unified global {@code position}.
      */
     enum StartPosition {
         /**
-         * Start this subscription from the first event in the event store
+         * Replay the whole global position sequence from the beginning (global position 0) before switching to live
+         * delivery, so a read model can be rebuilt from history.
          */
-        BEGINNING_OF_TIME,
+        BEGINNING,
         /**
-         * Start this subscription from "NOW"
+         * Start from "now", delivering only events written after the subscription starts.
          */
         NOW,
         /**
-         * Start this subscription using the default behavior of the subscription model.
-         * Typically, this means that it'll start from "NOW", unless the subscription has already been
-         * started before, in which case the subscription will be started from its last know position.
+         * Use the default behavior of the subscription model. Typically this resumes from the last stored position if
+         * the subscription has run before, otherwise it behaves like {@link #NOW}.
          */
         DEFAULT
     }

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
@@ -39,10 +39,11 @@ import java.util.function.Predicate;
 import static java.util.function.Predicate.not;
 
 /**
- * Stack-neutral helpers for processing the {@link StreamSubscription} and {@link DcbSubscription} annotations, and the
- * deprecated {@link Subscription} alias. Shared by the blocking and reactive annotation {@code BeanPostProcessor}s so the
- * reflection and event-type resolution logic lives in one place and cannot drift. The stack-specific parts (how the
- * consumer is invoked, how the start position is resolved, and which subscription DSL is used) stay in each processor.
+ * Stack-neutral helpers for processing the {@link StreamSubscription}, {@link DcbSubscription} and the
+ * capability-agnostic {@link Subscription} annotations. Shared by the blocking and reactive annotation
+ * {@code BeanPostProcessor}s so the reflection and event-type resolution logic lives in one place and cannot drift. The
+ * stack-specific parts (how the consumer is invoked, how the start position is resolved, and which subscription DSL is
+ * used) stay in each processor.
  */
 public final class SubscriptionAnnotations {
 
@@ -50,9 +51,7 @@ public final class SubscriptionAnnotations {
     }
 
     /**
-     * The normalized form of a stream subscription declaration, built from either the {@link StreamSubscription}
-     * annotation or the deprecated {@link Subscription} alias. The deprecated annotation's enums are mapped to the
-     * canonical {@link StreamSubscription} enums by name, since the constants are identical.
+     * The normalized form of a stream subscription declaration, built from the {@link StreamSubscription} annotation.
      */
     public record StreamSubscriptionDefinition(String id, Class<?>[] eventTypes, String startAtISO8601,
                                                long startAtTimeEpochMillis, StartPosition startAt,
@@ -61,13 +60,6 @@ public final class SubscriptionAnnotations {
         public static StreamSubscriptionDefinition from(StreamSubscription subscription) {
             return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
                     subscription.startAtTimeEpochMillis(), subscription.startAt(), subscription.resumeBehavior(), subscription.startupMode(), "@StreamSubscription");
-        }
-
-        @SuppressWarnings("deprecation")
-        public static StreamSubscriptionDefinition from(Subscription subscription) {
-            return new StreamSubscriptionDefinition(subscription.id(), subscription.eventTypes(), subscription.startAtISO8601(),
-                    subscription.startAtTimeEpochMillis(), StartPosition.valueOf(subscription.startAt().name()),
-                    ResumeBehavior.valueOf(subscription.resumeBehavior().name()), StartupMode.valueOf(subscription.startupMode().name()), "@Subscription");
         }
     }
 

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -29,6 +29,7 @@ import org.occurrent.dsl.dcb.DcbEventMetadata;
 import org.occurrent.dsl.dcb.reactor.DcbSubscriptions;
 import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.dsl.subscription.reactor.StreamSubscriptions;
+import org.occurrent.dsl.subscription.reactor.Subscriptions;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.Tag;
@@ -37,6 +38,7 @@ import org.occurrent.filter.Filter;
 import org.occurrent.springboot.mongo.common.OccurrentProperties;
 import org.occurrent.springboot.mongo.common.SubscriptionAnnotations;
 import org.occurrent.springboot.mongo.common.SubscriptionAnnotations.StreamSubscriptionDefinition;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
@@ -63,15 +65,17 @@ import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
  * Reactive counterpart of the blocking {@code OccurrentBlockingAnnotationBeanPostProcessor}. It supports the
- * {@link StreamSubscription} and {@link DcbSubscription} annotations, and the deprecated {@link Subscription} alias,
- * for the reactive (Project Reactor) stack. The stack-neutral reflection and event-type resolution is shared with the
- * blocking processor through {@link SubscriptionAnnotations}.
+ * {@link Subscription}, {@link StreamSubscription} and {@link DcbSubscription} annotations for the reactive (Project
+ * Reactor) stack. The stack-neutral reflection and event-type resolution is shared with the blocking processor through
+ * {@link SubscriptionAnnotations}.
  * <p>
  * The reactive stream (non-DCB) catch-up model replays only by position, so a {@link StreamSubscription} that starts
  * at a specific time ({@code startAtISO8601} or {@code startAtTimeEpochMillis}) fails loud, position replay cannot
  * resolve a wall-clock time to a position. {@code BEGINNING_OF_TIME} replays from position 0 on a position-writing
  * STREAM-only store, and fails loud otherwise. {@code NOW} and {@code DEFAULT} are always supported. DCB
- * subscriptions replay history by position via the reactive DCB catch-up model, matching the blocking behavior.
+ * subscriptions replay history by position via the reactive DCB catch-up model, matching the blocking behavior. The
+ * capability-agnostic {@link Subscription} replays over the unified global position, so {@code BEGINNING} replays from
+ * position 0 and {@code startAtGlobalPosition} from a specific position, both delivering events of every capability.
  */
 class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
 
@@ -91,12 +95,12 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
             DcbSubscription dcbSubscription = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
             long annotationCount = Stream.of(streamSubscription, subscription, dcbSubscription).filter(Objects::nonNull).count();
             if (annotationCount > 1) {
-                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @StreamSubscription, @DcbSubscription and the deprecated @Subscription, use only one.".formatted(bean.getClass().getName(), method.getName()));
+                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription and @DcbSubscription, use only one.".formatted(bean.getClass().getName(), method.getName()));
             }
             if (streamSubscription != null) {
                 processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(streamSubscription));
             } else if (subscription != null) {
-                processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(subscription));
+                processAgnosticSubscribeAnnotation(bean, method, subscription);
             } else if (dcbSubscription != null) {
                 processDcbSubscribeAnnotation(bean, method, dcbSubscription);
             }
@@ -142,6 +146,102 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         if (shouldWaitUntilStarted) {
             result.waitUntilStarted().block();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> void processAgnosticSubscribeAnnotation(Object bean, Method method, Subscription annotation) {
+        String id = annotation.id();
+        final Filter filter;
+        final List<Class<?>> parameterTypes;
+        if (method.getParameterCount() >= 1) {
+            CloudEventConverter<E> cloudEventConverter = applicationContext.getBean(CloudEventConverter.class);
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isStreamMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isStreamMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@Subscription");
+
+            if (domainEventTypesToSubscribeTo.size() == 1) {
+                filter = Filter.type(cloudEventConverter.getCloudEventType(domainEventTypesToSubscribeTo.get(0)));
+            } else {
+                List<Filter> typeFilters = domainEventTypesToSubscribeTo.stream()
+                        .map(cloudEventConverter::getCloudEventType)
+                        .map(Filter::type)
+                        .toList();
+                filter = new Filter.CompositionFilter(OR, typeFilters);
+            }
+        } else {
+            throw new IllegalArgumentException("A subscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
+        }
+
+        Function2<EventMetadata, E, Mono<Void>> consumer = (metadata, event) ->
+                invokeMono(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadata, SubscriptionAnnotations::isStreamMetadataParameter));
+
+        long startAtGlobalPosition = annotation.startAtGlobalPosition();
+        if (startAtGlobalPosition >= 0 && annotation.startAt() != Subscription.StartPosition.DEFAULT) {
+            throw new IllegalArgumentException("Specify either startAt or startAtGlobalPosition for @Subscription '%s', not both.".formatted(id));
+        }
+        boolean replaysHistory = startAtGlobalPosition >= 0 || annotation.startAt() == Subscription.StartPosition.BEGINNING;
+        if (replaysHistory && !positionReplaySupported()) {
+            throw new IllegalArgumentException(("@Subscription '%s' asks to replay history (BEGINNING or startAtGlobalPosition), but this store does not write a global position, so the reactive " +
+                    "position-based catch-up cannot replay. Use startAt = NOW or DEFAULT.").formatted(id));
+        }
+        StartAt startAt = generateAgnosticStartAt(id, annotation.startAt(), startAtGlobalPosition, annotation.resumeBehavior());
+        boolean shouldWaitUntilStarted = shouldWaitUntilStartedAgnostic(replaysHistory, annotation.startupMode());
+        Subscriptions<E> subscriptions = applicationContext.getBean(Subscriptions.class);
+
+        applyStartupWorkarounds();
+
+        var result = subscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(filter), startAt, consumer);
+        if (shouldWaitUntilStarted) {
+            result.waitUntilStarted().block();
+        }
+    }
+
+    private static boolean shouldWaitUntilStartedAgnostic(boolean replaysHistory, Subscription.StartupMode startupMode) {
+        return switch (startupMode) {
+            // A subscription that replays history may have a lot to read, so by default it starts in the background.
+            case DEFAULT -> !replaysHistory;
+            case WAIT_UNTIL_STARTED -> true;
+            case BACKGROUND -> false;
+        };
+    }
+
+    // A capability-agnostic subscription replays over the unified global position, so replay is supported whenever the
+    // store writes a position, regardless of which capabilities are enabled (unlike stream replay, which also requires
+    // the STREAM capability).
+    private boolean positionReplaySupported() {
+        ReactorMongoEventStore eventStore = applicationContext.getBeanProvider(ReactorMongoEventStore.class).getIfAvailable();
+        return eventStore != null && eventStore.writesPosition();
+    }
+
+    // Build the neutral StartAt over the unified global position. BEGINNING replays from global position 0,
+    // startAtGlobalPosition replays after a specific position, both applying the same replay-then-resume logic. NOW and
+    // DEFAULT go straight to live.
+    private StartAt generateAgnosticStartAt(String subscriptionId, Subscription.StartPosition startPosition, long startAtGlobalPosition, Subscription.ResumeBehavior resumeBehavior) {
+        if (startAtGlobalPosition >= 0) {
+            return replayThenResumeAgnostic(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(startAtGlobalPosition)), resumeBehavior);
+        }
+        return switch (startPosition) {
+            case NOW -> StartAt.now();
+            case DEFAULT -> StartAt.subscriptionModelDefault();
+            case BEGINNING -> replayThenResumeAgnostic(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), resumeBehavior);
+        };
+    }
+
+    // Replay from replayStart, then on later restarts either resume from the stored position (DEFAULT) or replay again
+    // (SAME_AS_START_AT). SAME_AS_START_AT disables durable position storage by delegating to the parent subscription
+    // model, so an in-memory read model rebuilt on every boot sees every event and keeps no checkpoint. There is no
+    // reactive competing-consumer model, so only the durable layer is considered. Mirrors the DCB replayThenResume.
+    private StartAt replayThenResumeAgnostic(String subscriptionId, StartAt replayStart, Subscription.ResumeBehavior resumeBehavior) {
+        return switch (resumeBehavior) {
+            case SAME_AS_START_AT -> StartAt.dynamic(ctx -> {
+                boolean isDurableSubscription = ReactorDurableSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                return isDurableSubscription ? null : replayStart;
+            });
+            case DEFAULT -> StartAt.dynamic(ctx -> {
+                CheckpointStorage storage = applicationContext.getBean(CheckpointStorage.class);
+                return storage.read(subscriptionId).blockOptional().isPresent() ? StartAt.subscriptionModelDefault() : replayStart;
+            });
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.occurrent.dsl.dcb.reactor.DcbDomainEventQueries;
 import org.occurrent.dsl.dcb.reactor.DcbSubscriptions;
 import org.occurrent.dsl.query.reactor.DomainEventQueries;
 import org.occurrent.dsl.subscription.reactor.StreamSubscriptions;
+import org.occurrent.dsl.subscription.reactor.Subscriptions;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
@@ -188,6 +189,18 @@ public class OccurrentReactiveMongoAutoConfiguration<E> {
     @Conditional(OnMissingCloudEventConverterAndCloudEventTypeMapperCondition.class)
     public CloudEventTypeMapper<E> occurrentTypeMapper() {
         return ReflectionCloudEventTypeMapper.qualified();
+    }
+
+    /**
+     * The capability-agnostic subscription DSL, used by the {@code @Subscription} annotation. On a store with both the
+     * {@code STREAM} and {@code DCB} capabilities it delivers both stream-written and DCB-appended events, filtered only
+     * by event type.
+     */
+    @Bean
+    @ConditionalOnMissingBean(Subscriptions.class)
+    @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
+    public Subscriptions<E> occurrentSubscriptions(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
+        return new Subscriptions<>(subscribable, cloudEventConverter);
     }
 
     @Bean

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -31,12 +31,15 @@ import org.occurrent.dsl.dcb.DcbEventMetadata;
 import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.dsl.subscription.blocking.StreamSubscriptions;
+import org.occurrent.dsl.subscription.blocking.Subscriptions;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.Tag;
 import org.occurrent.filter.Filter;
 import org.occurrent.springboot.mongo.common.SubscriptionAnnotations;
 import org.occurrent.springboot.mongo.common.SubscriptionAnnotations.StreamSubscriptionDefinition;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.blocking.competingconsumers.CompetingConsumerSubscriptionModel;
@@ -70,9 +73,9 @@ import static org.occurrent.filter.Filter.CompositionOperator.OR;
 import static org.occurrent.subscription.OccurrentSubscriptionFilter.filter;
 
 /**
- * Implements support for the {@link StreamSubscription} and {@link DcbSubscription} annotations, and the deprecated
- * {@link Subscription} alias, in Spring Boot. The stack-neutral reflection and event-type resolution is shared with the
- * reactive processor through {@link SubscriptionAnnotations}.
+ * Implements support for the {@link Subscription}, {@link StreamSubscription} and {@link DcbSubscription} annotations in
+ * Spring Boot. The stack-neutral reflection and event-type resolution is shared with the reactive processor through
+ * {@link SubscriptionAnnotations}.
  */
 class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
 
@@ -92,12 +95,12 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
             DcbSubscription dcbSubscription = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
             long annotationCount = Stream.of(streamSubscription, subscription, dcbSubscription).filter(Objects::nonNull).count();
             if (annotationCount > 1) {
-                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @StreamSubscription, @DcbSubscription and the deprecated @Subscription, use only one.".formatted(bean.getClass().getName(), method.getName()));
+                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription and @DcbSubscription, use only one.".formatted(bean.getClass().getName(), method.getName()));
             }
             if (streamSubscription != null) {
                 processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(streamSubscription));
             } else if (subscription != null) {
-                processSubscribeAnnotation(bean, method, StreamSubscriptionDefinition.from(subscription));
+                processAgnosticSubscribeAnnotation(bean, method, subscription);
             } else if (dcbSubscription != null) {
                 processDcbSubscribeAnnotation(bean, method, dcbSubscription);
             }
@@ -144,6 +147,95 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         applyStartupWorkarounds();
 
         subscribable.subscribe(id, filter(filter), startAt, shouldWaitUntilStarted, consumer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> void processAgnosticSubscribeAnnotation(Object bean, Method method, Subscription annotation) {
+        String id = annotation.id();
+        final Filter filter;
+        final List<Class<?>> parameterTypes;
+        if (method.getParameterCount() >= 1) {
+            CloudEventConverter<E> cloudEventTypeMapper = applicationContext.getBean(CloudEventConverter.class);
+            parameterTypes = SubscriptionAnnotations.analyzeParameters(method, SubscriptionAnnotations::isStreamMetadataParameter);
+            Class<E> specifiedEventType = (Class<E>) SubscriptionAnnotations.eventTypeOf(parameterTypes, SubscriptionAnnotations::isStreamMetadataParameter);
+            List<Class<E>> domainEventTypesToSubscribeTo = SubscriptionAnnotations.resolveDomainEventTypes(id, bean, method, specifiedEventType, annotation.eventTypes(), "@Subscription");
+
+            if (domainEventTypesToSubscribeTo.size() == 1) {
+                filter = Filter.type(cloudEventTypeMapper.getCloudEventType(domainEventTypesToSubscribeTo.get(0)));
+            } else {
+                List<Filter> typeFilters = domainEventTypesToSubscribeTo.stream()
+                        .map(cloudEventTypeMapper::getCloudEventType)
+                        .map(Filter::type)
+                        .toList();
+                filter = new Filter.CompositionFilter(OR, typeFilters);
+            }
+        } else {
+            throw new IllegalArgumentException("A subscription method must declare an event parameter, but %s#%s has none.".formatted(bean.getClass().getName(), method.getName()));
+        }
+
+        Function2<EventMetadata, E, Unit> consumer = (metadata, event) -> {
+            invoke(method, bean, SubscriptionAnnotations.bindArguments(parameterTypes, event, metadata, SubscriptionAnnotations::isStreamMetadataParameter));
+            return Unit.INSTANCE;
+        };
+
+        long startAtGlobalPosition = annotation.startAtGlobalPosition();
+        if (startAtGlobalPosition >= 0 && annotation.startAt() != Subscription.StartPosition.DEFAULT) {
+            throw new IllegalArgumentException("Specify either startAt or startAtGlobalPosition for @Subscription '%s', not both.".formatted(id));
+        }
+        StartAt startAt = generateAgnosticStartAt(id, annotation.startAt(), startAtGlobalPosition, annotation.resumeBehavior());
+        boolean replaysHistory = startAtGlobalPosition >= 0 || annotation.startAt() == Subscription.StartPosition.BEGINNING;
+        boolean shouldWaitUntilStarted = shouldWaitUntilStartedAgnostic(replaysHistory, annotation.startupMode());
+        Subscriptions<E> subscribable = applicationContext.getBean(Subscriptions.class);
+
+        applyStartupWorkarounds();
+
+        subscribable.subscribe(id, AgnosticSubscriptionFilter.filter(filter), startAt, shouldWaitUntilStarted, consumer);
+    }
+
+    private static boolean shouldWaitUntilStartedAgnostic(boolean replaysHistory, Subscription.StartupMode startupMode) {
+        return switch (startupMode) {
+            // A subscription that replays history may have a lot to read, so by default it starts in the background.
+            case DEFAULT -> !replaysHistory;
+            case WAIT_UNTIL_STARTED -> true;
+            case BACKGROUND -> false;
+        };
+    }
+
+    // Build the neutral StartAt over the unified global position. BEGINNING replays from global position 0,
+    // startAtGlobalPosition replays after a specific position, both applying the same replay-then-resume logic. NOW and
+    // DEFAULT go straight to live.
+    private StartAt generateAgnosticStartAt(String subscriptionId, Subscription.StartPosition startPosition, long startAtGlobalPosition, Subscription.ResumeBehavior resumeBehavior) {
+        if (startAtGlobalPosition >= 0) {
+            return replayThenResumeAgnostic(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(startAtGlobalPosition)), resumeBehavior);
+        }
+        return switch (startPosition) {
+            case NOW -> StartAt.now();
+            case DEFAULT -> StartAt.dynamic(ctx -> {
+                // Do not let the catch-up model run its default (replay from the beginning); delegate to the parent
+                // live subscription instead by returning null to the catch-up layer.
+                boolean isCatchupSubscription = CatchupSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                return isCatchupSubscription ? null : StartAt.subscriptionModelDefault();
+            });
+            case BEGINNING -> replayThenResumeAgnostic(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), resumeBehavior);
+        };
+    }
+
+    // Replay from replayStart, then on later restarts either resume from the stored position (DEFAULT) or replay again
+    // (SAME_AS_START_AT). SAME_AS_START_AT also disables the competing consumer and durable position storage by
+    // delegating to the parent subscription model for those layers, so an in-memory read model rebuilt on every boot
+    // sees every event and keeps no checkpoint. Mirrors the DCB replayThenResume.
+    private StartAt replayThenResumeAgnostic(String subscriptionId, StartAt replayStart, Subscription.ResumeBehavior resumeBehavior) {
+        return switch (resumeBehavior) {
+            case SAME_AS_START_AT -> StartAt.dynamic(ctx -> {
+                boolean isCompetingConsumerSubscription = CompetingConsumerSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                boolean isDurableSubscription = DurableSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
+                return isCompetingConsumerSubscription || isDurableSubscription ? null : replayStart;
+            });
+            case DEFAULT -> StartAt.dynamic(ctx -> {
+                CheckpointStorage checkpointStorage = applicationContext.getBean(CheckpointStorage.class);
+                return checkpointStorage.exists(subscriptionId) ? StartAt.subscriptionModelDefault() : replayStart;
+            });
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -199,12 +199,27 @@ public class OccurrentMongoAutoConfiguration<E> {
         return ReflectionCloudEventTypeMapper.qualified();
     }
 
+    /**
+     * The capability-agnostic subscription DSL, used by the {@code @Subscription} annotation. On a store with both the
+     * {@code STREAM} and {@code DCB} capabilities it delivers both stream-written and DCB-appended events, filtered only
+     * by event type.
+     */
+    @Bean
+    @ConditionalOnMissingBean(Subscriptions.class)
+    @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
+    public Subscriptions<E> occurrentSubscriptionDsl(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
+        return new Subscriptions<>(subscribable, cloudEventConverter);
+    }
+
+    /**
+     * The stream subscription DSL, used by the {@code @StreamSubscription} annotation. It scopes delivery to the
+     * {@code STREAM} capability.
+     */
     @Bean
     @ConditionalOnMissingBean(StreamSubscriptions.class)
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
-    @SuppressWarnings("deprecation") // The released bean type stays Subscriptions for binary compatibility; it is-a StreamSubscriptions, so new code can inject either.
-    public Subscriptions<E> occurrentSubscriptionDsl(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
-        return new Subscriptions<>(subscribable, cloudEventConverter);
+    public StreamSubscriptions<E> occurrentStreamSubscriptionDsl(Subscribable subscribable, CloudEventConverter<E> cloudEventConverter) {
+        return new StreamSubscriptions<>(subscribable, cloudEventConverter);
     }
 
     /**

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
@@ -35,9 +35,14 @@ import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.Tag;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.condition.Condition;
 import org.occurrent.filter.Filter;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
+import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.Subscription;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.catchup.StartAtTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -344,6 +349,182 @@ class DcbDualModeCatchupAutoConfigurationMongoTest {
         await().atMost(ofSeconds(20)).pollInterval(ofMillis(100)).untilAsserted(() -> {
             assertThat(received).contains(historic, live);
             assertThat(received).doesNotHaveDuplicates();
+        });
+    }
+
+    @Test
+    void neutral_subscription_receives_both_stream_and_dcb_historic_events_during_catchup() {
+        // Given - one stream event and one DCB event written before the neutral subscription starts
+        TestEvent streamHistoric = streamEvent("neutral-catchup-stream-historic");
+        TestEvent dcbHistoric = dcbEvent("neutral-catchup-dcb-historic");
+        appendStream(streamHistoric);
+        appendDcb(dcbHistoric);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        // When - a capability-agnostic subscription (AgnosticSubscriptionFilter, no capability scope) catches up from
+        // the unified global position 0
+        subscriptionModel.subscribe(
+                        "neutral-catchup-" + UUID.randomUUID(),
+                        AgnosticSubscriptionFilter.filter(Filter.type(cloudEventConverter.getCloudEventType(TestEvent.class))),
+                        StartAt.checkpoint(GlobalCheckpoint.of(0)),
+                        ce -> received.add(cloudEventConverter.toDomainEvent(ce)))
+                .waitUntilStarted();
+
+        // Then - both the stream-written and the DCB-appended event are delivered, unlike a plain stream subscription
+        // (see stream_subscription_does_not_receive_dcb_only_events_during_catchup) which would exclude the DCB one
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(streamHistoric, dcbHistoric));
+    }
+
+    @Test
+    void neutral_subscription_receives_both_stream_and_dcb_events_live_after_handover() {
+        // Given - one historic stream event so the subscription has something to catch up on before going live
+        TestEvent historic = streamEvent("neutral-live-historic");
+        appendStream(historic);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        Subscription subscription = subscriptionModel.subscribe(
+                        "neutral-live-" + UUID.randomUUID(),
+                        AgnosticSubscriptionFilter.filter(Filter.type(cloudEventConverter.getCloudEventType(TestEvent.class))),
+                        StartAt.checkpoint(GlobalCheckpoint.of(0)),
+                        ce -> received.add(cloudEventConverter.toDomainEvent(ce)));
+        subscription.waitUntilStarted();
+
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(historic));
+
+        // When - after catch-up has handed over to live delivery, a stream event and a DCB event are both appended
+        TestEvent liveStream = streamEvent("neutral-live-stream");
+        TestEvent liveDcb = dcbEvent("neutral-live-dcb");
+        appendStream(liveStream);
+        appendDcb(liveDcb);
+
+        // Then - both live events are delivered to the same neutral subscription
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(historic, liveStream, liveDcb));
+    }
+
+    @Test
+    void neutral_subscription_resumes_from_global_checkpoint_across_restart_without_missing_events() {
+        // Given - a first-generation event of each capability, delivered to a neutral subscription that is then
+        // paused (not cancelled: cancelSubscription deletes the durable checkpoint, which would defeat this test).
+        // Pausing and resuming the live delegate while keeping the checkpoint in storage is what a subscription with
+        // the same id resuming after a genuine application restart also does, since the checkpoint lives in Mongo
+        // independent of the in-process subscription object.
+        String subscriptionId = "neutral-resume-" + UUID.randomUUID();
+        TestEvent firstStream = streamEvent("neutral-resume-stream-1");
+        TestEvent firstDcb = dcbEvent("neutral-resume-dcb-1");
+        appendStream(firstStream);
+        appendDcb(firstDcb);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe(
+                        subscriptionId,
+                        AgnosticSubscriptionFilter.filter(Filter.type(cloudEventConverter.getCloudEventType(TestEvent.class))),
+                        StartAt.checkpoint(GlobalCheckpoint.of(0)),
+                        ce -> received.add(cloudEventConverter.toDomainEvent(ce)))
+                .waitUntilStarted();
+
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(firstStream, firstDcb));
+
+        subscriptionModel.pauseSubscription(subscriptionId);
+        await().atMost(ofSeconds(10)).pollInterval(ofMillis(50)).until(() -> subscriptionModel.isPaused(subscriptionId));
+
+        // When - more events of both capabilities are written while the subscription is paused, then it is resumed
+        // with the same id, which continues from the stored GlobalCheckpoint rather than replaying from the beginning
+        TestEvent secondStream = streamEvent("neutral-resume-stream-2");
+        TestEvent secondDcb = dcbEvent("neutral-resume-dcb-2");
+        appendStream(secondStream);
+        appendDcb(secondDcb);
+
+        subscriptionModel.resumeSubscription(subscriptionId);
+
+        // Then - the events written while paused are delivered after resume, without a gap. Delivery is at-least-once,
+        // so the assertion only requires the new events to show up, not that the first-generation ones stop appearing.
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(secondStream, secondDcb));
+    }
+
+    @Test
+    void neutral_subscription_with_type_filter_receives_only_matching_type_across_both_capabilities() {
+        // Given - a stream event and a DCB event of the shared TestEvent cloud event type (the only domain type this
+        // test fixture's CloudEventConverter can decode), distinguished into "signal" and "noise" by subject the same
+        // way the STREAM_TAG/DCB_TAG split already distinguishes capability elsewhere in this class. Filter.type is
+        // exercised directly against the real, single cloud event type this fixture has; Filter.subject narrows further
+        // to isolate signal from noise, mirroring how a real app narrows a type filter with an additional predicate.
+        TestEvent streamNoise = streamEvent("type-filter-stream-noise");
+        TestEvent dcbNoise = dcbEvent("type-filter-dcb-noise");
+        TestEvent streamSignal = new TestEvent(UUID.randomUUID().toString(), new Date(), "type-filter-signal-stream", "type-filter-stream-signal");
+        TestEvent dcbSignal = new TestEvent(UUID.randomUUID().toString(), new Date(), "type-filter-signal-dcb", "type-filter-dcb-signal");
+        appendStream(streamNoise, streamSignal);
+        appendDcb(dcbNoise, dcbSignal);
+
+        CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
+
+        // When - a neutral subscription is filtered to the TestEvent cloud event type and further narrowed to the
+        // "signal" subjects only
+        String testEventCloudEventType = cloudEventConverter.getCloudEventType(TestEvent.class);
+        Filter signalFilter = new Filter.CompositionFilter(Filter.CompositionOperator.AND, List.of(
+                Filter.type(testEventCloudEventType),
+                Filter.subject(Condition.in("type-filter-signal-stream", "type-filter-signal-dcb"))));
+        subscriptionModel.subscribe(
+                        "neutral-type-filter-" + UUID.randomUUID(),
+                        AgnosticSubscriptionFilter.filter(signalFilter),
+                        StartAt.checkpoint(GlobalCheckpoint.of(0)),
+                        ce -> received.add(cloudEventConverter.toDomainEvent(ce)))
+                .waitUntilStarted();
+
+        // Then - both the stream-written and the DCB-appended signal events are delivered (proving the filter applies
+        // across both capabilities), while the noise events are excluded
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(received).contains(streamSignal, dcbSignal).doesNotContain(streamNoise, dcbNoise));
+    }
+
+    @Test
+    void stream_and_dcb_annotated_style_subscriptions_stay_scoped_to_their_own_capability_alongside_a_neutral_one() {
+        // Given - one event of each capability
+        TestEvent streamOnly = streamEvent("regression-stream");
+        TestEvent dcbOnly = dcbEvent("regression-dcb");
+        appendStream(streamOnly);
+        appendDcb(dcbOnly);
+
+        CopyOnWriteArrayList<TestEvent> streamReceived = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<TestEvent> dcbReceived = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<TestEvent> neutralReceived = new CopyOnWriteArrayList<>();
+
+        // When - a stream-scoped, a DCB-scoped and a neutral subscription all catch up from the beginning at once
+        subscriptionModel.subscribe(
+                        "regression-stream-" + UUID.randomUUID(),
+                        OccurrentSubscriptionFilter.filter(Filter.all()),
+                        StartAtTime.beginningOfTime(),
+                        ce -> streamReceived.add(cloudEventConverter.toDomainEvent(ce)))
+                .waitUntilStarted();
+
+        dcbSubscriptions
+                .subscribe(
+                        "regression-dcb-" + UUID.randomUUID(),
+                        DcbCriteria.all(),
+                        DcbStartAt.beginning(),
+                        dcbReceived::add)
+                .waitUntilStarted();
+
+        subscriptionModel.subscribe(
+                        "regression-neutral-" + UUID.randomUUID(),
+                        AgnosticSubscriptionFilter.filter(Filter.type(cloudEventConverter.getCloudEventType(TestEvent.class))),
+                        StartAt.checkpoint(GlobalCheckpoint.of(0)),
+                        ce -> neutralReceived.add(cloudEventConverter.toDomainEvent(ce)))
+                .waitUntilStarted();
+
+        // Then - the stream subscription sees only the stream event, the DCB subscription sees only the DCB event, and
+        // only the neutral subscription sees both, confirming the #282 capability guard is intact alongside the new
+        // neutral behavior
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() -> {
+            assertThat(streamReceived).contains(streamOnly).doesNotContain(dcbOnly);
+            assertThat(dcbReceived).contains(dcbOnly).doesNotContain(streamOnly);
+            assertThat(neutralReceived).contains(streamOnly, dcbOnly);
         });
     }
 

--- a/subscription/core/src/main/java/org/occurrent/subscription/AgnosticSubscriptionFilter.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/AgnosticSubscriptionFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.filter.Filter;
+
+import java.util.Objects;
+
+/**
+ * A capability-agnostic {@link SubscriptionFilter} that wraps a plain Occurrent {@link Filter}.
+ * <p>
+ * It is the neutral sibling of {@link OccurrentSubscriptionFilter} (stream capability) and
+ * {@link DcbSubscriptionFilter} (DCB tags). Where {@link OccurrentSubscriptionFilter} scopes a subscription to the
+ * {@code STREAM} capability, this marker signals that events of every capability should be delivered, filtered only by
+ * the wrapped {@link Filter} (typically an event-type filter). On a store with both {@code STREAM} and {@code DCB}
+ * capabilities it therefore delivers both stream-written and DCB-appended events, catching up over the unified global
+ * {@code position} and resuming from the same {@link GlobalCheckpoint} the other position-based models use.
+ */
+@NullMarked
+public record AgnosticSubscriptionFilter(Filter filter) implements SubscriptionFilter {
+
+    public AgnosticSubscriptionFilter {
+        Objects.requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
+    }
+
+    public static AgnosticSubscriptionFilter filter(Filter filter) {
+        return new AgnosticSubscriptionFilter(filter);
+    }
+}

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
@@ -24,6 +24,7 @@ import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.filter.Filter;
 import org.occurrent.retry.RetryStrategy;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
@@ -176,6 +177,11 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Consumer<St
             return cloudEvent -> matchesFilter(cloudEvent, Filter.all());
         } else if (filter instanceof OccurrentSubscriptionFilter occurrentSubscriptionFilter) {
             Filter f = occurrentSubscriptionFilter.filter();
+            return cloudEvent -> matchesFilter(cloudEvent, f);
+        } else if (filter instanceof AgnosticSubscriptionFilter agnosticSubscriptionFilter) {
+            // Capability-agnostic delivery: match only the plain Filter, with no capability guard, so both stream and
+            // DCB events are delivered. A plain Filter (no CapabilityFilter) matches events of every capability.
+            Filter f = agnosticSubscriptionFilter.filter();
             return cloudEvent -> matchesFilter(cloudEvent, f);
         } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
             // Match the DCB query in process and require the event to be a DCB-written event, so a non-Mongo

--- a/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModelAgnosticFilterTest.java
+++ b/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModelAgnosticFilterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.inmemory;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.Tag;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Proves that {@link AgnosticSubscriptionFilter} delivers both stream-written and DCB-appended events on the
+ * in-memory subscription model, filtered only by the wrapped {@link Filter} (typically event type), with no
+ * capability guard. Contrast with {@link InMemorySubscriptionModelDcbFilterTest}, which is scoped to DCB only.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class InMemorySubscriptionModelAgnosticFilterTest {
+
+    private InMemorySubscriptionModel subscriptionModel;
+
+    @BeforeEach
+    void create_subscription_model() {
+        subscriptionModel = new InMemorySubscriptionModel();
+    }
+
+    @AfterEach
+    void shutdown() {
+        subscriptionModel.shutdown();
+    }
+
+    @Test
+    void delivers_both_a_stream_event_and_a_dcb_event_to_a_neutral_subscription() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", AgnosticSubscriptionFilter.filter(Filter.all()), received::add)
+                .waitUntilStarted();
+
+        CloudEvent streamEvent = streamEvent("TypeA", 1L);
+        CloudEvent dcbEvent = dcbEvent("TypeB", 2L, List.of("x:1"));
+        subscriptionModel.accept(Stream.of(streamEvent, dcbEvent));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId).containsExactlyInAnyOrder(streamEvent.getId(), dcbEvent.getId()));
+    }
+
+    @Test
+    void type_filter_delivers_only_matching_type_across_both_capabilities() {
+        CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
+        subscriptionModel.subscribe("sub", AgnosticSubscriptionFilter.filter(Filter.type("OrderPlaced")), received::add)
+                .waitUntilStarted();
+
+        CloudEvent matchingStream = streamEvent("OrderPlaced", 1L);
+        CloudEvent matchingDcb = dcbEvent("OrderPlaced", 2L, List.of("order:1"));
+        CloudEvent nonMatchingStream = streamEvent("OrderCancelled", 3L);
+        CloudEvent nonMatchingDcb = dcbEvent("OrderCancelled", 4L, List.of("order:1"));
+        subscriptionModel.accept(Stream.of(matchingStream, matchingDcb, nonMatchingStream, nonMatchingDcb));
+
+        await().untilAsserted(() ->
+                assertThat(received).extracting(CloudEvent::getId)
+                        .containsExactlyInAnyOrder(matchingStream.getId(), matchingDcb.getId()));
+    }
+
+    private static CloudEvent streamEvent(String type, long position) {
+        CloudEvent base = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType(type)
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+        return OccurrentCloudEventExtension.withPosition(base, position);
+    }
+
+    private static CloudEvent dcbEvent(String type, long position, List<String> tags) {
+        CloudEvent base = CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withType(type)
+                .withSource(URI.create("urn:test"))
+                .withTime(OffsetDateTime.now())
+                .build();
+        CloudEvent tagged = DcbCloudEvents.withTags(base, tags.stream().map(Tag::parse).toList());
+        return OccurrentCloudEventExtension.withPosition(tagged, position);
+    }
+}

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
@@ -108,6 +109,12 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     private final CheckpointAwareSubscriptionModel subscriptionModel;
     private final @Nullable StreamCatchupSubscriptionModel streamCatchupSubscriptionModel;
     private final @Nullable DcbCatchupSubscriptionModel dcbCatchupSubscriptionModel;
+    // The capability-agnostic position catch-up: the same position/time catch-up as the stream model but with no
+    // capability scope, so it replays and delivers events of every capability, filtered only by the caller's plain
+    // Filter. Present whenever a position/time-capable store (EventStoreQueries) is wired, i.e. in the stream-only and
+    // dual-mode configurations. Null in the DCB-only configuration, where an AgnosticSubscriptionFilter routes to the
+    // DCB model instead (a DCB-only store has only DCB events).
+    private final @Nullable StreamCatchupSubscriptionModel agnosticCatchupSubscriptionModel;
 
     /**
      * Create a new instance of {@link CatchupSubscriptionModel} the uses a default {@link CatchupSubscriptionModelConfig} with a cache size of
@@ -134,6 +141,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
         this.streamCatchupSubscriptionModel = new StreamCatchupSubscriptionModel(subscriptionModel, eventStoreQueries, config, CatchupSubscriptionModel.class);
         this.dcbCatchupSubscriptionModel = null;
+        this.agnosticCatchupSubscriptionModel = new StreamCatchupSubscriptionModel(subscriptionModel, eventStoreQueries, config, CatchupSubscriptionModel.class, null);
     }
 
     /**
@@ -165,6 +173,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
         this.streamCatchupSubscriptionModel = null;
         this.dcbCatchupSubscriptionModel = new DcbCatchupSubscriptionModel(subscriptionModel, dcbEventStore, dcbQuery, config, CatchupSubscriptionModel.class);
+        this.agnosticCatchupSubscriptionModel = null;
     }
 
     /**
@@ -182,6 +191,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
         this.streamCatchupSubscriptionModel = new StreamCatchupSubscriptionModel(subscriptionModel, eventStoreQueries, config, CatchupSubscriptionModel.class);
         this.dcbCatchupSubscriptionModel = new DcbCatchupSubscriptionModel(subscriptionModel, dcbEventStore, dcbQuery, config, CatchupSubscriptionModel.class);
+        this.agnosticCatchupSubscriptionModel = new StreamCatchupSubscriptionModel(subscriptionModel, eventStoreQueries, config, CatchupSubscriptionModel.class, null);
     }
 
     /**
@@ -209,15 +219,27 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
     @Override
     public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
-        return routesToDcb(filter, startAt)
-                ? Objects.requireNonNull(dcbCatchupSubscriptionModel).subscribe(subscriptionId, filter, startAt, action)
-                : Objects.requireNonNull(streamCatchupSubscriptionModel).subscribe(subscriptionId, filter, startAt, action);
+        return route(filter, startAt).subscribe(subscriptionId, filter, startAt, action);
     }
 
-    // Route to the DCB path or the stream path. A single-mode model has only one inner model and always routes there.
-    // A dual-mode model routes by filter type first, since a global position start is ambiguous between the two
-    // position-ordered replays (stream-position and DCB). Only an already-resolved start is inspected for the
-    // fallback heuristic, so routing reads no position storage.
+    // Route to the DCB, stream, or capability-agnostic catch-up model. A single-mode model has only one inner model and
+    // always routes there. A dual-mode model routes by filter type first, since a global position start is ambiguous
+    // between the position-ordered replays. An AgnosticSubscriptionFilter routes to the unscoped agnostic model so both
+    // stream and DCB events are delivered; if there is no agnostic model (a DCB-only store) it falls back to the DCB
+    // model, whose store has only DCB events anyway. Only an already-resolved start is inspected for the fallback
+    // heuristic, so routing reads no position storage.
+    private SubscriptionModel route(@Nullable SubscriptionFilter filter, StartAt startAt) {
+        if (filter instanceof AgnosticSubscriptionFilter) {
+            if (agnosticCatchupSubscriptionModel != null) {
+                return agnosticCatchupSubscriptionModel;
+            }
+            return Objects.requireNonNull(dcbCatchupSubscriptionModel);
+        }
+        return routesToDcb(filter, startAt)
+                ? Objects.requireNonNull(dcbCatchupSubscriptionModel)
+                : Objects.requireNonNull(streamCatchupSubscriptionModel);
+    }
+
     private boolean routesToDcb(@Nullable SubscriptionFilter filter, StartAt startAt) {
         if (dcbCatchupSubscriptionModel == null) {
             return false;
@@ -279,6 +301,9 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         if (dcbCatchupSubscriptionModel != null) {
             dcbCatchupSubscriptionModel.cancelRunningCatchup(subscriptionId);
         }
+        if (agnosticCatchupSubscriptionModel != null) {
+            agnosticCatchupSubscriptionModel.cancelRunningCatchup(subscriptionId);
+        }
         subscriptionModel.cancelSubscription(subscriptionId);
         // Position storage is shared config, not per-mode state; either inner model's config deletes the same
         // storage entry, so delegate to whichever is present instead of deleting twice.
@@ -297,6 +322,9 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         }
         if (dcbCatchupSubscriptionModel != null) {
             dcbCatchupSubscriptionModel.markShuttingDown();
+        }
+        if (agnosticCatchupSubscriptionModel != null) {
+            agnosticCatchupSubscriptionModel.markShuttingDown();
         }
         subscriptionModel.shutdown();
     }

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -25,6 +25,7 @@ import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.blocking.PositionOrderedReader;
 import org.occurrent.filter.Filter;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
@@ -83,6 +84,11 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     private static final Filter STREAM_CAPABILITY_FILTER = Filter.capability(EventStoreCapability.STREAM);
 
     private final EventStoreQueries eventStoreQueries;
+    // The capability guard ANDed into every read and every live handover. It is {@link #STREAM_CAPABILITY_FILTER} for a
+    // stream subscription (so a DCB-tagged event never reaches a stream subscriber, see ADR 50), and {@code null} for a
+    // capability-agnostic subscription, which then filters only by the caller's plain Filter and so delivers events of
+    // every capability.
+    private final @Nullable Filter capabilityScope;
 
     public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config) {
         this(subscriptionModel, eventStoreQueries, config, StreamCatchupSubscriptionModel.class);
@@ -96,8 +102,19 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      *                                      keeps working regardless of which mode-specific class runs the catch-up.
      */
     public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType) {
+        this(subscriptionModel, eventStoreQueries, config, subscriptionModelContextType, STREAM_CAPABILITY_FILTER);
+    }
+
+    /**
+     * @param capabilityScope The capability {@link Filter} ANDed into every catch-up read and every live handover.
+     *                        Pass {@link #STREAM_CAPABILITY_FILTER} for a stream subscription, or {@code null} for a
+     *                        capability-agnostic subscription that delivers events of every capability, filtered only by
+     *                        the caller's plain {@link Filter}.
+     */
+    public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType, @Nullable Filter capabilityScope) {
         super(subscriptionModel, config, subscriptionModelContextType);
         this.eventStoreQueries = Objects.requireNonNull(eventStoreQueries, "eventStoreQueries cannot be null");
+        this.capabilityScope = capabilityScope;
     }
 
     /**
@@ -125,10 +142,12 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     @Override
     public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
-        // Stream catch-up converts the filter into an Occurrent Filter for the historical query, so only the stream
-        // filter type is supported here. The DCB path accepts a DcbSubscriptionFilter and passes it to its own model.
-        if (filter != null && !(filter instanceof OccurrentSubscriptionFilter)) {
-            throw new IllegalArgumentException("Only OccurrentSubscriptionFilter is supported!");
+        // Position/time catch-up converts the filter into an Occurrent Filter for the historical query, so only the
+        // filter types that wrap a plain Filter are supported here: OccurrentSubscriptionFilter (stream) and
+        // AgnosticSubscriptionFilter (capability-agnostic). The DCB path accepts a DcbSubscriptionFilter and passes it
+        // to its own model.
+        if (filter != null && !(filter instanceof OccurrentSubscriptionFilter) && !(filter instanceof AgnosticSubscriptionFilter)) {
+            throw new IllegalArgumentException("Only OccurrentSubscriptionFilter or AgnosticSubscriptionFilter is supported!");
         }
         boolean positionMode = streamStoreWritesPosition();
         final StartAt firstStartAt;
@@ -139,12 +158,12 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             if (checkpoint == null) {
                 // Resumed straight to live without a catch-up phase, so scope the delegated subscription the same way
                 // the handover would, keeping DCB events out.
-                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withStreamCapability(filter), startAt, action);
+                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), startAt, action);
             } else if (positionMode && isTimeBasedCheckpoint(checkpoint)) {
                 // The store now writes position, but this stored token predates that and is time-based. Reading it as a
                 // position would misinterpret a timestamp or replay from an unrelated cursor, so re-resolve to the
                 // model default instead.
-                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withStreamCapability(filter), StartAt.subscriptionModelDefault(), action);
+                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), StartAt.subscriptionModelDefault(), action);
             } else {
                 firstStartAt = StartAt.checkpoint(checkpoint);
             }
@@ -152,7 +171,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             StartAt startAtGeneratedByDynamic = startAt.get(generateSubscriptionModelContext());
             if (startAtGeneratedByDynamic == null) {
                 // We're not allowed to start this subscription model, defer to parent!
-                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withStreamCapability(filter), startAt, action);
+                return getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), startAt, action);
             } else {
                 firstStartAt = startAtGeneratedByDynamic;
             }
@@ -169,12 +188,12 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
                 // A specific wall-clock time has no position to map to, so replay it through the legacy time-based
                 // catch-up even on a position store.
                 case SPECIFIC_TIME -> streamTimeCatchup(subscriptionId, filter, startAt, action, firstStartAt);
-                case LIVE -> subscriptionModel.subscribe(subscriptionId, withStreamCapability(filter), firstStartAt, action);
+                case LIVE -> subscriptionModel.subscribe(subscriptionId, withCapabilityScope(filter), firstStartAt, action);
             };
         }
         return switch (streamStart) {
             case BEGINNING_OF_TIME, SPECIFIC_TIME -> streamTimeCatchup(subscriptionId, filter, startAt, action, firstStartAt);
-            case GLOBAL_POSITION, LIVE -> subscriptionModel.subscribe(subscriptionId, withStreamCapability(filter), firstStartAt, action);
+            case GLOBAL_POSITION, LIVE -> subscriptionModel.subscribe(subscriptionId, withCapabilityScope(filter), firstStartAt, action);
         };
     }
 
@@ -364,7 +383,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             });
             subscription = new CancelledSubscription(subscriptionId);
         } else {
-            subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, withStreamCapability(filter), startAtToUse, liveConsumer);
+            subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), startAtToUse, liveConsumer);
         }
         return subscription;
     }
@@ -377,7 +396,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     private Subscription startPositionCatchupSubscriptionForStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
         runningCatchupSubscriptions.put(subscriptionId, true);
         PositionOrderedReader positionOrderedReader = (PositionOrderedReader) eventStoreQueries;
-        Filter streamFilter = withStreamCapability(filter == null ? Filter.all() : ((OccurrentSubscriptionFilter) filter).filter());
+        Filter streamFilter = withCapabilityScope(plainFilterOf(filter));
         long windowSize = config.dcbCatchupPositionWindowSize;
 
         StartAt nextStartAt = firstStartAt.get(generateSubscriptionModelContext());
@@ -464,7 +483,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         return cursor;
     }
 
-    private static Filter deriveFilterToUseDuringCatchupPhase(@Nullable SubscriptionFilter filter, Checkpoint checkpoint) {
+    private Filter deriveFilterToUseDuringCatchupPhase(@Nullable SubscriptionFilter filter, Checkpoint checkpoint) {
         final Filter timeFilter;
         if (isBeginningOfTime(checkpoint)) {
             timeFilter = Filter.all();
@@ -477,24 +496,43 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         if (filter == null) {
             catchupFilter = timeFilter;
         } else {
-            Filter userSuppliedFilter = ((OccurrentSubscriptionFilter) filter).filter();
+            Filter userSuppliedFilter = plainFilterOf(filter);
             catchupFilter = timeFilter.and(userSuppliedFilter);
         }
-        return withStreamCapability(catchupFilter);
+        return withCapabilityScope(catchupFilter);
     }
 
-    // ANDs the stream-capability guard onto the caller's filter, so a store with the DCB capability also enabled never
-    // returns a DCB-tagged event through this stream catch-up path. Since Filter.all() means "no constraint", ANDing the
-    // capability onto it is exactly the capability filter alone.
-    private static Filter withStreamCapability(Filter filter) {
-        return filter instanceof Filter.All ? STREAM_CAPABILITY_FILTER : filter.and(STREAM_CAPABILITY_FILTER);
+    // Unwraps the plain Filter from the (possibly null) subscription filter, accepting both the stream marker
+    // (OccurrentSubscriptionFilter) and the capability-agnostic marker (AgnosticSubscriptionFilter). A null filter means
+    // "no constraint", i.e. Filter.all().
+    private static Filter plainFilterOf(@Nullable SubscriptionFilter filter) {
+        if (filter == null) {
+            return Filter.all();
+        } else if (filter instanceof OccurrentSubscriptionFilter occurrentSubscriptionFilter) {
+            return occurrentSubscriptionFilter.filter();
+        } else if (filter instanceof AgnosticSubscriptionFilter agnosticSubscriptionFilter) {
+            return agnosticSubscriptionFilter.filter();
+        }
+        throw new IllegalArgumentException("Only OccurrentSubscriptionFilter or AgnosticSubscriptionFilter is supported!");
+    }
+
+    // ANDs the capability scope onto the caller's filter, so a stream subscription on a store that also has the DCB
+    // capability never returns a DCB-tagged event. When the scope is null (a capability-agnostic subscription) the
+    // caller's filter is returned unchanged, so events of every capability are delivered. Since Filter.all() means "no
+    // constraint", ANDing the scope onto it is exactly the scope filter alone.
+    private Filter withCapabilityScope(Filter filter) {
+        if (capabilityScope == null) {
+            return filter;
+        }
+        return filter instanceof Filter.All ? capabilityScope : filter.and(capabilityScope);
     }
 
     // Wraps the caller's (possibly null) subscription filter into a capability-scoped OccurrentSubscriptionFilter to
-    // hand to the delegated live subscription, so live delivery after handover excludes DCB events just like the replay.
-    private static OccurrentSubscriptionFilter withStreamCapability(@Nullable SubscriptionFilter filter) {
-        Filter callerFilter = filter == null ? Filter.all() : ((OccurrentSubscriptionFilter) filter).filter();
-        return OccurrentSubscriptionFilter.filter(withStreamCapability(callerFilter));
+    // hand to the delegated live subscription, so live delivery after handover applies the same capability scope as the
+    // replay. It always produces an OccurrentSubscriptionFilter (never the agnostic marker) because the live subscription
+    // models only understand OccurrentSubscriptionFilter and DcbSubscriptionFilter.
+    private OccurrentSubscriptionFilter withCapabilityScope(@Nullable SubscriptionFilter filter) {
+        return OccurrentSubscriptionFilter.filter(withCapabilityScope(plainFilterOf(filter)));
     }
 
     private void runCatchupForStream(Stream<CloudEvent> cloudEvents, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModel.java
@@ -23,6 +23,7 @@ import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.GlobalCheckpoint;
@@ -48,6 +49,11 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
 
     private final @Nullable ReactorStreamCatchupSubscriptionModel streamCatchupSubscriptionModel;
     private final @Nullable ReactorDcbCatchupSubscriptionModel dcbCatchupSubscriptionModel;
+    // The capability-agnostic position catch-up: the same position catch-up as the stream model but with no capability
+    // scope, so it replays and delivers events of every capability, filtered only by the caller's plain Filter. Present
+    // whenever a PositionOrderedReader is wired (stream-only and dual-mode). Null in the DCB-only configuration, where
+    // an AgnosticSubscriptionFilter routes to the DCB model instead (a DCB-only store has only DCB events).
+    private final @Nullable ReactorStreamCatchupSubscriptionModel agnosticCatchupSubscriptionModel;
 
     /**
      * Create a stream-only instance. Every subscription routes to the stream catch-up model.
@@ -59,6 +65,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
     public ReactorCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, PositionOrderedReader positionOrderedReader, @Nullable Filter defaultFilter, long windowSize, int handoverCacheSize) {
         this.streamCatchupSubscriptionModel = new ReactorStreamCatchupSubscriptionModel(requireNonNull(subscriptionModel, CheckpointAwareSubscriptionModel.class.getSimpleName() + " cannot be null"), positionOrderedReader, defaultFilter, windowSize, handoverCacheSize);
         this.dcbCatchupSubscriptionModel = null;
+        this.agnosticCatchupSubscriptionModel = new ReactorStreamCatchupSubscriptionModel(subscriptionModel, positionOrderedReader, defaultFilter, windowSize, handoverCacheSize, null);
     }
 
     /**
@@ -71,6 +78,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
     public ReactorCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, DcbEventStore dcbEventStore, @Nullable DcbCriteria defaultQuery, long windowSize, int handoverCacheSize) {
         this.streamCatchupSubscriptionModel = null;
         this.dcbCatchupSubscriptionModel = new ReactorDcbCatchupSubscriptionModel(requireNonNull(subscriptionModel, CheckpointAwareSubscriptionModel.class.getSimpleName() + " cannot be null"), dcbEventStore, defaultQuery, windowSize, handoverCacheSize);
+        this.agnosticCatchupSubscriptionModel = null;
     }
 
     /**
@@ -83,6 +91,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
         requireNonNull(subscriptionModel, CheckpointAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
         this.streamCatchupSubscriptionModel = new ReactorStreamCatchupSubscriptionModel(subscriptionModel, positionOrderedReader, defaultFilter, windowSize, handoverCacheSize);
         this.dcbCatchupSubscriptionModel = new ReactorDcbCatchupSubscriptionModel(subscriptionModel, dcbEventStore, defaultQuery, windowSize, handoverCacheSize);
+        this.agnosticCatchupSubscriptionModel = new ReactorStreamCatchupSubscriptionModel(subscriptionModel, positionOrderedReader, defaultFilter, windowSize, handoverCacheSize, null);
     }
 
     public ReactorCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, PositionOrderedReader positionOrderedReader, DcbEventStore dcbEventStore, @Nullable DcbCriteria defaultQuery, @Nullable Filter defaultFilter) {
@@ -92,9 +101,21 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
     @Override
     public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
+        return route(filter, startAt).subscribe(filter, startAt);
+    }
+
+    // Route to the DCB, stream, or capability-agnostic catch-up model. An AgnosticSubscriptionFilter routes to the
+    // unscoped agnostic model so both stream and DCB events are delivered; if there is no agnostic model (a DCB-only
+    // store) it falls back to the DCB model, whose store has only DCB events anyway.
+    private CheckpointAwareSubscriptionModel route(@Nullable SubscriptionFilter filter, StartAt startAt) {
+        if (filter instanceof AgnosticSubscriptionFilter) {
+            return agnosticCatchupSubscriptionModel != null
+                    ? agnosticCatchupSubscriptionModel
+                    : requireNonNull(dcbCatchupSubscriptionModel);
+        }
         return routesToDcb(filter, startAt)
-                ? requireNonNull(dcbCatchupSubscriptionModel).subscribe(filter, startAt)
-                : requireNonNull(streamCatchupSubscriptionModel).subscribe(filter, startAt);
+                ? requireNonNull(dcbCatchupSubscriptionModel)
+                : requireNonNull(streamCatchupSubscriptionModel);
     }
 
     // Route to the DCB path or the stream path. A single-mode model has only one inner model and always routes there.

--- a/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelRoutingTest.java
+++ b/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelRoutingTest.java
@@ -31,6 +31,7 @@ import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
@@ -79,6 +80,22 @@ class ReactorCatchupSubscriptionModelRoutingTest {
         // Routed to the DCB model: passes the DCB filter-type check, then fails loud on the missing resume token.
         StepVerifier.create(catchup.subscribe(DcbSubscriptionFilter.filter(DcbCriteria.tags(Tag.parse("name:1"))), StartAt.checkpoint(GlobalCheckpoint.of(0))))
                 .expectError(IllegalStateException.class)
+                .verify();
+    }
+
+    @Test
+    void an_agnostic_filter_routes_to_the_neutral_unscoped_model_not_stream_or_dcb() {
+        ReactorCatchupSubscriptionModel catchup = dualMode();
+
+        // A null/agnostic capability scope: routed to the neutral inner model, which accepts any SubscriptionFilter
+        // (including AgnosticSubscriptionFilter) and fails loud on the missing resume token, same as the scoped models.
+        // Reaching either scoped model's filter-type IllegalArgumentException would prove misrouting.
+        StepVerifier.create(catchup.subscribe(AgnosticSubscriptionFilter.filter(Filter.all()), StartAt.checkpoint(GlobalCheckpoint.of(0))))
+                .expectErrorSatisfies(error -> {
+                    if (error instanceof IllegalArgumentException illegalArgumentException) {
+                        throw new AssertionError("Agnostic subscription was misrouted to a capability-scoped model", illegalArgumentException);
+                    }
+                })
                 .verify();
     }
 

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
@@ -25,6 +25,7 @@ import org.occurrent.eventstore.api.PositionRange;
 import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.inmemory.filtermatching.FilterMatcher;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.OccurrentSubscriptionFilter;
 import org.occurrent.subscription.CheckpointAwareCloudEvent;
@@ -101,6 +102,11 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
     private final @Nullable Filter defaultFilter;
     private final long windowSize;
     private final int handoverCacheSize;
+    // The capability guard ANDed into every replay read and the live subscription. It is {@link #STREAM_CAPABILITY_FILTER}
+    // for a stream subscription (so a DCB-tagged event never reaches a stream subscriber, see ADR 50), and {@code null}
+    // for a capability-agnostic subscription, which then filters only by the caller's plain Filter and so delivers
+    // events of every capability.
+    private final @Nullable Filter capabilityScope;
 
     public ReactorStreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, PositionOrderedReader positionOrderedReader) {
         this(subscriptionModel, positionOrderedReader, null, DEFAULT_POSITION_WINDOW_SIZE, DEFAULT_HANDOVER_CACHE_SIZE);
@@ -120,9 +126,20 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
     }
 
     public ReactorStreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, PositionOrderedReader positionOrderedReader, @Nullable Filter defaultFilter, long windowSize, int handoverCacheSize) {
+        this(subscriptionModel, positionOrderedReader, defaultFilter, windowSize, handoverCacheSize, STREAM_CAPABILITY_FILTER);
+    }
+
+    /**
+     * @param capabilityScope The capability {@link Filter} ANDed into every replay read and the live subscription.
+     *                        Pass {@link #STREAM_CAPABILITY_FILTER} for a stream subscription, or {@code null} for a
+     *                        capability-agnostic subscription that delivers events of every capability, filtered only by
+     *                        the caller's plain {@link Filter}.
+     */
+    public ReactorStreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, PositionOrderedReader positionOrderedReader, @Nullable Filter defaultFilter, long windowSize, int handoverCacheSize, @Nullable Filter capabilityScope) {
         this.subscriptionModel = requireNonNull(subscriptionModel, CheckpointAwareSubscriptionModel.class.getSimpleName() + " cannot be null");
         this.positionOrderedReader = requireNonNull(positionOrderedReader, PositionOrderedReader.class.getSimpleName() + " cannot be null");
         this.defaultFilter = defaultFilter;
+        this.capabilityScope = capabilityScope;
         if (windowSize <= 0) {
             throw new IllegalArgumentException("Window size must be greater than zero");
         }
@@ -150,8 +167,10 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
             resolvedFilter = defaultFilter;
         } else if (filter instanceof OccurrentSubscriptionFilter occurrentSubscriptionFilter) {
             resolvedFilter = occurrentSubscriptionFilter.filter();
+        } else if (filter instanceof AgnosticSubscriptionFilter agnosticSubscriptionFilter) {
+            resolvedFilter = agnosticSubscriptionFilter.filter();
         } else {
-            return Flux.error(new IllegalArgumentException(ReactorStreamCatchupSubscriptionModel.class.getSimpleName() + " only supports an " + OccurrentSubscriptionFilter.class.getSimpleName() + ", but got " + filter.getClass().getName()));
+            return Flux.error(new IllegalArgumentException(ReactorStreamCatchupSubscriptionModel.class.getSimpleName() + " only supports an " + OccurrentSubscriptionFilter.class.getSimpleName() + " or " + AgnosticSubscriptionFilter.class.getSimpleName() + ", but got " + filter.getClass().getName()));
         }
         return subscribe(resolvedFilter, startAt);
     }
@@ -171,10 +190,11 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
         requireNonNull(callerFilter, "Filter cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
 
-        // AND the stream-capability guard onto the caller's filter, so a store with the DCB capability also enabled
-        // never replays or delivers a DCB-tagged event through this stream catch-up path, in either the replay reads,
-        // the live subscription filter, or the in-process live predicate below (see ADR 50).
-        Filter filter = withStreamCapability(callerFilter);
+        // AND the capability scope onto the caller's filter. For a stream subscription this keeps a DCB-tagged event
+        // out of the replay reads, the live subscription filter, and the in-process live predicate below (see ADR 50).
+        // For a capability-agnostic subscription the scope is null, so the caller's filter is used unchanged and events
+        // of every capability are delivered.
+        Filter filter = withCapabilityScope(callerFilter);
 
         StartAt resolved = startAt.get(new SubscriptionModelContext(ReactorStreamCatchupSubscriptionModel.class));
         if (!(resolved instanceof StartAt.StartAtCheckpoint position) || !GlobalCheckpoint.isGlobalCheckpoint(position.checkpoint)) {
@@ -191,10 +211,14 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
         return pipeline.catchup(subscriptionModel, OccurrentSubscriptionFilter.filter(filter), livePredicate, startPosition);
     }
 
-    // ANDs the stream-capability guard onto the caller's filter. Since Filter.all() means "no constraint", ANDing the
-    // capability onto it is exactly the capability filter alone.
-    private static Filter withStreamCapability(Filter filter) {
-        return filter instanceof Filter.All ? STREAM_CAPABILITY_FILTER : filter.and(STREAM_CAPABILITY_FILTER);
+    // ANDs the capability scope onto the caller's filter. When the scope is null (a capability-agnostic subscription)
+    // the caller's filter is returned unchanged, so events of every capability are delivered. Since Filter.all() means
+    // "no constraint", ANDing the scope onto it is exactly the scope filter alone.
+    private Filter withCapabilityScope(Filter filter) {
+        if (capabilityScope == null) {
+            return filter;
+        }
+        return filter instanceof Filter.All ? capabilityScope : filter.and(capabilityScope);
     }
 
     // Reads stream events in position order through the PositionOrderedReader, wrapping each with its position so a


### PR DESCRIPTION
Revives `@Subscription` and the `Subscriptions` DSL, both currently deprecated aliases for the stream forms, as the capability-neutral default. On a store with both `STREAM` and `DCB` capabilities they now deliver both stream-written and DCB-appended events, filtered only by event type, with catch-up over the unified global position and resume via `GlobalCheckpoint`. `@StreamSubscription`/`StreamSubscriptions` (stream-only) and `@DcbSubscription`/`DcbSubscriptions` (DCB, tags) stay as the explicit capability-scoped forms.

## Why

Most consumers, projections and read models, react to events by type and do not care which write model produced them. Forcing them to pick `@StreamSubscription` or `@DcbSubscription` is friction with no neutral option. The capability distinction only ever leaked into subscriptions through catch-up start positions, which ADR 24 split into stream and DCB types back when a stream position and a DCB position were different things. ADR 45 removed that ground by making `position` a single global axis shared by every event, and `GlobalCheckpoint` is already the capability-neutral resume token both existing catch-up models persist. Live delivery was already capability-agnostic. So a neutral subscription with catch-up is a small graft on existing machinery, not a new subsystem.

## The change

The neutral catch-up is the position-based stream catch-up minus the `Filter.capability(STREAM)` guard from #282. I parameterized the blocking and reactor stream catch-up models with a nullable capability scope: the stream constructors inject `Filter.capability(STREAM)` (behavior identical to today), and a new unscoped instance passes null, so it filters only by the caller's plain `Filter` and delivers events of every capability. A new `AgnosticSubscriptionFilter` marker routes to that unscoped instance through a third branch in the dual-mode dispatcher. On a DCB-only store the neutral marker falls back to the DCB model, whose store has only DCB events anyway. At the live handover the marker is always unwrapped to an `OccurrentSubscriptionFilter`, since the live change-stream models only understand the stream and DCB markers.

Type-safety is preserved the way ADR 24 intended. The neutral form exposes only capability-neutral start positions (now, beginning, model default, an explicit global position), never a DCB position, a stream-only time, or `tags`, so there is no mismatched combination to form.

Reviving `@Subscription` is safe. Today it means stream-only. The only behavior change, also delivering DCB events, appears solely on a store that has the DCB capability enabled, and those stores are new since DCB is unreleased. On a stream-only store it behaves exactly as before.

Full reasoning in [ADR 51](doc/architecture/decisions/0051-capability-agnostic-subscription.md).

## Verification

New integration tests on a dual `STREAM`+`DCB` store: a neutral subscription receives both a stream and a DCB event during catch-up and again live after handover, resumes from a stored `GlobalCheckpoint` across a restart without gaps, and honors a type filter across both capabilities. A regression guard confirms `@StreamSubscription` and `@DcbSubscription` stay scoped to their own capability alongside a neutral one. In-memory and reactor routing are covered too. Full serial `mvn clean install` is green, and the #282 capability-filter regression suite still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
