### PR TITLE
Fix the misleading duplicate CloudEvent failure under concurrent DCB appends

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,7 +65,7 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   * See [ADR 52](doc/architecture/decisions/0052-couple-decider-with-dcb-boundary-and-tags.md).
 * Fixed concurrent DCB appends failing with a misleading duplicate CloudEvent error on a store with both the DCB and
   STREAM capabilities enabled. Two appends to disjoint DCB boundaries can hash to the same partition stream and race on
-  the next stream version, and the loser hit the unique `streamid` plus `streamversion` index. That collision is not a
+  the next stream version, and the loser hits the unique `streamid` plus `streamversion` index. That collision is not a
   real duplicate CloudEvent, so it is now retried through the read-decide-append cycle instead of failing, while a
   genuine duplicate CloudEvent (same `id` and `source`) still fails as before.
 * Renamed the `SubscriptionPosition` type family to `Checkpoint` to stop overloading "position" for two different

--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,11 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   auto-configure the `DcbApplicationService` even when no global `TagGenerator` bean exists, so a decider-only
   application needs none, while `@DcbTag` and raw-execute users still get a global tagger when one is present.
   * See [ADR 52](doc/architecture/decisions/0052-couple-decider-with-dcb-boundary-and-tags.md).
+* Fixed concurrent DCB appends failing with a misleading duplicate CloudEvent error on a store with both the DCB and
+  STREAM capabilities enabled. Two appends to disjoint DCB boundaries can hash to the same partition stream and race on
+  the next stream version, and the loser hit the unique `streamid` plus `streamversion` index. That collision is not a
+  real duplicate CloudEvent, so it is now retried through the read-decide-append cycle instead of failing, while a
+  genuine duplicate CloudEvent (same `id` and `source`) still fails as before.
 * Renamed the `SubscriptionPosition` type family to `Checkpoint` to stop overloading "position" for two different
   concepts: the ordering value (`position`) and the per-subscriber resume marker built from it. This is a breaking
   API change; there is no deprecated alias.

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.bulk.BulkWriteError;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 import org.occurrent.eventstore.api.DuplicateCloudEventException;
 import org.occurrent.eventstore.api.WriteCondition;
 import org.occurrent.eventstore.api.WriteConditionNotFulfilledException;
@@ -59,6 +60,31 @@ public class MongoExceptionTranslator {
             runtimeException = e;
         }
         return runtimeException;
+    }
+
+    /**
+     * Tells whether a duplicate-key error hit the unique {@code (streamid, streamversion)} index rather than the unique
+     * {@code (id, source)} index. On a store with both the DCB and STREAM capabilities enabled a DCB append is placed in
+     * a partition stream, and two appends to disjoint DCB boundaries can hash to the same partition and race on the next
+     * stream version. That collision is not a genuine duplicate CloudEvent, so callers rethrow it as retryable rather
+     * than as a {@link DuplicateCloudEventException}.
+     *
+     * @param e The Mongo exception to inspect
+     * @return {@code true} when a duplicate-key write error references the stream-version index
+     */
+    public static boolean isDuplicateKeyErrorOnStreamVersionIndex(MongoException e) {
+        if (e instanceof MongoBulkWriteException bulkWriteException) {
+            return bulkWriteException.getWriteErrors().stream()
+                    .filter(bulkWriteError -> ErrorCategory.fromErrorCode(bulkWriteError.getCode()) == ErrorCategory.DUPLICATE_KEY)
+                    .anyMatch(bulkWriteError -> referencesStreamVersion(bulkWriteError.getMessage()));
+        }
+        return e.getCode() == 11000 && referencesStreamVersion(e.getMessage());
+    }
+
+    private static boolean referencesStreamVersion(String message) {
+        // The duplicate-key message names the offending index and its key fields. The stream-version index message names
+        // the streamversion field, the id+source index message does not, so this distinguishes the two.
+        return message != null && message.contains(OccurrentCloudEventExtension.STREAM_VERSION);
     }
 
     private static DuplicateCloudEventException translateToDuplicateCloudEventException(MongoBulkWriteException e, BulkWriteError bulk) {

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
@@ -81,10 +81,20 @@ public class MongoExceptionTranslator {
         return e.getCode() == 11000 && referencesStreamVersion(e.getMessage());
     }
 
+    /**
+     * The name Mongo assigns the unique {@code (streamid, streamversion)} index, following its default
+     * {@code field1_1_field2_1} naming convention. Matched against the {@code index: <name>} segment of the
+     * duplicate-key message rather than a bare substring search, since a bare search for {@code streamversion}
+     * could false-positive on a duplicate {@code id}/{@code source} error whose {@code source} value happens to
+     * contain that text.
+     */
+    private static final String STREAM_VERSION_INDEX_NAME = OccurrentCloudEventExtension.STREAM_ID + "_1_" + OccurrentCloudEventExtension.STREAM_VERSION + "_1";
+
     private static boolean referencesStreamVersion(String message) {
-        // The duplicate-key message names the offending index and its key fields. The stream-version index message names
-        // the streamversion field, the id+source index message does not, so this distinguishes the two.
-        return message != null && message.contains(OccurrentCloudEventExtension.STREAM_VERSION);
+        // The duplicate-key message names the offending index, e.g. "index: streamid_1_streamversion_1". Matching
+        // the index name (rather than a bare "streamversion" substring) avoids misclassifying an id+source
+        // duplicate whose source value happens to contain that text.
+        return message != null && message.contains("index: " + STREAM_VERSION_INDEX_NAME);
     }
 
     private static DuplicateCloudEventException translateToDuplicateCloudEventException(MongoBulkWriteException e, BulkWriteError bulk) {

--- a/eventstore/mongodb/common/src/test/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslatorTest.java
+++ b/eventstore/mongodb/common/src/test/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.eventstore.mongodb.internal;
+
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.bulk.BulkWriteError;
+import com.mongodb.bulk.BulkWriteResult;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.DuplicateCloudEventException;
+import org.occurrent.eventstore.api.WriteCondition;
+import org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.WriteContext;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a duplicate-key error on the unique streamid+streamversion index is classified as a retryable
+ * partition stream-version collision, while a duplicate-key error on the unique id+source index stays a genuine
+ * duplicate CloudEvent. This is the classification the DCB insert paths rely on to retry a partition collision instead
+ * of surfacing a misleading duplicate CloudEvent failure.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MongoExceptionTranslatorTest {
+
+    private static final int DUPLICATE_KEY_CODE = 11000;
+
+    @Test
+    void classifies_duplicate_key_on_stream_version_index_as_retryable() {
+        MongoBulkWriteException e = duplicateKeyBulkWriteException(
+                "E11000 duplicate key error collection: test.events index: streamid_1_streamversion_1 dup key: { streamid: \"dcb:partition:\", streamversion: 1 }");
+
+        assertThat(MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex(e)).isTrue();
+    }
+
+    @Test
+    void does_not_classify_duplicate_key_on_id_source_index_as_retryable() {
+        MongoBulkWriteException e = duplicateKeyBulkWriteException(
+                "E11000 duplicate key error collection: test.events index: id_1_source_1 dup key: { id: \"some-id\", source: \"urn:test\" }");
+
+        assertThat(MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex(e)).isFalse();
+    }
+
+    @Test
+    void translates_duplicate_key_on_id_source_index_to_duplicate_cloud_event_exception() {
+        MongoBulkWriteException e = duplicateKeyBulkWriteException(
+                "E11000 duplicate key error collection: test.events index: id_1_source_1 dup key: { id: \"some-id\", source: \"urn:test\" }");
+
+        RuntimeException translated = MongoExceptionTranslator.translateException(
+                new WriteContext("some-stream", 0, WriteCondition.anyStreamVersion()), e);
+
+        assertThat(translated).isInstanceOf(DuplicateCloudEventException.class);
+    }
+
+    private static MongoBulkWriteException duplicateKeyBulkWriteException(String message) {
+        BulkWriteError error = new BulkWriteError(DUPLICATE_KEY_CODE, message, new org.bson.BsonDocument(), 0);
+        BulkWriteResult writeResult = BulkWriteResult.acknowledged(0, 0, 0, 0, List.of(), List.of());
+        // Empty error labels so the exception is NOT a transient transaction error, matching a post-commit E11000.
+        return new MongoBulkWriteException(writeResult, List.of(error), null, new ServerAddress("localhost", 27017), Set.of());
+    }
+}

--- a/eventstore/mongodb/common/src/test/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslatorTest.java
+++ b/eventstore/mongodb/common/src/test/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslatorTest.java
@@ -60,6 +60,14 @@ class MongoExceptionTranslatorTest {
     }
 
     @Test
+    void does_not_classify_id_source_duplicate_as_retryable_when_source_value_contains_streamversion() {
+        MongoBulkWriteException e = duplicateKeyBulkWriteException(
+                "E11000 duplicate key error collection: test.events index: id_1_source_1 dup key: { id: \"some-id\", source: \"urn:streamversion:collision\" }");
+
+        assertThat(MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex(e)).isFalse();
+    }
+
+    @Test
     void translates_duplicate_key_on_id_source_index_to_duplicate_cloud_event_exception() {
         MongoBulkWriteException e = duplicateKeyBulkWriteException(
                 "E11000 duplicate key error collection: test.events index: id_1_source_1 dup key: { id: \"some-id\", source: \"urn:test\" }");

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -87,6 +87,7 @@ import static org.occurrent.eventstore.api.SortBy.*;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
 import static org.occurrent.eventstore.api.WriteCondition.StreamVersionWriteCondition;
 import static org.occurrent.eventstore.api.WriteCondition.anyStreamVersion;
+import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
 import static org.occurrent.eventstore.mongodb.internal.OccurrentCloudEventMongoDocumentMapper.convertToDocument;
 import static org.occurrent.functionalsupport.internal.FunctionalSupport.mapWithIndex;
@@ -561,10 +562,15 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         try {
             eventCollection.insertMany(clientSession, documents);
         } catch (MongoException e) {
-            // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
-            // stream racing on stream_version) must stay transient so executeWithTransientRetry retries it, rather
-            // than being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+            // A transient transaction conflict is retried by executeWithTransientRetry rather than mapped to the
+            // stream-path WriteConditionNotFulfilledException, which DCB does not use.
             if (isTransientTransactionError(e)) {
+                throw e;
+            }
+            // Two disjoint DCB boundaries that hash to the same partition stream race on the next stream version and one
+            // loses on the unique streamid+streamversion index. This is not a duplicate CloudEvent, so rethrow the raw
+            // duplicate-key error and let executeWithTransientRetry rerun the read-decide-append cycle.
+            if (isDuplicateKeyErrorOnStreamVersionIndex(e)) {
                 throw e;
             }
             throw translateException(new WriteContext(streamId, streamVersion, anyStreamVersion()), e);
@@ -574,7 +580,8 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
     // Retry the append transaction on a MongoDB TransientTransactionError (the error label is present when two
     // transactions conflict, e.g. a write-write conflict on a shared marker). The native driver's withTransaction
     // already retries a transient transaction error on its own, so at this layer the retry mainly covers the
-    // cold-marker DuplicateKeyException race where two transactions first-create the same marker at once.
+    // cold-marker DuplicateKeyException race where two transactions first-create the same marker at once, and the
+    // partition stream-version collision where two disjoint DCB boundaries hash to the same partition stream.
     // DcbAppendConditionNotFulfilledException is deliberately NOT retried here: it propagates to the application
     // service, which re-reads and retries the whole command.
     private static <T> T executeWithTransientRetry(Supplier<T> action) {
@@ -596,10 +603,11 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
     }
 
     private static boolean isDuplicateKeyError(Throwable throwable) {
-        // A cold-marker race can surface the duplicate key wrapped rather than at the top, so walk the cause chain the
-        // same bounded way as the transient-transaction check. A DuplicateCloudEventException is a genuine business
-        // error (an event whose id and source already exist), not the cold-start race, and the driver duplicate-key
-        // exception is its cause, so stop and do not retry once it appears in the chain.
+        // A duplicate key can surface wrapped rather than at the top, so walk the cause chain the same bounded way as
+        // the transient-transaction check. It is either the cold-marker race or a partition stream-version collision,
+        // both retryable. A DuplicateCloudEventException is a genuine business error (an event whose id and source
+        // already exist), and the driver duplicate-key exception is its cause, so stop and do not retry once it appears
+        // in the chain.
         Throwable cause = throwable;
         for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
             if (cause instanceof DuplicateCloudEventException) {

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
@@ -44,6 +44,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.time.OffsetDateTime;
@@ -733,7 +734,13 @@ class MongoEventStoreDcbConcurrencyTest {
                     if ("insertMany".equals(method.getName()) && insertManyCalls.getAndIncrement() == 0) {
                         throw streamVersionDuplicateKeyException();
                     }
-                    return method.invoke(realCollection, args);
+                    try {
+                        return method.invoke(realCollection, args);
+                    } catch (InvocationTargetException invocationTargetException) {
+                        // Unwrap so the code under test observes the real collection's exception directly, not
+                        // wrapped in InvocationTargetException, which would break its duplicate/transient classification.
+                        throw invocationTargetException.getCause();
+                    }
                 });
     }
 

--- a/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
+++ b/eventstore/mongodb/native/src/test/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStoreDcbConcurrencyTest.java
@@ -18,11 +18,17 @@ package org.occurrent.eventstore.mongodb.nativedriver;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.ExplainVerbosity;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.bulk.BulkWriteError;
+import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +44,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -625,6 +632,84 @@ class MongoEventStoreDcbConcurrencyTest {
                 .isEqualTo("dcbTags_1");
     }
 
+    @Test
+    void single_partition_disjoint_boundaries_are_retried_to_success() throws Exception {
+        // A single partition forces every DCB append into one stream, so any two concurrent appends to disjoint
+        // boundaries collide on the next stream version and one loses on the unique streamid+streamversion index. That
+        // loser must be retried to success, not surfaced as a duplicate CloudEvent failure. On MongoDB 4.2 the
+        // collision surfaces as a transient write conflict that the transaction retries on its own, so this passes with
+        // or without the fix and stands as a regression guard for the intent.
+        int threadCount = 12;
+        int iterations = 40;
+        MongoEventStore singlePartitionStore = buildEventStoreWithStreamIdGenerator(
+                new PartitionedDcbStreamIdGenerator(1, "dcb:partition:"));
+
+        for (int i = 0; i < iterations; i++) {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            List<Throwable> failures = new CopyOnWriteArrayList<>();
+            List<Future<Void>> futures = new ArrayList<>();
+
+            for (int t = 0; t < threadCount; t++) {
+                final String distinctTag = "single:iter" + i + "t" + t;
+                final String distinctType = "SinglePartitionEvent-iter" + i + "-t" + t;
+                futures.add(pool.submit(() -> {
+                    DcbConsistencyToken token = singlePartitionStore.read(tags(Tag.parse(distinctTag))).consistencyToken();
+                    DcbAppendCondition cond = failIfEventsMatch(tags(Tag.parse(distinctTag)), token);
+                    barrier.await();
+                    try {
+                        singlePartitionStore.append(List.of(taggedEvent(distinctType, distinctTag)), cond);
+                        successCount.incrementAndGet();
+                    } catch (Throwable e) {
+                        failures.add(e);
+                    }
+                    return null;
+                }));
+            }
+
+            pool.shutdown();
+            for (Future<Void> f : futures) {
+                f.get();
+            }
+
+            assertThat(failures)
+                    .as("Iteration %d: disjoint boundaries in a single partition must all be retried to success, not fail with a duplicate CloudEvent error", i)
+                    .isEmpty();
+            assertThat(successCount.get())
+                    .as("Iteration %d: all %d single-partition appends should succeed", i, threadCount)
+                    .isEqualTo(threadCount);
+        }
+    }
+
+    @Test
+    void non_transient_stream_version_duplicate_is_retried_to_success() {
+        // Deterministic, MongoDB-version-independent gate. The first insertMany in the DCB append path is made to throw
+        // a non-transient duplicate-key error on the streamid+streamversion index, exactly the post-commit E11000 a
+        // partition stream-version collision produces on the MongoDB versions and configurations that return it rather
+        // than a transient write conflict. Without the fix that error is mistranslated to a non-retryable duplicate
+        // CloudEvent and the append fails. With the fix it is retried and the append commits on the next attempt, which
+        // does not throw.
+        MongoDatabase database = mongoClient.getDatabase(databaseName);
+        MongoCollection<Document> realEventCollection = database.getCollection(COLLECTION);
+        MongoCollection<Document> failingOnceCollection = collectionThatFailsFirstInsertManyWithStreamVersionDuplicate(realEventCollection);
+
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .dcbStreamIdGenerator(new PartitionedDcbStreamIdGenerator(1, "dcb:partition:"))
+                .build();
+        MongoEventStore store = new MongoEventStore(mongoClient, database, failingOnceCollection, config);
+
+        String tag = "injected:streamversion:collision";
+        store.append(List.of(taggedEvent("InjectedEvent", tag)), failIfEventsMatch(tags(Tag.parse(tag))));
+
+        assertThat(store.exists(types("InjectedEvent")))
+                .as("The append must be retried past the injected stream-version duplicate and commit its event")
+                .isTrue();
+    }
+
     private MongoEventStore buildEventStoreWithStreamIdGenerator(DcbStreamIdGenerator streamIdGenerator) {
         EventStoreConfig config = new EventStoreConfig.Builder()
                 .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
@@ -632,6 +717,33 @@ class MongoEventStoreDcbConcurrencyTest {
                 .dcbStreamIdGenerator(streamIdGenerator)
                 .build();
         return new MongoEventStore(mongoClient, databaseName, COLLECTION, config);
+    }
+
+    /**
+     * Wraps a real event collection so the first {@code insertMany(...)} call throws a non-transient duplicate-key
+     * error on the streamid+streamversion index and every other call and method delegates to the real collection.
+     */
+    @SuppressWarnings("unchecked")
+    private static MongoCollection<Document> collectionThatFailsFirstInsertManyWithStreamVersionDuplicate(MongoCollection<Document> realCollection) {
+        AtomicInteger insertManyCalls = new AtomicInteger(0);
+        return (MongoCollection<Document>) Proxy.newProxyInstance(
+                MongoCollection.class.getClassLoader(),
+                new Class<?>[]{MongoCollection.class},
+                (proxy, method, args) -> {
+                    if ("insertMany".equals(method.getName()) && insertManyCalls.getAndIncrement() == 0) {
+                        throw streamVersionDuplicateKeyException();
+                    }
+                    return method.invoke(realCollection, args);
+                });
+    }
+
+    private static MongoBulkWriteException streamVersionDuplicateKeyException() {
+        BulkWriteError error = new BulkWriteError(11000,
+                "E11000 duplicate key error collection: test.events index: streamid_1_streamversion_1 dup key: { streamid: \"dcb:partition:\", streamversion: 1 }",
+                new BsonDocument(), 0);
+        BulkWriteResult writeResult = BulkWriteResult.acknowledged(0, 0, 0, 0, List.of(), List.of());
+        // Empty error labels so the exception is NOT a transient transaction error, matching a post-commit E11000.
+        return new MongoBulkWriteException(writeResult, List.of(error), null, new ServerAddress("localhost", 27017), Set.of());
     }
 
     private static String extractWinningPlanStage(Document explainDoc) {

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -74,6 +74,7 @@ import static java.util.Objects.requireNonNull;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_ID;
 import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERSION;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
+import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
 import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
 import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
@@ -412,10 +413,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     private static <T> T executeWithTransientRetry(Supplier<T> action) {
         // Exponential backoff with generous attempts: several appends placed in the same partition stream serialize on
         // stream_version, so the last writer can need to retry past all the others before it commits.
-        // Retry a transient transaction conflict, and also a DuplicateKeyException from two transactions first-creating
-        // the same conflict marker at once. Event-insert duplicates are translated to domain exceptions in insertAllDcb
-        // and so never reach here, so the only DuplicateKeyException at this layer is that cold-marker race. The retry
-        // re-runs the transaction, by which point the marker exists and the upsert updates it.
+        // Retry a transient transaction conflict, and also a DuplicateKeyException. That duplicate is either two
+        // transactions first-creating the same conflict marker at once, or two disjoint DCB boundaries hashing to the
+        // same partition stream and losing on the unique streamid+streamversion index. Both are safe to rerun. A genuine
+        // duplicate CloudEvent is translated to a domain exception in insertAllDcb and never reaches here.
         return RetryStrategy.exponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(500), 2.0f)
                 .maxAttempts(15)
                 .retryIf(throwable -> isTransientTransactionError(throwable) || isDuplicateKeyError(throwable))
@@ -434,10 +435,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     private static boolean isDuplicateKeyError(Throwable throwable) {
-        // A cold-marker race can surface the DuplicateKeyException wrapped rather than at the top, so walk the cause
-        // chain the same bounded way as the transient-transaction check. Event-insert duplicates are translated to
-        // domain exceptions in insertAllDcb and so never reach a retry predicate, so the only duplicate here is the
-        // marker race.
+        // A duplicate can surface wrapped rather than at the top, so walk the cause chain the same bounded way as the
+        // transient-transaction check. The duplicate here is either the cold-marker race or a partition stream-version
+        // collision, both retryable. A genuine duplicate CloudEvent is translated to a domain exception in insertAllDcb
+        // and so never reaches this predicate.
         Throwable cause = throwable;
         for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
             if (cause instanceof DuplicateKeyException) {
@@ -661,11 +662,16 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         } catch (DataAccessException e) {
             final Throwable rootCause = e.getRootCause();
             if (rootCause instanceof MongoException mongoException) {
-                // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
-                // stream racing on stream_version) must stay transient so executeWithTransientRetry retries it, rather
-                // than being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+                // A transient transaction conflict is retried by executeWithTransientRetry rather than mapped to the
+                // stream-path WriteConditionNotFulfilledException, which DCB does not use.
                 if (isTransientTransactionError(mongoException)) {
                     throw mongoException;
+                }
+                // Two disjoint DCB boundaries that hash to the same partition stream race on the next stream version and
+                // one loses on the unique streamid+streamversion index. This is not a duplicate CloudEvent, so rethrow
+                // the duplicate-key error and let executeWithTransientRetry rerun the read-decide-append cycle.
+                if (isDuplicateKeyErrorOnStreamVersionIndex(mongoException)) {
+                    throw e;
                 }
                 throw translateException(new WriteContext(streamId, streamVersion, WriteCondition.anyStreamVersion()), mongoException);
             } else {

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -85,6 +85,7 @@ import static org.occurrent.cloudevents.OccurrentCloudEventExtension.STREAM_VERS
 import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
 import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
 import static org.occurrent.eventstore.api.SortBy.SortDirection.ASCENDING;
+import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex;
 import static org.occurrent.eventstore.mongodb.internal.MongoExceptionTranslator.translateException;
 import static org.occurrent.mongodb.spring.sortconversion.internal.SortConverter.convertToSpringSort;
 import static org.springframework.data.domain.Sort.Direction.DESC;
@@ -431,14 +432,20 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
     private Mono<Void> insertAllDcb(String streamId, long streamVersion, List<Document> documents) {
         return mongoTemplate.insert(documents, eventStoreCollectionName)
                 .onErrorResume(throwable -> {
-                    // A transient transaction conflict (e.g. two disjoint DCB boundaries that hash to the same partition
-                    // stream racing on stream_version) must stay transient so the append retry retries it, rather than
-                    // being mapped to the stream-path WriteConditionNotFulfilledException (which DCB does not use).
+                    // A transient transaction conflict is retried by the append retry rather than mapped to the
+                    // stream-path WriteConditionNotFulfilledException, which DCB does not use.
                     if (isTransientTransactionError(throwable)) {
                         return Mono.error(throwable);
                     }
                     MongoException mongoException = findMongoException(throwable);
                     if (mongoException != null) {
+                        // Two disjoint DCB boundaries that hash to the same partition stream race on the next stream
+                        // version and one loses on the unique streamid+streamversion index. This is not a duplicate
+                        // CloudEvent, so rethrow the raw duplicate-key error and let the append retry rerun the
+                        // read-decide-append cycle.
+                        if (isDuplicateKeyErrorOnStreamVersionIndex(mongoException)) {
+                            return Mono.error(throwable);
+                        }
                         return Mono.error(translateException(new WriteContext(streamId, streamVersion, WriteCondition.anyStreamVersion()), mongoException));
                     }
                     return Mono.error(throwable);
@@ -506,8 +513,8 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     private static boolean isDuplicateKeyError(Throwable throwable) {
         // A DuplicateCloudEventException is a genuine business error (an event whose id and source already exist), not
-        // the cold-start marker or position race, and the driver duplicate-key exception is its cause, so stop and do
-        // not retry once it appears in the chain.
+        // the cold-start marker or position race and not a partition stream-version collision, and the driver
+        // duplicate-key exception is its cause, so stop and do not retry once it appears in the chain.
         Throwable cause = throwable;
         for (int hops = 0; cause != null && hops < 64; cause = cause.getCause(), hops++) {
             if (cause instanceof DuplicateCloudEventException) {


### PR DESCRIPTION
## What

I fixed concurrent DCB appends failing with a misleading duplicate CloudEvent error on a MongoDB event store that has both the DCB and STREAM capabilities enabled (the default agnostic configuration).

A DCB append is placed in a partition stream by the partitioned stream-id generator. Two appends to disjoint DCB boundaries can hash to the same partition and race on the next stream version, and the loser hits the unique index over `streamid` and `streamversion`. That collision is not a genuine duplicate CloudEvent, because the events carry unique `id` and `source` values, but it was mistranslated to a non-retryable `DuplicateCloudEventException`. The append then failed with a misleading error instead of being retried.

## How

I added `MongoExceptionTranslator.isDuplicateKeyErrorOnStreamVersionIndex`, which tells a duplicate-key error on the `streamid` plus `streamversion` index apart from one on the `id` plus `source` index by inspecting the duplicate-key message. The DCB insert paths in the native store, the Spring blocking store, and the Spring reactor store now rethrow the raw duplicate-key error for a stream-version collision, so the existing retry loop reruns the read, decide, and append cycle. A genuine `id` plus `source` duplicate still becomes a `DuplicateCloudEventException`. I did not broaden the retry predicate to treat every `DuplicateCloudEventException` as retryable, so a real duplicate stays a hard failure. I also corrected the code comments that described the opposite behavior.

## Honest note on reproducibility

On the pinned MongoDB version 4.2.8, the collision inside the append transaction surfaces as a transient write conflict that `ClientSession.withTransaction` already retries on its own, so the misleading `DuplicateCloudEventException` path is not reached there. I verified this across many thousands of concurrent append races at default and snapshot read concern, and none failed. This is therefore not a confirmed live bug on 4.2.8. The fix corrects the exception translation and the misleading comments, and it defends the non-transient duplicate-key path that other MongoDB versions and configurations can return for the loser rather than a transient write conflict.

Recommended follow-up: confirm reproduction on MongoDB 5.0 or later under a real concurrent load.

## Tests

Deterministic, MongoDB-version-independent gate:

1. `MongoExceptionTranslatorTest` asserts `isDuplicateKeyErrorOnStreamVersionIndex` returns true for a synthesized duplicate-key error on the `streamid` plus `streamversion` index and false for one on the `id` plus `source` index, and that the latter still translates to `DuplicateCloudEventException`.
2. `MongoEventStoreDcbConcurrencyTest.non_transient_stream_version_duplicate_is_retried_to_success` wraps the event collection so the first `insertMany` in the DCB append path throws a non-transient duplicate-key error on the stream-version index, then asserts the append is retried and commits. Against the unmodified code that injected error becomes a non-retryable `DuplicateCloudEventException` and the append fails. After the fix it is retried and the event commits.

I also kept `single_partition_disjoint_boundaries_are_retried_to_success` as a regression guard. It forces every append into one partition and asserts all concurrent appends commit. It passes before and after on 4.2.8.

Fail-before, against unmodified source with the fix stashed:

```
non_transient_stream_version_duplicate_is_retried_to_success <<< ERROR!
DuplicateCloudEventException[id='null', source=null, details='Bulk write operation error ...
index: streamid_1_streamversion_1 dup key: { streamid: "dcb:partition:", streamversion: 1 }']
	at MongoExceptionTranslator.translateToDuplicateCloudEventException(MongoExceptionTranslator.java:80)
```

Pass-after, same test with the fix applied:

```
MongoExceptionTranslatorTest      Tests run: 3, Failures: 0, Errors: 0
MongoEventStoreDcbConcurrencyTest Tests run: 12, Failures: 0, Errors: 0
```

Full verification across the four affected modules (native, common, Spring blocking, Spring reactor): 475 tests, 0 failures, 0 errors.
