### PR TITLE
Fix broken Javadoc links and add ADR status lines

### DIFF
--- a/doc/architecture/decisions/0016-withdrawn-number-not-used.md
+++ b/doc/architecture/decisions/0016-withdrawn-number-not-used.md
@@ -1,0 +1,9 @@
+# 16. Withdrawn
+
+Date: 2026-07-07
+
+## Status
+
+Withdrawn
+
+This ADR number was not used.

--- a/doc/architecture/decisions/0029-rename-subscriptions-dsl-to-stream-subscriptions.md
+++ b/doc/architecture/decisions/0029-rename-subscriptions-dsl-to-stream-subscriptions.md
@@ -6,6 +6,8 @@ Date: 2026-06-28
 
 Accepted
 
+Superseded in part by ADR 0051
+
 ## Context
 
 The stream and DCB sides of the subscription API are named explicitly everywhere now: `@StreamSubscription` and `@DcbSubscription` (ADR 0026, ADR 0027), `StreamSubscriptionModel` and `DcbSubscriptionModel` (ADR 0024), and the DCB DSL `DcbSubscriptions`. The one name left behind is the stream subscription DSL itself, the Kotlin class `Subscriptions` and its builder `subscriptions(...)`. Next to `DcbSubscriptions` it reads as if it covers every subscription rather than the stream ones, the same lopsidedness the annotation rename fixed.

--- a/doc/architecture/decisions/0044-reactive-spring-boot-starter.md
+++ b/doc/architecture/decisions/0044-reactive-spring-boot-starter.md
@@ -6,6 +6,8 @@ Date: 2026-07-02
 
 Accepted
 
+Superseded in part by ADR 0045
+
 ## Context
 
 Occurrent had one Spring Boot starter, `spring-boot-starter-mongodb`, which wires the blocking stack: a `SpringMongoEventStore`, a competing-consumer durable catch-up subscription model, the blocking DSLs, the blocking application service, and annotation-driven subscriptions through `@StreamSubscription` and `@DcbSubscription`. The reactive (Project Reactor) stack was complete at the library level (event store, application service, query DSLs, subscription model with resilience and lifecycle, durable and DCB catch-up wrappers, position storage) but had no auto-configuration, so a reactive application had to hand-wire every bean.

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Subscription.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Subscription.java
@@ -172,8 +172,8 @@ public @interface Subscription {
          */
         SAME_AS_START_AT,
         /**
-         * Use the default resume behavior of the underlying subscription model. For example, if the {@link StartPosition} is set to {@link StartPosition#BEGINNING_OF_TIME},
-         * and {@code ResumeBehavior} is set to {@link ResumeBehavior#DEFAULT}, then the subscription will <i>start</i> from the beginning of time the first time it's run,
+         * Use the default resume behavior of the underlying subscription model. For example, if the {@link StartPosition} is set to {@link StartPosition#BEGINNING},
+         * and {@code ResumeBehavior} is set to {@link ResumeBehavior#DEFAULT}, then the subscription will <i>start</i> from the beginning the first time it's run,
          * then on application restart, it'll continue from the last received event (the checkpoint for the subscription) on restart.
          */
         DEFAULT
@@ -185,7 +185,7 @@ public @interface Subscription {
     enum StartupMode {
         /**
          * Occurrent will determine the startup mode based on the other properties of the subscription (such as {@link #startAt()} and {@link #resumeBehavior()}).
-         * It'll use {@link #BACKGROUND} if the subscription needs to replay historic events before subscribing to new ones (e.g. if {@link #startAt()} is {@link StartPosition#BEGINNING_OF_TIME}),
+         * It'll use {@link #BACKGROUND} if the subscription needs to replay historic events before subscribing to new ones (e.g. if {@link #startAt()} is {@link StartPosition#BEGINNING}),
          * otherwise {@link #WAIT_UNTIL_STARTED} will be used.
          */
         DEFAULT,


### PR DESCRIPTION
I fix two broken Javadoc links to a nonexistent StartPosition#BEGINNING_OF_TIME constant in `Subscription.java`. Both references are at lines 175 and 188 in the ResumeBehavior and StartupMode enum documentation. The StartPosition enum defines only BEGINNING, NOW, and DEFAULT, so these broken links fail doclint. I retarget both to `StartPosition#BEGINNING` since the surrounding prose clearly discusses replaying from the beginning.

I add superseded-in-part status lines to two ADRs. ADR 0029 decided that `Subscriptions` is a deprecated subclass of `StreamSubscriptions` for stream-only use. ADR 0051 revives it as the capability-neutral default, so I note the superseding. ADR 0044 decided that stream history replay fails in the reactive starter because no reactive stream catch-up model exists. ADR 0045 adds unified global position and enables reactive stream catch-up, so I note the superseding.

I create ADR 0016 as a withdrawn stub to fill the numbering gap in the ADR log.

Verification: `rtk mvn -pl framework/annotations -am compile` returns BUILD SUCCESS.