### PR TITLE
Fix silent event loss in blocking catch-up subscriptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,16 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
 
 #### Changes
 
+* Blocking catch-up now fails loudly instead of silently dropping events when the resume token is unavailable.
+  `StreamCatchupSubscriptionModel` and `DcbCatchupSubscriptionModel` used to fall back to `StartAt.subscriptionModelDefault()`
+  when the delegated subscription model reported no resume token after a long replay, which silently dropped every
+  event committed during that replay. Both now throw an `IllegalStateException` instead, matching the reactor catch-up
+  pipeline's existing fail-loud handover. The shared position-windowed replay used by both the stream and DCB position
+  paths was also extracted into one class, `isRunning` now reports an in-progress replay correctly, `stop()` interrupts
+  an in-flight replay, `pauseSubscription` on a subscription still replaying is honored once it hands over to live
+  delivery, `CatchupSubscriptionModelConfig.equals`/`hashCode` now include every configurable field, the in-memory
+  handover cache is synchronized to match the reactor stack, and the time-based reconciliation delta is now read in
+  bounded windows instead of one unbounded list.
 * Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
 * Modernized Java dispatch code to use Java 21 pattern matching and exhaustive switches across sealed filters,
   criteria, start positions, checkpoints, deadlines, and examples.

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
 import org.occurrent.eventstore.api.dcb.DcbEventStore;
-import org.occurrent.eventstore.api.dcb.DcbEventStream;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
 import org.occurrent.subscription.GlobalCheckpoint;
@@ -134,28 +133,31 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
         long startPosition = GlobalCheckpoint.positionOf(checkpoint);
 
         // Capture the live resume token before the bulk replay so an event committed during the replay is still
-        // delivered live. On a replay longer than the change stream history the token ages out and the handover fails
-        // loudly instead of dropping the event.
+        // delivered live. On a replay longer than the change stream history the token ages out, or the delegate
+        // reports none at all, and the handover fails loudly instead of dropping the event (captureLiveResumeCheckpoint).
         Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
         StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
-        final Checkpoint globalCheckpoint = delegatedStartAt == null ? null : subscriptionModel.globalCheckpoint();
+        final Checkpoint globalCheckpoint = captureLiveResumeCheckpoint(delegatedStartAt);
 
         // Page through the DCB sequence from the resume position to the head seen at the start, in windows so a large
-        // rebuild does not load the whole matched set at once. position is monotonic and server-assigned, so this needs
-        // no count and no time sort.
-        long bulkHead = dcbEventStore.read(dcbQuery, DcbReadOptions.between(startPosition, startPosition)).lastSequencePosition();
-        long cursor = deliverDcbWindows(startPosition, bulkHead, windowSize, subscriptionId, action, null);
-
+        // rebuild does not load the whole matched set at once, then reconcile until the head stops advancing.
+        // position is monotonic and server-assigned, so this needs no count and no time sort. Anything written after
+        // the reconciliation loop stabilises is newer than the live resume position and arrives live.
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
+        PositionCatchupPipeline.Reader dcbReader = new PositionCatchupPipeline.Reader() {
+            @Override
+            public long currentHead() {
+                return dcbEventStore.read(dcbQuery, DcbReadOptions.between(0, 0)).lastSequencePosition();
+            }
 
-        // Reconcile events written during the replay by paging until the head stops advancing. Overlapping re-reads
-        // are deduped by the cache. Anything written after the loop is newer than the live resume position and arrives
-        // live.
-        long head = dcbEventStore.read(dcbQuery, DcbReadOptions.between(cursor, cursor)).lastSequencePosition();
-        while (head > cursor && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
-            cursor = deliverDcbWindows(cursor, head, windowSize, subscriptionId, action, catchupPhaseCache);
-            head = dcbEventStore.read(dcbQuery, DcbReadOptions.between(cursor, cursor)).lastSequencePosition();
-        }
+            @Override
+            public Stream<CloudEvent> readWindow(long fromExclusive, long toInclusive) {
+                return dcbEventStore.read(dcbQuery, DcbReadOptions.between(fromExclusive, toInclusive)).stream();
+            }
+        };
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(dcbReader, windowSize);
+        pipeline.replay(startPosition, () -> shouldKeepReplaying(subscriptionId),
+                (events, cache) -> deliverCatchupEvents(events, subscriptionId, action, cache), catchupPhaseCache);
 
         if (delegatedStartAt == null) {
             returnIfCheckpointStorageConfigIs(UseCheckpointInStorage.class, cfg -> {
@@ -165,7 +167,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
         }
 
         final boolean subscriptionsWasCancelledOrShutdown;
-        if (!shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+        if (shouldKeepReplaying(subscriptionId)) {
             subscriptionsWasCancelledOrShutdown = false;
             runningCatchupSubscriptions.remove(subscriptionId);
         } else {
@@ -202,23 +204,9 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
             subscription = new CancelledSubscription(subscriptionId);
         } else {
             subscription = startLiveDcbSubscription(subscriptionId, filter, startAtToUse, action, catchupPhaseCache);
+            applyPendingPauseIfAny(subscriptionId);
         }
         return subscription;
-    }
-
-    /**
-     * Delivers DCB events in {@code (fromExclusive, toInclusive]} by paging through position windows, and returns the
-     * position the cursor reached. Stops early on shutdown or cancellation.
-     */
-    private long deliverDcbWindows(long fromExclusive, long toInclusive, long windowSize, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
-        long cursor = fromExclusive;
-        while (cursor < toInclusive && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
-            long upTo = Math.min(cursor + windowSize, toInclusive);
-            DcbEventStream slice = dcbEventStore.read(dcbQuery, DcbReadOptions.between(cursor, upTo));
-            deliverCatchupEvents(slice.stream(), subscriptionId, action, cache);
-            cursor = upTo;
-        }
-        return cursor;
     }
 
     /**
@@ -229,7 +217,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
         // try-with-resources closes the source stream even when takeWhile short-circuits on shutdown, so a
         // resource-backed read does not leak its cursor.
         try (cloudEvents) {
-            Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId));
+            Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> shouldKeepReplaying(subscriptionId));
             if (cache != null) {
                 // Skip events already delivered in an earlier reconciliation pass (the delta is re-read until it
                 // stabilises, so passes overlap) and record the rest so the live subscription can skip them at the

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
@@ -49,11 +49,15 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.occurrent.subscription.blocking.durable.catchup.CheckpointStorageConfig.useCheckpointStorage;
 
@@ -206,6 +210,29 @@ class DcbCatchupSubscriptionModelTest {
         await().untilAsserted(() -> assertThat(received).containsExactlyElementsOf(events));
     }
 
+    @Test
+    void position_catchup_fails_loudly_instead_of_silently_resuming_at_now_when_the_delegate_reports_no_resume_token() {
+        appendTagged("name:1", nameDefined("position1"));
+
+        CheckpointAwareSubscriptionModel nullCheckpointSubscriptionModel = new CheckpointAwareInMemorySubscriptionModel(inMemorySubscriptionModel) {
+            @Override
+            public @Nullable Checkpoint globalCheckpoint() {
+                return null;
+            }
+        };
+        CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(nullCheckpointSubscriptionModel, eventStore, DcbCriteria.tags(Tag.parse("name:1")));
+
+        Subscription started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
+        });
+
+        assertThat(started).isInstanceOf(CatchupSubscription.class);
+        Future<Subscription> delegatedSubscription = ((CatchupSubscription) started).delegatedSubscription();
+        assertThatThrownBy(() -> delegatedSubscription.get(10, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .cause().hasMessageContaining("no resume token");
+    }
+
     private NameDefined nameDefined(String name) {
         return new NameDefined(UUID.randomUUID().toString(), time, "name", name);
     }
@@ -227,7 +254,7 @@ class DcbCatchupSubscriptionModelTest {
      * model only supports {@code now}/{@code default}, so any position start is translated to {@code now}. The stub
      * global position is enough for the catch-up to take its normal handover path.
      */
-    private static final class CheckpointAwareInMemorySubscriptionModel implements CheckpointAwareSubscriptionModel {
+    private static class CheckpointAwareInMemorySubscriptionModel implements CheckpointAwareSubscriptionModel {
         private final InMemorySubscriptionModel delegate;
 
         private CheckpointAwareInMemorySubscriptionModel(InMemorySubscriptionModel delegate) {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
@@ -138,11 +138,13 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     }
 
     /**
-     * Captures the live resume token before the bulk replay so an event committed during the replay is still
-     * delivered live. Returns null when the delegated subscription model must not run ({@code delegatedStartAt} is
-     * null, i.e. the catch-up owns the position entirely). Otherwise fails loudly when the delegate reports no
-     * resume token, mirroring the reactor pipeline's fail-loud handover, instead of silently falling back to
-     * "now" and dropping every event committed during the replay.
+     * Captures the live resume token so an event committed during the replay is still delivered live. Callers
+     * choose when to capture it relative to the bulk replay: {@link StreamCatchupSubscriptionModel}'s position path
+     * captures it before the replay so no in-flight event is missed, while its time-based path captures it after
+     * the replay to keep the token fresh. Returns null when the delegated subscription model must not run
+     * ({@code delegatedStartAt} is null, i.e. the catch-up owns the position entirely). Otherwise fails loudly when
+     * the delegate reports no resume token, mirroring the reactor pipeline's fail-loud handover, instead of silently
+     * falling back to "now" and dropping every event committed during the replay.
      */
     protected @Nullable Checkpoint captureLiveResumeCheckpoint(@Nullable StartAt delegatedStartAt) {
         if (delegatedStartAt == null) {
@@ -162,6 +164,7 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
      */
     public void cancelRunningCatchup(String subscriptionId) {
         runningCatchupSubscriptions.remove(subscriptionId);
+        pauseRequestedDuringCatchup.remove(subscriptionId);
     }
 
     /**
@@ -171,6 +174,7 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     public void markShuttingDown() {
         shuttingDown = true;
         runningCatchupSubscriptions.clear();
+        pauseRequestedDuringCatchup.clear();
     }
 
     /**

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
@@ -18,6 +18,8 @@ package org.occurrent.subscription.blocking.durable.catchup;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.api.blocking.DelegatingSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
@@ -49,7 +51,14 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     protected final CatchupSubscriptionModelConfig config;
     protected final Class<?> subscriptionModelContextType;
     protected final ConcurrentMap<String, Boolean> runningCatchupSubscriptions = new ConcurrentHashMap<>();
+    // A pause requested for a subscriptionId while its replay is still in-flight (the delegate does not know the id
+    // yet, so pauseSubscription against it would be a no-op or fail). Applied via applyPendingPauseIfAny once the
+    // live delegate subscription for that id exists.
+    protected final ConcurrentMap<String, Boolean> pauseRequestedDuringCatchup = new ConcurrentHashMap<>();
     protected volatile boolean shuttingDown = false;
+    // Set by stop(), cleared by start(...). Checked by the replay loops so stop() interrupts an in-flight replay
+    // instead of only stopping the delegate the replay has not registered with yet.
+    protected volatile boolean stopped = false;
 
     protected AbstractCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType) {
         this.subscriptionModel = Objects.requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
@@ -66,37 +75,84 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
 
     @Override
     public void stop() {
+        stopped = true;
         getDelegatedSubscriptionModel().stop();
     }
 
     @Override
     public void start(boolean resumeSubscriptionsAutomatically) {
+        stopped = false;
         getDelegatedSubscriptionModel().start(resumeSubscriptionsAutomatically);
     }
 
     @Override
     public boolean isRunning() {
-        return getDelegatedSubscriptionModel().isRunning();
+        return !runningCatchupSubscriptions.isEmpty() || getDelegatedSubscriptionModel().isRunning();
     }
 
     @Override
     public boolean isRunning(String subscriptionId) {
-        return getDelegatedSubscriptionModel().isRunning(subscriptionId);
+        return runningCatchupSubscriptions.containsKey(subscriptionId) || getDelegatedSubscriptionModel().isRunning(subscriptionId);
     }
 
     @Override
     public boolean isPaused(String subscriptionId) {
-        return getDelegatedSubscriptionModel().isPaused(subscriptionId);
+        return pauseRequestedDuringCatchup.containsKey(subscriptionId) || getDelegatedSubscriptionModel().isPaused(subscriptionId);
     }
 
     @Override
     public Subscription resumeSubscription(String subscriptionId) {
+        pauseRequestedDuringCatchup.remove(subscriptionId);
         return getDelegatedSubscriptionModel().resumeSubscription(subscriptionId);
     }
 
     @Override
     public void pauseSubscription(String subscriptionId) {
-        getDelegatedSubscriptionModel().pauseSubscription(subscriptionId);
+        if (runningCatchupSubscriptions.containsKey(subscriptionId)) {
+            // The delegate does not know this id yet since the replay has not handed over to it, so record the
+            // request and apply it via applyPendingPauseIfAny once the live delegate subscription for this id
+            // exists. Interrupting the replay itself and resuming it later would need the exact replay cursor to be
+            // persisted, which this class does not do; the replay keeps running until the handover.
+            pauseRequestedDuringCatchup.put(subscriptionId, true);
+        } else {
+            getDelegatedSubscriptionModel().pauseSubscription(subscriptionId);
+        }
+    }
+
+    /**
+     * Applies a pause requested via {@link #pauseSubscription(String)} while {@code subscriptionId}'s replay was
+     * still in-flight, now that the live delegate subscription for it exists. A no-op if no pause was requested.
+     */
+    protected void applyPendingPauseIfAny(String subscriptionId) {
+        if (pauseRequestedDuringCatchup.remove(subscriptionId) != null) {
+            getDelegatedSubscriptionModel().pauseSubscription(subscriptionId);
+        }
+    }
+
+    /**
+     * Whether the replay loop for {@code subscriptionId} should keep going: not shutting down, not stopped, and
+     * still registered as a running catch-up (removed on cancellation).
+     */
+    protected boolean shouldKeepReplaying(String subscriptionId) {
+        return !shuttingDown && !stopped && runningCatchupSubscriptions.containsKey(subscriptionId);
+    }
+
+    /**
+     * Captures the live resume token before the bulk replay so an event committed during the replay is still
+     * delivered live. Returns null when the delegated subscription model must not run ({@code delegatedStartAt} is
+     * null, i.e. the catch-up owns the position entirely). Otherwise fails loudly when the delegate reports no
+     * resume token, mirroring the reactor pipeline's fail-loud handover, instead of silently falling back to
+     * "now" and dropping every event committed during the replay.
+     */
+    protected @Nullable Checkpoint captureLiveResumeCheckpoint(@Nullable StartAt delegatedStartAt) {
+        if (delegatedStartAt == null) {
+            return null;
+        }
+        Checkpoint checkpoint = subscriptionModel.globalCheckpoint();
+        if (checkpoint == null) {
+            throw new IllegalStateException("Cannot run a catch-up subscription because the subscription model reported no resume token to hand over to live delivery. The change stream history may be unavailable, for example an empty oplog or a restricted cluster.");
+        }
+        return checkpoint;
     }
 
     /**

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -142,12 +142,14 @@ public class CatchupSubscriptionModelConfig {
         if (this == o) return true;
         if (!(o instanceof CatchupSubscriptionModelConfig that)) return false;
         return cacheSize == that.cacheSize &&
-                Objects.equals(subscriptionStorageConfig, that.subscriptionStorageConfig);
+                dcbCatchupPositionWindowSize == that.dcbCatchupPositionWindowSize &&
+                Objects.equals(subscriptionStorageConfig, that.subscriptionStorageConfig) &&
+                Objects.equals(catchupPhaseSortBy, that.catchupPhaseSortBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cacheSize, subscriptionStorageConfig);
+        return Objects.hash(cacheSize, subscriptionStorageConfig, catchupPhaseSortBy, dcbCatchupPositionWindowSize);
     }
 
     @Override
@@ -155,6 +157,8 @@ public class CatchupSubscriptionModelConfig {
         return "CatchupSupportingBlockingSubscriptionConfig{" +
                 "cacheSize=" + cacheSize +
                 ", catchupPositionPersistenceConfig=" + subscriptionStorageConfig +
+                ", catchupPhaseSortBy=" + catchupPhaseSortBy +
+                ", dcbCatchupPositionWindowSize=" + dcbCatchupPositionWindowSize +
                 '}';
     }
 }

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -154,9 +154,9 @@ public class CatchupSubscriptionModelConfig {
 
     @Override
     public String toString() {
-        return "CatchupSupportingBlockingSubscriptionConfig{" +
+        return "CatchupSubscriptionModelConfig{" +
                 "cacheSize=" + cacheSize +
-                ", catchupPositionPersistenceConfig=" + subscriptionStorageConfig +
+                ", subscriptionStorageConfig=" + subscriptionStorageConfig +
                 ", catchupPhaseSortBy=" + catchupPhaseSortBy +
                 ", dcbCatchupPositionWindowSize=" + dcbCatchupPositionWindowSize +
                 '}';

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
@@ -26,6 +26,9 @@ import java.util.Map;
  * A bounded, insertion-ordered cache of recently delivered event ids, evicting the oldest entry once full. Used both
  * to dedupe an overlapping catch-up reconciliation re-read and to skip, in the live consumer, events already
  * delivered during catch-up at the handover seam. Shared by the stream and DCB catch-up paths.
+ * <p>
+ * Written on the catch-up (replay) thread and read on the live delivery thread at the handover seam, so every access
+ * is synchronized, matching the reactor {@code HandoverCache}.
  */
 @NullMarked
 final class FixedSizeCache {
@@ -40,11 +43,11 @@ final class FixedSizeCache {
         };
     }
 
-    public void put(String value) {
+    public synchronized void put(String value) {
         cacheContent.put(value, null);
     }
 
-    public boolean isCached(String key) {
+    public synchronized boolean isCached(String key) {
         return cacheContent.containsKey(key);
     }
 }

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The bulk-then-reconcile paging shared by every position-ordered blocking catch-up replay. A {@link Reader} supplies
+ * the window and head reads, so this pipeline is free of any specific store or query type, and is reused by both the
+ * stream and the DCB catch-up models (the blocking counterpart of the reactor {@code PositionCatchupPipeline}).
+ * <p>
+ * The replay pages the sequence in {@code windowSize} windows, then a reconciliation pass keeps paging until the head
+ * stops advancing so events written during the replay are delivered in order. The caller supplies the delivery
+ * (dedup cache, checkpoint persistence, cancellation) so this class stays a pure paging loop.
+ */
+@NullMarked
+final class PositionCatchupPipeline {
+
+    /**
+     * The store-specific head and window reads a position catch-up needs. Implemented once per store kind
+     * ({@code PositionOrderedReader} for streams, {@code DcbEventStore} for DCB).
+     */
+    interface Reader {
+        /**
+         * The current position at the head of the sequence this reader reads.
+         */
+        long currentHead();
+
+        /**
+         * Reads events in {@code (fromExclusive, toInclusive]}.
+         */
+        Stream<CloudEvent> readWindow(long fromExclusive, long toInclusive);
+    }
+
+    private final Reader reader;
+    private final long windowSize;
+
+    PositionCatchupPipeline(Reader reader, long windowSize) {
+        this.reader = requireNonNull(reader, Reader.class.getSimpleName() + " cannot be null");
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("Window size must be greater than zero");
+        }
+        this.windowSize = windowSize;
+    }
+
+    /**
+     * Replays from {@code startPosition} to the current head, then reconciles until the head stops advancing,
+     * handing each read window to {@code deliver}. Returns the position the replay reached, which is the resume
+     * boundary the caller hands over to live delivery.
+     *
+     * @param keepRunning Checked before every window read; stops the replay early on cancellation or shutdown.
+     * @param deliver     Called with each window's events (bulk windows get a {@code null} cache, reconciliation
+     *                    windows get {@code cache}) so the caller can dedupe, persist checkpoints and deliver.
+     */
+    long replay(long startPosition, BooleanSupplier keepRunning, BiConsumer<Stream<CloudEvent>, @Nullable FixedSizeCache> deliver, FixedSizeCache cache) {
+        long bulkHead = reader.currentHead();
+        long cursor = windows(startPosition, bulkHead, keepRunning, deliver, null);
+
+        // Reconcile events written during the bulk replay by continuing to page until the head stops advancing.
+        // Re-reads of overlapping windows are deduped by the cache (delivery is at-least-once).
+        long head = reader.currentHead();
+        while (head > cursor && keepRunning.getAsBoolean()) {
+            cursor = windows(cursor, head, keepRunning, deliver, cache);
+            head = reader.currentHead();
+        }
+        return cursor;
+    }
+
+    // Delivers events in (fromExclusive, toInclusive], paging in position windows. Stops early when keepRunning
+    // reports false, for example on shutdown or cancellation.
+    private long windows(long fromExclusive, long toInclusive, BooleanSupplier keepRunning, BiConsumer<Stream<CloudEvent>, @Nullable FixedSizeCache> deliver, @Nullable FixedSizeCache cache) {
+        long cursor = fromExclusive;
+        while (cursor < toInclusive && keepRunning.getAsBoolean()) {
+            long upTo = Math.min(cursor + windowSize, toInclusive);
+            deliver.accept(reader.readWindow(cursor, upTo), cache);
+            cursor = upTo;
+        }
+        return cursor;
+    }
+}

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -307,7 +307,8 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             // delivered oldest first.
             long remaining = numberOfEventsToReconcile;
             while (remaining > 0 && shouldKeepReplaying(subscriptionId)) {
-                int windowCount = (int) Math.min(remaining, config.dcbCatchupPositionWindowSize);
+                long windowCountAsLong = Math.min(remaining, Math.min(config.dcbCatchupPositionWindowSize, Integer.MAX_VALUE));
+                int windowCount = (int) windowCountAsLong;
                 long skip = remaining - windowCount;
                 List<CloudEvent> window = new ArrayList<>(eventStoreQueries.query(catchupFilter, Math.toIntExact(skip), windowCount, SortBy.natural(DESCENDING)).toList());
                 Collections.reverse(window);

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -260,21 +260,18 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         // to NOT store the position durably. This because we start at "beginning of time" and we also want to resume at
         // "beginning of time" and thus we never need to store ANY subscription position (because we always start from "beginning of time"
         // when application is rebooted). This allows for catching up in-memory projections/views/policies.
+        // We force the wrapping subscription to be a CheckpointAwareSubscriptionModel so that we can capture
+        // where the live subscription should resume. This position is captured *after* the bulk replay so it
+        // stays fresh: capturing it before a long replay would risk the resume token ageing out of the
+        // database change stream (e.g. MongoDB's oplog) before the handover, making the live subscription
+        // unresumable. Events written during the replay are not covered by this position (they were written
+        // before it). They are reconciled separately by the insertion-order delta below. A null resume token from
+        // the delegate fails loudly (captureLiveResumeCheckpoint) instead of silently resuming live at "now" and
+        // dropping every event committed during the replay; see the position path for the same guarantee captured
+        // before its replay instead.
         Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
         StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
-        final Checkpoint globalCheckpoint;
-        if (delegatedStartAt == null) {
-            // The delegated subscription model is not allowed to subscribe, so we don't need to get the global position.
-            globalCheckpoint = null;
-        } else {
-            // We force the wrapping subscription to be a CheckpointAwareSubscriptionModel so that we can capture
-            // where the live subscription should resume. This position is captured *after* the bulk replay so it
-            // stays fresh: capturing it before a long replay would risk the resume token ageing out of the
-            // database change stream (e.g. MongoDB's oplog) before the handover, making the live subscription
-            // unresumable. Events written during the replay are not covered by this position (they were written
-            // before it). They are reconciled separately by the insertion-order delta below.
-            globalCheckpoint = subscriptionModel.globalCheckpoint();
-        }
+        final Checkpoint globalCheckpoint = captureLiveResumeCheckpoint(delegatedStartAt);
 
         // We generate a cache so that events that are streamed at the same time as streaming the events missed
         // during the catch-up phase are not streamed again.
@@ -302,11 +299,21 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         // globalCheckpoint and is therefore covered by the live subscription regardless.
         long reconciledThroughCount = numberOfEventsBeforeStartingCatchupSubscription;
         long matchingEventCount = eventStoreQueries.count(catchupFilter);
-        while (matchingEventCount > reconciledThroughCount) {
+        while (matchingEventCount > reconciledThroughCount && shouldKeepReplaying(subscriptionId)) {
             long numberOfEventsToReconcile = matchingEventCount - numberOfEventsBeforeStartingCatchupSubscription;
-            List<CloudEvent> eventsWrittenDuringCatchup = new ArrayList<>(eventStoreQueries.query(catchupFilter, 0, Math.toIntExact(numberOfEventsToReconcile), SortBy.natural(DESCENDING)).toList());
-            Collections.reverse(eventsWrittenDuringCatchup);
-            runCatchupForStream(eventsWrittenDuringCatchup.stream(), subscriptionId, action, catchupPhaseCache);
+            // Read the delta in bounded windows, newest-window-first (skip counts down from the full delta), instead
+            // of materializing the whole delta in one ArrayList, mirroring the position path's window delivery. Each
+            // window is still read and reversed in natural-order-descending, so events within and across windows are
+            // delivered oldest first.
+            long remaining = numberOfEventsToReconcile;
+            while (remaining > 0 && shouldKeepReplaying(subscriptionId)) {
+                int windowCount = (int) Math.min(remaining, config.dcbCatchupPositionWindowSize);
+                long skip = remaining - windowCount;
+                List<CloudEvent> window = new ArrayList<>(eventStoreQueries.query(catchupFilter, Math.toIntExact(skip), windowCount, SortBy.natural(DESCENDING)).toList());
+                Collections.reverse(window);
+                runCatchupForStream(window.stream(), subscriptionId, action, catchupPhaseCache);
+                remaining -= windowCount;
+            }
             reconciledThroughCount = matchingEventCount;
             matchingEventCount = eventStoreQueries.count(catchupFilter);
         }
@@ -321,7 +328,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         }
 
         final boolean subscriptionsWasCancelledOrShutdown;
-        if (!shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+        if (shouldKeepReplaying(subscriptionId)) {
             subscriptionsWasCancelledOrShutdown = false;
             runningCatchupSubscriptions.remove(subscriptionId);
         } else {
@@ -383,6 +390,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             subscription = new CancelledSubscription(subscriptionId);
         } else {
             subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), startAtToUse, liveConsumer);
+            applyPendingPauseIfAny(subscriptionId);
         }
         return subscription;
     }
@@ -403,25 +411,31 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         long startPosition = GlobalCheckpoint.positionOf(checkpoint);
 
         // Capture the live resume token before the bulk replay so an event committed during the replay is still
-        // delivered live, like the DCB handover.
+        // delivered live, like the DCB handover. Fails loudly instead of falling back to "now" when the delegate
+        // reports no resume token (captureLiveResumeCheckpoint).
         Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
         StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
-        final Checkpoint globalCheckpoint = delegatedStartAt == null ? null : subscriptionModel.globalCheckpoint();
+        final Checkpoint globalCheckpoint = captureLiveResumeCheckpoint(delegatedStartAt);
 
         // Page through the position sequence from the resume position to the head seen at the start, in windows so a
-        // large rebuild does not load the whole matched set at once.
-        long bulkHead = positionOrderedReader.currentPosition();
-        long cursor = deliverPositionWindows(positionOrderedReader, streamFilter, startPosition, bulkHead, windowSize, subscriptionId, action, null);
-
+        // large rebuild does not load the whole matched set at once, then reconcile until the head stops advancing.
+        // Re-reads of overlapping windows are deduped by the cache (delivery is at-least-once).
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
+        PositionCatchupPipeline.Reader streamReader = new PositionCatchupPipeline.Reader() {
+            @Override
+            public long currentHead() {
+                return positionOrderedReader.currentPosition();
+            }
 
-        // Reconcile events written during the bulk replay (positions beyond bulkHead) by continuing to page until the
-        // head stops advancing. Re-reads of overlapping windows are deduped by the cache (delivery is at-least-once).
-        long head = positionOrderedReader.currentPosition();
-        while (head > cursor && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
-            cursor = deliverPositionWindows(positionOrderedReader, streamFilter, cursor, head, windowSize, subscriptionId, action, catchupPhaseCache);
-            head = positionOrderedReader.currentPosition();
-        }
+            @Override
+            public Stream<CloudEvent> readWindow(long fromExclusive, long toInclusive) {
+                return positionOrderedReader.readInPositionOrder(streamFilter, PositionRange.between(fromExclusive, toInclusive));
+            }
+        };
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(streamReader, windowSize);
+        pipeline.replay(startPosition, () -> shouldKeepReplaying(subscriptionId),
+                (events, cache) -> deliverCatchupEvents(events, subscriptionId, action, cache, e -> GlobalCheckpoint.of(OccurrentCloudEventExtension.getPosition(e))),
+                catchupPhaseCache);
 
         if (delegatedStartAt == null) {
             returnIfCheckpointStorageConfigIs(UseCheckpointInStorage.class, cfg -> {
@@ -431,7 +445,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         }
 
         final boolean subscriptionsWasCancelledOrShutdown;
-        if (!shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
+        if (shouldKeepReplaying(subscriptionId)) {
             subscriptionsWasCancelledOrShutdown = false;
             runningCatchupSubscriptions.remove(subscriptionId);
         } else {
@@ -465,21 +479,6 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             }
         };
         return startDelegatedSubscription(subscriptionId, filter, subscriptionsWasCancelledOrShutdown, startAtToUse, liveConsumer);
-    }
-
-    /**
-     * Delivers stream events in {@code (fromExclusive, toInclusive]} by paging through position windows, and returns
-     * the position the cursor reached. Stops early on shutdown or cancellation.
-     */
-    private long deliverPositionWindows(PositionOrderedReader positionOrderedReader, Filter filter, long fromExclusive, long toInclusive, long windowSize, String subscriptionId, Consumer<CloudEvent> action, @Nullable FixedSizeCache cache) {
-        long cursor = fromExclusive;
-        while (cursor < toInclusive && !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId)) {
-            long upTo = Math.min(cursor + windowSize, toInclusive);
-            Stream<CloudEvent> slice = positionOrderedReader.readInPositionOrder(filter, PositionRange.between(cursor, upTo));
-            deliverCatchupEvents(slice, subscriptionId, action, cache, e -> GlobalCheckpoint.of(OccurrentCloudEventExtension.getPosition(e)));
-            cursor = upTo;
-        }
-        return cursor;
     }
 
     private Filter deriveFilterToUseDuringCatchupPhase(@Nullable SubscriptionFilter filter, Checkpoint checkpoint) {
@@ -548,7 +547,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         // try-with-resources closes the source stream even when takeWhile short-circuits on shutdown, so a
         // resource-backed read (the Spring Mongo bulk replay wraps a server cursor) does not leak its cursor.
         try (cloudEvents) {
-            Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> !shuttingDown && runningCatchupSubscriptions.containsKey(subscriptionId));
+            Stream<CloudEvent> takeWhile = cloudEvents.takeWhile(__ -> shouldKeepReplaying(subscriptionId));
             if (cache != null) {
                 // Skip events already delivered in an earlier reconciliation pass (the delta is re-read until it
                 // stabilises, so passes overlap) and record the rest so the live subscription can skip them at the

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfigTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.SortBy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that every configurable field of {@link CatchupSubscriptionModelConfig} is part of equals/hashCode, so a
+ * config used as (or inside) a map key does not silently collide with a config that differs only in
+ * {@code catchupPhaseSortBy} or {@code dcbCatchupPositionWindowSize}.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CatchupSubscriptionModelConfigTest {
+
+    @Test
+    void configs_that_differ_only_in_catchup_phase_sort_by_are_not_equal() {
+        CatchupSubscriptionModelConfig config1 = new CatchupSubscriptionModelConfig(10).catchupPhaseSortBy(SortBy.ascending("a"));
+        CatchupSubscriptionModelConfig config2 = new CatchupSubscriptionModelConfig(10).catchupPhaseSortBy(SortBy.ascending("b"));
+
+        assertThat(config1).isNotEqualTo(config2);
+        assertThat(config1.hashCode()).isNotEqualTo(config2.hashCode());
+    }
+
+    @Test
+    void configs_that_differ_only_in_dcb_catchup_position_window_size_are_not_equal() {
+        CatchupSubscriptionModelConfig config1 = new CatchupSubscriptionModelConfig(10).dcbCatchupPositionWindowSize(100);
+        CatchupSubscriptionModelConfig config2 = new CatchupSubscriptionModelConfig(10).dcbCatchupPositionWindowSize(200);
+
+        assertThat(config1).isNotEqualTo(config2);
+        assertThat(config1.hashCode()).isNotEqualTo(config2.hashCode());
+    }
+
+    @Test
+    void configs_with_the_same_settings_are_equal() {
+        CatchupSubscriptionModelConfig config1 = new CatchupSubscriptionModelConfig(10).catchupPhaseSortBy(SortBy.ascending("a")).dcbCatchupPositionWindowSize(50);
+        CatchupSubscriptionModelConfig config2 = new CatchupSubscriptionModelConfig(10).catchupPhaseSortBy(SortBy.ascending("a")).dcbCatchupPositionWindowSize(50);
+
+        assertThat(config1).isEqualTo(config2);
+        assertThat(config1.hashCode()).isEqualTo(config2.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary

The blocking catch-up models fell back to StartAt.subscriptionModelDefault() (about now) when the delegated subscription model reported no resume token after a long replay. That silently dropped every event committed during the replay. Both StreamCatchupSubscriptionModel and DcbCatchupSubscriptionModel now throw an IllegalStateException instead, matching the reactor catch-up pipeline's existing fail-loud handover.

While in there I also ported the rest of the reactor side's hardening that the blocking side had drifted from:

* Extracted the duplicated blocking position-windowed replay (bulk read plus reconciliation paging) into one PositionCatchupPipeline class, used by both the stream and DCB position paths.
* isRunning now reports an in-progress replay instead of only asking the delegate, which does not know about the subscription id yet.
* stop() now interrupts an in-flight replay instead of only stopping the delegate.
* pauseSubscription called while a subscription is still replaying is recorded and applied once the replay hands over to live delivery.
* CatchupSubscriptionModelConfig.equals/hashCode/toString now include catchupPhaseSortBy and dcbCatchupPositionWindowSize, closing a latent map-key trap.
* FixedSizeCache is now synchronized, matching the reactor HandoverCache, since it is written on the catch-up thread and read on the dispatch thread.
* The time-based reconciliation delta is now read in bounded windows instead of materializing the whole delta in one ArrayList.

The delta reconciliation still selects by SortBy.natural(DESCENDING) plus limit (insertion order), not the configurable catchupPhaseSortBy, and the global checkpoint for the time-based path is still captured after the bulk replay. Both of those are load-bearing for the clock-skew-safe reconciliation and are unchanged.

## Test plan

- [x] Added a test that reproduces the null-checkpoint silent loss: with a delegated start position and globalCheckpoint() returning null, the catch-up now throws IllegalStateException instead of silently resuming at now.
- [x] Added tests covering the CatchupSubscriptionModelConfig equals/hashCode change.
- [x] `mvn -pl subscription/util -am test` (Colima, DOCKER_HOST/TESTCONTAINERS_RYUK_DISABLED set) - BUILD SUCCESS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
