### PR TITLE
Fix capability-agnostic subscriptions throwing at startup on MongoDB

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,9 +22,9 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   that construct subscription filters directly.
 * Fixed the capability-agnostic `Subscriptions` DSL and `@Subscription` (ADR 0051) on the MongoDB stack. The MongoDB
   live subscription models (the Spring blocking and reactor models through their shared change-stream options builder,
-  and the native driver model) did not recognize the `AgnosticSubscriptionFilter` the agnostic DSL produces and threw
-  `Unrecognized SubscriptionFilter for MongoDB subscription` when the subscription started. They now apply its plain
-  `Filter` the same way a `StreamSubscriptionFilter` is applied.
+  and the native driver model) did not recognize the `AgnosticSubscriptionFilter` the agnostic DSL produces and threw an
+  `IllegalArgumentException` when the subscription started. They now apply its plain `Filter` the same way a
+  `StreamSubscriptionFilter` is applied.
 * Blocking catch-up subscriptions now run their replay handoff work on Java virtual threads instead of the common
   `ForkJoinPool`, avoiding common-pool starvation from blocking event-store reads and subscriber callbacks. The Spring
   Boot Mongo starter also honors `spring.threads.virtual.enabled=true` for its blocking Mongo subscription executor.

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,11 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 * Renamed `OccurrentSubscriptionFilter` to `StreamSubscriptionFilter` to make the stream-scoped subscription marker
   explicit next to `AgnosticSubscriptionFilter` and `DcbSubscriptionFilter`. This is a breaking API change for callers
   that construct subscription filters directly.
+* Fixed the capability-agnostic `Subscriptions` DSL and `@Subscription` (ADR 0051) on the MongoDB stack. The MongoDB
+  live subscription models (the Spring blocking and reactor models through their shared change-stream options builder,
+  and the native driver model) did not recognize the `AgnosticSubscriptionFilter` the agnostic DSL produces and threw
+  `Unrecognized SubscriptionFilter for MongoDB subscription` when the subscription started. They now apply its plain
+  `Filter` the same way a `StreamSubscriptionFilter` is applied.
 * Blocking catch-up subscriptions now run their replay handoff work on Java virtual threads instead of the common
   `ForkJoinPool`, avoiding common-pool starvation from blocking event-store reads and subscriber callbacks. The Spring
   Boot Mongo starter also honors `spring.threads.virtual.enabled=true` for its blocking Mongo subscription executor.

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -282,6 +282,12 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
             Filter streamFilter = streamSubscriptionFilter.filter();
             Bson bson = FilterToBsonFilterConverter.convertFilterToBsonFilter(MongoFilterSpecification.FULL_DOCUMENT, timeRepresentation, streamFilter);
             pipeline = Collections.singletonList(match(bson));
+        } else if (filter instanceof AgnosticSubscriptionFilter agnosticSubscriptionFilter) {
+            // Capability-agnostic: the change stream applies the plain Filter, the same as a stream filter. The stream
+            // versus DCB scoping lives in the catch-up layer, not here.
+            Filter agnosticFilter = agnosticSubscriptionFilter.filter();
+            Bson bson = FilterToBsonFilterConverter.convertFilterToBsonFilter(MongoFilterSpecification.FULL_DOCUMENT, timeRepresentation, agnosticFilter);
+            pipeline = Collections.singletonList(match(bson));
         } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
             pipeline = Collections.singletonList(DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.criteria()));
         } else if (filter instanceof MongoFilterSpecification.MongoJsonFilterSpecification jsonFilterSpecification) {

--- a/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/native/blocking/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModelTest.java
@@ -37,6 +37,7 @@ import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
 import org.occurrent.filter.Filter;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.retry.RetryStrategy;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.internal.ExecutorShutdown;
 import org.occurrent.subscription.mongodb.MongoFilterSpecification.MongoJsonFilterSpecification;
@@ -526,6 +527,82 @@ public class NativeMongoSubscriptionModelTest {
 
             Filter filter = Filter.id(nameDefined2.eventId()).and(type(NameDefined.class.getName()));
             subscriptionModel.subscribe(subscriberId, StreamSubscriptionFilter.filter(filter), state::add).waitUntilStarted();
+
+            // When
+            mongoEventStore.write("1", 0, serialize(nameDefined1));
+            mongoEventStore.write("1", 1, serialize(nameWasChanged1));
+            mongoEventStore.write("2", 0, serialize(nameDefined2));
+            mongoEventStore.write("2", 1, serialize(nameWasChanged2));
+
+            // Then
+            await().atMost(FIVE_SECONDS).until(state::size, is(1));
+            assertThat(state).extracting(CloudEvent::getId, CloudEvent::getType).containsOnly(tuple(nameDefined2.eventId(), NameDefined.class.getName()));
+        }
+    }
+
+    @Nested
+    @DisplayName("SubscriptionFilter using AgnosticSubscriptionFilter")
+    class AgnosticSubscriptionFilterTest {
+
+        @Test
+        void using_occurrent_subscription_filter_for_type() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriberId = UUID.randomUUID().toString();
+            subscriptionModel.subscribe(subscriberId, AgnosticSubscriptionFilter.filter(type(NameDefined.class.getName())), state::add).waitUntilStarted();
+            NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "name3");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(4), "name2", "name4");
+
+            // When
+            mongoEventStore.write("1", 0, serialize(nameDefined1));
+            mongoEventStore.write("1", 1, serialize(nameWasChanged1));
+            mongoEventStore.write("2", 0, serialize(nameDefined2));
+            mongoEventStore.write("2", 1, serialize(nameWasChanged2));
+
+            // Then
+            await().atMost(FIVE_SECONDS).until(state::size, is(2));
+            assertThat(state).extracting(CloudEvent::getType).containsOnly(NameDefined.class.getName());
+        }
+
+        @Test
+        void using_occurrent_subscription_filter_for_data() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriberId = UUID.randomUUID().toString();
+            subscriptionModel.subscribe(subscriberId, AgnosticSubscriptionFilter.filter(data("name", Condition.eq("name3"))), state::add).waitUntilStarted();
+            NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "name3");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(4), "name2", "name4");
+
+            // When
+            mongoEventStore.write("1", 0, serialize(nameDefined1));
+            mongoEventStore.write("1", 1, serialize(nameWasChanged1));
+            mongoEventStore.write("2", 0, serialize(nameDefined2));
+            mongoEventStore.write("2", 1, serialize(nameWasChanged2));
+
+            // Then
+            await().atMost(FIVE_SECONDS).until(state::size, is(1));
+            assertThat(state).extracting(CloudEvent::getId).containsOnly(nameWasChanged1.eventId());
+        }
+
+        @Test
+        void using_occurrent_subscription_filter_dsl_composition() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriberId = UUID.randomUUID().toString();
+            NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "name3");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(4), "name2", "name4");
+
+            Filter filter = Filter.id(nameDefined2.eventId()).and(type(NameDefined.class.getName()));
+            subscriptionModel.subscribe(subscriberId, AgnosticSubscriptionFilter.filter(filter), state::add).waitUntilStarted();
 
             // When
             mongoEventStore.write("1", 0, serialize(nameDefined1));

--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelTest.java
@@ -39,6 +39,7 @@ import org.occurrent.filter.Filter;
 import org.occurrent.functional.CheckedFunction;
 import org.occurrent.functional.Not;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.CheckpointAwareCloudEvent;
 import org.occurrent.subscription.StartAt;
@@ -651,6 +652,59 @@ public class SpringMongoSubscriptionModelTest {
 
             Filter filter = Filter.id(nameDefined2.eventId()).and(Filter.type(NameDefined.class.getName()));
             subscriptionModel.subscribe(subscriberId, StreamSubscriptionFilter.filter(filter), state::add).waitUntilStarted();
+
+            // When
+            mongoEventStore.write("1", 0, serialize(nameDefined1));
+            mongoEventStore.write("1", 1, serialize(nameWasChanged1));
+            mongoEventStore.write("2", 0, serialize(nameDefined2));
+            mongoEventStore.write("2", 1, serialize(nameWasChanged2));
+
+            // Then
+            await().atMost(FIVE_SECONDS).until(state::size, is(1));
+            assertThat(state).extracting(CloudEvent::getId, CloudEvent::getType).containsOnly(tuple(nameDefined2.eventId(), NameDefined.class.getName()));
+        }
+    }
+
+    @Nested
+    @DisplayName("SubscriptionFilter using AgnosticSubscriptionFilter")
+    class AgnosticSubscriptionFilterTest {
+
+        @Test
+        void using_occurrent_subscription_filter_for_type() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriberId = UUID.randomUUID().toString();
+            subscriptionModel.subscribe(subscriberId, AgnosticSubscriptionFilter.filter(Filter.type(NameDefined.class.getName())), state::add).waitUntilStarted();
+            NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "name3");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(4), "name2", "name4");
+
+            // When
+            mongoEventStore.write("1", 0, serialize(nameDefined1));
+            mongoEventStore.write("1", 1, serialize(nameWasChanged1));
+            mongoEventStore.write("2", 0, serialize(nameDefined2));
+            mongoEventStore.write("2", 1, serialize(nameWasChanged2));
+
+            // Then
+            await().atMost(FIVE_SECONDS).until(state::size, is(2));
+            assertThat(state).extracting(CloudEvent::getType).containsOnly(NameDefined.class.getName());
+        }
+
+        @Test
+        void using_occurrent_subscription_filter_dsl_composition() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();
+            String subscriberId = UUID.randomUUID().toString();
+            NameDefined nameDefined1 = new NameDefined(UUID.randomUUID().toString(), now, "name", "name1");
+            NameDefined nameDefined2 = new NameDefined(UUID.randomUUID().toString(), now.plusSeconds(2), "name2", "name2");
+            NameWasChanged nameWasChanged1 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(3), "name", "name3");
+            NameWasChanged nameWasChanged2 = new NameWasChanged(UUID.randomUUID().toString(), now.plusSeconds(4), "name2", "name4");
+
+            Filter filter = Filter.id(nameDefined2.eventId()).and(Filter.type(NameDefined.class.getName()));
+            subscriptionModel.subscribe(subscriberId, AgnosticSubscriptionFilter.filter(filter), state::add).waitUntilStarted();
 
             // When
             mongoEventStore.write("1", 0, serialize(nameDefined1));

--- a/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
+++ b/subscription/mongodb/spring/common/src/main/java/org/occurrent/subscription/mongodb/spring/internal/ApplyFilterToChangeStreamOptionsBuilder.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.filter.Filter;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilter;
@@ -52,6 +53,12 @@ public class ApplyFilterToChangeStreamOptionsBuilder {
         } else if (filter instanceof StreamSubscriptionFilter streamSubscriptionFilter) {
             Filter streamFilter = streamSubscriptionFilter.filter();
             Criteria criteria = convertFilterToCriteria(FULL_DOCUMENT, timeRepresentation, streamFilter);
+            changeStreamOptions = changeStreamOptionsBuilder.filter(newAggregation(match(criteria))).build();
+        } else if (filter instanceof AgnosticSubscriptionFilter agnosticSubscriptionFilter) {
+            // Capability-agnostic: the change stream applies the plain Filter, the same as a stream filter. The stream
+            // versus DCB scoping lives in the catch-up layer, not here.
+            Filter agnosticFilter = agnosticSubscriptionFilter.filter();
+            Criteria criteria = convertFilterToCriteria(FULL_DOCUMENT, timeRepresentation, agnosticFilter);
             changeStreamOptions = changeStreamOptionsBuilder.filter(newAggregation(match(criteria))).build();
         } else if (filter instanceof DcbSubscriptionFilter dcbSubscriptionFilter) {
             Document matchStage = DcbSubscriptionFilterConverter.toChangeStreamMatchStage(dcbSubscriptionFilter.criteria());


### PR DESCRIPTION
The capability-agnostic `Subscriptions` DSL and `@Subscription` (ADR 0051) produce an `AgnosticSubscriptionFilter`, but the MongoDB live subscription models never learned to handle it. Any agnostic subscription on the Mongo stack threw `IllegalArgumentException: Unrecognized SubscriptionFilter for MongoDB subscription` the moment the subscription started, so the whole application context failed to come up.

This reproduces on `main`, independent of the DcbDecider work. The word-guessing-game plain `dcb` example hits it: `SendEmailToWinner` subscribes through `org.occurrent.dsl.subscription.blocking.Subscriptions`, and `BootstrapContextTest`, `GameplayReadPathsTest`, and `GameplayUsecasesAndPoliciesTest` all failed to load their Spring context.

## The fix

At the change-stream level an agnostic subscription is just a plain `Filter`, the same as a stream subscription. The difference between stream, DCB, and agnostic is which events they are scoped to, and that scoping already lives in the catch-up layer, which handled `AgnosticSubscriptionFilter` since ADR 0051. Only the live change-stream builders were missing the case.

Both places that translate a `SubscriptionFilter` into a change-stream pipeline now handle `AgnosticSubscriptionFilter` by applying its inner `Filter` exactly as a `StreamSubscriptionFilter`:

- `ApplyFilterToChangeStreamOptionsBuilder` in `subscription-mongodb-spring-common`, which both the blocking `SpringMongoSubscriptionModel` and the reactor `ReactorMongoSubscriptionModel` share, so one branch covers both stacks.
- `NativeMongoSubscriptionModel` in the native driver, which has the same dispatch and the same gap.

## Verification

`mvn -Pexamples-module -pl :example-domain-word-guessing-game-es-mongodb-spring-dcb,subscription/mongodb/spring/blocking,subscription/mongodb/native/blocking -am test` is green, including the three example tests that previously failed to load their context. Colima env as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
