### PR TITLE
Modernize Java pattern matching

### DIFF
--- a/application/cloudevent-type-mapper/reflection/src/main/java/org/occurrent/application/converter/typemapper/ReflectionCloudEventTypeMapper.java
+++ b/application/cloudevent-type-mapper/reflection/src/main/java/org/occurrent/application/converter/typemapper/ReflectionCloudEventTypeMapper.java
@@ -36,35 +36,25 @@ public class ReflectionCloudEventTypeMapper<T> implements CloudEventTypeMapper<T
 
     @Override
     public String getCloudEventType(Class<? extends T> type) {
-        final String cloudEventType;
-        if (className instanceof ClassName.Simple) {
-            cloudEventType = type.getSimpleName();
-        } else if (className instanceof ClassName.Qualified) {
-            cloudEventType = type.getName();
-        } else {
-            throw new IllegalStateException("Internal error: Invalid class name setting " + className);
-        }
-
-        return cloudEventType;
+        return switch (className) {
+            case ClassName.Simple<?> ignored -> type.getSimpleName();
+            case ClassName.Qualified ignored -> type.getName();
+        };
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <E extends T> Class<E> getDomainEventType(String cloudEventType) {
-        final Class<E> domainEvenType;
-        if (className instanceof ClassName.Simple) {
-            domainEvenType = (Class<E>) ((ClassName.Simple<T>) className).domainEventTypeFromCloudEventType().apply(cloudEventType);
-        } else if (className instanceof ClassName.Qualified) {
-            try {
-                //noinspection unchecked
-                domainEvenType = (Class<E>) Class.forName(cloudEventType);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
+        return switch (className) {
+            case ClassName.Simple<?> simple -> (Class<E>) simple.domainEventTypeFromCloudEventType().apply(cloudEventType);
+            case ClassName.Qualified ignored -> {
+                try {
+                    yield (Class<E>) Class.forName(cloudEventType);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
             }
-        } else {
-            throw new IllegalStateException("Internal error: Invalid class name setting " + className);
-        }
-        return domainEvenType;
+        };
     }
 
     /**

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 #### Changes
 
 * Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
+* Modernized Java dispatch code to use Java 21 pattern matching and exhaustive switches across sealed filters,
+  criteria, start positions, checkpoints, deadlines, and examples.
 * Renamed `OccurrentSubscriptionFilter` to `StreamSubscriptionFilter` to make the stream-scoped subscription marker
   explicit next to `AgnosticSubscriptionFilter` and `DcbSubscriptionFilter`. This is a breaking API change for callers
   that construct subscription filters directly.

--- a/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/ConditionMatcher.java
+++ b/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/ConditionMatcher.java
@@ -44,7 +44,14 @@ public class ConditionMatcher {
     private static final Set<String> ATTRIBUTE_NAMES = Set.of(SPEC_VERSION, ID, TYPE, TIME, SOURCE, SUBJECT, DATA_SCHEMA, DATA_CONTENT_TYPE);
 
     public static <T> boolean matchesCondition(CloudEvent cloudEvent, String fieldName, Condition<T> condition) {
-        if (condition instanceof MultiOperandCondition<T> operation) {
+        return switch (condition) {
+            case MultiOperandCondition<T> operation -> matchesMultiOperandCondition(cloudEvent, fieldName, operation);
+            case SingleOperandCondition<T> singleOperandCondition -> matchesSingleOperandCondition(cloudEvent, fieldName, singleOperandCondition);
+            case Condition.InOperandCondition<T> inOperandCondition -> matchesInOperandCondition(cloudEvent, fieldName, inOperandCondition);
+        };
+    }
+
+    private static <T> boolean matchesMultiOperandCondition(CloudEvent cloudEvent, String fieldName, MultiOperandCondition<T> operation) {
             Condition.MultiOperandConditionName operationName = operation.operationName();
             List<Condition<T>> operations = operation.operations();
             Stream<Boolean> filters = operations.stream().map(c -> matchesCondition(cloudEvent, fieldName, c));
@@ -53,20 +60,21 @@ public class ConditionMatcher {
                 case OR -> filters.anyMatch(isEqual(true));
                 case NOT -> filters.allMatch(isEqual(false));
             };
-        } else if (condition instanceof SingleOperandCondition<T> singleOperandCondition) {
+    }
+
+    private static <T> boolean matchesSingleOperandCondition(CloudEvent cloudEvent, String fieldName, SingleOperandCondition<T> singleOperandCondition) {
             T expected = singleOperandCondition.operand();
             SingleOperandConditionName singleOperandConditionName = singleOperandCondition.operandConditionName();
             Object actual = extractValue(cloudEvent, fieldName);
-            final boolean matches;
             if (singleOperandConditionName == EQ) {
-                matches = Objects.equals(actual, expected);
+                return Objects.equals(actual, expected);
             } else if (singleOperandConditionName == NE) {
-                matches = !Objects.equals(actual, expected);
+                return !Objects.equals(actual, expected);
             } else {
                 Comparable<Object> expectedComparable = toComparable(expected, "Expected value must implement " + Comparable.class.getName() + " in order to be used in Filter's");
                 Comparable<Object> actualComparable = toComparable(actual, "Value in CloudEvent must implement " + Comparable.class.getName() + " in order to be used in Filter's");
                 int comparisonResult = actualComparable.compareTo(expectedComparable);
-                matches = switch (singleOperandConditionName) {
+                return switch (singleOperandConditionName) {
                     case LT -> comparisonResult < 0;
                     case GT -> comparisonResult > 0;
                     case LTE -> comparisonResult <= 0;
@@ -74,14 +82,12 @@ public class ConditionMatcher {
                     default -> throw new IllegalStateException("Unexpected value: " + singleOperandConditionName);
                 };
             }
-            return matches;
-        } else if (condition instanceof Condition.InOperandCondition<T> inOperandCondition) {
+    }
+
+    private static <T> boolean matchesInOperandCondition(CloudEvent cloudEvent, String fieldName, Condition.InOperandCondition<T> inOperandCondition) {
             Object actual = extractValue(cloudEvent, fieldName);
             Collection<T> operand = inOperandCondition.operand();
             return operand.stream().anyMatch(it -> Objects.equals(it, actual));
-        } else {
-            throw new IllegalArgumentException("Unsupported condition: " + condition.getClass());
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/FilterMatcher.java
+++ b/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/FilterMatcher.java
@@ -39,31 +39,29 @@ public class FilterMatcher {
             throw new IllegalArgumentException(Filter.class.getSimpleName() + " cannot be null");
         }
 
-        final boolean matches;
-        if (filter instanceof All) {
-            matches = true;
-        } else if (filter instanceof SingleConditionFilter scf) {
-            matches = ConditionMatcher.matchesCondition(cloudEvent, scf.fieldName(), scf.condition());
-        } else if (filter instanceof CapabilityFilter cpf) {
-            // A DCB append always stamps the dcbtags extension on the live CloudEvent; a stream event never carries it.
-            boolean isDcbEvent = cloudEvent.getExtension(EventStoreCloudEventExtensions.DCB_TAGS) != null;
-            // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
-            // silently treated as a stream event.
-            boolean shouldBeDcbEvent = switch (cpf.capability()) {
-                case DCB -> true;
-                case STREAM -> false;
-            };
-            matches = isDcbEvent == shouldBeDcbEvent;
-        } else if (filter instanceof CompositionFilter cf) {
-            Predicate<Filter> matchingPredicate = f -> matchesFilter(cloudEvent, f);
-            matches = switch (cf.operator()) {
-                case AND -> cf.filters().stream().allMatch(matchingPredicate);
-                case OR -> cf.filters().stream().anyMatch(matchingPredicate);
-            };
-        } else {
-            throw new IllegalArgumentException("Unrecognized filter: " + filter.getClass().getName());
-        }
+        return switch (filter) {
+            case All ignored -> true;
+            case SingleConditionFilter scf -> ConditionMatcher.matchesCondition(cloudEvent, scf.fieldName(), scf.condition());
+            case CapabilityFilter cpf -> matchesCapabilityFilter(cloudEvent, cpf);
+            case CompositionFilter cf -> {
+                Predicate<Filter> matchingPredicate = f -> matchesFilter(cloudEvent, f);
+                yield switch (cf.operator()) {
+                    case AND -> cf.filters().stream().allMatch(matchingPredicate);
+                    case OR -> cf.filters().stream().anyMatch(matchingPredicate);
+                };
+            }
+        };
+    }
 
-        return matches;
+    private static boolean matchesCapabilityFilter(CloudEvent cloudEvent, CapabilityFilter cpf) {
+        // A DCB append always stamps the dcbtags extension on the live CloudEvent; a stream event never carries it.
+        boolean isDcbEvent = cloudEvent.getExtension(EventStoreCloudEventExtensions.DCB_TAGS) != null;
+        // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
+        // silently treated as a stream event.
+        boolean shouldBeDcbEvent = switch (cpf.capability()) {
+            case DCB -> true;
+            case STREAM -> false;
+        };
+        return isDcbEvent == shouldBeDcbEvent;
     }
 }

--- a/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/ConditionConverter.java
+++ b/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/ConditionConverter.java
@@ -23,7 +23,6 @@ import org.occurrent.condition.Condition.MultiOperandCondition;
 import org.occurrent.condition.Condition.SingleOperandCondition;
 import org.occurrent.condition.Condition.SingleOperandConditionName;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -32,7 +31,14 @@ import java.util.List;
 public class ConditionConverter {
 
     public static <T> Bson convertConditionToBsonCriteria(String fieldName, Condition<T> condition) {
-        if (condition instanceof MultiOperandCondition<T> operation) {
+        return switch (condition) {
+            case MultiOperandCondition<T> operation -> convertMultiOperandConditionToBsonCriteria(fieldName, operation);
+            case SingleOperandCondition<T> singleOperandCondition -> convertSingleOperandConditionToBsonCriteria(fieldName, singleOperandCondition);
+            case Condition.InOperandCondition<T> inOperandCondition -> Filters.in(fieldName, inOperandCondition.operand());
+        };
+    }
+
+    private static <T> Bson convertMultiOperandConditionToBsonCriteria(String fieldName, MultiOperandCondition<T> operation) {
             Condition.MultiOperandConditionName operationName = operation.operationName();
             List<Condition<T>> operations = operation.operations();
             Bson[] filters = operations.stream().map(c -> convertConditionToBsonCriteria(fieldName, c)).toArray(Bson[]::new);
@@ -41,7 +47,9 @@ public class ConditionConverter {
                 case OR -> Filters.or(filters);
                 case NOT -> Filters.not(filters[0]);
             };
-        } else if (condition instanceof SingleOperandCondition<T> singleOperandCondition) {
+    }
+
+    private static <T> Bson convertSingleOperandConditionToBsonCriteria(String fieldName, SingleOperandCondition<T> singleOperandCondition) {
             T operand = singleOperandCondition.operand();
             SingleOperandConditionName singleOperandConditionName = singleOperandCondition.operandConditionName();
             return switch (singleOperandConditionName) {
@@ -52,11 +60,5 @@ public class ConditionConverter {
                 case GTE -> Filters.gte(fieldName, operand);
                 case NE -> Filters.ne(fieldName, operand);
             };
-        } else if (condition instanceof Condition.InOperandCondition<T> inOperandCondition) {
-            Collection<T> operand = inOperandCondition.operand();
-            return Filters.in(fieldName, operand);
-        } else {
-            throw new IllegalArgumentException("Unsupported condition: " + condition.getClass());
-        }
     }
 }

--- a/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/FilterToBsonFilterConverter.java
+++ b/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/FilterToBsonFilterConverter.java
@@ -57,38 +57,39 @@ public class FilterToBsonFilterConverter {
     }
 
     private static Bson innerConvert(String fieldNamePrefix, TimeRepresentation timeRepresentation, Filter filter) {
-        final Bson criteria;
-        if (filter instanceof All) {
-            criteria = new BsonDocument();
-        } else if (filter instanceof SingleConditionFilter scf) {
-            Condition<?> conditionToUse = resolveSpecialCases(timeRepresentation, scf);
-            String fieldName = fieldNameOf(fieldNamePrefix, scf.fieldName());
-            criteria = convertConditionToBsonCriteria(fieldName, conditionToUse);
-        } else if (filter instanceof CapabilityFilter cpf) {
-            // Match on the sparse-indexed dcbTags array field (DcbDocumentMapper.DCB_TAGS_INDEX_FIELD; the literal is
-            // duplicated here to keep this module free of any DCB dependency) so the capability filter uses the ADR 49
-            // index. A DCB append always writes this array (an empty array for zero tags), while a stream write never
-            // does, so its presence is the discriminator: DCB events have it, stream events do not. This is equivalent
-            // to keying off the dcbtags CloudEvent extension because the stream write path now rejects dcbtags-carrying
-            // events, so the array and the extension always agree.
-            // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
-            // silently treated as a stream event.
-            boolean shouldHaveDcbTags = switch (cpf.capability()) {
-                case DCB -> true;
-                case STREAM -> false;
-            };
-            String fieldName = fieldNameOf(fieldNamePrefix, DCB_TAGS_FIELD);
-            criteria = Filters.exists(fieldName, shouldHaveDcbTags);
-        } else if (filter instanceof CompositionFilter cf) {
-            Bson[] composedBson = cf.filters().stream().map(f -> innerConvert(fieldNamePrefix, timeRepresentation, f)).toArray(Bson[]::new);
-            criteria = switch (cf.operator()) {
-                case AND -> Filters.and(composedBson);
-                case OR -> Filters.or(composedBson);
-            };
-        } else {
-            throw new IllegalStateException("Unexpected filter: " + filter.getClass().getName());
-        }
-        return criteria;
+        return switch (filter) {
+            case All ignored -> new BsonDocument();
+            case SingleConditionFilter scf -> {
+                Condition<?> conditionToUse = resolveSpecialCases(timeRepresentation, scf);
+                String fieldName = fieldNameOf(fieldNamePrefix, scf.fieldName());
+                yield convertConditionToBsonCriteria(fieldName, conditionToUse);
+            }
+            case CapabilityFilter cpf -> capabilityFilter(fieldNamePrefix, cpf);
+            case CompositionFilter cf -> {
+                Bson[] composedBson = cf.filters().stream().map(f -> innerConvert(fieldNamePrefix, timeRepresentation, f)).toArray(Bson[]::new);
+                yield switch (cf.operator()) {
+                    case AND -> Filters.and(composedBson);
+                    case OR -> Filters.or(composedBson);
+                };
+            }
+        };
+    }
+
+    private static Bson capabilityFilter(String fieldNamePrefix, CapabilityFilter cpf) {
+        // Match on the sparse-indexed dcbTags array field (DcbDocumentMapper.DCB_TAGS_INDEX_FIELD; the literal is
+        // duplicated here to keep this module free of any DCB dependency) so the capability filter uses the ADR 49
+        // index. A DCB append always writes this array (an empty array for zero tags), while a stream write never
+        // does, so its presence is the discriminator: DCB events have it, stream events do not. This is equivalent
+        // to keying off the dcbtags CloudEvent extension because the stream write path now rejects dcbtags-carrying
+        // events, so the array and the extension always agree.
+        // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
+        // silently treated as a stream event.
+        boolean shouldHaveDcbTags = switch (cpf.capability()) {
+            case DCB -> true;
+            case STREAM -> false;
+        };
+        String fieldName = fieldNameOf(fieldNamePrefix, DCB_TAGS_FIELD);
+        return Filters.exists(fieldName, shouldHaveDcbTags);
     }
 
     private static String fieldNameOf(String fieldNamePrefix, String fieldName) {

--- a/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/ConditionToCriteriaConverter.java
+++ b/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/ConditionToCriteriaConverter.java
@@ -30,7 +30,14 @@ import java.util.List;
 public class ConditionToCriteriaConverter {
 
     public static <T> Criteria convertConditionToCriteria(String fieldName, Condition<T> condition) {
-        if (condition instanceof MultiOperandCondition<T> operation) {
+        return switch (condition) {
+            case MultiOperandCondition<T> operation -> convertMultiOperandConditionToCriteria(fieldName, operation);
+            case SingleOperandCondition<T> singleOperandCondition -> convertSingleOperandConditionToCriteria(fieldName, singleOperandCondition);
+            case Condition.InOperandCondition<T> inOperandCondition -> Criteria.where(fieldName).in(inOperandCondition.operand());
+        };
+    }
+
+    private static <T> Criteria convertMultiOperandConditionToCriteria(String fieldName, MultiOperandCondition<T> operation) {
             Condition.MultiOperandConditionName operationName = operation.operationName();
             List<Condition<T>> operations = operation.operations();
             Criteria[] criteria = operations.stream().map(c -> convertConditionToCriteria(fieldName, c)).toArray(Criteria[]::new);
@@ -39,7 +46,9 @@ public class ConditionToCriteriaConverter {
                 case OR -> new Criteria().orOperator(criteria);
                 case NOT -> new Criteria().norOperator(criteria);
             };
-        } else if (condition instanceof SingleOperandCondition<T> singleOperandCondition) {
+    }
+
+    private static <T> Criteria convertSingleOperandConditionToCriteria(String fieldName, SingleOperandCondition<T> singleOperandCondition) {
             T value = singleOperandCondition.operand();
             Condition.SingleOperandConditionName singleOperandConditionName = singleOperandCondition.operandConditionName();
             return switch (singleOperandConditionName) {
@@ -50,11 +59,5 @@ public class ConditionToCriteriaConverter {
                 case GTE -> Criteria.where(fieldName).gte(value);
                 case NE -> Criteria.where(fieldName).ne(value);
             };
-        } else if (condition instanceof Condition.InOperandCondition<T> inOperandCondition) {
-            Collection<T> operand = inOperandCondition.operand();
-            return Criteria.where(fieldName).in(operand);
-        } else {
-            throw new IllegalArgumentException("Unsupported condition: " + condition.getClass());
-        }
     }
 }

--- a/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/FilterConverter.java
+++ b/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/FilterConverter.java
@@ -56,46 +56,40 @@ public class FilterConverter {
     }
 
     public static Criteria convertFilterToCriteria(String fieldNamePrefix, TimeRepresentation timeRepresentation, Filter filter) {
-        final Criteria criteria;
-        if (filter instanceof All) {
-            criteria = new Criteria();
-        } else if (filter instanceof SingleConditionFilter scf) {
-            Condition<?> conditionToUse = SpecialFilterHandling.resolveSpecialCases(timeRepresentation, scf);
-            String fieldName = fieldNameOf(fieldNamePrefix, scf.fieldName());
-            criteria = ConditionToCriteriaConverter.convertConditionToCriteria(fieldName, conditionToUse);
-        } else if (filter instanceof CapabilityFilter cpf) {
-            // Match on the sparse-indexed dcbTags array field (DcbDocumentMapper.DCB_TAGS_INDEX_FIELD; the literal is
-            // duplicated here to keep this module free of any DCB dependency) so the capability filter uses the ADR 49
-            // index. A DCB append always writes this array (an empty array for zero tags), while a stream write never
-            // does, so its presence is the discriminator: DCB events have it, stream events do not. This is equivalent
-            // to keying off the dcbtags CloudEvent extension because the stream write path now rejects dcbtags-carrying
-            // events, so the array and the extension always agree.
-            // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
-            // silently treated as a stream event.
-            boolean shouldHaveDcbTags = switch (cpf.capability()) {
-                case DCB -> true;
-                case STREAM -> false;
-            };
-            String fieldName = fieldNameOf(fieldNamePrefix, DCB_TAGS_FIELD);
-            criteria = Criteria.where(fieldName).exists(shouldHaveDcbTags);
-        } else if (filter instanceof CompositionFilter cf) {
-            Criteria[] composedCriteria = cf.filters().stream().map(f -> FilterConverter.convertFilterToCriteria(fieldNamePrefix, timeRepresentation, f)).toArray(Criteria[]::new);
-            Criteria c = new Criteria();
-            switch (cf.operator()) {
-                case AND:
-                    c.andOperator(composedCriteria);
-                    break;
-                case OR:
-                    c.orOperator(composedCriteria);
-                    break;
-                default:
-                    throw new IllegalStateException("Unexpected value: " + cf.operator());
+        return switch (filter) {
+            case All ignored -> new Criteria();
+            case SingleConditionFilter scf -> {
+                Condition<?> conditionToUse = SpecialFilterHandling.resolveSpecialCases(timeRepresentation, scf);
+                String fieldName = fieldNameOf(fieldNamePrefix, scf.fieldName());
+                yield ConditionToCriteriaConverter.convertConditionToCriteria(fieldName, conditionToUse);
             }
-            criteria = c;
-        } else {
-            throw new IllegalStateException("Unexpected filter: " + filter.getClass().getName());
-        }
-        return criteria;
+            case CapabilityFilter cpf -> capabilityCriteria(fieldNamePrefix, cpf);
+            case CompositionFilter cf -> {
+                Criteria[] composedCriteria = cf.filters().stream().map(f -> FilterConverter.convertFilterToCriteria(fieldNamePrefix, timeRepresentation, f)).toArray(Criteria[]::new);
+                Criteria c = new Criteria();
+                yield switch (cf.operator()) {
+                    case AND -> c.andOperator(composedCriteria);
+                    case OR -> c.orOperator(composedCriteria);
+                };
+            }
+        };
+    }
+
+    private static Criteria capabilityCriteria(String fieldNamePrefix, CapabilityFilter cpf) {
+        // Match on the sparse-indexed dcbTags array field (DcbDocumentMapper.DCB_TAGS_INDEX_FIELD; the literal is
+        // duplicated here to keep this module free of any DCB dependency) so the capability filter uses the ADR 49
+        // index. A DCB append always writes this array (an empty array for zero tags), while a stream write never
+        // does, so its presence is the discriminator: DCB events have it, stream events do not. This is equivalent
+        // to keying off the dcbtags CloudEvent extension because the stream write path now rejects dcbtags-carrying
+        // events, so the array and the extension always agree.
+        // Exhaustive switch so a new EventStoreCapability constant forces a compile error here rather than being
+        // silently treated as a stream event.
+        boolean shouldHaveDcbTags = switch (cpf.capability()) {
+            case DCB -> true;
+            case STREAM -> false;
+        };
+        String fieldName = fieldNameOf(fieldNamePrefix, DCB_TAGS_FIELD);
+        return Criteria.where(fieldName).exists(shouldHaveDcbTags);
     }
 
     private static String fieldNameOf(String fieldNamePrefix, String fieldName) {

--- a/common/mongodb/spring/sort-conversion/src/main/java/org/occurrent/mongodb/spring/sortconversion/internal/SortConverter.java
+++ b/common/mongodb/spring/sort-conversion/src/main/java/org/occurrent/mongodb/spring/sortconversion/internal/SortConverter.java
@@ -20,22 +20,15 @@ public class SortConverter {
      * @return A Spring {@code Sort} instance.
      */
     public static Sort convertToSpringSort(SortBy sortBy) {
-        final Sort sort;
-        if (sortBy instanceof SortBy.Unsorted) {
-            sort = Sort.unsorted();
-        } else if (sortBy instanceof SortBy.NaturalImpl) {
-            sort = Sort.by(toDirection(((SortBy.NaturalImpl) sortBy).direction), NATURAL);
-        } else if (sortBy instanceof SortBy.SingleFieldImpl singleField) {
-            sort = Sort.by(toDirection(singleField.direction), singleField.fieldName);
-        } else if (sortBy instanceof SortBy.MultipleSortStepsImpl) {
-            sort = ((SortBy.MultipleSortStepsImpl) sortBy).steps.stream()
+        return switch (sortBy) {
+            case SortBy.Unsorted ignored -> Sort.unsorted();
+            case SortBy.NaturalImpl natural -> Sort.by(toDirection(natural.direction), NATURAL);
+            case SortBy.SingleFieldImpl singleField -> Sort.by(toDirection(singleField.direction), singleField.fieldName);
+            case SortBy.MultipleSortStepsImpl multipleSortSteps -> multipleSortSteps.steps.stream()
                     .map(SortConverter::convertToSpringSort)
                     .reduce(Sort::and)
                     .orElseThrow(() -> new IllegalStateException("Internal error: Expecting " + SortBy.MultipleSortStepsImpl.class.getSimpleName() + " to have at least one step"));
-        } else {
-            throw new IllegalArgumentException("Internal error: Unrecognized " + SortBy.class.getSimpleName() + " instance: " + sortBy.getClass().getSimpleName());
-        }
-        return sort;
+        };
     }
 
     private static Sort.Direction toDirection(SortBy.SortDirection sortDirection) {

--- a/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/Deadline.java
+++ b/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/Deadline.java
@@ -33,34 +33,19 @@ public sealed interface Deadline {
      * @return Return the deadline time as a {@link Date}.
      */
     default Date toDate() {
-        if (this instanceof InstantDeadLine) {
-            return Date.from(toInstant());
-        } else if (this instanceof ZonedDateTimeDeadLine) {
-            return Date.from(toInstant());
-        } else if (this instanceof OffsetDateTimeDeadLine) {
-            return Date.from(toInstant());
-        } else if (this instanceof LocalDateTimeDeadLine) {
-            return Date.from(toInstant());
-        } else {
-            throw new IllegalStateException("Internal error: Cannot convert " + this.getClass().getSimpleName() + " to a " + Date.class.getName());
-        }
+        return Date.from(toInstant());
     }
 
     /**
      * @return Return the deadline time as an {@link Instant}.
      */
     default Instant toInstant() {
-        if (this instanceof InstantDeadLine) {
-            return ((InstantDeadLine) this).instant;
-        } else if (this instanceof ZonedDateTimeDeadLine) {
-            return ((ZonedDateTimeDeadLine) this).zonedDateTime.toInstant();
-        } else if (this instanceof OffsetDateTimeDeadLine) {
-            return ((OffsetDateTimeDeadLine) this).offsetDateTime.toInstant();
-        } else if (this instanceof LocalDateTimeDeadLine) {
-            return ((LocalDateTimeDeadLine) this).localDateTime.toInstant(UTC);
-        } else {
-            throw new IllegalStateException("Internal error: Cannot convert " + this.getClass().getSimpleName() + " to a " + Date.class.getName());
-        }
+        return switch (this) {
+            case InstantDeadLine deadline -> deadline.instant;
+            case ZonedDateTimeDeadLine deadline -> deadline.zonedDateTime.toInstant();
+            case OffsetDateTimeDeadLine deadline -> deadline.offsetDateTime.toInstant();
+            case LocalDateTimeDeadLine deadline -> deadline.localDateTime.toInstant(UTC);
+        };
     }
 
     /**

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/InMemoryDeadlineConsumerRegistry.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/InMemoryDeadlineConsumerRegistry.java
@@ -211,8 +211,7 @@ public class InMemoryDeadlineConsumerRegistry implements DeadlineConsumerRegistr
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Config)) return false;
-            Config config = (Config) o;
+            if (!(o instanceof Config config)) return false;
             return pollInterval == config.pollInterval && pollIntervalTimeUnit == config.pollIntervalTimeUnit && Objects.equals(retryStrategy, config.retryStrategy);
         }
 

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/DeadlineData.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/DeadlineData.java
@@ -41,8 +41,7 @@ public class DeadlineData {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DeadlineData)) return false;
-        DeadlineData that = (DeadlineData) o;
+        if (!(o instanceof DeadlineData that)) return false;
         return Objects.equals(id, that.id) && Objects.equals(category, that.category) && Objects.equals(deadline, that.deadline) && Objects.equals(data, that.data);
     }
 

--- a/deadline/inmemory/src/test/java/org/occurrent/deadline/inmemory/InMemoryDeadlineTest.java
+++ b/deadline/inmemory/src/test/java/org/occurrent/deadline/inmemory/InMemoryDeadlineTest.java
@@ -122,8 +122,7 @@ public class InMemoryDeadlineTest {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof MyDTO)) return false;
-            MyDTO myDTO = (MyDTO) o;
+            if (!(o instanceof MyDTO myDTO)) return false;
             return Objects.equals(something, myDTO.something);
         }
 

--- a/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/DeadlineJobRequest.java
+++ b/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/DeadlineJobRequest.java
@@ -69,8 +69,7 @@ public class DeadlineJobRequest implements JobRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DeadlineJobRequest)) return false;
-        DeadlineJobRequest that = (DeadlineJobRequest) o;
+        if (!(o instanceof DeadlineJobRequest that)) return false;
         return deadlineInEpochMilli == that.deadlineInEpochMilli && Objects.equals(id, that.id) && Objects.equals(category, that.category) && Objects.equals(data, that.data);
     }
 

--- a/deadline/jobrunr/src/test/java/org/occurrent/deadline/jobrunr/JobRunrDeadlineManagerTest.java
+++ b/deadline/jobrunr/src/test/java/org/occurrent/deadline/jobrunr/JobRunrDeadlineManagerTest.java
@@ -153,8 +153,7 @@ class JobRunrDeadlineManagerTest {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof MyDTO)) return false;
-            MyDTO myDTO = (MyDTO) o;
+            if (!(o instanceof MyDTO myDTO)) return false;
             return Objects.equals(something, myDTO.something);
         }
 

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/DuplicateCloudEventException.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/DuplicateCloudEventException.java
@@ -55,8 +55,7 @@ public class DuplicateCloudEventException extends RuntimeException {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DuplicateCloudEventException)) return false;
-        DuplicateCloudEventException that = (DuplicateCloudEventException) o;
+        if (!(o instanceof DuplicateCloudEventException that)) return false;
         return Objects.equals(id, that.id) && Objects.equals(source, that.source) && Objects.equals(details, that.details);
     }
 

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/LongConditionEvaluator.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/LongConditionEvaluator.java
@@ -20,7 +20,6 @@ import org.jspecify.annotations.NullMarked;
 import org.occurrent.condition.Condition;
 import org.occurrent.condition.Condition.*;
 
-import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -33,30 +32,33 @@ public class LongConditionEvaluator {
     public static boolean evaluate(Condition<Long> condition, long value) {
         Objects.requireNonNull(condition, "Condition cannot be null");
 
-        if (condition instanceof MultiOperandCondition<Long> operation) {
-            MultiOperandConditionName operationName = operation.operationName();
-            Stream<Condition<Long>> operations = operation.operations().stream();
-            return switch (operationName) {
-                case AND -> operations.allMatch(c -> evaluate(c, value));
-                case OR -> operations.anyMatch(c -> evaluate(c, value));
-                case NOT -> operations.noneMatch(c -> evaluate(c, value));
-            };
-        } else if (condition instanceof SingleOperandCondition<Long> singleOperandCondition) {
-            long operand = singleOperandCondition.operand();
-            SingleOperandConditionName singleOperandConditionName = singleOperandCondition.operandConditionName();
-            return switch (singleOperandConditionName) {
-                case EQ -> value == operand;
-                case LT -> value < operand;
-                case GT -> value > operand;
-                case LTE -> value <= operand;
-                case GTE -> value >= operand;
-                case NE -> value != operand;
-            };
-        } else if (condition instanceof InOperandCondition<Long> inOperandCondition) {
-            Collection<Long> longs = inOperandCondition.operand();
-            return longs.contains(value);
-        } else {
-            throw new IllegalArgumentException("Unsupported condition: " + condition.getClass());
-        }
+        return switch (condition) {
+            case MultiOperandCondition<Long> operation -> evaluate(operation, value);
+            case SingleOperandCondition<Long> singleOperandCondition -> evaluate(singleOperandCondition, value);
+            case InOperandCondition<Long> inOperandCondition -> inOperandCondition.operand().contains(value);
+        };
+    }
+
+    private static boolean evaluate(MultiOperandCondition<Long> operation, long value) {
+        MultiOperandConditionName operationName = operation.operationName();
+        Stream<Condition<Long>> operations = operation.operations().stream();
+        return switch (operationName) {
+            case AND -> operations.allMatch(c -> evaluate(c, value));
+            case OR -> operations.anyMatch(c -> evaluate(c, value));
+            case NOT -> operations.noneMatch(c -> evaluate(c, value));
+        };
+    }
+
+    private static boolean evaluate(SingleOperandCondition<Long> singleOperandCondition, long value) {
+        long operand = singleOperandCondition.operand();
+        SingleOperandConditionName singleOperandConditionName = singleOperandCondition.operandConditionName();
+        return switch (singleOperandConditionName) {
+            case EQ -> value == operand;
+            case LT -> value < operand;
+            case GT -> value > operand;
+            case LTE -> value <= operand;
+            case GTE -> value >= operand;
+            case NE -> value != operand;
+        };
     }
 }

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
@@ -212,8 +212,8 @@ public sealed interface SortBy {
         public MultipleSortSteps thenMerge(SortBy next) {
             Objects.requireNonNull(next, ComposableSortStep.class.getSimpleName() + " cannot be null");
             List<SortBy> newSteps = new ArrayList<>(steps);
-            if (next instanceof MultipleSortStepsImpl) {
-                newSteps.addAll(((MultipleSortStepsImpl) next).steps);
+            if (next instanceof MultipleSortStepsImpl multipleSortSteps) {
+                newSteps.addAll(multipleSortSteps.steps);
             } else {
                 newSteps.add(next);
             }

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteCondition.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteCondition.java
@@ -57,7 +57,7 @@ public sealed interface WriteCondition {
     }
 
     default boolean isAnyStreamVersion() {
-        return this instanceof StreamVersionWriteCondition && ((StreamVersionWriteCondition) this).isAny();
+        return this instanceof StreamVersionWriteCondition condition && condition.isAny();
     }
 
     record StreamVersionWriteCondition(Condition<Long> condition) implements WriteCondition {

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
@@ -43,8 +43,7 @@ public class WriteConditionNotFulfilledException extends RuntimeException {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof WriteConditionNotFulfilledException)) return false;
-        WriteConditionNotFulfilledException that = (WriteConditionNotFulfilledException) o;
+        if (!(o instanceof WriteConditionNotFulfilledException that)) return false;
         return eventStreamVersion == that.eventStreamVersion && Objects.equals(eventStreamId, that.eventStreamId) && Objects.equals(writeCondition, that.writeCondition) && Objects.equals(getMessage(), that.getMessage());
     }
 

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterToFilterMapper.java
@@ -59,32 +59,22 @@ public final class StreamReadFilterToFilterMapper {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static Filter map(StreamReadFilter filter) {
         requireNonNull(filter, "StreamReadFilter cannot be null");
-        if (filter instanceof AttributeFilter<?> af) {
-            return Filter.filter(af.attributeName(), (Condition) af.condition());
-        }
+        return switch (filter) {
+            case AttributeFilter<?> af -> Filter.filter(af.attributeName(), (Condition) af.condition());
+            case ExtensionFilter<?> ef -> Filter.filter(ef.extensionName(), (Condition) ef.condition());
+            case DataFilter<?> df -> Filter.data(df.path(), (Condition) df.condition());
+            case StreamReadFilter.CompositionFilter cf -> {
+                List<Filter> mapped = new ArrayList<>(cf.filters().size());
+                for (StreamReadFilter f : cf.filters()) {
+                    mapped.add(map(f));
+                }
 
-        if (filter instanceof ExtensionFilter<?> ef) {
-            return Filter.filter(ef.extensionName(), (Condition) ef.condition());
-        }
+                Filter.CompositionOperator op = cf.operator() == StreamReadFilter.CompositionOperator.AND
+                        ? Filter.CompositionOperator.AND
+                        : Filter.CompositionOperator.OR;
 
-        if (filter instanceof DataFilter<?> df) {
-            return Filter.data(df.path(), (Condition) df.condition());
-        }
-
-        if (filter instanceof StreamReadFilter.CompositionFilter cf) {
-
-            List<Filter> mapped = new ArrayList<>(cf.filters().size());
-            for (StreamReadFilter f : cf.filters()) {
-                mapped.add(map(f));
+                yield new Filter.CompositionFilter(op, mapped);
             }
-
-            Filter.CompositionOperator op = cf.operator() == StreamReadFilter.CompositionOperator.AND
-                    ? Filter.CompositionOperator.AND
-                    : Filter.CompositionOperator.OR;
-
-            return new Filter.CompositionFilter(op, mapped);
-        }
-
-        throw new IllegalArgumentException("Unknown StreamReadFilter implementation: " + filter.getClass().getName());
+        };
     }
 }

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidator.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/StreamReadFilterValidator.java
@@ -52,31 +52,20 @@ public final class StreamReadFilterValidator {
     }
 
     private static void validateInternal(StreamReadFilter filter) {
-        if (filter instanceof AttributeFilter<?> af) {
-            verifyForbiddenName(normalize(af.attributeName()), "attribute");
-            return;
-        }
-
-        if (filter instanceof ExtensionFilter<?> ef) {
-            verifyForbiddenName(normalize(ef.extensionName()), "extension");
-            return;
-        }
-
-        if (filter instanceof StreamReadFilter.DataFilter) {
-            // Allowed
-            return;
-        }
-
-        if (filter instanceof StreamReadFilter.CompositionFilter cf) {
-            List<StreamReadFilter> filters = cf.filters();
-            for (StreamReadFilter f : filters) {
-                requireNonNull(f, "StreamReadFilter composition cannot contain null");
-                validateInternal(f);
+        switch (filter) {
+            case AttributeFilter<?> af -> verifyForbiddenName(normalize(af.attributeName()), "attribute");
+            case ExtensionFilter<?> ef -> verifyForbiddenName(normalize(ef.extensionName()), "extension");
+            case StreamReadFilter.DataFilter<?> ignored -> {
+                // Allowed
             }
-            return;
+            case StreamReadFilter.CompositionFilter cf -> {
+                List<StreamReadFilter> filters = cf.filters();
+                for (StreamReadFilter f : filters) {
+                    requireNonNull(f, "StreamReadFilter composition cannot contain null");
+                    validateInternal(f);
+                }
+            }
         }
-
-        throw new IllegalArgumentException("Unknown StreamReadFilter implementation: " + filter.getClass().getName());
     }
 
     private static void verifyForbiddenName(String normalizedName, String kind) {

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCloudEvents.java
@@ -108,10 +108,11 @@ public final class DcbCloudEvents {
     public static boolean matches(CloudEvent cloudEvent, DcbCriteria criteria) {
         requireNonNull(cloudEvent, "CloudEvent cannot be null");
         requireNonNull(criteria, "Criteria cannot be null");
-        if (criteria instanceof DcbCriteria.MatchAll) {
-            return true;
-        }
-        return itemsOf(criteria).stream().anyMatch(item -> matches(cloudEvent, item));
+        return switch (criteria) {
+            case DcbCriteria.MatchAll ignored -> true;
+            case DcbCriterion item -> matches(cloudEvent, item);
+            case DcbCriteria.Items items -> items.items().stream().anyMatch(item -> matches(cloudEvent, item));
+        };
     }
 
     private static boolean matches(CloudEvent cloudEvent, DcbCriterion item) {
@@ -135,13 +136,11 @@ public final class DcbCloudEvents {
     }
 
     private static List<DcbCriterion> itemsOf(DcbCriteria criteria) {
-        if (criteria instanceof DcbCriterion item) {
-            return List.of(item);
-        }
-        if (criteria instanceof DcbCriteria.Items items) {
-            return items.items();
-        }
-        return List.of();
+        return switch (criteria) {
+            case DcbCriteria.MatchAll ignored -> List.of();
+            case DcbCriterion item -> List.of(item);
+            case DcbCriteria.Items items -> items.items();
+        };
     }
 
     /**

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCriteria.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbCriteria.java
@@ -138,8 +138,6 @@ public sealed interface DcbCriteria permits DcbCriteria.MatchAll, DcbCriteria.It
                 }
                 case DcbCriterion item -> items.add(item);
                 case Items existing -> items.addAll(existing.items());
-                default -> {
-                }
             }
         }
         return items.size() == 1 ? items.getFirst() : new Items(items);

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/ContentType.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/ContentType.java
@@ -8,21 +8,23 @@ class ContentType {
         if (contentTypeObject == null) {
             // An undefined content-type means application/json according to the cloud event spec
             return true;
-        } else if (!(contentTypeObject instanceof String)) {
+        }
+        if (!(contentTypeObject instanceof String contentType)) {
             return false;
         }
-        String contentType = ((String) contentTypeObject).toLowerCase();
-        return contentType.contains("/json") || contentType.contains("+json");
+        String lowerCaseContentType = contentType.toLowerCase();
+        return lowerCaseContentType.contains("/json") || lowerCaseContentType.contains("+json");
     }
 
     public static boolean isText(@Nullable Object contentTypeObject) {
         if (contentTypeObject == null) {
             // An undefined content-type means application/json according to the cloud event spec
             return false;
-        } else if (!(contentTypeObject instanceof String)) {
+        }
+        if (!(contentTypeObject instanceof String contentType)) {
             return false;
         }
-        String contentType = ((String) contentTypeObject).toLowerCase();
-        return contentType.trim().startsWith("text/") || contentType.contains("/xml") || contentType.contains("+xml") || contentType.contains("+csv");
+        String lowerCaseContentType = contentType.toLowerCase();
+        return lowerCaseContentType.trim().startsWith("text/") || lowerCaseContentType.contains("/xml") || lowerCaseContentType.contains("+xml") || lowerCaseContentType.contains("+csv");
     }
 }

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventReader.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventReader.java
@@ -77,10 +77,10 @@ public class DocumentCloudEventReader implements CloudEventReader {
             }
 
             // Switch on types document support
-            if (extension.getValue() instanceof Integer) {
-                writer.withContextAttribute(extension.getKey(), (Integer) extension.getValue());
-            } else if (extension.getValue() instanceof Boolean) {
-                writer.withContextAttribute(extension.getKey(), (Boolean) extension.getValue());
+            if (extension.getValue() instanceof Integer integer) {
+                writer.withContextAttribute(extension.getKey(), integer);
+            } else if (extension.getValue() instanceof Boolean bool) {
+                writer.withContextAttribute(extension.getKey(), bool);
             } else {
                 writer.withContextAttribute(extension.getKey(), extension.getValue().toString());
             }
@@ -93,12 +93,12 @@ public class DocumentCloudEventReader implements CloudEventReader {
             final CloudEventData ceData;
             if (isJson(contentType)) {
                 ceData = convertJsonData(data);
-            } else if (data instanceof byte[]) {
-                ceData = BytesCloudEventData.wrap((byte[]) data);
-            } else if (data instanceof String) {
-                ceData = BytesCloudEventData.wrap(((String) data).getBytes(UTF_8));
-            } else if (data instanceof Binary) {
-                ceData = BytesCloudEventData.wrap(((Binary) data).getData());
+            } else if (data instanceof byte[] byteArray) {
+                ceData = BytesCloudEventData.wrap(byteArray);
+            } else if (data instanceof String string) {
+                ceData = BytesCloudEventData.wrap(string.getBytes(UTF_8));
+            } else if (data instanceof Binary binary) {
+                ceData = BytesCloudEventData.wrap(binary.getData());
             } else {
                 throw CloudEventRWException.newInvalidDataType(data.getClass().getName(), String.class.getName(), byte[].class.getName(), Binary.class.getName());
             }
@@ -129,8 +129,8 @@ public class DocumentCloudEventReader implements CloudEventReader {
             } else {
                 ceData = BytesCloudEventData.wrap(json.getBytes(UTF_8));
             }
-        } else if (data instanceof Binary) {
-            ceData = BytesCloudEventData.wrap(((Binary) data).getData());
+        } else if (data instanceof Binary binary) {
+            ceData = BytesCloudEventData.wrap(binary.getData());
         } else {
             throw CloudEventRWException.newInvalidDataType(data.getClass().getName(), String.class.getName(), byte[].class.getName(), Map.class.getName(), Binary.class.getName());
         }

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
@@ -40,8 +40,7 @@ public class MongoExceptionTranslator {
      */
     public static RuntimeException translateException(WriteContext ctx, MongoException e) {
         final RuntimeException runtimeException;
-        if (e instanceof MongoBulkWriteException) {
-            MongoBulkWriteException mongoBulkWriteException = (MongoBulkWriteException) e;
+        if (e instanceof MongoBulkWriteException mongoBulkWriteException) {
             runtimeException = mongoBulkWriteException.getWriteErrors().stream()
                     .filter(bulkWriteError -> ErrorCategory.fromErrorCode(bulkWriteError.getCode()) == ErrorCategory.DUPLICATE_KEY)
                     .map(bulkWriteError -> translateToDuplicateCloudEventException(mongoBulkWriteException, bulkWriteError))

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
@@ -72,8 +72,7 @@ public class OccurrentCloudEventMongoDocumentMapper {
 
         if (timeRepresentation == DATE) {
             Object time = document.get("time"); // Be a bit nice and don't enforce Date here if TimeRepresentation has been changed
-            if (time instanceof Date) {
-                Date timeAsDate = (Date) time;
+            if (time instanceof Date timeAsDate) {
                 OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(timeAsDate.toInstant(), UTC);
                 String format = RFC_3339_DATE_TIME_FORMATTER.format(offsetDateTime);
                 document.put("time", format);

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/StreamVersionDiff.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/StreamVersionDiff.java
@@ -40,8 +40,7 @@ public class StreamVersionDiff {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof StreamVersionDiff)) return false;
-        StreamVersionDiff that = (StreamVersionDiff) o;
+        if (!(o instanceof StreamVersionDiff that)) return false;
         return oldStreamVersion == that.oldStreamVersion && newStreamVersion == that.newStreamVersion;
     }
 

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
@@ -79,7 +79,7 @@ public final class DcbMarkerModel {
         return keys;
     }
 
-    // A query here is either a single DcbCriterion alternative or an Items list (MatchAll is handled by the callers).
+    // MatchAll has no per-item markers. A DcbCriterion is one alternative, and Items contains several.
     public static List<DcbCriterion> dcbQueryItems(DcbCriteria query) {
         return switch (query) {
             case DcbCriteria.MatchAll ignored -> List.of();

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/DcbMarkerModel.java
@@ -81,10 +81,11 @@ public final class DcbMarkerModel {
 
     // A query here is either a single DcbCriterion alternative or an Items list (MatchAll is handled by the callers).
     public static List<DcbCriterion> dcbQueryItems(DcbCriteria query) {
-        if (query instanceof DcbCriterion item) {
-            return List.of(item);
-        }
-        return ((DcbCriteria.Items) query).items();
+        return switch (query) {
+            case DcbCriteria.MatchAll ignored -> List.of();
+            case DcbCriterion item -> List.of(item);
+            case DcbCriteria.Items items -> items.items();
+        };
     }
 
     public static Set<String> eventMarkerKeys(List<CloudEvent> events) {

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
@@ -124,8 +124,7 @@ public class EventStoreConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EventStoreConfig)) return false;
-        EventStoreConfig that = (EventStoreConfig) o;
+        if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(transactionOptions, that.transactionOptions) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;
     }
 

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
@@ -116,8 +116,7 @@ public class EventStoreConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EventStoreConfig)) return false;
-        EventStoreConfig that = (EventStoreConfig) o;
+        if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionTemplate, that.transactionTemplate) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;
     }
 

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
@@ -113,8 +113,7 @@ public class EventStoreConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EventStoreConfig)) return false;
-        EventStoreConfig that = (EventStoreConfig) o;
+        if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionalOperator, that.transactionalOperator) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;
     }
 

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameAlreadyEnded.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameAlreadyEnded.java
@@ -30,8 +30,7 @@ public class GameAlreadyEnded extends RuntimeException {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof GameAlreadyEnded)) return false;
-        GameAlreadyEnded that = (GameAlreadyEnded) o;
+        if (!(o instanceof GameAlreadyEnded that)) return false;
         return Objects.equals(gameId, that.gameId);
     }
 

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameNotStarted.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameNotStarted.java
@@ -30,8 +30,7 @@ public class GameNotStarted extends RuntimeException {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof GameNotStarted)) return false;
-        GameNotStarted that = (GameNotStarted) o;
+        if (!(o instanceof GameNotStarted that)) return false;
         return Objects.equals(gameId, that.gameId);
     }
 

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/Guess.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/Guess.java
@@ -31,8 +31,7 @@ public class Guess {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Guess)) return false;
-        Guess that = (Guess) o;
+        if (!(o instanceof Guess that)) return false;
         return value == that.value;
     }
 

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/MaxNumberOfGuesses.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/MaxNumberOfGuesses.java
@@ -35,8 +35,7 @@ public class MaxNumberOfGuesses {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MaxNumberOfGuesses)) return false;
-        MaxNumberOfGuesses that = (MaxNumberOfGuesses) o;
+        if (!(o instanceof MaxNumberOfGuesses that)) return false;
         return value == that.value;
     }
 

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/NumberGuessingGame.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/NumberGuessingGame.java
@@ -70,15 +70,17 @@ public class NumberGuessingGame {
 
     private static GameState rehydrate(Stream<GameEvent> events) {
         return events.collect(GameState::new, (state, gameEvent) -> {
-            if (gameEvent instanceof NumberGuessingGameWasStarted) {
-                NumberGuessingGameWasStarted numberGuessingGameWasStarted = (NumberGuessingGameWasStarted) gameEvent;
-                state.started = true;
-                state.secretNumberToGuess = numberGuessingGameWasStarted.secretNumberToGuess();
-                state.maxNumberOfGuesses = numberGuessingGameWasStarted.maxNumberOfGuesses();
-            } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall || gameEvent instanceof PlayerGuessedANumberThatWasTooBig) {
-                state.numberOfGuesses = state.numberOfGuesses + 1;
-            } else {
-                state.ended = true;
+            switch (gameEvent) {
+                case NumberGuessingGameWasStarted numberGuessingGameWasStarted -> {
+                    state.started = true;
+                    state.secretNumberToGuess = numberGuessingGameWasStarted.secretNumberToGuess();
+                    state.maxNumberOfGuesses = numberGuessingGameWasStarted.maxNumberOfGuesses();
+                }
+                case PlayerGuessedANumberThatWasTooSmall ignored -> state.numberOfGuesses = state.numberOfGuesses + 1;
+                case PlayerGuessedANumberThatWasTooBig ignored -> state.numberOfGuesses = state.numberOfGuesses + 1;
+                case PlayerGuessedTheRightNumber ignored -> state.ended = true;
+                case GuessingAttemptsExhausted ignored -> state.ended = true;
+                case NumberGuessingGameEnded ignored -> state.ended = true;
             }
         }, EMPTY);
     }

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/Bootstrap.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/Bootstrap.java
@@ -130,14 +130,11 @@ public class Bootstrap {
                             integrationEvent.setSecretNumberToGuess(e.secretNumberToGuess());
                             integrationEvent.setMaxNumberOfGuesses(e.maxNumberOfGuesses());
                             integrationEvent.setStartedAt(toDate(e.timestamp()));
-                        } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall) {
-                            PlayerGuessedANumberThatWasTooSmall e = (PlayerGuessedANumberThatWasTooSmall) gameEvent;
+                        } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall e) {
                             integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
-                        } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooBig) {
-                            PlayerGuessedANumberThatWasTooBig e = (PlayerGuessedANumberThatWasTooBig) gameEvent;
+                        } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooBig e) {
                             integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
-                        } else if (gameEvent instanceof PlayerGuessedTheRightNumber) {
-                            PlayerGuessedTheRightNumber e = (PlayerGuessedTheRightNumber) gameEvent;
+                        } else if (gameEvent instanceof PlayerGuessedTheRightNumber e) {
                             integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
                             integrationEvent.setRightNumberWasGuessed(true);
                         } else if (gameEvent instanceof GuessingAttemptsExhausted) {
@@ -185,14 +182,11 @@ public class Bootstrap {
                                 gameStatus.gameId = event.gameId();
                                 gameStatus.secretNumber = ((NumberGuessingGameWasStarted) event).secretNumberToGuess();
                                 gameStatus.maxNumberOfGuesses = ((NumberGuessingGameWasStarted) event).maxNumberOfGuesses();
-                            } else if (event instanceof PlayerGuessedANumberThatWasTooSmall) {
-                                PlayerGuessedANumberThatWasTooSmall e = (PlayerGuessedANumberThatWasTooSmall) event;
+                            } else if (event instanceof PlayerGuessedANumberThatWasTooSmall e) {
                                 gameStatus.guesses.add(new GameStatus.GuessAndTime(e.guessedNumber(), e.timestamp()));
-                            } else if (event instanceof PlayerGuessedANumberThatWasTooBig) {
-                                PlayerGuessedANumberThatWasTooBig e = (PlayerGuessedANumberThatWasTooBig) event;
+                            } else if (event instanceof PlayerGuessedANumberThatWasTooBig e) {
                                 gameStatus.guesses.add(new GameStatus.GuessAndTime(e.guessedNumber(), e.timestamp()));
-                            } else if (event instanceof PlayerGuessedTheRightNumber) {
-                                PlayerGuessedTheRightNumber e = (PlayerGuessedTheRightNumber) event;
+                            } else if (event instanceof PlayerGuessedTheRightNumber e) {
                                 gameStatus.guesses.add(new GameStatus.GuessAndTime(e.guessedNumber(), e.timestamp()));
                             }
                         }, (gameStatus, gameStatus2) -> {

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/Serialization.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/Serialization.java
@@ -104,37 +104,27 @@ public class Serialization {
     }
 
     private byte[] toBytes(GameEvent event) {
-        final Map<String, Object> eventAsMap;
-        if (event instanceof GuessingAttemptsExhausted || event instanceof NumberGuessingGameEnded) {
-            eventAsMap = null;
-        } else if (event instanceof NumberGuessingGameWasStarted) {
-            NumberGuessingGameWasStarted e = (NumberGuessingGameWasStarted) event;
-            eventAsMap = new HashMap<String, Object>() {{
+        final Map<String, Object> eventAsMap = switch (event) {
+            case GuessingAttemptsExhausted ignored -> null;
+            case NumberGuessingGameEnded ignored -> null;
+            case NumberGuessingGameWasStarted e -> new HashMap<String, Object>() {{
                 put("startedBy", e.startedBy().toString());
                 put("secretNumberToGuess", e.secretNumberToGuess());
                 put("maxNumberOfGuesses", e.maxNumberOfGuesses());
             }};
-        } else if (event instanceof PlayerGuessedANumberThatWasTooBig) {
-            PlayerGuessedANumberThatWasTooBig e = (PlayerGuessedANumberThatWasTooBig) event;
-            eventAsMap = new HashMap<String, Object>() {{
+            case PlayerGuessedANumberThatWasTooBig e -> new HashMap<String, Object>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else if (event instanceof PlayerGuessedANumberThatWasTooSmall) {
-            PlayerGuessedANumberThatWasTooSmall e = (PlayerGuessedANumberThatWasTooSmall) event;
-            eventAsMap = new HashMap<String, Object>() {{
+            case PlayerGuessedANumberThatWasTooSmall e -> new HashMap<String, Object>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else if (event instanceof PlayerGuessedTheRightNumber) {
-            PlayerGuessedTheRightNumber e = (PlayerGuessedTheRightNumber) event;
-            eventAsMap = new HashMap<String, Object>() {{
+            case PlayerGuessedTheRightNumber e -> new HashMap<String, Object>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else {
-            throw new IllegalArgumentException("Unrecognized event: " + event.getClass().getName());
-        }
+        };
 
         if (eventAsMap == null) {
             return null;

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/NumberGuessingGameCompleted.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/NumberGuessingGameCompleted.java
@@ -104,8 +104,7 @@ public class NumberGuessingGameCompleted {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof NumberGuessingGameCompleted)) return false;
-        NumberGuessingGameCompleted that = (NumberGuessingGameCompleted) o;
+        if (!(o instanceof NumberGuessingGameCompleted that)) return false;
         return secretNumberToGuess == that.secretNumberToGuess &&
                 maxNumberOfGuesses == that.maxNumberOfGuesses &&
                 rightNumberWasGuessed == that.rightNumberWasGuessed &&
@@ -178,8 +177,7 @@ public class NumberGuessingGameCompleted {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof GuessedNumber)) return false;
-            GuessedNumber that = (GuessedNumber) o;
+            if (!(o instanceof GuessedNumber that)) return false;
             return number == that.number &&
                     Objects.equals(playerId, that.playerId) &&
                     Objects.equals(guessedAt, that.guessedAt);

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/GameOverview.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/GameOverview.java
@@ -45,8 +45,7 @@ public class GameOverview {
             @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
-                if (!(o instanceof Ongoing)) return false;
-                Ongoing ongoing = (Ongoing) o;
+                if (!(o instanceof Ongoing ongoing)) return false;
                 return numberOfAttemptsLeft == ongoing.numberOfAttemptsLeft;
             }
 
@@ -75,8 +74,7 @@ public class GameOverview {
             @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
-                if (!(o instanceof Ended)) return false;
-                Ended ended = (Ended) o;
+                if (!(o instanceof Ended ended)) return false;
                 return playerGuessedTheRightNumber == ended.playerGuessedTheRightNumber &&
                         Objects.equals(endedAt, ended.endedAt);
             }

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/InsertGameIntoLatestGamesOverview.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/InsertGameIntoLatestGamesOverview.java
@@ -47,8 +47,7 @@ public class InsertGameIntoLatestGamesOverview {
         return cloudEvent -> {
             GameEvent gameEvent = deserialize.apply(cloudEvent);
 
-            if (gameEvent instanceof NumberGuessingGameWasStarted) {
-                NumberGuessingGameWasStarted e = (NumberGuessingGameWasStarted) gameEvent;
+            if (gameEvent instanceof NumberGuessingGameWasStarted e) {
                 Document game = new Document();
                 game.put("_id", gameEvent.gameId().toString());
                 game.put("startedAt", toDate(gameEvent.timestamp()));
@@ -62,15 +61,17 @@ public class InsertGameIntoLatestGamesOverview {
                     return;
                 }
 
-                if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall || gameEvent instanceof PlayerGuessedANumberThatWasTooBig) {
-                    game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
-                } else if (gameEvent instanceof PlayerGuessedTheRightNumber) {
-                    game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
-                    game.put("playerGuessedTheRightNumber", true);
-                } else if (gameEvent instanceof GuessingAttemptsExhausted) {
-                    game.put("playerGuessedTheRightNumber", false);
-                } else if (gameEvent instanceof NumberGuessingGameEnded) {
-                    game.put("endedAt", toDate(gameEvent.timestamp()));
+                switch (gameEvent) {
+                    case NumberGuessingGameWasStarted ignored -> {
+                    }
+                    case PlayerGuessedANumberThatWasTooSmall ignored -> game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                    case PlayerGuessedANumberThatWasTooBig ignored -> game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                    case PlayerGuessedTheRightNumber ignored -> {
+                        game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                        game.put("playerGuessedTheRightNumber", true);
+                    }
+                    case GuessingAttemptsExhausted ignored -> game.put("playerGuessedTheRightNumber", false);
+                    case NumberGuessingGameEnded ignored -> game.put("endedAt", toDate(gameEvent.timestamp()));
                 }
 
                 latestGamesOverviewCollection.replaceOne(findGame, game, new ReplaceOptions().upsert(true));

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/infrastructure/NumberGuessGameCloudEventConverter.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/infrastructure/NumberGuessGameCloudEventConverter.java
@@ -114,33 +114,27 @@ public class NumberGuessGameCloudEventConverter implements CloudEventConverter<G
     }
 
     private byte[] toBytes(GameEvent event) {
-        final Map<String, Object> eventAsMap;
-        if (event instanceof GuessingAttemptsExhausted || event instanceof NumberGuessingGameEnded) {
-            eventAsMap = null;
-        } else if (event instanceof NumberGuessingGameWasStarted e) {
-            eventAsMap = new HashMap<>() {{
+        final Map<String, Object> eventAsMap = switch (event) {
+            case GuessingAttemptsExhausted ignored -> null;
+            case NumberGuessingGameEnded ignored -> null;
+            case NumberGuessingGameWasStarted e -> new HashMap<>() {{
                 put("startedBy", e.startedBy().toString());
                 put("secretNumberToGuess", e.secretNumberToGuess());
                 put("maxNumberOfGuesses", e.maxNumberOfGuesses());
             }};
-        } else if (event instanceof PlayerGuessedANumberThatWasTooBig e) {
-            eventAsMap = new HashMap<>() {{
+            case PlayerGuessedANumberThatWasTooBig e -> new HashMap<>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else if (event instanceof PlayerGuessedANumberThatWasTooSmall e) {
-            eventAsMap = new HashMap<>() {{
+            case PlayerGuessedANumberThatWasTooSmall e -> new HashMap<>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else if (event instanceof PlayerGuessedTheRightNumber e) {
-            eventAsMap = new HashMap<>() {{
+            case PlayerGuessedTheRightNumber e -> new HashMap<>() {{
                 put("playerId", e.playerId().toString());
                 put("guessedNumber", e.guessedNumber());
             }};
-        } else {
-            throw new IllegalArgumentException("Unrecognized event: " + event.getClass().getName());
-        }
+        };
 
         if (eventAsMap == null) {
             return null;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/NumberGuessingGameCompleted.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/NumberGuessingGameCompleted.java
@@ -104,8 +104,7 @@ class NumberGuessingGameCompleted {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof NumberGuessingGameCompleted)) return false;
-        NumberGuessingGameCompleted that = (NumberGuessingGameCompleted) o;
+        if (!(o instanceof NumberGuessingGameCompleted that)) return false;
         return secretNumberToGuess == that.secretNumberToGuess &&
                 maxNumberOfGuesses == that.maxNumberOfGuesses &&
                 rightNumberWasGuessed == that.rightNumberWasGuessed &&
@@ -178,8 +177,7 @@ class NumberGuessingGameCompleted {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof GuessedNumber)) return false;
-            GuessedNumber that = (GuessedNumber) o;
+            if (!(o instanceof GuessedNumber that)) return false;
             return number == that.number &&
                     Objects.equals(playerId, that.playerId) &&
                     Objects.equals(guessedAt, that.guessedAt);

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/WhenGameEndedThenPublishIntegrationEvent.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/WhenGameEndedThenPublishIntegrationEvent.java
@@ -50,22 +50,23 @@ class WhenGameEndedThenPublishIntegrationEvent {
         long streamVersion = metadata.getStreamVersion();
         NumberGuessingGameCompleted numberGuessingGameCompleted = domainEventQueries.query(subject(eq(gameId)).and(streamVersion(lte(streamVersion))))
                 .collect(NumberGuessingGameCompleted::new, (integrationEvent, gameEvent) -> {
-                    if (gameEvent instanceof NumberGuessingGameWasStarted e) {
-                        integrationEvent.setGameId(gameEvent.gameId().toString());
-                        integrationEvent.setSecretNumberToGuess(e.secretNumberToGuess());
-                        integrationEvent.setMaxNumberOfGuesses(e.maxNumberOfGuesses());
-                        integrationEvent.setStartedAt(toDate(e.timestamp()));
-                    } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall e) {
-                        integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
-                    } else if (gameEvent instanceof PlayerGuessedANumberThatWasTooBig e) {
-                        integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
-                    } else if (gameEvent instanceof PlayerGuessedTheRightNumber e) {
-                        integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
-                        integrationEvent.setRightNumberWasGuessed(true);
-                    } else if (gameEvent instanceof GuessingAttemptsExhausted) {
-                        integrationEvent.setRightNumberWasGuessed(false);
-                    } else if (gameEvent instanceof NumberGuessingGameEnded) {
-                        integrationEvent.setEndedAt(toDate(gameEvent.timestamp()));
+                    switch (gameEvent) {
+                        case NumberGuessingGameWasStarted e -> {
+                            integrationEvent.setGameId(gameEvent.gameId().toString());
+                            integrationEvent.setSecretNumberToGuess(e.secretNumberToGuess());
+                            integrationEvent.setMaxNumberOfGuesses(e.maxNumberOfGuesses());
+                            integrationEvent.setStartedAt(toDate(e.timestamp()));
+                        }
+                        case PlayerGuessedANumberThatWasTooSmall e ->
+                                integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
+                        case PlayerGuessedANumberThatWasTooBig e ->
+                                integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
+                        case PlayerGuessedTheRightNumber e -> {
+                            integrationEvent.addGuess(new GuessedNumber(e.playerId().toString(), e.guessedNumber(), toDate(e.timestamp())));
+                            integrationEvent.setRightNumberWasGuessed(true);
+                        }
+                        case GuessingAttemptsExhausted ignored -> integrationEvent.setRightNumberWasGuessed(false);
+                        case NumberGuessingGameEnded ignored -> integrationEvent.setEndedAt(toDate(gameEvent.timestamp()));
                     }
                 }, (i1, i2) -> {
                 });

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/GameOverview.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/GameOverview.java
@@ -45,8 +45,7 @@ public class GameOverview {
             @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
-                if (!(o instanceof Ongoing)) return false;
-                Ongoing ongoing = (Ongoing) o;
+                if (!(o instanceof Ongoing ongoing)) return false;
                 return numberOfAttemptsLeft == ongoing.numberOfAttemptsLeft;
             }
 
@@ -75,8 +74,7 @@ public class GameOverview {
             @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
-                if (!(o instanceof Ended)) return false;
-                Ended ended = (Ended) o;
+                if (!(o instanceof Ended ended)) return false;
                 return playerGuessedTheRightNumber == ended.playerGuessedTheRightNumber &&
                         Objects.equals(endedAt, ended.endedAt);
             }

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/InsertGameIntoLatestGamesOverview.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/InsertGameIntoLatestGamesOverview.java
@@ -71,15 +71,17 @@ class InsertGameIntoLatestGamesOverview {
                 return;
             }
 
-            if (gameEvent instanceof PlayerGuessedANumberThatWasTooSmall || gameEvent instanceof PlayerGuessedANumberThatWasTooBig) {
-                game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
-            } else if (gameEvent instanceof PlayerGuessedTheRightNumber) {
-                game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
-                game.put("playerGuessedTheRightNumber", true);
-            } else if (gameEvent instanceof GuessingAttemptsExhausted) {
-                game.put("playerGuessedTheRightNumber", false);
-            } else if (gameEvent instanceof NumberGuessingGameEnded) {
-                game.put("endedAt", toDate(gameEvent.timestamp()));
+            switch (gameEvent) {
+                case NumberGuessingGameWasStarted ignored -> {
+                }
+                case PlayerGuessedANumberThatWasTooSmall ignored -> game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                case PlayerGuessedANumberThatWasTooBig ignored -> game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                case PlayerGuessedTheRightNumber ignored -> {
+                    game.put("numberOfGuesses", (int) game.get("numberOfGuesses") + 1);
+                    game.put("playerGuessedTheRightNumber", true);
+                }
+                case GuessingAttemptsExhausted ignored -> game.put("playerGuessedTheRightNumber", false);
+                case NumberGuessingGameEnded ignored -> game.put("endedAt", toDate(gameEvent.timestamp()));
             }
 
             mongoOperations.findAndReplace(query, game, new FindAndReplaceOptions().upsert(), LatestGamesOverviewCollection.NAME);

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/MostNumberOfWorkouts.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/MostNumberOfWorkouts.java
@@ -69,8 +69,7 @@ public class MostNumberOfWorkouts {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof PersonWithMostNumberOfWorkouts)) return false;
-            PersonWithMostNumberOfWorkouts that = (PersonWithMostNumberOfWorkouts) o;
+            if (!(o instanceof PersonWithMostNumberOfWorkouts that)) return false;
             return count == that.count &&
                     Objects.equals(name, that.name);
         }

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/WorkoutWasCompleted.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/WorkoutWasCompleted.java
@@ -71,8 +71,7 @@ public class WorkoutWasCompleted {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof WorkoutWasCompleted)) return false;
-        WorkoutWasCompleted that = (WorkoutWasCompleted) o;
+        if (!(o instanceof WorkoutWasCompleted that)) return false;
         return Objects.equals(eventId, that.eventId) &&
                 Objects.equals(workoutId, that.workoutId) &&
                 Objects.equals(completedBy, that.completedBy) &&

--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentName.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentName.java
@@ -66,8 +66,7 @@ public class CurrentName {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CurrentName)) return false;
-        CurrentName that = (CurrentName) o;
+        if (!(o instanceof CurrentName that)) return false;
         return Objects.equals(id, that.id) &&
                 Objects.equals(name, that.name);
     }

--- a/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/CurrentName.java
+++ b/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/CurrentName.java
@@ -66,8 +66,7 @@ public class CurrentName {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CurrentName)) return false;
-        CurrentName that = (CurrentName) o;
+        if (!(o instanceof CurrentName that)) return false;
         return Objects.equals(id, that.id) &&
                 Objects.equals(name, that.name);
     }

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -345,26 +345,22 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
     // TODO Also check resume behavior if subscription exists!
     private static boolean shouldWaitUntilStarted(StartPositionToUse startPositionToUse, StartupMode startupMode) {
         return switch (startupMode) {
-            case DEFAULT -> {
-                if (startPositionToUse instanceof StartPositionToUse.StartAtISO8601 || startPositionToUse instanceof StartPositionToUse.StartAtTimeEpoch) {
-                    yield false;
-                } else {
-                    StartPositionToUse.StartAtStartPosition startPosition = (StartPositionToUse.StartAtStartPosition) startPositionToUse;
-                    yield switch (startPosition.startPosition) {
-                        case BEGINNING_OF_TIME -> false;
-                        case NOW, DEFAULT -> true;
-                    };
-                }
-            }
+            case DEFAULT -> switch (startPositionToUse) {
+                case StartPositionToUse.StartAtISO8601 ignored -> false;
+                case StartPositionToUse.StartAtTimeEpoch ignored -> false;
+                case StartPositionToUse.StartAtStartPosition startPosition -> switch (startPosition.startPosition) {
+                    case BEGINNING_OF_TIME -> false;
+                    case NOW, DEFAULT -> true;
+                };
+            };
             case WAIT_UNTIL_STARTED -> true;
             case BACKGROUND -> false;
         };
     }
 
     private @NonNull StartAt generateStartAt(String subscriptionId, StartPositionToUse startPositionToUse, ResumeBehavior resumeBehavior) {
-        final StartAt startAt;
-        if (startPositionToUse instanceof StartPositionToUse.StartAtISO8601 iso8601) {
-            startAt = switch (resumeBehavior) {
+        return switch (startPositionToUse) {
+            case StartPositionToUse.StartAtISO8601 iso8601 -> switch (resumeBehavior) {
                 case SAME_AS_START_AT -> StartAt.dynamic(ctx -> {
                     boolean isCompetingConsumerSubscription = CompetingConsumerSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
                     if (isCompetingConsumerSubscription) {
@@ -400,11 +396,11 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
                     }
                 });
             };
-        } else if (startPositionToUse instanceof StartPositionToUse.StartAtTimeEpoch epoch) {
-            OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(epoch.startAtTimeEpoch), ZoneOffset.UTC);
-            startAt = generateStartAt(subscriptionId, new StartPositionToUse.StartAtISO8601(offsetDateTime), resumeBehavior);
-        } else if (startPositionToUse instanceof StartPositionToUse.StartAtStartPosition startAtStartPosition) {
-            startAt = switch (startAtStartPosition.startPosition) {
+            case StartPositionToUse.StartAtTimeEpoch epoch -> {
+                OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(epoch.startAtTimeEpoch), ZoneOffset.UTC);
+                yield generateStartAt(subscriptionId, new StartPositionToUse.StartAtISO8601(offsetDateTime), resumeBehavior);
+            }
+            case StartPositionToUse.StartAtStartPosition startAtStartPosition -> switch (startAtStartPosition.startPosition) {
                 case BEGINNING_OF_TIME -> switch (resumeBehavior) {
                     case SAME_AS_START_AT -> StartAt.dynamic(ctx -> {
                         boolean isCompetingConsumerSubscription = CompetingConsumerSubscriptionModel.class.isAssignableFrom(ctx.subscriptionModelType());
@@ -450,11 +446,7 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
                     return isCatchupSubscription ? null : StartAt.subscriptionModelDefault();
                 });
             };
-        } else {
-            throw new IllegalStateException("Internal error: Didn't recognize start position");
-        }
-
-        return startAt;
+        };
     }
 
     private static StartPositionToUse findStartPositionToUseOrThrow(String subscriptionId, String startAtISO8601, long startAtTimeEpoch, StartPosition startPosition) {
@@ -474,15 +466,13 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         if (definedStartPositions.isEmpty()) {
             throw new IllegalArgumentException("You need to specify at least one valid start position for subscription '%s'.".formatted(subscriptionId));
         } else if (definedStartPositions.size() > 1) {
-            String startPositionNames = definedStartPositions.stream().map(position -> {
-                if (position instanceof StartPositionToUse.StartAtISO8601) {
-                    return "startAtISO8601";
-                } else if (position instanceof StartPositionToUse.StartAtTimeEpoch) {
-                    return "startAtTimeEpoch";
-                } else {
-                    return "startAt";
-                }
-            }).collect(Collectors.joining(" and "));
+            String startPositionNames = definedStartPositions.stream()
+                    .map(position -> switch (position) {
+                        case StartPositionToUse.StartAtISO8601 ignored -> "startAtISO8601";
+                        case StartPositionToUse.StartAtTimeEpoch ignored -> "startAtTimeEpoch";
+                        case StartPositionToUse.StartAtStartPosition ignored -> "startAt";
+                    })
+                    .collect(Collectors.joining(" and "));
             throw new IllegalArgumentException("You can only specify one start position for subscription '%s', both %s are defined.".formatted(subscriptionId, startPositionNames));
         } else {
             return definedStartPositions.get(0);

--- a/subscription/core/src/main/java/org/occurrent/subscription/CheckpointAwareCloudEvent.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/CheckpointAwareCloudEvent.java
@@ -106,8 +106,7 @@ public final class CheckpointAwareCloudEvent implements CloudEvent {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CheckpointAwareCloudEvent)) return false;
-        CheckpointAwareCloudEvent that = (CheckpointAwareCloudEvent) o;
+        if (!(o instanceof CheckpointAwareCloudEvent that)) return false;
         return Objects.equals(cloudEvent, that.cloudEvent) &&
                 Objects.equals(checkpoint, that.checkpoint);
     }

--- a/subscription/core/src/main/java/org/occurrent/subscription/StartAt.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/StartAt.java
@@ -36,15 +36,30 @@ public sealed interface StartAt {
     StartAt get(SubscriptionModelContext context);
 
     default boolean isNow() {
-        return this instanceof Now;
+        return switch (this) {
+            case Now ignored -> true;
+            case Default ignored -> false;
+            case Dynamic ignored -> false;
+            case StartAtCheckpoint ignored -> false;
+        };
     }
 
     default boolean isDefault() {
-        return this instanceof Default;
+        return switch (this) {
+            case Default ignored -> true;
+            case Now ignored -> false;
+            case Dynamic ignored -> false;
+            case StartAtCheckpoint ignored -> false;
+        };
     }
 
     default boolean isDynamic() {
-        return this instanceof Dynamic;
+        return switch (this) {
+            case Dynamic ignored -> true;
+            case Now ignored -> false;
+            case Default ignored -> false;
+            case StartAtCheckpoint ignored -> false;
+        };
     }
 
     final class Now implements StartAt {
@@ -95,8 +110,8 @@ public sealed interface StartAt {
         @Override
         public StartAt get(SubscriptionModelContext context) {
             StartAt startAt = function.apply(context);
-            if (startAt instanceof Dynamic) {
-                return startAt.get(context);
+            if (startAt instanceof Dynamic dynamic) {
+                return dynamic.get(context);
             }
             return startAt;
         }

--- a/subscription/core/src/main/java/org/occurrent/subscription/StringBasedCheckpoint.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/StringBasedCheckpoint.java
@@ -35,8 +35,7 @@ public class StringBasedCheckpoint implements Checkpoint {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof StringBasedCheckpoint)) return false;
-        StringBasedCheckpoint that = (StringBasedCheckpoint) o;
+        if (!(o instanceof StringBasedCheckpoint that)) return false;
         return Objects.equals(value, that.value);
     }
 

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
@@ -76,8 +76,7 @@ public class InMemorySubscription implements Subscription, Runnable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof InMemorySubscription)) return false;
-        InMemorySubscription that = (InMemorySubscription) o;
+        if (!(o instanceof InMemorySubscription that)) return false;
         return shutdown == that.shutdown && Objects.equals(id, that.id) && Objects.equals(queue, that.queue) && Objects.equals(consumer, that.consumer) && Objects.equals(matcher, that.matcher) && Objects.equals(retryStrategy, that.retryStrategy);
     }
 

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoOperationTimeCheckpoint.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoOperationTimeCheckpoint.java
@@ -44,8 +44,7 @@ public class MongoOperationTimeCheckpoint implements Checkpoint {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MongoOperationTimeCheckpoint)) return false;
-        MongoOperationTimeCheckpoint that = (MongoOperationTimeCheckpoint) o;
+        if (!(o instanceof MongoOperationTimeCheckpoint that)) return false;
         return Objects.equals(operationTime, that.operationTime);
     }
 

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoResumeTokenCheckpoint.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoResumeTokenCheckpoint.java
@@ -44,8 +44,7 @@ public class MongoResumeTokenCheckpoint implements Checkpoint {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MongoResumeTokenCheckpoint)) return false;
-        MongoResumeTokenCheckpoint that = (MongoResumeTokenCheckpoint) o;
+        if (!(o instanceof MongoResumeTokenCheckpoint that)) return false;
         return Objects.equals(resumeToken, that.resumeToken);
     }
 

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/DcbSubscriptionFilterConverter.java
@@ -67,13 +67,11 @@ public final class DcbSubscriptionFilterConverter {
 
     // A bare DcbCriterion is a single alternative, Items is several, and MatchAll yields no constraint (position only).
     private static List<DcbCriterion> itemsOf(DcbCriteria query) {
-        if (query instanceof DcbCriterion item) {
-            return List.of(item);
-        }
-        if (query instanceof DcbCriteria.Items items) {
-            return items.items();
-        }
-        return List.of();
+        return switch (query) {
+            case DcbCriteria.MatchAll ignored -> List.of();
+            case DcbCriterion item -> List.of(item);
+            case DcbCriteria.Items items -> items.items();
+        };
     }
 
     private static Document toItemCondition(DcbCriterion item) {

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCommons.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCommons.java
@@ -93,18 +93,18 @@ public class MongoCommons {
         StartAt startAtValue = startAt == null ? null : startAt.get(ctx);
         if (startAtValue == null || startAtValue.isNow() || startAtValue.isDefault()) {
             return t;
-        } else if (!(startAtValue instanceof StartAtCheckpoint)) {
+        }
+        if (!(startAtValue instanceof StartAtCheckpoint position)) {
             throw new IllegalArgumentException("Unrecognized " + StartAt.class.getSimpleName() + " implementation: " + startAtValue.getClass().getName());
         }
 
         final T withStartPositionApplied;
-        StartAtCheckpoint position = (StartAtCheckpoint) startAtValue;
         Checkpoint changeStreamPosition = position.checkpoint;
-        if (changeStreamPosition instanceof MongoResumeTokenCheckpoint) {
-            BsonDocument resumeToken = ((MongoResumeTokenCheckpoint) changeStreamPosition).resumeToken;
+        if (changeStreamPosition instanceof MongoResumeTokenCheckpoint mongoResumeTokenCheckpoint) {
+            BsonDocument resumeToken = mongoResumeTokenCheckpoint.resumeToken;
             withStartPositionApplied = applyResumeToken.apply(t, resumeToken);
-        } else if (changeStreamPosition instanceof MongoOperationTimeCheckpoint) {
-            withStartPositionApplied = applyOperationTime.apply(t, ((MongoOperationTimeCheckpoint) changeStreamPosition).operationTime);
+        } else if (changeStreamPosition instanceof MongoOperationTimeCheckpoint mongoOperationTimeCheckpoint) {
+            withStartPositionApplied = applyOperationTime.apply(t, mongoOperationTimeCheckpoint.operationTime);
         } else {
             String changeStreamPositionString = changeStreamPosition.asString();
             if (changeStreamPositionString.contains(RESUME_TOKEN)) {

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -278,28 +278,26 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
         final List<Bson> pipeline;
         if (filter == null) {
             pipeline = Collections.emptyList();
-        } else if (filter instanceof StreamSubscriptionFilter) {
-            Filter streamFilter = ((StreamSubscriptionFilter) filter).filter();
+        } else if (filter instanceof StreamSubscriptionFilter streamSubscriptionFilter) {
+            Filter streamFilter = streamSubscriptionFilter.filter();
             Bson bson = FilterToBsonFilterConverter.convertFilterToBsonFilter(MongoFilterSpecification.FULL_DOCUMENT, timeRepresentation, streamFilter);
             pipeline = Collections.singletonList(match(bson));
         } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
             pipeline = Collections.singletonList(DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.criteria()));
-        } else if (filter instanceof MongoFilterSpecification.MongoJsonFilterSpecification) {
-            pipeline = Collections.singletonList(Document.parse(((MongoFilterSpecification.MongoJsonFilterSpecification) filter).getJson()));
-        } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification) {
-            Bson[] aggregationStages = ((MongoFilterSpecification.MongoBsonFilterSpecification) filter).getAggregationStages();
+        } else if (filter instanceof MongoFilterSpecification.MongoJsonFilterSpecification jsonFilterSpecification) {
+            pipeline = Collections.singletonList(Document.parse(jsonFilterSpecification.getJson()));
+        } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification bsonFilterSpecification) {
+            Bson[] aggregationStages = bsonFilterSpecification.getAggregationStages();
             DocumentAdapter documentAdapter = new DocumentAdapter(MongoClientSettings.getDefaultCodecRegistry());
             pipeline = Stream.of(aggregationStages).map(aggregationStage -> {
-                final Document result;
-                if (aggregationStage instanceof Document) {
-                    result = (Document) aggregationStage;
-                } else if (aggregationStage instanceof BsonDocument) {
-                    result = documentAdapter.fromBson((BsonDocument) aggregationStage);
-                } else {
-                    BsonDocument bsonDocument = aggregationStage.toBsonDocument(null, MongoClientSettings.getDefaultCodecRegistry());
-                    result = documentAdapter.fromBson(bsonDocument);
-                }
-                return result;
+                return switch (aggregationStage) {
+                    case Document document -> document;
+                    case BsonDocument bsonDocument -> documentAdapter.fromBson(bsonDocument);
+                    default -> {
+                        BsonDocument bsonDocument = aggregationStage.toBsonDocument(null, MongoClientSettings.getDefaultCodecRegistry());
+                        yield documentAdapter.fromBson(bsonDocument);
+                    }
+                };
             }).collect(Collectors.toList());
         } else {
             throw new IllegalArgumentException("Invalid " + SubscriptionFilter.class.getSimpleName());
@@ -443,8 +441,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof InternalSubscription)) return false;
-            InternalSubscription that = (InternalSubscription) o;
+            if (!(o instanceof InternalSubscription that)) return false;
             return Objects.equals(filter, that.filter) && Objects.equals(startedLatch, that.startedLatch) && Objects.equals(stoppedLatch, that.stoppedLatch) && Objects.equals(cursor, that.cursor) && Objects.equals(currentStartAt, that.currentStartAt) && Objects.equals(action, that.action);
         }
 

--- a/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
+++ b/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
@@ -97,10 +97,10 @@ public class SpringMongoCheckpointStorage implements CheckpointStorage {
     @Override
     public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
         Supplier<Checkpoint> save = () -> {
-            if (checkpoint instanceof MongoResumeTokenCheckpoint) {
-                persistResumeTokenStreamPosition(subscriptionId, ((MongoResumeTokenCheckpoint) checkpoint).resumeToken);
-            } else if (checkpoint instanceof MongoOperationTimeCheckpoint) {
-                persistOperationTimeStreamPosition(subscriptionId, ((MongoOperationTimeCheckpoint) checkpoint).operationTime);
+            if (checkpoint instanceof MongoResumeTokenCheckpoint mongoResumeTokenCheckpoint) {
+                persistResumeTokenStreamPosition(subscriptionId, mongoResumeTokenCheckpoint.resumeToken);
+            } else if (checkpoint instanceof MongoOperationTimeCheckpoint mongoOperationTimeCheckpoint) {
+                persistOperationTimeStreamPosition(subscriptionId, mongoOperationTimeCheckpoint.operationTime);
             } else {
                 String checkpointString = checkpoint.asString();
                 Document document = MongoCommons.generateGenericCheckpointDocument(subscriptionId, checkpointString);

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
@@ -78,8 +78,7 @@ public class SpringMongoSubscription implements Subscription {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof SpringMongoSubscription)) return false;
-        SpringMongoSubscription that = (SpringMongoSubscription) o;
+        if (!(o instanceof SpringMongoSubscription that)) return false;
         return shutdown == that.shutdown && Objects.equals(subscriptionId, that.subscriptionId) && Objects.equals(subscriptionReference, that.subscriptionReference);
     }
 

--- a/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
+++ b/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
@@ -49,29 +49,27 @@ public class ApplyFilterToChangeStreamOptionsBuilder {
         final ChangeStreamOptions changeStreamOptions;
         if (filter == null) {
             changeStreamOptions = changeStreamOptionsBuilder.build();
-        } else if (filter instanceof StreamSubscriptionFilter) {
-            Filter streamFilter = ((StreamSubscriptionFilter) filter).filter();
+        } else if (filter instanceof StreamSubscriptionFilter streamSubscriptionFilter) {
+            Filter streamFilter = streamSubscriptionFilter.filter();
             Criteria criteria = convertFilterToCriteria(FULL_DOCUMENT, timeRepresentation, streamFilter);
             changeStreamOptions = changeStreamOptionsBuilder.filter(newAggregation(match(criteria))).build();
         } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
             Document matchStage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.criteria());
             changeStreamOptions = changeStreamOptionsBuilder.filter(matchStage).build();
-        } else if (filter instanceof MongoJsonFilterSpecification) {
-            changeStreamOptions = changeStreamOptionsBuilder.filter(Document.parse(((MongoJsonFilterSpecification) filter).getJson())).build();
-        } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification) {
-            Bson[] aggregationStages = ((MongoFilterSpecification.MongoBsonFilterSpecification) filter).getAggregationStages();
+        } else if (filter instanceof MongoJsonFilterSpecification jsonFilterSpecification) {
+            changeStreamOptions = changeStreamOptionsBuilder.filter(Document.parse(jsonFilterSpecification.getJson())).build();
+        } else if (filter instanceof MongoFilterSpecification.MongoBsonFilterSpecification bsonFilterSpecification) {
+            Bson[] aggregationStages = bsonFilterSpecification.getAggregationStages();
             DocumentAdapter documentAdapter = new DocumentAdapter(MongoClientSettings.getDefaultCodecRegistry());
             Document[] documents = Stream.of(aggregationStages).map(aggregationStage -> {
-                final Document result;
-                if (aggregationStage instanceof Document) {
-                    result = (Document) aggregationStage;
-                } else if (aggregationStage instanceof BsonDocument) {
-                    result = documentAdapter.fromBson((BsonDocument) aggregationStage);
-                } else {
-                    BsonDocument bsonDocument = aggregationStage.toBsonDocument(null, MongoClientSettings.getDefaultCodecRegistry());
-                    result = documentAdapter.fromBson(bsonDocument);
-                }
-                return result;
+                return switch (aggregationStage) {
+                    case Document document -> document;
+                    case BsonDocument bsonDocument -> documentAdapter.fromBson(bsonDocument);
+                    default -> {
+                        BsonDocument bsonDocument = aggregationStage.toBsonDocument(null, MongoClientSettings.getDefaultCodecRegistry());
+                        yield documentAdapter.fromBson(bsonDocument);
+                    }
+                };
             }).toArray(Document[]::new);
 
             changeStreamOptions = changeStreamOptionsBuilder.filter(documents).build();

--- a/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
+++ b/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
@@ -62,10 +62,10 @@ public class ReactorCheckpointStorage implements CheckpointStorage {
     @Override
     public Mono<Checkpoint> save(String subscriptionId, Checkpoint changeStreamPosition) {
         Mono<?> result;
-        if (changeStreamPosition instanceof MongoResumeTokenCheckpoint) {
-            result = persistResumeTokenStreamPosition(subscriptionId, ((MongoResumeTokenCheckpoint) changeStreamPosition).resumeToken);
-        } else if (changeStreamPosition instanceof MongoOperationTimeCheckpoint) {
-            result = persistOperationTimeStreamPosition(subscriptionId, ((MongoOperationTimeCheckpoint) changeStreamPosition).operationTime);
+        if (changeStreamPosition instanceof MongoResumeTokenCheckpoint mongoResumeTokenCheckpoint) {
+            result = persistResumeTokenStreamPosition(subscriptionId, mongoResumeTokenCheckpoint.resumeToken);
+        } else if (changeStreamPosition instanceof MongoOperationTimeCheckpoint mongoOperationTimeCheckpoint) {
+            result = persistOperationTimeStreamPosition(subscriptionId, mongoOperationTimeCheckpoint.operationTime);
         } else {
             String checkpointString = changeStreamPosition.asString();
             Document document = MongoCommons.generateGenericCheckpointDocument(subscriptionId, checkpointString);

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
@@ -248,10 +248,10 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
     // again is a no-op; generateSubscriptionModelContext() is used anyway for consistency with the other call sites.
     private boolean isDcbCatchupPosition(StartAt startAt) {
         StartAt start = startAt.get(generateSubscriptionModelContext());
-        if (!(start instanceof StartAtCheckpoint)) {
+        if (!(start instanceof StartAtCheckpoint position)) {
             return false;
         }
-        return GlobalCheckpoint.isGlobalCheckpoint(((StartAtCheckpoint) start).checkpoint);
+        return GlobalCheckpoint.isGlobalCheckpoint(position.checkpoint);
     }
 
     @Override

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
@@ -37,8 +37,7 @@ public class CompetingConsumerSubscription implements Subscription {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CompetingConsumerSubscription)) return false;
-        CompetingConsumerSubscription that = (CompetingConsumerSubscription) o;
+        if (!(o instanceof CompetingConsumerSubscription that)) return false;
         return Objects.equals(subscriptionId, that.subscriptionId) && Objects.equals(subscriberId, that.subscriberId) && Objects.equals(subscription, that.subscription);
     }
 

--- a/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelConfig.java
+++ b/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelConfig.java
@@ -51,8 +51,7 @@ public class DurableSubscriptionModelConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DurableSubscriptionModelConfig)) return false;
-        DurableSubscriptionModelConfig that = (DurableSubscriptionModelConfig) o;
+        if (!(o instanceof DurableSubscriptionModelConfig that)) return false;
         return Objects.equals(persistCloudEventPositionPredicate, that.persistCloudEventPositionPredicate);
     }
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -139,8 +139,7 @@ public class CatchupSubscriptionModelConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CatchupSubscriptionModelConfig)) return false;
-        CatchupSubscriptionModelConfig that = (CatchupSubscriptionModelConfig) o;
+        if (!(o instanceof CatchupSubscriptionModelConfig that)) return false;
         return cacheSize == that.cacheSize &&
                 Objects.equals(subscriptionStorageConfig, that.subscriptionStorageConfig);
     }

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -577,11 +577,11 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
 
     public static boolean isTimeBasedCheckpoint(StartAt startAt, Class<?> contextType) {
         StartAt start = startAt.get(new SubscriptionModelContext(contextType));
-        if (!(start instanceof StartAtCheckpoint)) {
+        if (!(start instanceof StartAtCheckpoint position)) {
             return false;
         }
 
-        Checkpoint checkpoint = ((StartAtCheckpoint) start).checkpoint;
+        Checkpoint checkpoint = position.checkpoint;
         return isTimeBasedCheckpoint(checkpoint);
     }
 

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelConfig.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelConfig.java
@@ -51,8 +51,7 @@ public class ReactorDurableSubscriptionModelConfig {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ReactorDurableSubscriptionModelConfig)) return false;
-        ReactorDurableSubscriptionModelConfig that = (ReactorDurableSubscriptionModelConfig) o;
+        if (!(o instanceof ReactorDurableSubscriptionModelConfig that)) return false;
         return Objects.equals(persistCloudEventPositionPredicate, that.persistCloudEventPositionPredicate);
     }
 


### PR DESCRIPTION
## Summary

I modernized the Java 21 type-dispatch code across the repository, with the main focus on sealed hierarchies and cast-heavy branches.

The changes cover:

* exhaustive switches for `Condition`, `Filter`, `SortBy`, `StreamReadFilter`, `DcbCriteria`, `StartAt`, and deadline variants
* pattern variables for checkpoint, Mongo filter, CloudEvent data, and example event dispatch
* Java 21 switches in the number guessing examples, where `GameEvent` is sealed
* a changelog entry under `Changelog next version`

I kept `SubscriptionFilter` open because Mongo-specific filter specs live outside `subscription/core`, so sealing it there would create a module layering problem.

## Verification

* `rtk mvn -q -Pexamples-module test-compile`
* `rtk git diff --check`
