### PR TITLE
Add JSpecify nullness defaults across Java packages

### DIFF
--- a/application/cloudevent-converter/api/pom.xml
+++ b/application/cloudevent-converter/api/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-api</artifactId>
         </dependency>

--- a/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/CloudEventConverter.java
+++ b/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/CloudEventConverter.java
@@ -17,6 +17,7 @@
 package org.occurrent.application.converter;
 
 import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -73,7 +74,7 @@ public interface CloudEventConverter<T> {
      * @param events The domain events to convert to cloud events
      * @return A stram of cloud events.
      */
-    default Stream<CloudEvent> toCloudEvents(Stream<T> events) {
+    default Stream<CloudEvent> toCloudEvents(@Nullable Stream<T> events) {
         Stream<T> stream = events == null ? Stream.empty() : events;
         return stream.map(this::toCloudEvent);
     }
@@ -85,7 +86,7 @@ public interface CloudEventConverter<T> {
      * @param events The cloud events to convert to domain events
      * @return A stram of cloud events.
      */
-    default Stream<T> toDomainEvents(Stream<CloudEvent> events) {
+    default Stream<T> toDomainEvents(@Nullable Stream<CloudEvent> events) {
         Stream<CloudEvent> stream = events == null ? Stream.empty() : events;
         return stream.map(this::toDomainEvent);
     }

--- a/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/CloudEventConverter.java
+++ b/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/CloudEventConverter.java
@@ -71,8 +71,8 @@ public interface CloudEventConverter<T> {
      * The reason for implementing this method is to allow adding things such as correlation id
      * that should be the same for all events in a stream.
      *
-     * @param events The domain events to convert to cloud events
-     * @return A stram of cloud events.
+     * @param events The domain events to convert to cloud events, or {@code null} to convert no events
+     * @return A stream of cloud events.
      */
     default Stream<CloudEvent> toCloudEvents(@Nullable Stream<T> events) {
         Stream<T> stream = events == null ? Stream.empty() : events;
@@ -83,8 +83,8 @@ public interface CloudEventConverter<T> {
      * Convert a stream of cloud events into a stream of domain events.
      * Typically, you only need to implement {@link #toDomainEvent(CloudEvent)}.
      *
-     * @param events The cloud events to convert to domain events
-     * @return A stram of cloud events.
+     * @param events The cloud events to convert to domain events, or {@code null} to convert no events
+     * @return A stream of domain events.
      */
     default Stream<T> toDomainEvents(@Nullable Stream<CloudEvent> events) {
         Stream<CloudEvent> stream = events == null ? Stream.empty() : events;

--- a/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/package-info.java
+++ b/application/cloudevent-converter/api/src/main/java/org/occurrent/application/converter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-converter/core/pom.xml
+++ b/application/cloudevent-converter/core/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-converter-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-converter/core/src/main/java/org/occurrent/application/converter/internal/CloudEventConverterSupport.java
+++ b/application/cloudevent-converter/core/src/main/java/org/occurrent/application/converter/internal/CloudEventConverterSupport.java
@@ -21,6 +21,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.data.PojoCloudEventData;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
 import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
 
@@ -45,7 +46,7 @@ public final class CloudEventConverterSupport {
     private CloudEventConverterSupport() {
     }
 
-    public static <T> CloudEvent toCloudEvent(T domainEvent, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, OffsetDateTime> timeMapper, Function<T, String> subjectMapper, String contentType, Function<T, Map<String, Object>> dataMapper, ThrowingFunction<Map<String, Object>, byte[]> dataSerializer) {
+    public static <T> CloudEvent toCloudEvent(T domainEvent, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, @Nullable OffsetDateTime> timeMapper, Function<T, @Nullable String> subjectMapper, String contentType, Function<T, Map<String, Object>> dataMapper, ThrowingFunction<Map<String, Object>, byte[]> dataSerializer) {
         requireNonNull(domainEvent, "Domain event cannot be null");
         Map<String, Object> data = dataMapper.apply(domainEvent);
         PojoCloudEventData<Map<String, Object>> cloudEventData = PojoCloudEventData.wrap(data, value -> {
@@ -95,7 +96,7 @@ public final class CloudEventConverterSupport {
         return ReflectionCloudEventTypeMapper.qualified();
     }
 
-    public static <T> Function<T, OffsetDateTime> defaultTimeMapperFunction() {
+    public static <T> Function<T, @Nullable OffsetDateTime> defaultTimeMapperFunction() {
         return __ -> OffsetDateTime.now(UTC);
     }
 
@@ -104,7 +105,7 @@ public final class CloudEventConverterSupport {
      * Returns the original mapper unchanged when {@code precision} is {@code null}. This is useful when the event store
      * uses {@code TimeRepresentation.DATE}, which cannot represent sub-millisecond precision.
      */
-    public static <T> Function<T, OffsetDateTime> truncatingTimeMapper(Function<T, OffsetDateTime> timeMapper, ChronoUnit precision) {
+    public static <T> Function<T, @Nullable OffsetDateTime> truncatingTimeMapper(Function<T, @Nullable OffsetDateTime> timeMapper, @Nullable ChronoUnit precision) {
         if (precision == null) {
             return timeMapper;
         }
@@ -114,7 +115,7 @@ public final class CloudEventConverterSupport {
         };
     }
 
-    public static <T> Function<T, String> defaultSubjectMapperFunction() {
+    public static <T> Function<T, @Nullable String> defaultSubjectMapperFunction() {
         return __ -> null;
     }
 

--- a/application/cloudevent-converter/core/src/main/java/org/occurrent/application/converter/internal/package-info.java
+++ b/application/cloudevent-converter/core/src/main/java/org/occurrent/application/converter/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-converter/generic/pom.xml
+++ b/application/cloudevent-converter/generic/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-converter-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-converter/generic/src/main/java/org/occurrent/application/converter/generic/GenericCloudEventConverter.java
+++ b/application/cloudevent-converter/generic/src/main/java/org/occurrent/application/converter/generic/GenericCloudEventConverter.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.application.converter.generic;
 
+import org.jspecify.annotations.Nullable;
 import io.cloudevents.CloudEvent;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.typemapper.CloudEventTypeGetter;
@@ -72,7 +73,7 @@ public class GenericCloudEventConverter<T> implements CloudEventConverter<T> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof GenericCloudEventConverter)) return false;
         GenericCloudEventConverter<?> that = (GenericCloudEventConverter<?>) o;

--- a/application/cloudevent-converter/generic/src/main/java/org/occurrent/application/converter/generic/package-info.java
+++ b/application/cloudevent-converter/generic/src/main/java/org/occurrent/application/converter/generic/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.generic;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-converter/jackson/pom.xml
+++ b/application/cloudevent-converter/jackson/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-converter-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-converter/jackson/src/main/java/org/occurrent/application/converter/jackson/JacksonCloudEventConverter.java
+++ b/application/cloudevent-converter/jackson/src/main/java/org/occurrent/application/converter/jackson/JacksonCloudEventConverter.java
@@ -20,6 +20,7 @@ package org.occurrent.application.converter.jackson;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.internal.CloudEventConverterSupport;
 import org.occurrent.application.converter.internal.CloudEventConverterSupport.ThrowingBiFunction;
@@ -42,8 +43,8 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
     private final URI cloudEventSource;
     private final Function<T, String> idMapper;
     private final CloudEventTypeMapper<T> cloudEventTypeMapper;
-    private final Function<T, OffsetDateTime> timeMapper;
-    private final Function<T, String> subjectMapper;
+    private final Function<T, @Nullable OffsetDateTime> timeMapper;
+    private final Function<T, @Nullable String> subjectMapper;
     private final String contentType;
 
     /**
@@ -67,7 +68,7 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         this(objectMapper, cloudEventSource, defaultIdMapperFunction(), defaultTypeMapper(), defaultTimeMapperFunction(), defaultSubjectMapperFunction(), DEFAULT_CONTENT_TYPE);
     }
 
-    private JacksonCloudEventConverter(ObjectMapper objectMapper, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, OffsetDateTime> timeMapper, Function<T, String> subjectMapper, String contentType) {
+    private JacksonCloudEventConverter(ObjectMapper objectMapper, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, @Nullable OffsetDateTime> timeMapper, Function<T, @Nullable String> subjectMapper, String contentType) {
         this.objectMapper = java.util.Objects.requireNonNull(objectMapper, ObjectMapper.class.getSimpleName() + " cannot be null");
         this.cloudEventSource = java.util.Objects.requireNonNull(cloudEventSource, "cloudEventSource cannot be null");
         this.idMapper = java.util.Objects.requireNonNull(idMapper, "idMapper cannot be null");
@@ -123,8 +124,8 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         private String contentType = DEFAULT_CONTENT_TYPE;
         private Function<T, String> idMapper = defaultIdMapperFunction();
         private CloudEventTypeMapper<T> cloudEventTypeMapper = defaultTypeMapper();
-        private Function<T, OffsetDateTime> timeMapper = defaultTimeMapperFunction();
-        private Function<T, String> subjectMapper = defaultSubjectMapperFunction();
+        private Function<T, @Nullable OffsetDateTime> timeMapper = defaultTimeMapperFunction();
+        private Function<T, @Nullable String> subjectMapper = defaultSubjectMapperFunction();
 
         public Builder(ObjectMapper objectMapper, URI cloudEventSource) {
             this.objectMapper = objectMapper;
@@ -158,7 +159,7 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         /**
          * @param timeMapper A function that generates the cloud event time based on the domain event. By default, {@code OffsetDateTime.now(UTC)} is always returned.
          */
-        public Builder<T> timeMapper(Function<T, OffsetDateTime> timeMapper) {
+        public Builder<T> timeMapper(Function<T, @Nullable OffsetDateTime> timeMapper) {
             this.timeMapper = timeMapper;
             return this;
         }
@@ -166,7 +167,7 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         /**
          * @param subjectMapper A function that generates the cloud event subject based on the domain event. By default, {@code null} is always returned.
          */
-        public Builder<T> subjectMapper(Function<T, String> subjectMapper) {
+        public Builder<T> subjectMapper(Function<T, @Nullable String> subjectMapper) {
             this.subjectMapper = subjectMapper;
             return this;
         }
@@ -187,11 +188,11 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         return CloudEventConverterSupport.defaultTypeMapper();
     }
 
-    static <T> Function<T, OffsetDateTime> defaultTimeMapperFunction() {
+    static <T> Function<T, @Nullable OffsetDateTime> defaultTimeMapperFunction() {
         return CloudEventConverterSupport.defaultTimeMapperFunction();
     }
 
-    static <T> Function<T, String> defaultSubjectMapperFunction() {
+    static <T> Function<T, @Nullable String> defaultSubjectMapperFunction() {
         return CloudEventConverterSupport.defaultSubjectMapperFunction();
     }
 }

--- a/application/cloudevent-converter/jackson/src/main/java/org/occurrent/application/converter/jackson/package-info.java
+++ b/application/cloudevent-converter/jackson/src/main/java/org/occurrent/application/converter/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.jackson;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-converter/jackson/src/main/kotlin/org/occurrent/application/converter/jackson/JacksonCloudEventConverterExtensions.kt
+++ b/application/cloudevent-converter/jackson/src/main/kotlin/org/occurrent/application/converter/jackson/JacksonCloudEventConverterExtensions.kt
@@ -39,10 +39,10 @@ typealias ContentType = String
  * @param subjectMapper Extract the subject from the event (defaults to `null`)
  * @param timeMapper Extract the time from the event (uses `OffsetDateTime.now(UTC)` by default)
  */
-fun <E> jacksonCloudEventConverter(
+fun <E : Any> jacksonCloudEventConverter(
     objectMapper: ObjectMapper, cloudEventSource: URI, idMapper: (E) -> CloudEventId = { e -> JacksonCloudEventConverter.defaultIdMapperFunction<E>().apply(e) },
     typeMapper: CloudEventTypeMapper<E> = JacksonCloudEventConverter.defaultTypeMapper(),
-    timeMapper: (E) -> OffsetDateTime = { e -> JacksonCloudEventConverter.defaultTimeMapperFunction<E>().apply(e) },
+    timeMapper: (E) -> OffsetDateTime? = { e -> JacksonCloudEventConverter.defaultTimeMapperFunction<E>().apply(e) },
     subjectMapper: (E) -> Subject? = { e -> JacksonCloudEventConverter.defaultSubjectMapperFunction<E>().apply(e) },
     contentType: ContentType = JacksonCloudEventConverter.DEFAULT_CONTENT_TYPE
 ): JacksonCloudEventConverter<E> {

--- a/application/cloudevent-converter/jackson3/pom.xml
+++ b/application/cloudevent-converter/jackson3/pom.xml
@@ -43,6 +43,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-converter-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-converter/jackson3/src/main/java/org/occurrent/application/converter/jackson3/JacksonCloudEventConverter.java
+++ b/application/cloudevent-converter/jackson3/src/main/java/org/occurrent/application/converter/jackson3/JacksonCloudEventConverter.java
@@ -18,6 +18,7 @@
 package org.occurrent.application.converter.jackson3;
 
 import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.internal.CloudEventConverterSupport;
 import org.occurrent.application.converter.internal.CloudEventConverterSupport.ThrowingBiFunction;
@@ -44,8 +45,8 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
     private final URI cloudEventSource;
     private final Function<T, String> idMapper;
     private final CloudEventTypeMapper<T> cloudEventTypeMapper;
-    private final Function<T, OffsetDateTime> timeMapper;
-    private final Function<T, String> subjectMapper;
+    private final Function<T, @Nullable OffsetDateTime> timeMapper;
+    private final Function<T, @Nullable String> subjectMapper;
     private final String contentType;
 
     /**
@@ -66,7 +67,7 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         this(objectMapper, cloudEventSource, defaultIdMapperFunction(), defaultTypeMapper(), defaultTimeMapperFunction(), defaultSubjectMapperFunction(), DEFAULT_CONTENT_TYPE);
     }
 
-    private JacksonCloudEventConverter(ObjectMapper objectMapper, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, OffsetDateTime> timeMapper, Function<T, String> subjectMapper, String contentType) {
+    private JacksonCloudEventConverter(ObjectMapper objectMapper, URI cloudEventSource, Function<T, String> idMapper, CloudEventTypeMapper<T> cloudEventTypeMapper, Function<T, @Nullable OffsetDateTime> timeMapper, Function<T, @Nullable String> subjectMapper, String contentType) {
         this.objectMapper = java.util.Objects.requireNonNull(objectMapper, ObjectMapper.class.getSimpleName() + " cannot be null");
         this.cloudEventSource = java.util.Objects.requireNonNull(cloudEventSource, "cloudEventSource cannot be null");
         this.idMapper = java.util.Objects.requireNonNull(idMapper, "idMapper cannot be null");
@@ -110,9 +111,9 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         private String contentType = DEFAULT_CONTENT_TYPE;
         private Function<T, String> idMapper = defaultIdMapperFunction();
         private CloudEventTypeMapper<T> cloudEventTypeMapper = defaultTypeMapper();
-        private Function<T, OffsetDateTime> timeMapper = defaultTimeMapperFunction();
-        private Function<T, String> subjectMapper = defaultSubjectMapperFunction();
-        private ChronoUnit timePrecision = null;
+        private Function<T, @Nullable OffsetDateTime> timeMapper = defaultTimeMapperFunction();
+        private Function<T, @Nullable String> subjectMapper = defaultSubjectMapperFunction();
+        private @Nullable ChronoUnit timePrecision = null;
 
         public Builder(ObjectMapper objectMapper, URI cloudEventSource) {
             this.objectMapper = objectMapper;
@@ -134,12 +135,12 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
             return this;
         }
 
-        public Builder<T> timeMapper(Function<T, OffsetDateTime> timeMapper) {
+        public Builder<T> timeMapper(Function<T, @Nullable OffsetDateTime> timeMapper) {
             this.timeMapper = timeMapper;
             return this;
         }
 
-        public Builder<T> subjectMapper(Function<T, String> subjectMapper) {
+        public Builder<T> subjectMapper(Function<T, @Nullable String> subjectMapper) {
             this.subjectMapper = subjectMapper;
             return this;
         }
@@ -167,11 +168,11 @@ public class JacksonCloudEventConverter<T> implements CloudEventConverter<T> {
         return CloudEventConverterSupport.defaultTypeMapper();
     }
 
-    static <T> Function<T, OffsetDateTime> defaultTimeMapperFunction() {
+    static <T> Function<T, @Nullable OffsetDateTime> defaultTimeMapperFunction() {
         return CloudEventConverterSupport.defaultTimeMapperFunction();
     }
 
-    static <T> Function<T, String> defaultSubjectMapperFunction() {
+    static <T> Function<T, @Nullable String> defaultSubjectMapperFunction() {
         return CloudEventConverterSupport.defaultSubjectMapperFunction();
     }
 }

--- a/application/cloudevent-converter/jackson3/src/main/java/org/occurrent/application/converter/jackson3/package-info.java
+++ b/application/cloudevent-converter/jackson3/src/main/java/org/occurrent/application/converter/jackson3/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.jackson3;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-converter/jackson3/src/main/kotlin/org/occurrent/application/converter/jackson3/JacksonCloudEventConverterExtensions.kt
+++ b/application/cloudevent-converter/jackson3/src/main/kotlin/org/occurrent/application/converter/jackson3/JacksonCloudEventConverterExtensions.kt
@@ -38,12 +38,12 @@ typealias ContentType = String
  * @param subjectMapper Extract the subject from the event (defaults to `null`)
  * @param timeMapper Extract the time from the event (uses `OffsetDateTime.now(UTC)` by default)
  */
-fun <E> jacksonCloudEventConverter(
+fun <E : Any> jacksonCloudEventConverter(
     objectMapper: ObjectMapper,
     cloudEventSource: URI,
     idMapper: (E) -> CloudEventId = { e -> JacksonCloudEventConverter.defaultIdMapperFunction<E>().apply(e) },
     typeMapper: CloudEventTypeMapper<E> = JacksonCloudEventConverter.defaultTypeMapper(),
-    timeMapper: (E) -> OffsetDateTime = { e -> JacksonCloudEventConverter.defaultTimeMapperFunction<E>().apply(e) },
+    timeMapper: (E) -> OffsetDateTime? = { e -> JacksonCloudEventConverter.defaultTimeMapperFunction<E>().apply(e) },
     subjectMapper: (E) -> Subject? = { e -> JacksonCloudEventConverter.defaultSubjectMapperFunction<E>().apply(e) },
     contentType: ContentType = JacksonCloudEventConverter.DEFAULT_CONTENT_TYPE
 ): JacksonCloudEventConverter<E> {

--- a/application/cloudevent-converter/xstream/pom.xml
+++ b/application/cloudevent-converter/xstream/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-converter-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-converter/xstream/src/main/java/org/occurrent/application/converter/xstream/package-info.java
+++ b/application/cloudevent-converter/xstream/src/main/java/org/occurrent/application/converter/xstream/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.xstream;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-type-mapper/api/pom.xml
+++ b/application/cloudevent-type-mapper/api/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <optional>true</optional>

--- a/application/cloudevent-type-mapper/api/src/main/java/org/occurrent/application/converter/typemapper/package-info.java
+++ b/application/cloudevent-type-mapper/api/src/main/java/org/occurrent/application/converter/typemapper/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.typemapper;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/cloudevent-type-mapper/reflection/pom.xml
+++ b/application/cloudevent-type-mapper/reflection/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>cloudevent-type-mapper-api</artifactId>
             <version>${project.version}</version>

--- a/application/cloudevent-type-mapper/reflection/src/main/java/org/occurrent/application/converter/typemapper/package-info.java
+++ b/application/cloudevent-type-mapper/reflection/src/main/java/org/occurrent/application/converter/typemapper/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.converter.typemapper;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/command-composition/pom.xml
+++ b/application/command-composition/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <optional>true</optional>

--- a/application/command-composition/src/main/java/org/occurrent/application/composition/command/internal/package-info.java
+++ b/application/command-composition/src/main/java/org/occurrent/application/composition/command/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.composition.command.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/command-composition/src/main/java/org/occurrent/application/composition/command/package-info.java
+++ b/application/command-composition/src/main/java/org/occurrent/application/composition/command/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.composition.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/command-composition/src/main/java/org/occurrent/application/composition/command/partial/package-info.java
+++ b/application/command-composition/src/main/java/org/occurrent/application/composition/command/partial/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.composition.command.partial;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
@@ -149,7 +149,7 @@ public final class ExecuteOptions<E> {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         var that = (ExecuteOptions) obj;

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/package-info.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/dcb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.blocking.dcb;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/package-info.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/generic/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.blocking.generic;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/package-info.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/common/src/main/java/org/occurrent/application/service/dcb/package-info.java
+++ b/application/service/common/src/main/java/org/occurrent/application/service/dcb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.dcb;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/common/src/main/java/org/occurrent/application/service/package-info.java
+++ b/application/service/common/src/main/java/org/occurrent/application/service/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/dcb-annotation/src/main/java/org/occurrent/application/service/dcb/annotation/AnnotationTagGenerator.java
+++ b/application/service/dcb-annotation/src/main/java/org/occurrent/application/service/dcb/annotation/AnnotationTagGenerator.java
@@ -17,6 +17,7 @@
 package org.occurrent.application.service.dcb.annotation;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.annotation.DcbTag;
 import org.occurrent.application.service.dcb.TagGenerator;
 import org.occurrent.eventstore.api.dcb.Tag;
@@ -156,7 +157,7 @@ public final class AnnotationTagGenerator<E> implements TagGenerator<E> {
         }
     }
 
-    private static Method findGetter(Class<?> clazz, String fieldName) {
+    private static @Nullable Method findGetter(Class<?> clazz, String fieldName) {
         String capitalized = Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1);
         Set<String> candidateNames = Set.of("get" + capitalized, "is" + capitalized, fieldName);
         // Walk the hierarchy from the concrete class up (so a subclass getter wins) and use getDeclaredMethods, which

--- a/application/service/dcb-annotation/src/main/java/org/occurrent/application/service/dcb/annotation/package-info.java
+++ b/application/service/dcb-annotation/src/main/java/org/occurrent/application/service/dcb/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.dcb.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/package-info.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/dcb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.reactor.dcb;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/generic/package-info.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/generic/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.reactor.generic;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/package-info.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.application.service.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 * Added package-level JSpecify nullness defaults across the Java modules and tightened Kotlin wrappers around nullable
   state, retry results, and optional CloudEvent time and subject values.
 * Fixed `RetryStrategy.none().execute(Function<RetryInfo, T>)` so the function receives a non-null first-attempt
-  `RetryInfo` instead of `null`.
+  `RetryInfo` instead of `null`, and corrected the `Function` overload documentation and null-check message.
 * Renamed `OccurrentSubscriptionFilter` to `StreamSubscriptionFilter` to make the stream-scoped subscription marker
   explicit next to `AgnosticSubscriptionFilter` and `DcbSubscriptionFilter`. This is a breaking API change for callers
   that construct subscription filters directly.

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 * Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
 * Modernized Java dispatch code to use Java 21 pattern matching and exhaustive switches across sealed filters,
   criteria, start positions, checkpoints, deadlines, and examples.
+* Added package-level JSpecify nullness defaults across the Java modules and tightened Kotlin wrappers around nullable
+  state, retry results, and optional CloudEvent time and subject values.
 * Renamed `OccurrentSubscriptionFilter` to `StreamSubscriptionFilter` to make the stream-scoped subscription marker
   explicit next to `AgnosticSubscriptionFilter` and `DcbSubscriptionFilter`. This is a breaking API change for callers
   that construct subscription filters directly.

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   criteria, start positions, checkpoints, deadlines, and examples.
 * Added package-level JSpecify nullness defaults across the Java modules and tightened Kotlin wrappers around nullable
   state, retry results, and optional CloudEvent time and subject values.
+* Fixed `RetryStrategy.none().execute(Function<RetryInfo, T>)` so the function receives a non-null first-attempt
+  `RetryInfo` instead of `null`.
 * Renamed `OccurrentSubscriptionFilter` to `StreamSubscriptionFilter` to make the stream-scoped subscription marker
   explicit next to `AgnosticSubscriptionFilter` and `DcbSubscriptionFilter`. This is a breaking API change for callers
   that construct subscription filters directly.

--- a/cloudevents-extension/pom.xml
+++ b/cloudevents-extension/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-core</artifactId>
         </dependency>

--- a/cloudevents-extension/src/main/java/org/occurrent/cloudevents/package-info.java
+++ b/cloudevents-extension/src/main/java/org/occurrent/cloudevents/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.cloudevents;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/eventstore-capability/pom.xml
+++ b/common/eventstore-capability/pom.xml
@@ -27,4 +27,12 @@
 
     <name>${mavenProjectName}</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/common/eventstore-capability/src/main/java/org/occurrent/eventstore/api/package-info.java
+++ b/common/eventstore-capability/src/main/java/org/occurrent/eventstore/api/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/filter/pom.xml
+++ b/common/filter/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <optional>true</optional>

--- a/common/filter/src/main/java/org/occurrent/condition/package-info.java
+++ b/common/filter/src/main/java/org/occurrent/condition/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.condition;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/filter/src/main/java/org/occurrent/filter/package-info.java
+++ b/common/filter/src/main/java/org/occurrent/filter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.filter;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/filter/src/main/kotlin/org/occurrent/condition/ConditionExtensions.kt
+++ b/common/filter/src/main/kotlin/org/occurrent/condition/ConditionExtensions.kt
@@ -17,5 +17,5 @@
 
 package org.occurrent.condition
 
-fun <T> isIn(values: Collection<T>): Condition<T> = Condition.`in`(values)
-fun <T> isIn(value: T, vararg moreValues: T): Condition<T> = Condition.`in`(value, *moreValues)
+fun <T : Any> isIn(values: Collection<T>): Condition<T> = Condition.`in`(values)
+fun <T : Any> isIn(value: T, vararg moreValues: T): Condition<T> = Condition.`in`(value, *moreValues)

--- a/common/functional-support/pom.xml
+++ b/common/functional-support/pom.xml
@@ -27,4 +27,12 @@
 
     <name>${mavenProjectName}</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/common/functional-support/src/main/java/org/occurrent/functionalsupport/internal/FunctionalSupport.java
+++ b/common/functional-support/src/main/java/org/occurrent/functionalsupport/internal/FunctionalSupport.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.functionalsupport.internal;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -97,7 +98,7 @@ public class FunctionalSupport {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof Pair)) return false;
             Pair<?, ?> pair = (Pair<?, ?>) o;

--- a/common/functional-support/src/main/java/org/occurrent/functionalsupport/internal/package-info.java
+++ b/common/functional-support/src/main/java/org/occurrent/functionalsupport/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.functionalsupport.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/package-info.java
+++ b/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.inmemory.filtermatching;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/mongodb/native/filter-bsonfilter-conversion/pom.xml
+++ b/common/mongodb/native/filter-bsonfilter-conversion/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>filter</artifactId>
             <version>${project.version}</version>

--- a/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/package-info.java
+++ b/common/mongodb/native/filter-bsonfilter-conversion/src/main/java/org/occurrent/mongodb/spring/filterbsonfilterconversion/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.mongodb.spring.filterbsonfilterconversion.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/mongodb/specialfilterhandling/pom.xml
+++ b/common/mongodb/specialfilterhandling/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>mongodb-timerepresentation</artifactId>
             <version>${project.version}</version>

--- a/common/mongodb/specialfilterhandling/src/main/java/org/occurrent/mongodb/specialfilterhandling/internal/package-info.java
+++ b/common/mongodb/specialfilterhandling/src/main/java/org/occurrent/mongodb/specialfilterhandling/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.mongodb.specialfilterhandling.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/mongodb/spring/filter-query-conversion/pom.xml
+++ b/common/mongodb/spring/filter-query-conversion/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
         </dependency>

--- a/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/package-info.java
+++ b/common/mongodb/spring/filter-query-conversion/src/main/java/org/occurrent/mongodb/spring/filterqueryconversion/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.mongodb.spring.filterqueryconversion.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/mongodb/spring/sort-conversion/pom.xml
+++ b/common/mongodb/spring/sort-conversion/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
         </dependency>

--- a/common/mongodb/spring/sort-conversion/src/main/java/org/occurrent/mongodb/spring/sortconversion/internal/package-info.java
+++ b/common/mongodb/spring/sort-conversion/src/main/java/org/occurrent/mongodb/spring/sortconversion/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.mongodb.spring.sortconversion.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/mongodb/timerepresentation/pom.xml
+++ b/common/mongodb/timerepresentation/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>time</artifactId>
             <version>${project.version}</version>

--- a/common/mongodb/timerepresentation/src/main/java/org/occurrent/mongodb/timerepresentation/package-info.java
+++ b/common/mongodb/timerepresentation/src/main/java/org/occurrent/mongodb/timerepresentation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.mongodb.timerepresentation;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
+++ b/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
@@ -115,14 +115,14 @@ public interface RetryStrategy {
     }
 
     /**
-     * Execute a {@link Supplier} with the configured retry settings.
-     * Rethrows the exception from the supplier if retry strategy is exhausted.
+     * Execute a {@link Function} with the configured retry settings.
+     * Rethrows the exception from the function if retry strategy is exhausted.
      *
      * @param function A function that takes {@link RetryInfo} and returns the result
-     * @return The result of the supplier, if successful.
+     * @return The result of the function, if successful.
      */
     default <T extends @Nullable Object> T execute(Function<RetryInfo, T> function) {
-        Objects.requireNonNull(function, Supplier.class.getSimpleName() + " cannot be null");
+        Objects.requireNonNull(function, Function.class.getSimpleName() + " cannot be null");
         return executeWithRetry(function, __ -> true, this).apply(firstAttemptRetryInfo());
     }
 

--- a/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
+++ b/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.function.*;
 
 import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
+import static org.occurrent.retry.internal.RetryExecution.firstAttemptRetryInfo;
 
 /**
  * Retry strategy to use if the action throws an exception.
@@ -123,7 +124,7 @@ public interface RetryStrategy {
      */
     default <T extends @Nullable Object> T execute(Function<RetryInfo, T> function) {
         Objects.requireNonNull(function, Supplier.class.getSimpleName() + " cannot be null");
-        return executeWithRetry(function, __ -> true, this).apply(null);
+        return executeWithRetry(function, __ -> true, this).apply(firstAttemptRetryInfo());
     }
 
     /**

--- a/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
+++ b/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.function.*;
 
 import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
-import static org.occurrent.retry.internal.RetryExecution.firstAttemptRetryInfo;
 
 /**
  * Retry strategy to use if the action throws an exception.
@@ -125,6 +124,50 @@ public interface RetryStrategy {
     default <T extends @Nullable Object> T execute(Function<RetryInfo, T> function) {
         Objects.requireNonNull(function, Supplier.class.getSimpleName() + " cannot be null");
         return executeWithRetry(function, __ -> true, this).apply(firstAttemptRetryInfo());
+    }
+
+    private static RetryInfo firstAttemptRetryInfo() {
+        return new RetryInfo() {
+            @Override
+            public int getRetryCount() {
+                return 0;
+            }
+
+            @Override
+            public int getAttemptNumber() {
+                return 1;
+            }
+
+            @Override
+            public int getMaxAttempts() {
+                return 1;
+            }
+
+            @Override
+            public int getAttemptsLeft() {
+                return 1;
+            }
+
+            @Override
+            public boolean isInfiniteRetriesLeft() {
+                return false;
+            }
+
+            @Override
+            public Duration getBackoff() {
+                return Duration.ZERO;
+            }
+
+            @Override
+            public boolean isLastAttempt() {
+                return true;
+            }
+
+            @Override
+            public boolean isFirstAttempt() {
+                return true;
+            }
+        };
     }
 
     /**

--- a/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
+++ b/common/retry/src/main/java/org/occurrent/retry/RetryStrategy.java
@@ -18,6 +18,7 @@ package org.occurrent.retry;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.internal.RetryImpl;
 
 import java.time.Duration;
@@ -120,7 +121,7 @@ public interface RetryStrategy {
      * @param function A function that takes {@link RetryInfo} and returns the result
      * @return The result of the supplier, if successful.
      */
-    default <T> T execute(Function<RetryInfo, T> function) {
+    default <T extends @Nullable Object> T execute(Function<RetryInfo, T> function) {
         Objects.requireNonNull(function, Supplier.class.getSimpleName() + " cannot be null");
         return executeWithRetry(function, __ -> true, this).apply(null);
     }
@@ -132,7 +133,7 @@ public interface RetryStrategy {
      * @param supplier The supplier to execute
      * @return The result of the supplier, if successful.
      */
-    default <T> T execute(Supplier<T> supplier) {
+    default <T extends @Nullable Object> T execute(Supplier<T> supplier) {
         Objects.requireNonNull(supplier, Supplier.class.getSimpleName() + " cannot be null");
         return executeWithRetry(supplier, __ -> true, this).get();
     }

--- a/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
@@ -17,6 +17,7 @@
 package org.occurrent.retry.internal;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.AfterRetryInfo.ResultOfRetryAttempt;
 import org.occurrent.retry.Backoff;
 import org.occurrent.retry.MaxAttempts;
@@ -38,11 +39,11 @@ import java.util.stream.Stream;
  */
 public class RetryExecution {
 
-    public static <T1> Supplier<T1> executeWithRetry(@NonNull Supplier<T1> supplier, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
+    public static <T1 extends @Nullable Object> Supplier<T1> executeWithRetry(@NonNull Supplier<T1> supplier, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
         return () -> executeWithRetry((Function<RetryInfo, T1>) __ -> supplier.get(), shutdownPredicate, retryStrategy).apply(null);
     }
 
-    public static <T1> Function<RetryInfo, T1> executeWithRetry(@NonNull Function<RetryInfo, T1> function, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
+    public static <T1 extends @Nullable Object> Function<RetryInfo, T1> executeWithRetry(@NonNull Function<RetryInfo, T1> function, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
         if (retryStrategy instanceof DontRetry) {
             return function;
         }
@@ -83,7 +84,7 @@ public class RetryExecution {
         }, retry, delay).apply(null);
     }
 
-    private static <T1> Function<RetryInfo, T1> executeWithRetry(
+    private static <T1 extends @Nullable Object> Function<RetryInfo, T1> executeWithRetry(
             Function<RetryInfo, T1> fn,
             RetryImpl retry,
             Iterator<Long> delay

--- a/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  */
 public class RetryExecution {
 
-    public static RetryInfo firstAttemptRetryInfo() {
+    private static RetryInfo firstAttemptRetryInfo() {
         return new RetryInfoImpl(1, 0, new MaxAttempts.Limit(1), Duration.ZERO);
     }
 

--- a/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/RetryExecution.java
@@ -39,8 +39,12 @@ import java.util.stream.Stream;
  */
 public class RetryExecution {
 
+    public static RetryInfo firstAttemptRetryInfo() {
+        return new RetryInfoImpl(1, 0, new MaxAttempts.Limit(1), Duration.ZERO);
+    }
+
     public static <T1 extends @Nullable Object> Supplier<T1> executeWithRetry(@NonNull Supplier<T1> supplier, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
-        return () -> executeWithRetry((Function<RetryInfo, T1>) __ -> supplier.get(), shutdownPredicate, retryStrategy).apply(null);
+        return () -> executeWithRetry((Function<RetryInfo, T1>) __ -> supplier.get(), shutdownPredicate, retryStrategy).apply(firstAttemptRetryInfo());
     }
 
     public static <T1 extends @Nullable Object> Function<RetryInfo, T1> executeWithRetry(@NonNull Function<RetryInfo, T1> function, @NonNull Predicate<Throwable> shutdownPredicate, @NonNull RetryStrategy retryStrategy) {
@@ -73,15 +77,17 @@ public class RetryExecution {
     }
 
     private static Runnable executeWithRetry(Runnable runnable, RetryImpl retry, Iterator<Long> delay) {
-        Consumer<Void> runnableConsumer = __ -> runnable.run();
-        return () -> executeWithRetry(runnableConsumer, retry, delay).accept(null);
+        return () -> executeWithRetry(__ -> {
+            runnable.run();
+            return null;
+        }, retry, delay).apply(firstAttemptRetryInfo());
     }
 
     private static <T1> Consumer<T1> executeWithRetry(@NonNull Consumer<T1> fn, @NonNull RetryImpl retry, @NonNull Iterator<Long> delay) {
         return t1 -> executeWithRetry(retryInfo -> {
             fn.accept(t1);
             return null;
-        }, retry, delay).apply(null);
+        }, retry, delay).apply(firstAttemptRetryInfo());
     }
 
     private static <T1 extends @Nullable Object> Function<RetryInfo, T1> executeWithRetry(

--- a/common/retry/src/main/java/org/occurrent/retry/internal/RetryImpl.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/RetryImpl.java
@@ -172,7 +172,7 @@ public final class RetryImpl implements RetryStrategy.Retry {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof RetryImpl that)) return false;
         return Objects.equals(backoff, that.backoff) && Objects.equals(maxAttempts, that.maxAttempts) && Objects.equals(retryPredicate, that.retryPredicate) && Objects.equals(errorListener, that.errorListener) && Objects.equals(onBeforeRetryListener, that.onBeforeRetryListener) && Objects.equals(onAfterRetryListener, that.onAfterRetryListener) && Objects.equals(onRetryableErrorListener, that.onRetryableErrorListener) && Objects.equals(errorMapper, that.errorMapper);

--- a/common/retry/src/main/java/org/occurrent/retry/internal/RetryInfoImpl.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/RetryInfoImpl.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.retry.internal;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.MaxAttempts;
 import org.occurrent.retry.RetryInfo;
 
@@ -88,7 +89,7 @@ class RetryInfoImpl implements RetryInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof RetryInfoImpl retryInfo)) return false;
         return attemptNumber == retryInfo.attemptNumber && retryCount == retryInfo.retryCount && Objects.equals(maxAttempts, retryInfo.maxAttempts) && Objects.equals(backoff, retryInfo.backoff);

--- a/common/retry/src/main/java/org/occurrent/retry/internal/package-info.java
+++ b/common/retry/src/main/java/org/occurrent/retry/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.retry.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/retry/src/main/java/org/occurrent/retry/package-info.java
+++ b/common/retry/src/main/java/org/occurrent/retry/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.retry;
+
+import org.jspecify.annotations.NullMarked;

--- a/common/retry/src/test/java/org/occurrent/retry/RetryStrategyTest.java
+++ b/common/retry/src/test/java/org/occurrent/retry/RetryStrategyTest.java
@@ -39,6 +39,28 @@ public class RetryStrategyTest {
         );
     }
 
+    @Test
+    void passes_retry_info_when_retry_strategy_is_none() {
+        // Given
+        RetryStrategy retryStrategy = RetryStrategy.none();
+
+        // When
+        RetryInfo retryInfo = retryStrategy.execute(info -> info);
+
+        // Then
+        assertAll(
+                () -> assertThat(retryInfo.getRetryCount()).isZero(),
+                () -> assertThat(retryInfo.getAttemptNumber()).isOne(),
+                () -> assertThat(retryInfo.getNumberOfPreviousAttempts()).isZero(),
+                () -> assertThat(retryInfo.getBackoff()).isEqualTo(Duration.ZERO),
+                () -> assertThat(retryInfo.getMaxAttempts()).isOne(),
+                () -> assertThat(retryInfo.getAttemptsLeft()).isOne(),
+                () -> assertThat(retryInfo.isFirstAttempt()).isTrue(),
+                () -> assertThat(retryInfo.isLastAttempt()).isTrue(),
+                () -> assertThat(retryInfo.isInfiniteRetriesLeft()).isFalse()
+        );
+    }
+
     @Timeout(2)
     @Test
     void example_of_retry_executed_with_function_that_takes_retry_info() {

--- a/common/time/pom.xml
+++ b/common/time/pom.xml
@@ -28,6 +28,11 @@
     <name>${mavenProjectName}</name>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/common/time/src/main/java/org/occurrent/time/internal/package-info.java
+++ b/common/time/src/main/java/org/occurrent/time/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.time.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/deadline/api/blocking/pom.xml
+++ b/deadline/api/blocking/pom.xml
@@ -16,5 +16,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/Deadline.java
+++ b/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/Deadline.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.deadline.api.blocking;
 
+import org.jspecify.annotations.Nullable;
 import java.time.*;
 import java.util.Date;
 import java.util.Objects;
@@ -174,7 +175,7 @@ public sealed interface Deadline {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof ZonedDateTimeDeadLine that)) return false;
             return Objects.equals(zonedDateTime, that.zonedDateTime);
@@ -202,7 +203,7 @@ public sealed interface Deadline {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof OffsetDateTimeDeadLine that)) return false;
             return Objects.equals(offsetDateTime, that.offsetDateTime);
@@ -230,7 +231,7 @@ public sealed interface Deadline {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof LocalDateTimeDeadLine that)) return false;
             return Objects.equals(localDateTime, that.localDateTime);
@@ -258,7 +259,7 @@ public sealed interface Deadline {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof InstantDeadLine that)) return false;
             return Objects.equals(instant, that.instant);

--- a/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/package-info.java
+++ b/deadline/api/blocking/src/main/java/org/occurrent/deadline/api/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.deadline.api.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/deadline/inmemory/pom.xml
+++ b/deadline/inmemory/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>deadline-api-blocking</artifactId>
             <version>${project.version}</version>

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/InMemoryDeadlineConsumerRegistry.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/InMemoryDeadlineConsumerRegistry.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.deadline.inmemory;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.deadline.api.blocking.DeadlineConsumer;
 import org.occurrent.deadline.api.blocking.DeadlineConsumerRegistry;
 import org.occurrent.deadline.inmemory.internal.DeadlineData;
@@ -209,7 +210,7 @@ public class InMemoryDeadlineConsumerRegistry implements DeadlineConsumerRegistr
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof Config config)) return false;
             return pollInterval == config.pollInterval && pollIntervalTimeUnit == config.pollIntervalTimeUnit && Objects.equals(retryStrategy, config.retryStrategy);

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/DeadlineData.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/DeadlineData.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.deadline.inmemory.internal;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.deadline.api.blocking.Deadline;
 
 import java.util.Objects;
@@ -39,7 +40,7 @@ public class DeadlineData {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof DeadlineData that)) return false;
         return Objects.equals(id, that.id) && Objects.equals(category, that.category) && Objects.equals(deadline, that.deadline) && Objects.equals(data, that.data);

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/package-info.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.deadline.inmemory.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/package-info.java
+++ b/deadline/inmemory/src/main/java/org/occurrent/deadline/inmemory/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.deadline.inmemory;
+
+import org.jspecify.annotations.NullMarked;

--- a/deadline/jobrunr/pom.xml
+++ b/deadline/jobrunr/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>deadline-api-blocking</artifactId>
             <version>${project.version}</version>

--- a/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/DeadlineJobRequest.java
+++ b/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/DeadlineJobRequest.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.deadline.jobrunr.internal;
 
+import org.jspecify.annotations.Nullable;
 import org.jobrunr.jobs.lambdas.JobRequest;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.occurrent.deadline.jobrunr.JobRunrDeadlineConsumerRegistry;
@@ -67,7 +68,7 @@ public class DeadlineJobRequest implements JobRequest {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof DeadlineJobRequest that)) return false;
         return deadlineInEpochMilli == that.deadlineInEpochMilli && Objects.equals(id, that.id) && Objects.equals(category, that.category) && Objects.equals(data, that.data);

--- a/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/package-info.java
+++ b/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.deadline.jobrunr.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/package-info.java
+++ b/deadline/jobrunr/src/main/java/org/occurrent/deadline/jobrunr/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.deadline.jobrunr;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/package-info.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.dcb.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -117,7 +117,7 @@ class DcbDslKotlinTest {
         subscriptionModel.subscribeDcb(
             subscriptionId = "subscription",
             cloudEventConverter = cloudEventConverter,
-            query = DcbCriteria.tags(listOf(Tag.of("name", "1"))).excludingTypes(listOf(NameWasChanged::class.qualifiedName!!))
+            query = DcbCriteria.tags(listOf(Tag.of("name", "1"))).excludingTypes(listOf(NameWasChanged::class.java.name))
         ) {
             received.add(it)
         }

--- a/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/package-info.java
+++ b/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.dcb;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/package-info.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/decider/src/main/java/org/occurrent/dsl/decider/CompositeState.java
+++ b/dsl/decider/src/main/java/org/occurrent/dsl/decider/CompositeState.java
@@ -17,6 +17,8 @@
 
 package org.occurrent.dsl.decider;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,8 +31,8 @@ import java.util.List;
  * The vararg {@code compose} produces this type. The two and three decider overloads in the Kotlin DSL produce typed
  * {@code Pair} and {@code Triple} states instead, so reach for this only when composing four or more deciders.
  */
-public record CompositeState(List<Object> states) {
-    public CompositeState(List<Object> states) {
+public record CompositeState(List<@Nullable Object> states) {
+    public CompositeState(List<@Nullable Object> states) {
         this.states = Collections.unmodifiableList(new ArrayList<>(states));
     }
 
@@ -39,7 +41,7 @@ public record CompositeState(List<Object> states) {
      * safe by construction because slice {@code i} always holds the state of decider {@code i}.
      */
     @SuppressWarnings("unchecked")
-    public <T> T slice(int index) {
+    public <T extends @Nullable Object> T slice(int index) {
         return (T) states.get(index);
     }
 }

--- a/dsl/decider/src/main/java/org/occurrent/dsl/decider/Decider.java
+++ b/dsl/decider/src/main/java/org/occurrent/dsl/decider/Decider.java
@@ -34,7 +34,7 @@ import java.util.function.Predicate;
  * @param <S> The state that the decider work
  * @param <E> The type of events that the decider returns
  */
-public interface Decider<C, S, E> {
+public interface Decider<C, S extends @Nullable Object, E> {
     /**
      * The state a decider starts from, before any events have been applied.
      */
@@ -220,21 +220,21 @@ public interface Decider<C, S, E> {
     /**
      * The outcome of a decision: the resulting {@code state} and the new {@code events} that were produced.
      */
-    record Decision<S, E>(S state, List<E> events) {
+    record Decision<S extends @Nullable Object, E>(S state, List<E> events) {
     }
 
     /**
      * Create a decider from functions instead of implementing the interface. This overload is never terminal. See
      * {@link #create(Object, BiFunction, BiFunction, Predicate)} to also supply an {@code isTerminal} predicate.
      */
-    static <C, S, E> Decider<C, S, E> create(S initialState, @NonNull BiFunction<C, S, List<E>> decide, @NonNull BiFunction<S, E, S> evolve) {
+    static <C, S extends @Nullable Object, E> Decider<C, S, E> create(S initialState, @NonNull BiFunction<C, S, List<E>> decide, @NonNull BiFunction<S, E, S> evolve) {
         return create(initialState, decide, evolve, __ -> false);
     }
 
     /**
      * Create a decider from functions instead of implementing the interface, including an {@code isTerminal} predicate.
      */
-    static <C, S, E> Decider<C, S, E> create(S initialState, @NonNull BiFunction<C, S, List<E>> decide, @NonNull BiFunction<S, E, S> evolve,
+    static <C, S extends @Nullable Object, E> Decider<C, S, E> create(S initialState, @NonNull BiFunction<C, S, List<E>> decide, @NonNull BiFunction<S, E, S> evolve,
                                              @NonNull Predicate<S> isTerminal) {
 
         return new Decider<>() {
@@ -282,7 +282,7 @@ public interface Decider<C, S, E> {
      * @param commandType the command type the decider understands
      * @param eventType   the event type the decider understands
      */
-    static <C, S, E, SubC extends C, SubE extends E> Decider<C, S, E> adapt(@NonNull Decider<SubC, S, SubE> decider,
+    static <C, S extends @Nullable Object, E, SubC extends C, SubE extends E> Decider<C, S, E> adapt(@NonNull Decider<SubC, S, SubE> decider,
                                                                             @NonNull Class<SubC> commandType,
                                                                             @NonNull Class<SubE> eventType) {
         return create(
@@ -325,10 +325,10 @@ public interface Decider<C, S, E> {
      */
     static <C, E> Decider<C, CompositeState, E> compose(@NonNull List<? extends Decider<C, ?, E>> deciders) {
         @SuppressWarnings("unchecked")
-        List<Decider<C, Object, E>> slices = (List<Decider<C, Object, E>>) new ArrayList<>(deciders);
+        List<Decider<C, @Nullable Object, E>> slices = (List<Decider<C, @Nullable Object, E>>) new ArrayList<>(deciders);
 
-        List<Object> initialStates = new ArrayList<>();
-        for (Decider<C, Object, E> decider : slices) {
+        List<@Nullable Object> initialStates = new ArrayList<>();
+        for (Decider<C, @Nullable Object, E> decider : slices) {
             initialStates.add(decider.initialState());
         }
 
@@ -342,10 +342,10 @@ public interface Decider<C, S, E> {
                     return events;
                 },
                 (composite, event) -> {
-                    List<Object> next = new ArrayList<>(composite.states());
+                    List<@Nullable Object> next = new ArrayList<>(composite.states());
                     for (int i = 0; i < slices.size(); i++) {
-                        Decider<C, Object, E> decider = slices.get(i);
-                        Object slice = next.get(i);
+                        Decider<C, @Nullable Object, E> decider = slices.get(i);
+                        @Nullable Object slice = next.get(i);
                         if (!decider.isTerminal(slice)) {
                             next.set(i, decider.evolve(slice, event));
                         }

--- a/dsl/decider/src/main/java/org/occurrent/dsl/decider/package-info.java
+++ b/dsl/decider/src/main/java/org/occurrent/dsl/decider/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.decider;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/decider/src/main/kotlin/org/occurrent/dsl/decider/DeciderExtensions.kt
+++ b/dsl/decider/src/main/kotlin/org/occurrent/dsl/decider/DeciderExtensions.kt
@@ -22,7 +22,7 @@ import org.occurrent.dsl.decider.Decider.Decision
 /**
  * A utility function for creating deciders a bit more nicer in Kotlin
  */
-fun <C, S, E> decider(initialState: S, decide: (C, S) -> List<E>, evolve: (S, E) -> S, isTerminal: (S) -> Boolean = { false }): Decider<C, S, E> = Decider.create(initialState, decide, evolve, isTerminal)
+fun <C : Any, S, E : Any> decider(initialState: S, decide: (C, S) -> List<E>, evolve: (S, E) -> S, isTerminal: (S) -> Boolean = { false }): Decider<C, S, E> = Decider.create(initialState, decide, evolve, isTerminal)
 
 /**
  * Widen a feature decider so it can run where a decider over broader command and event types is expected, for example
@@ -35,8 +35,8 @@ fun <C, S, E> decider(initialState: S, decide: (C, S) -> List<E>, evolve: (S, E)
  * val widened: Decider<DomainCommand, CourseState, DomainEvent> = courseDecider.adapt()
  * ```
  */
-inline fun <reified SubC : C, S, reified SubE : E, C, E : Any> Decider<SubC, S, SubE>.adapt(): Decider<C, S, E> =
-    Decider.adapt(this, SubC::class.java, SubE::class.java)
+inline fun <reified SubC : C, S, reified SubE : E, C : Any, E : Any> Decider<SubC, S, SubE>.adapt(): Decider<C, S, E> =
+    Decider.adapt<C, S, E, SubC, SubE>(this, SubC::class.java, SubE::class.java)
 
 /**
  * Widen only the event type of a decider, from [SubE] to the broader [E], leaving the command type unchanged. Events that
@@ -149,7 +149,7 @@ inline fun <C : Any, reified C1 : C, S1, reified E1 : E, reified C2 : C, S2, rei
  *     compose(listOf(courseDecider.adapt(), studentDecider.adapt(), enrollmentDecider.adapt(), roomDecider.adapt()))
  * ```
  */
-fun <C, E : Any> compose(deciders: List<Decider<C, *, E>>): Decider<C, CompositeState, E> =
+fun <C : Any, E : Any> compose(deciders: List<Decider<C, *, E>>): Decider<C, CompositeState, E> =
     Decider.compose(deciders)
 
 /**
@@ -163,13 +163,13 @@ fun <C, E : Any> compose(deciders: List<Decider<C, *, E>>): Decider<C, Composite
  *     compose(courseDecider.adapt(), studentDecider.adapt(), enrollmentDecider.adapt(), roomDecider.adapt())
  * ```
  */
-fun <C, E : Any> compose(first: Decider<C, *, E>, second: Decider<C, *, E>, third: Decider<C, *, E>, fourth: Decider<C, *, E>, vararg rest: Decider<C, *, E>): Decider<C, CompositeState, E> =
+fun <C : Any, E : Any> compose(first: Decider<C, *, E>, second: Decider<C, *, E>, third: Decider<C, *, E>, fourth: Decider<C, *, E>, vararg rest: Decider<C, *, E>): Decider<C, CompositeState, E> =
     Decider.compose(listOf(first, second, third, fourth, *rest))
 
-fun <C, S, E> Decider<C, S, E>.decide(events: List<E>, command: C, vararg moreCommands: C): Decision<S, E> = decideOnEvents(events, listOf(command, *moreCommands))
-fun <C, S, E> Decider<C, S, E>.decide(events: List<E>, commands: List<C>): Decision<S, E> = decideOnEvents(events, commands)
-fun <C, S, E> Decider<C, S, E>.decide(state: S, command: C, vararg moreCommands: C): Decision<S, E> = decideOnState(state, listOf(command, *moreCommands))
-fun <C, S, E> Decider<C, S, E>.decide(state: S, commands: List<C>): Decision<S, E> = decideOnState(state, commands)
+fun <C : Any, S, E : Any> Decider<C, S, E>.decide(events: List<E>, command: C, vararg moreCommands: C): Decision<S, E> = decideOnEvents(events, listOf(command, *moreCommands))
+fun <C : Any, S, E : Any> Decider<C, S, E>.decide(events: List<E>, commands: List<C>): Decision<S, E> = decideOnEvents(events, commands)
+fun <C : Any, S, E : Any> Decider<C, S, E>.decide(state: S, command: C, vararg moreCommands: C): Decision<S, E> = decideOnState(state, listOf(command, *moreCommands))
+fun <C : Any, S, E : Any> Decider<C, S, E>.decide(state: S, commands: List<C>): Decision<S, E> = decideOnState(state, commands)
 
-operator fun <S, E> Decision<S, E>.component1(): S = state
-operator fun <S, E> Decision<S, E>.component2(): List<E> = events
+operator fun <S, E : Any> Decision<S, E>.component1(): S = state
+operator fun <S, E : Any> Decision<S, E>.component2(): List<E> = events

--- a/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/package-info.java
+++ b/dsl/query-dsl/blocking/src/main/java/org/occurrent/dsl/query/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.query.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/query-dsl/blocking/src/test/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesKotlinTest.kt
+++ b/dsl/query-dsl/blocking/src/test/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesKotlinTest.kt
@@ -86,7 +86,7 @@ class DomainEventQueriesKotlinTest {
         )
 
         // When
-        val events = domainEventQueries.queryForSequence(type(NameWasChanged::class.qualifiedName), SortBy.natural(ASCENDING)).toList()
+        val events = domainEventQueries.queryForSequence(type(NameWasChanged::class.java.name), SortBy.natural(ASCENDING)).toList()
 
         // Then
         assertAll(
@@ -128,7 +128,7 @@ class DomainEventQueriesKotlinTest {
         )
 
         // When
-        val events = domainEventQueries.queryForList(type(NameWasChanged::class.qualifiedName), SortBy.natural(ASCENDING))
+        val events = domainEventQueries.queryForList(type(NameWasChanged::class.java.name), SortBy.natural(ASCENDING))
 
         // Then
         assertAll(
@@ -149,7 +149,7 @@ class DomainEventQueriesKotlinTest {
         )
 
         // When
-        val sequence: Sequence<NameWasChanged> = domainEventQueries.queryForSequence(type(NameWasChanged::class.qualifiedName))
+        val sequence: Sequence<NameWasChanged> = domainEventQueries.queryForSequence(type(NameWasChanged::class.java.name))
 
         // Then
         val events: List<NameWasChanged> = sequence.toList()
@@ -171,7 +171,7 @@ class DomainEventQueriesKotlinTest {
         )
 
         // When
-        val events: List<NameWasChanged> = domainEventQueries.queryForList(type(NameWasChanged::class.qualifiedName))
+        val events: List<NameWasChanged> = domainEventQueries.queryForList(type(NameWasChanged::class.java.name))
 
         // Then
         assertAll(
@@ -192,7 +192,7 @@ class DomainEventQueriesKotlinTest {
         )
 
         // When
-        val event = domainEventQueries.queryOne<NameWasChanged>(type(NameWasChanged::class.qualifiedName))
+        val event = domainEventQueries.queryOne<NameWasChanged>(type(NameWasChanged::class.java.name))
 
         // Then
         assertThat(event).isEqualTo(NameWasChanged("eventId2", time, "name", "Jane Doe"))

--- a/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/package-info.java
+++ b/dsl/query-dsl/reactor/src/main/java/org/occurrent/dsl/query/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.query.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/query-dsl/reactor/src/test/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesKotlinTest.kt
+++ b/dsl/query-dsl/reactor/src/test/kotlin/org/occurrent/dsl/query/reactor/DomainEventQueriesKotlinTest.kt
@@ -110,7 +110,7 @@ class DomainEventQueriesKotlinTest {
         ).block()
 
         // When
-        val events = domainEventQueries.queryForList(Filter.type(NameWasChanged::class.qualifiedName), SortBy.natural(ASCENDING)).block()
+        val events = domainEventQueries.queryForList(Filter.type(NameWasChanged::class.java.name), SortBy.natural(ASCENDING)).block()
 
         // Then
         assertAll(

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/MaterializedView.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/MaterializedView.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.dsl.view;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 
 import java.util.function.Function;
@@ -27,11 +28,11 @@ import java.util.function.Function;
 public interface MaterializedView<E> {
     void update(E event);
 
-    default <S, ID> void updateFromRepository(ID id, E event, View<S, E> view, ViewStateRepository<S, ID> repository) {
+    default <S extends @Nullable Object, ID> void updateFromRepository(ID id, E event, View<S, E> view, ViewStateRepository<S, ID> repository) {
         updateFromRepository(id, event, view, repository, RetryStrategy.none());
     }
 
-    default <S, ID> void updateFromRepository(ID id, E event, View<S, E> view, ViewStateRepository<S, ID> repository, RetryStrategy retryStrategy) {
+    default <S extends @Nullable Object, ID> void updateFromRepository(ID id, E event, View<S, E> view, ViewStateRepository<S, ID> repository, RetryStrategy retryStrategy) {
         retryStrategy.execute(() -> {
             S currentState = repository.findById(id).orElse(view.initialState());
             S updatedState = view.evolve(currentState, event);
@@ -39,7 +40,7 @@ public interface MaterializedView<E> {
         });
     }
 
-    static <S, E, ID> MaterializedView<E> create(Function<E, ID> idMapper, View<S, E> view, ViewStateRepository<S, ID> repository) {
+    static <S extends @Nullable Object, E, ID> MaterializedView<E> create(Function<E, ID> idMapper, View<S, E> view, ViewStateRepository<S, ID> repository) {
         return new MaterializedView<>() {
             @Override
             public void update(E event) {

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  * @param <S> The type of the state that this view produces
  * @param <E> The type of the event that is used to create the state
  */
-public interface View<S, E> {
+public interface View<S extends @Nullable Object, E> {
     /**
      * @return The initial state
      */
@@ -92,7 +92,7 @@ public interface View<S, E> {
         return evolve(initialState(), events);
     }
 
-    static <S, E> View<S, E> create(S initialState, @NonNull BiFunction<S, E, S> evolve) {
+    static <S extends @Nullable Object, E> View<S, E> create(S initialState, @NonNull BiFunction<S, E, S> evolve) {
         return new View<>() {
             @Override
             public S initialState() {

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
  * @param <S>  The state to store
  * @param <ID> The id that uniquely identifies the state
  */
-public interface ViewStateRepository<S, ID> {
+public interface ViewStateRepository<S extends @Nullable Object, ID> {
     Optional<@NonNull S> findById(@NonNull ID id);
 
     void save(@NonNull ID id, @NonNull S state);
@@ -45,7 +45,7 @@ public interface ViewStateRepository<S, ID> {
         return findById(id).orElse(initialState);
     }
 
-    static <S, ID> ViewStateRepository<S, ID> create(Function<@NonNull ID, @Nullable S> findById, BiConsumer<@NonNull ID, @NonNull S> save) {
+    static <S extends @Nullable Object, ID> ViewStateRepository<S, ID> create(Function<@NonNull ID, @Nullable S> findById, BiConsumer<@NonNull ID, @NonNull S> save) {
         return new ViewStateRepository<>() {
             @Override
             public Optional<S> findById(@NonNull ID id) {

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/package-info.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.view;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/SpringMongoViewExtensions.kt
+++ b/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/SpringMongoViewExtensions.kt
@@ -31,16 +31,16 @@ interface StateConverter<S_VIEW, S_DTO> {
     fun fromDTO(dto: S_DTO): S_VIEW
 }
 
-inline fun <reified S, E, VIEW_ID : Any> View<S, E>.currentState(mongoOperations: MongoOperations, id: VIEW_ID): S? {
+inline fun <reified S : Any, E : Any, VIEW_ID : Any> View<S, E>.currentState(mongoOperations: MongoOperations, id: VIEW_ID): S? {
     return mongoOperations.findById(id)
 }
 
-inline fun <reified S, E, VIEW_ID : Any> View<S, E>.materialized(
+inline fun <reified S, E : Any, VIEW_ID : Any> View<S, E>.materialized(
     mongoOperations: MongoOperations,
     crossinline deriveViewIdFromEvent: (E) -> VIEW_ID
 ): MaterializedView<E> = materialized(mongoOperations, SpringMongoViewConfig.config(), deriveViewIdFromEvent)
 
-inline fun <reified S, E, VIEW_ID : Any> View<S, E>.materialized(
+inline fun <reified S, E : Any, VIEW_ID : Any> View<S, E>.materialized(
     mongoOperations: MongoOperations,
     config: SpringMongoViewConfig = SpringMongoViewConfig.config(),
     crossinline deriveViewIdFromEvent: (E) -> VIEW_ID
@@ -52,13 +52,13 @@ inline fun <reified S, E, VIEW_ID : Any> View<S, E>.materialized(
     return materialized(mongoOperations, noopStateConvert, config, deriveViewIdFromEvent)
 }
 
-inline fun <S_VIEW, reified S_DTO : Any, E, VIEW_ID : Any> View<S_VIEW, E>.materialized(
+inline fun <S_VIEW, reified S_DTO : Any, E : Any, VIEW_ID : Any> View<S_VIEW, E>.materialized(
     mongoOperations: MongoOperations,
     converter: StateConverter<S_VIEW, S_DTO>,
     crossinline deriveViewIdFromEvent: (E) -> VIEW_ID
 ): MaterializedView<E> = materialized(mongoOperations, converter, SpringMongoViewConfig.config(), deriveViewIdFromEvent)
 
-inline fun <S_VIEW, reified S_DTO : Any, E, VIEW_ID : Any> View<S_VIEW, E>.materialized(
+inline fun <S_VIEW, reified S_DTO : Any, E : Any, VIEW_ID : Any> View<S_VIEW, E>.materialized(
     mongoOperations: MongoOperations,
     converter: StateConverter<S_VIEW, S_DTO>,
     config: SpringMongoViewConfig = SpringMongoViewConfig.config(),
@@ -127,7 +127,7 @@ inline fun <S_VIEW, reified S_DTO : Any, E, VIEW_ID : Any> View<S_VIEW, E>.mater
     }
 }
 
-fun <S : Any, E, VIEW_ID : Any> View<S, E>.materialized(
+fun <S : Any, E : Any, VIEW_ID : Any> View<S, E>.materialized(
     crudRepository: CrudRepository<S, VIEW_ID>,
     deriveViewIdFromEvent: (E) -> VIEW_ID
 ): MaterializedView<E> {
@@ -138,7 +138,7 @@ fun <S : Any, E, VIEW_ID : Any> View<S, E>.materialized(
     return materialized(crudRepository, noopStateConvert, deriveViewIdFromEvent)
 }
 
-fun <S_VIEW, S_DTO : Any, E, VIEW_ID : Any> View<S_VIEW, E>.materialized(
+fun <S_VIEW, S_DTO : Any, E : Any, VIEW_ID : Any> View<S_VIEW, E>.materialized(
     crudRepository: CrudRepository<S_DTO, VIEW_ID>,
     converter: StateConverter<S_VIEW, S_DTO>,
     deriveViewIdFromEvent: (E) -> VIEW_ID

--- a/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/ViewExtensions.kt
+++ b/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/ViewExtensions.kt
@@ -19,7 +19,7 @@ package org.occurrent.dsl.view
 
 import java.util.stream.Stream
 
-fun <S, E> view(initialState: S, updateState: (S, E) -> S): View<S, E> = View.create(initialState, updateState)
+fun <S, E : Any> view(initialState: S, updateState: (S, E) -> S): View<S, E> = View.create(initialState, updateState)
 
 // =========================
 // Single event (convenience)

--- a/eventstore/api/blocking/src/main/java/org/occurrent/eventstore/api/blocking/package-info.java
+++ b/eventstore/api/blocking/src/main/java/org/occurrent/eventstore/api/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/DuplicateCloudEventException.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/DuplicateCloudEventException.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.eventstore.api;
 
+import org.jspecify.annotations.Nullable;
 import java.net.URI;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -53,7 +54,7 @@ public class DuplicateCloudEventException extends RuntimeException {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof DuplicateCloudEventException that)) return false;
         return Objects.equals(id, that.id) && Objects.equals(source, that.source) && Objects.equals(details, that.details);

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/SortBy.java
@@ -2,6 +2,7 @@ package org.occurrent.eventstore.api;
 
 import io.cloudevents.core.v1.CloudEventV1;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 
 import java.util.*;
@@ -102,7 +103,7 @@ public sealed interface SortBy {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof NaturalImpl natural)) return false;
             return direction == natural.direction;
@@ -157,7 +158,7 @@ public sealed interface SortBy {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof SingleFieldImpl that)) return false;
             return Objects.equals(fieldName, that.fieldName) && direction == that.direction;
@@ -221,7 +222,7 @@ public sealed interface SortBy {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof MultipleSortStepsImpl that)) return false;
             return Objects.equals(steps, that.steps);

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/WriteConditionNotFulfilledException.java
@@ -17,6 +17,7 @@
 package org.occurrent.eventstore.api;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -41,7 +42,7 @@ public class WriteConditionNotFulfilledException extends RuntimeException {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof WriteConditionNotFulfilledException that)) return false;
         return eventStreamVersion == that.eventStreamVersion && Objects.equals(eventStreamId, that.eventStreamId) && Objects.equals(writeCondition, that.writeCondition) && Objects.equals(getMessage(), that.getMessage());

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/package-info.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/package-info.java
+++ b/eventstore/api/common/src/main/java/org/occurrent/eventstore/api/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/api/dcb-reactor/src/main/java/org/occurrent/eventstore/api/dcb/reactor/package-info.java
+++ b/eventstore/api/dcb-reactor/src/main/java/org/occurrent/eventstore/api/dcb/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/package-info.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api.dcb;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/api/reactor/pom.xml
+++ b/eventstore/api/reactor/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-api-common</artifactId>
             <version>${project.version}</version>

--- a/eventstore/api/reactor/src/main/java/org/occurrent/eventstore/api/reactor/package-info.java
+++ b/eventstore/api/reactor/src/main/java/org/occurrent/eventstore/api/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.api.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -602,7 +602,7 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof EventStreamImpl that)) return false;
             return version == that.version &&

--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/package-info.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.inmemory;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/migration/position-backfill/src/main/java/org/occurrent/eventstore/mongodb/migration/positionbackfill/package-info.java
+++ b/eventstore/migration/position-backfill/src/main/java/org/occurrent/eventstore/mongodb/migration/positionbackfill/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.migration.positionbackfill;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/package-info.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.cloudevent;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/StreamVersionDiff.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/StreamVersionDiff.java
@@ -17,6 +17,7 @@
 
 package org.occurrent.eventstore.mongodb.internal;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -38,7 +39,7 @@ public class StreamVersionDiff {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof StreamVersionDiff that)) return false;
         return oldStreamVersion == that.oldStreamVersion && newStreamVersion == that.newStreamVersion;

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/package-info.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/package-info.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.dcb.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/EventStoreConfig.java
@@ -122,7 +122,7 @@ public class EventStoreConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(transactionOptions, that.transactionOptions) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/package-info.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.nativedriver;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
@@ -18,6 +18,7 @@ package org.occurrent.eventstore.mongodb.spring.blocking;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
@@ -114,7 +115,7 @@ public class EventStoreConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionTemplate, that.transactionTemplate) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/package-info.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/EventStoreConfig.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.eventstore.mongodb.spring.reactor;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator;
 import org.occurrent.eventstore.api.dcb.PartitionedDcbStreamIdGenerator;
@@ -111,7 +112,7 @@ public class EventStoreConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof EventStoreConfig that)) return false;
         return Objects.equals(eventStoreCollectionName, that.eventStoreCollectionName) && Objects.equals(transactionalOperator, that.transactionalOperator) && timeRepresentation == that.timeRepresentation && Objects.equals(queryOptions, that.queryOptions) && Objects.equals(readOptions, that.readOptions) && Objects.equals(eventStoreCapabilities, that.eventStoreCapabilities) && Objects.equals(dcbStreamIdGenerator, that.dcbStreamIdGenerator) && streamPositionEnabled == that.streamPositionEnabled && streamPositionExplicitlyEnabled == that.streamPositionExplicitlyEnabled && requireBackfilledPosition == that.requireBackfilledPosition;

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/package-info.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.eventstore.mongodb.spring.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/model/pom.xml
+++ b/example/domain/number-guessing-game/model/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameAlreadyEnded.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameAlreadyEnded.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.model;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -28,7 +29,7 @@ public class GameAlreadyEnded extends RuntimeException {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof GameAlreadyEnded that)) return false;
         return Objects.equals(gameId, that.gameId);

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameNotStarted.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/GameNotStarted.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.model;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -28,7 +29,7 @@ public class GameNotStarted extends RuntimeException {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof GameNotStarted that)) return false;
         return Objects.equals(gameId, that.gameId);

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/Guess.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/Guess.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.model;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 public class Guess {
@@ -29,7 +30,7 @@ public class Guess {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof Guess that)) return false;
         return value == that.value;

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/MaxNumberOfGuesses.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/MaxNumberOfGuesses.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.model;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 public class MaxNumberOfGuesses {
@@ -33,7 +34,7 @@ public class MaxNumberOfGuesses {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof MaxNumberOfGuesses that)) return false;
         return value == that.value;

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/domainevents/package-info.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/domainevents/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.model.domainevents;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/package-info.java
+++ b/example/domain/number-guessing-game/model/src/main/java/org/occurrent/example/domain/numberguessinggame/model/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/NumberGuessingGameCompleted.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/NumberGuessingGameCompleted.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver.integrationevent;
 
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -102,7 +103,7 @@ public class NumberGuessingGameCompleted {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof NumberGuessingGameCompleted that)) return false;
         return secretNumberToGuess == that.secretNumberToGuess &&
@@ -175,7 +176,7 @@ public class NumberGuessingGameCompleted {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof GuessedNumber that)) return false;
             return number == that.number &&

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/integrationevent/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver.integrationevent;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/gamestatus/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/gamestatus/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver.view.gamestatus;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/GameOverview.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/GameOverview.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver.view.latestgamesoverview;
 
+import org.jspecify.annotations.Nullable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -43,7 +44,7 @@ public class GameOverview {
             }
 
             @Override
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (this == o) return true;
                 if (!(o instanceof Ongoing ongoing)) return false;
                 return numberOfAttemptsLeft == ongoing.numberOfAttemptsLeft;
@@ -72,7 +73,7 @@ public class GameOverview {
             }
 
             @Override
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (this == o) return true;
                 if (!(o instanceof Ended ended)) return false;
                 return playerGuessedTheRightNumber == ended.playerGuessedTheRightNumber &&

--- a/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/native/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/nativedriver/view/latestgamesoverview/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.nativedriver.view.latestgamesoverview;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/pom.xml
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/pom.xml
@@ -28,6 +28,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>example-number-guessing-game-model</artifactId>
             <version>${project.version}</version>

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/api/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/api/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/config/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/config/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/infrastructure/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/infrastructure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.infrastructure;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/NumberGuessingGameCompleted.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/NumberGuessingGameCompleted.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
 
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -102,7 +103,7 @@ class NumberGuessingGameCompleted {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof NumberGuessingGameCompleted that)) return false;
         return secretNumberToGuess == that.secretNumberToGuess &&
@@ -175,7 +176,7 @@ class NumberGuessingGameCompleted {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof GuessedNumber that)) return false;
             return number == that.number &&

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/policy/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.policy;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/gamestatus/impl/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/gamestatus/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.gamestatus.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/gamestatus/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/gamestatus/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.gamestatus;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/GameOverview.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/GameOverview.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.latestgamesoverview;
 
+import org.jspecify.annotations.Nullable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -43,7 +44,7 @@ public class GameOverview {
             }
 
             @Override
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (this == o) return true;
                 if (!(o instanceof Ongoing ongoing)) return false;
                 return numberOfAttemptsLeft == ongoing.numberOfAttemptsLeft;
@@ -72,7 +73,7 @@ public class GameOverview {
             }
 
             @Override
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (this == o) return true;
                 if (!(o instanceof Ended ended)) return false;
                 return playerGuessedTheRightNumber == ended.playerGuessedTheRightNumber &&

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.latestgamesoverview.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/latestgamesoverview/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.latestgamesoverview;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/numberofstartedgames/package-info.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/view/numberofstartedgames/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.domain.numberguessinggame.mongodb.spring.blocking.view.numberofstartedgames;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/forwarder/mongodb-subscription-to-spring-event/pom.xml
+++ b/example/forwarder/mongodb-subscription-to-spring-event/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>subscription-mongodb-spring-reactor-position-storage</artifactId>
             <version>${project.version}</version>

--- a/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/package-info.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/main/java/org/occurrent/example/springevent/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.springevent;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/projection/global-position-catchup/pom.xml
+++ b/example/projection/global-position-catchup/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-inmemory</artifactId>
             <version>${project.version}</version>

--- a/example/projection/global-position-catchup/src/main/java/org/occurrent/example/projection/globalposition/package-info.java
+++ b/example/projection/global-position-catchup/src/main/java/org/occurrent/example/projection/globalposition/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.projection.globalposition;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/pom.xml
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-spring-blocking</artifactId>
             <version>${project.version}</version>

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/MostNumberOfWorkouts.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/MostNumberOfWorkouts.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.projections.adhoc;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -67,7 +68,7 @@ public class MostNumberOfWorkouts {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof PersonWithMostNumberOfWorkouts that)) return false;
             return count == that.count &&

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/WorkoutWasCompleted.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/WorkoutWasCompleted.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.projections.adhoc;
 
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonSerialize;
 import tools.jackson.core.JsonGenerator;
@@ -69,7 +70,7 @@ public class WorkoutWasCompleted {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof WorkoutWasCompleted that)) return false;
         return Objects.equals(eventId, that.eventId) &&

--- a/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/package-info.java
+++ b/example/projection/spring-adhoc-evenstore-mongodb-queries/src/main/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.eventstore.mongodb.spring.projections.adhoc;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/projection/spring-reactor-transactional-projection-mongodb/pom.xml
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-spring-reactor</artifactId>
             <version>${project.version}</version>

--- a/example/projection/spring-reactor-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/CurrentName.java
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/CurrentName.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.reactor.transactional;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -65,7 +66,7 @@ public class CurrentName {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CurrentName that)) return false;
         return Objects.equals(userId, that.userId) && Objects.equals(name, that.name);

--- a/example/projection/spring-reactor-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/package-info.java
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.eventstore.mongodb.spring.reactor.transactional;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/projection/spring-subscription-based-mongodb-projections/pom.xml
+++ b/example/projection/spring-subscription-based-mongodb-projections/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-spring-blocking</artifactId>
             <version>${project.version}</version>

--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentName.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/CurrentName.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.subscriptionprojections;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -64,7 +65,7 @@ public class CurrentName {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CurrentName that)) return false;
         return Objects.equals(id, that.id) &&

--- a/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/package-info.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/main/java/org/occurrent/example/eventstore/mongodb/spring/subscriptionprojections/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.eventstore.mongodb.spring.subscriptionprojections;
+
+import org.jspecify.annotations.NullMarked;

--- a/example/projection/spring-transactional-projection-mongodb/pom.xml
+++ b/example/projection/spring-transactional-projection-mongodb/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>eventstore-mongodb-spring-blocking</artifactId>
             <version>${project.version}</version>

--- a/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/CurrentName.java
+++ b/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/CurrentName.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.example.eventstore.mongodb.spring.transactional;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -64,7 +65,7 @@ public class CurrentName {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CurrentName that)) return false;
         return Objects.equals(id, that.id) &&

--- a/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/package-info.java
+++ b/example/projection/spring-transactional-projection-mongodb/src/main/java/org/occurrent/example/eventstore/mongodb/spring/transactional/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.example.eventstore.mongodb.spring.transactional;
+
+import org.jspecify.annotations.NullMarked;

--- a/framework/annotations/pom.xml
+++ b/framework/annotations/pom.xml
@@ -27,4 +27,12 @@
 
     <name>${mavenProjectName}</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/framework/annotations/src/main/java/org/occurrent/annotation/package-info.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/Jackson3CloudEventConverterConfiguration.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/Jackson3CloudEventConverterConfiguration.java
@@ -50,20 +50,17 @@ public class Jackson3CloudEventConverterConfiguration {
         CloudEventTypeMapper<E> typeMapper = cloudEventTypeMapper.orElseGet(ReflectionCloudEventTypeMapper::qualified);
         JacksonCloudEventConverter.Builder<E> builder = new JacksonCloudEventConverter.Builder<E>(om, occurrentProperties.getCloudEventConverter().getCloudEventSource())
                 .typeMapper(typeMapper);
-        ChronoUnit timePrecision = resolveTimePrecision(occurrentProperties);
-        if (timePrecision != null) {
-            builder.timePrecision(timePrecision);
-        }
+        resolveTimePrecision(occurrentProperties).ifPresent(builder::timePrecision);
         return builder.build();
     }
 
     // An explicit time-precision wins. Otherwise, when the event store uses TimeRepresentation.DATE (which cannot store
     // sub-millisecond precision), default to MILLIS so that Instant.now()/OffsetDateTime.now() values just work.
-    private static ChronoUnit resolveTimePrecision(OccurrentProperties occurrentProperties) {
+    private static Optional<ChronoUnit> resolveTimePrecision(OccurrentProperties occurrentProperties) {
         ChronoUnit configured = occurrentProperties.getCloudEventConverter().getTimePrecision();
         if (configured != null) {
-            return configured;
+            return Optional.of(configured);
         }
-        return occurrentProperties.getEventStore().getTimeRepresentation() == TimeRepresentation.DATE ? ChronoUnit.MILLIS : null;
+        return occurrentProperties.getEventStore().getTimeRepresentation() == TimeRepresentation.DATE ? Optional.of(ChronoUnit.MILLIS) : Optional.empty();
     }
 }

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/package-info.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.springboot.mongo.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/package-info.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.springboot.mongo.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/package-info.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.springboot.mongo.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/package-info.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.api.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/package-info.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.api.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/core/src/main/java/org/occurrent/subscription/CheckpointAwareCloudEvent.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/CheckpointAwareCloudEvent.java
@@ -104,7 +104,7 @@ public final class CheckpointAwareCloudEvent implements CloudEvent {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@org.jspecify.annotations.Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CheckpointAwareCloudEvent that)) return false;
         return Objects.equals(cloudEvent, that.cloudEvent) &&

--- a/subscription/core/src/main/java/org/occurrent/subscription/StringBasedCheckpoint.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/StringBasedCheckpoint.java
@@ -17,6 +17,7 @@
 package org.occurrent.subscription;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -33,7 +34,7 @@ public class StringBasedCheckpoint implements Checkpoint {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof StringBasedCheckpoint that)) return false;
         return Objects.equals(value, that.value);

--- a/subscription/core/src/main/java/org/occurrent/subscription/internal/package-info.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/core/src/main/java/org/occurrent/subscription/package-info.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
@@ -18,6 +18,7 @@ package org.occurrent.subscription.inmemory;
 
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.DurationToTimeoutConverter.Timeout;
@@ -74,7 +75,7 @@ public class InMemorySubscription implements Subscription, Runnable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof InMemorySubscription that)) return false;
         return shutdown == that.shutdown && Objects.equals(id, that.id) && Objects.equals(queue, that.queue) && Objects.equals(consumer, that.consumer) && Objects.equals(matcher, that.matcher) && Objects.equals(retryStrategy, that.retryStrategy);

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/package-info.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.inmemory;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoOperationTimeCheckpoint.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoOperationTimeCheckpoint.java
@@ -20,6 +20,7 @@ import org.bson.BsonTimestamp;
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
 
 import java.util.Objects;
@@ -42,7 +43,7 @@ public class MongoOperationTimeCheckpoint implements Checkpoint {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof MongoOperationTimeCheckpoint that)) return false;
         return Objects.equals(operationTime, that.operationTime);

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoResumeTokenCheckpoint.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/MongoResumeTokenCheckpoint.java
@@ -20,6 +20,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.Document;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
 
 import java.util.Objects;
@@ -42,7 +43,7 @@ public class MongoResumeTokenCheckpoint implements Checkpoint {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof MongoResumeTokenCheckpoint that)) return false;
         return Objects.equals(resumeToken, that.resumeToken);

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/package-info.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/package-info.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/package-info.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.blocking.ccs.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/native/blocking-competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
+++ b/subscription/mongodb/native/blocking-competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/native/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/package-info.java
+++ b/subscription/mongodb/native/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.nativedriver.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -439,7 +439,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof InternalSubscription that)) return false;
             return Objects.equals(filter, that.filter) && Objects.equals(startedLatch, that.startedLatch) && Objects.equals(stoppedLatch, that.stoppedLatch) && Objects.equals(cursor, that.cursor) && Objects.equals(currentStartAt, that.currentStartAt) && Objects.equals(action, that.action);

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/package-info.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.nativedriver.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/blocking-competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
+++ b/subscription/mongodb/spring/blocking-competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
+++ b/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
@@ -17,6 +17,7 @@
 package org.occurrent.subscription.mongodb.spring.blocking;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.api.blocking.Subscription;
 
@@ -76,7 +77,7 @@ public class SpringMongoSubscription implements Subscription {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof SpringMongoSubscription that)) return false;
         return shutdown == that.shutdown && Objects.equals(subscriptionId, that.subscriptionId) && Objects.equals(subscriptionReference, that.subscriptionReference);

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
@@ -409,7 +409,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (!(o instanceof InternalSubscription that)) return false;
             return Objects.equals(occurrentSubscription, that.occurrentSubscription) && Objects.equals(changeStreamRequestBuilder, that.changeStreamRequestBuilder);
@@ -440,7 +440,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
 
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof SpringMongoSubscriptionModel that)) return false;
         return restartSubscriptionsOnChangeStreamHistoryLost == that.restartSubscriptionsOnChangeStreamHistoryLost && shutdown == that.shutdown && Objects.equals(eventCollection, that.eventCollection) && Objects.equals(messageListenerContainer, that.messageListenerContainer) && Objects.equals(runningSubscriptions, that.runningSubscriptions) && Objects.equals(pausedSubscriptions, that.pausedSubscriptions) && timeRepresentation == that.timeRepresentation && Objects.equals(mongoOperations, that.mongoOperations) && Objects.equals(retryStrategy, that.retryStrategy);
     }

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/package-info.java
+++ b/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/package-info.java
+++ b/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/package-info.java
+++ b/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.mongodb.spring.reactor;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/redis/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/package-info.java
+++ b/subscription/redis/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.redis.spring.blocking;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -329,11 +329,11 @@ public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSu
         subscriptionModel.shutdown();
     }
 
-    public static boolean isTimeBasedCheckpoint(StartAt startAt) {
+    static boolean isTimeBasedCheckpoint(StartAt startAt) {
         return StreamCatchupSubscriptionModel.isTimeBasedCheckpoint(startAt, CatchupSubscriptionModel.class);
     }
 
-    public static boolean isTimeBasedCheckpoint(Checkpoint checkpoint) {
+    static boolean isTimeBasedCheckpoint(Checkpoint checkpoint) {
         return StreamCatchupSubscriptionModel.isTimeBasedCheckpoint(checkpoint);
     }
 

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/package-info.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
@@ -35,7 +35,7 @@ public class CompetingConsumerSubscription implements Subscription {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CompetingConsumerSubscription that)) return false;
         return Objects.equals(subscriptionId, that.subscriptionId) && Objects.equals(subscriberId, that.subscriberId) && Objects.equals(subscription, that.subscription);

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/package-info.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.blocking.competingconsumers;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelConfig.java
+++ b/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelConfig.java
@@ -18,6 +18,7 @@ package org.occurrent.subscription.blocking.durable;
 
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.util.predicate.EveryN;
 
 import java.util.Objects;
@@ -49,7 +50,7 @@ public class DurableSubscriptionModelConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof DurableSubscriptionModelConfig that)) return false;
         return Objects.equals(persistCloudEventPositionPredicate, that.persistCloudEventPositionPredicate);

--- a/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/package-info.java
+++ b/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.blocking.durable;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -17,6 +17,7 @@
 package org.occurrent.subscription.blocking.durable.catchup;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
 import org.occurrent.subscription.api.blocking.Subscription;
@@ -137,7 +138,7 @@ public class CatchupSubscriptionModelConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof CatchupSubscriptionModelConfig that)) return false;
         return cacheSize == that.cacheSize &&

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -100,7 +100,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      *                                      class here so a caller that pattern-matches on the public dispatcher type
      *                                      keeps working regardless of which mode-specific class runs the catch-up.
      */
-    public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType) {
+    StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType) {
         this(subscriptionModel, eventStoreQueries, config, subscriptionModelContextType, STREAM_CAPABILITY_FILTER);
     }
 
@@ -110,7 +110,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      *                        capability-agnostic subscription that delivers events of every capability, filtered only by
      *                        the caller's plain {@link Filter}.
      */
-    public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType, @Nullable Filter capabilityScope) {
+    StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType, @Nullable Filter capabilityScope) {
         super(subscriptionModel, config, subscriptionModelContextType);
         this.eventStoreQueries = Objects.requireNonNull(eventStoreQueries, "eventStoreQueries cannot be null");
         this.capabilityScope = capabilityScope;
@@ -134,7 +134,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      * Whether the wrapped store carries a global position. A store without {@link PositionOrderedReader}, or one that
      * reports {@code writesPosition()==false}, stays on the time-ordered catch-up path.
      */
-    public boolean streamStoreWritesPosition() {
+    private boolean streamStoreWritesPosition() {
         return eventStoreQueries instanceof PositionOrderedReader positionOrderedReader && positionOrderedReader.writesPosition();
     }
 
@@ -225,7 +225,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      * routing, which needs the same check before any mode-specific class is even chosen; {@code contextType} is the
      * class the dispatcher (or this class, standalone) reports to a caller-supplied {@code StartAt.dynamic}.
      */
-    public static boolean startsAtExplicitGlobalPosition(StartAt startAt, Class<?> contextType) {
+    static boolean startsAtExplicitGlobalPosition(StartAt startAt, Class<?> contextType) {
         StartAt start = startAt.get(new SubscriptionModelContext(contextType));
         return start instanceof StartAtCheckpoint position
                 && GlobalCheckpoint.isGlobalCheckpoint(position.checkpoint);
@@ -575,7 +575,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         subscriptionModel.shutdown();
     }
 
-    public static boolean isTimeBasedCheckpoint(StartAt startAt, Class<?> contextType) {
+    static boolean isTimeBasedCheckpoint(StartAt startAt, Class<?> contextType) {
         StartAt start = startAt.get(new SubscriptionModelContext(contextType));
         if (!(start instanceof StartAtCheckpoint position)) {
             return false;
@@ -585,7 +585,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         return isTimeBasedCheckpoint(checkpoint);
     }
 
-    public static boolean isTimeBasedCheckpoint(Checkpoint checkpoint) {
+    static boolean isTimeBasedCheckpoint(Checkpoint checkpoint) {
         return checkpoint instanceof TimeBasedCheckpoint ||
                 (checkpoint instanceof StringBasedCheckpoint && isRfc3339Timestamp(checkpoint.asString()));
     }

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/package-info.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/predicates/pom.xml
+++ b/subscription/util/predicates/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-api</artifactId>
         </dependency>

--- a/subscription/util/predicates/src/main/java/org/occurrent/subscription/util/predicate/package-info.java
+++ b/subscription/util/predicates/src/main/java/org/occurrent/subscription/util/predicate/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.util.predicate;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/package-info.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelConfig.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelConfig.java
@@ -18,6 +18,7 @@ package org.occurrent.subscription.reactor.durable;
 
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.util.predicate.EveryN;
 
 import java.util.Objects;
@@ -49,7 +50,7 @@ public class ReactorDurableSubscriptionModelConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (!(o instanceof ReactorDurableSubscriptionModelConfig that)) return false;
         return Objects.equals(persistCloudEventPositionPredicate, that.persistCloudEventPositionPredicate);

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/package-info.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.reactor.durable;
+
+import org.jspecify.annotations.NullMarked;

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/package-info.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import org.jspecify.annotations.NullMarked;

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -40,6 +40,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
         </dependency>

--- a/test-support/src/main/java/org/occurrent/command/package-info.java
+++ b/test-support/src/main/java/org/occurrent/command/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/test-support/src/main/java/org/occurrent/domain/Name.java
+++ b/test-support/src/main/java/org/occurrent/domain/Name.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.domain;
 
+import org.jspecify.annotations.Nullable;
 import org.occurrent.command.ChangeName;
 import org.occurrent.command.DefineName;
 import org.occurrent.time.TimeConversion;
@@ -48,10 +49,10 @@ public class Name {
         return changeName(events, UUID.randomUUID().toString(), changeName.time(), changeName.userId(), changeName.newName());
     }
 
-    public static List<DomainEvent> changeNameFromCurrent(String eventId, LocalDateTime time, String userId, String currentName, String newName) {
+    public static List<DomainEvent> changeNameFromCurrent(String eventId, LocalDateTime time, String userId, @Nullable String currentName, String newName) {
         if (Objects.equals(currentName, "John Doe")) {
             throw new IllegalArgumentException("Cannot change name from John Doe since this is the ultimate name");
-        } else if (currentName.isEmpty()) {
+        } else if (currentName == null || currentName.isEmpty()) {
             throw new IllegalArgumentException("Cannot change name because it is currently undefined");
         }
         return Collections.singletonList(new NameWasChanged(eventId, TimeConversion.toDate(time), userId, newName));

--- a/test-support/src/main/java/org/occurrent/domain/package-info.java
+++ b/test-support/src/main/java/org/occurrent/domain/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/test-support/src/main/java/org/occurrent/functional/package-info.java
+++ b/test-support/src/main/java/org/occurrent/functional/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.functional;
+
+import org.jspecify.annotations.NullMarked;

--- a/test-support/src/main/java/org/occurrent/testsupport/mongodb/package-info.java
+++ b/test-support/src/main/java/org/occurrent/testsupport/mongodb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.testsupport.mongodb;
+
+import org.jspecify.annotations.NullMarked;

--- a/test-support/src/main/java/org/occurrent/time/package-info.java
+++ b/test-support/src/main/java/org/occurrent/time/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.time;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## What

- Added package-level `@NullMarked` defaults across all main Java packages.
- Added optional `jspecify` dependencies to modules that now publish nullness metadata.
- Made existing nullable contracts explicit for retry results, decider and view state, optional CloudEvent time and subject values, nullable stream inputs, and reflective lookups.
- Removed Kotlin `qualifiedName` null assertions where Java class names give a non-null value directly.
- Updated `changelog.md`.

## Verification

- `rtk mvn -q -Pexamples-module test-compile`
- `rtk mvn -q -pl common/filter,common/retry,application/cloudevent-converter/jackson,application/cloudevent-converter/jackson3,dsl/decider,dsl/query-dsl/blocking,dsl/query-dsl/reactor,dsl/view-dsl,test-support -am test`
- `rtk mvn -q -pl dsl/dcb-dsl/blocking -am test-compile`
- `rtk git diff --cached --check`
