### PR TITLE
Fix duplicate flood and reconcile livelock in catch-up handover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,20 @@ DCB is a capability layered on the existing CloudEvent storage, not a new store 
   delivery, `CatchupSubscriptionModelConfig.equals`/`hashCode` now include every configurable field, the in-memory
   handover cache is synchronized to match the reactor stack, and the time-based reconciliation delta is now read in
   bounded windows instead of one unbounded list.
+* The catch-up-to-live handover dedup now scales to the during-replay overlap with a configurable ceiling, so a large
+  rebuild with heavy concurrent writes gets far fewer duplicate deliveries while delivery stays at-least-once. The
+  dedup id set previously capped at a fixed size (1000 in the reactor models, 100 in the blocking models) and, once the
+  overlap the live subscription re-delivers grew past that cap, evicted ids the live stream then re-delivered as
+  duplicates. It now grows to cover that overlap (bounded by the write volume during the replay, not by total history)
+  up to a ceiling that defaults to 100000 and is configurable through the catch-up config. Exceeding the ceiling only
+  yields extra duplicates, never loss, and dedup stays keyed by id so a low-position event that commits late is still
+  delivered by the live stream. Both the reactor and blocking stream and DCB catch-up paths get this.
+* Catch-up reconcile no longer livelocks under sustained writes. The reconciliation pass that drains events written
+  during the bulk replay used to re-read the store head after every window and keep paging until the head stopped
+  advancing, so a continuous write rate meant it never handed over to live delivery. It now snapshots the head once at
+  reconcile start and drains up to that snapshot, then hands over to live. Anything committed after the snapshot is
+  delivered by the live subscription, which resumes from the pre-bulk token, so the change loses nothing. Both the
+  reactor and blocking stream and DCB catch-up paths get this.
 * Occurrent now requires Java 21 instead of Java 17. This raises the minimum JDK needed to build and run Occurrent. Stored data is unaffected, so an existing application only needs to move its runtime to Java 21.
 * Modernized Java dispatch code to use Java 21 pattern matching and exhaustive switches across sealed filters,
   criteria, start positions, checkpoints, deadlines, and examples.

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -104,7 +104,7 @@ import java.util.function.Consumer;
 @NullMarked
 public class CatchupSubscriptionModel implements SubscriptionModel, DelegatingSubscriptionModel {
 
-    private static final int DEFAULT_CACHE_SIZE = 100;
+    private static final int DEFAULT_CACHE_SIZE = CatchupSubscriptionModelConfig.DEFAULT_HANDOVER_CACHE_SIZE;
 
     private final CheckpointAwareSubscriptionModel subscriptionModel;
     private final @Nullable StreamCatchupSubscriptionModel streamCatchupSubscriptionModel;

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -35,6 +35,22 @@ public class CatchupSubscriptionModelConfig {
 
     static final long DEFAULT_DCB_CATCHUP_POSITION_WINDOW_SIZE = 1000;
 
+    /**
+     * Default ceiling on the number of event ids kept to deduplicate the catch-up-to-live handover seam, used by the
+     * convenience constructors that do not take an explicit {@code cacheSize}. The dedup cache grows to cover the
+     * overlap the live subscription re-delivers (bounded by the write volume during the replay, not by total history)
+     * and evicts oldest-first only once it would exceed this ceiling. Exceeding it yields extra duplicate deliveries,
+     * never loss (delivery is at-least-once). It is well above the previous {@code 100} so a rebuild with heavy
+     * concurrent writes no longer evicts the overlap before the live subscription re-delivers it. Each id is a short
+     * string, so lower it to cap memory or raise it to cut duplicates further.
+     */
+    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
+
+    /**
+     * The ceiling on the number of CloudEvent ids kept in-memory to deduplicate the switch from catch-up mode to
+     * live subscription mode. The cache grows to cover the overlap the live subscription re-delivers up to this
+     * ceiling, then evicts oldest-first. Exceeding the ceiling yields extra duplicate deliveries, never loss.
+     */
     public final int cacheSize;
     public final CheckpointStorageConfig subscriptionStorageConfig;
     public final SortBy catchupPhaseSortBy;
@@ -63,7 +79,7 @@ public class CatchupSubscriptionModelConfig {
      * @param subscriptionStorageConfig Configures if and how checkpoint persistence should be handled during the catch-up phase.
      */
     public CatchupSubscriptionModelConfig(CheckpointStorageConfig subscriptionStorageConfig) {
-        this(100, subscriptionStorageConfig);
+        this(DEFAULT_HANDOVER_CACHE_SIZE, subscriptionStorageConfig);
     }
 
     /**

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
@@ -23,9 +23,16 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * A bounded, insertion-ordered cache of recently delivered event ids, evicting the oldest entry once full. Used both
- * to dedupe an overlapping catch-up reconciliation re-read and to skip, in the live consumer, events already
- * delivered during catch-up at the handover seam. Shared by the stream and DCB catch-up paths.
+ * An insertion-ordered cache of delivered event ids that grows to cover the replay-to-live overlap up to {@code size},
+ * evicting oldest-first once it would exceed it. Used both to dedupe an overlapping catch-up reconciliation re-read and
+ * to skip, in the live consumer, events already delivered during catch-up at the handover seam. Shared by the stream
+ * and DCB catch-up paths. The overlap it must cover is bounded by the write volume during the replay (the live change
+ * stream resumes from a recent token, not from history), not by total history.
+ * <p>
+ * Eviction is loss-safe by construction: dropping an id can only stop a re-delivered live event from being suppressed,
+ * so an overlap larger than {@code size} yields extra duplicate deliveries, never loss (delivery is at-least-once).
+ * Dedup is by id, never by position, so a low-position event that commits late (after the handover advanced past its
+ * position) is never in this cache and is always delivered by the live subscription.
  * <p>
  * Written on the catch-up (replay) thread and read on the live delivery thread at the handover seam, so every access
  * is synchronized, matching the reactor {@code HandoverCache}.

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
@@ -31,9 +31,11 @@ import static java.util.Objects.requireNonNull;
  * the window and head reads, so this pipeline is free of any specific store or query type, and is reused by both the
  * stream and the DCB catch-up models (the blocking counterpart of the reactor {@code PositionCatchupPipeline}).
  * <p>
- * The replay pages the sequence in {@code windowSize} windows, then a reconciliation pass keeps paging until the head
- * stops advancing so events written during the replay are delivered in order. The caller supplies the delivery
- * (dedup cache, checkpoint persistence, cancellation) so this class stays a pure paging loop.
+ * The replay pages the sequence in {@code windowSize} windows, then a single reconciliation pass drains up to a head
+ * snapshotted once at reconcile start so events written during the replay are delivered in order. It does not chase a
+ * moving head, which under sustained writes would never terminate, so anything committed after the snapshot head is
+ * left to the live subscription (resuming from the pre-bulk token), deduped by the caller's cache. The caller supplies
+ * the delivery (dedup cache, checkpoint persistence, cancellation) so this class stays a pure paging loop.
  */
 @NullMarked
 final class PositionCatchupPipeline {
@@ -66,9 +68,9 @@ final class PositionCatchupPipeline {
     }
 
     /**
-     * Replays from {@code startPosition} to the current head, then reconciles until the head stops advancing,
-     * handing each read window to {@code deliver}. Returns the position the replay reached, which is the resume
-     * boundary the caller hands over to live delivery.
+     * Replays from {@code startPosition} to the current head, then reconciles once up to a head snapshotted at
+     * reconcile start (it does not chase a moving head), handing each read window to {@code deliver}. Returns the
+     * position the replay reached, which is the resume boundary the caller hands over to live delivery.
      *
      * @param keepRunning Checked before every window read; stops the replay early on cancellation or shutdown.
      * @param deliver     Called with each window's events (bulk windows get a {@code null} cache, reconciliation
@@ -78,13 +80,15 @@ final class PositionCatchupPipeline {
         long bulkHead = reader.currentHead();
         long cursor = windows(startPosition, bulkHead, keepRunning, deliver, null);
 
-        // Reconcile events written during the bulk replay by continuing to page until the head stops advancing.
-        // Re-reads of overlapping windows are deduped by the cache (delivery is at-least-once).
-        long head = reader.currentHead();
-        while (head > cursor && keepRunning.getAsBoolean()) {
-            cursor = windows(cursor, head, keepRunning, deliver, cache);
-            head = reader.currentHead();
-        }
+        // Reconcile events written during the bulk replay by draining up to a head snapshotted once here. It does not
+        // chase a moving head: under sustained writes re-reading the head would advance forever and the catch-up would
+        // never hand over to live (a livelock). Anything committed after this snapshot head is delivered by the live
+        // subscription, which resumes from the pre-bulk token, deduped by the cache. Loss-safe: nothing in
+        // (snapshotHead, now] is skipped because live covers it, and nothing in (cursor, snapshotHead] is skipped
+        // because this pass drains it. Re-reads of the bulk-tail overlap are deduped by the cache (delivery is
+        // at-least-once).
+        long snapshotHead = reader.currentHead();
+        cursor = windows(cursor, snapshotHead, keepRunning, deliver, cache);
         return cursor;
     }
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipelineTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipelineTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Deterministic unit tests for the blocking {@link PositionCatchupPipeline}, the mirror of the reactor pipeline's
+ * reconcile. The reconcile drains up to a head snapshotted once, so it terminates even while the head keeps advancing.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PositionCatchupPipelineTest {
+
+    @Test
+    void reconcile_terminates_under_continuous_writes_by_draining_up_to_a_snapshot_head() {
+        // currentHead advances by 10 on every call, simulating writes that never stop during the catch-up. The old
+        // reconcile re-read the head after every window and would loop forever, never returning to hand over to live.
+        // The snapshot-bounded reconcile reads the head once for the bulk phase (10) and once for reconcile (20),
+        // drains positions 1..20, and returns. assertTimeoutPreemptively fails loudly if the livelock ever returns.
+        FakeReader reader = FakeReader.withEventsInRange(1, 100).headSupplier(advancingBy(10));
+        CopyOnWriteArrayList<String> delivered = new CopyOnWriteArrayList<>();
+        FixedSizeCache cache = new FixedSizeCache(1000);
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000);
+
+        long cursor = assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+                pipeline.replay(0, () -> true, (events, ignoredCache) -> events.forEach(e -> delivered.add(e.getId())), cache));
+
+        assertThat(cursor).isEqualTo(20L);
+        assertThat(delivered).isEqualTo(idsInRange(1, 20));
+    }
+
+    @Test
+    void reconcile_reads_the_head_only_for_the_bulk_phase_and_one_snapshot() {
+        // Two currentHead calls total: the bulk head, then the reconcile snapshot. Proves reconcile does not chase the
+        // head across repeated reads (which is what caused the livelock).
+        AtomicLong headReads = new AtomicLong();
+        FakeReader reader = FakeReader.withEventsInRange(1, 30);
+        reader.headSupplier(() -> {
+            headReads.incrementAndGet();
+            return 30L;
+        });
+        FixedSizeCache cache = new FixedSizeCache(1000);
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000);
+
+        long cursor = pipeline.replay(0, () -> true, (events, ignoredCache) -> events.forEach(CloudEvent::getId), cache);
+
+        assertThat(cursor).isEqualTo(30L);
+        assertThat(headReads).hasValue(2);
+    }
+
+    private static LongSupplier advancingBy(long step) {
+        AtomicLong head = new AtomicLong();
+        return () -> head.addAndGet(step);
+    }
+
+    private static List<String> idsInRange(long fromInclusive, long toInclusive) {
+        return LongStream.rangeClosed(fromInclusive, toInclusive).mapToObj(PositionCatchupPipelineTest::id).toList();
+    }
+
+    private static String id(long position) {
+        return "e" + position;
+    }
+
+    private static CloudEvent event(String id) {
+        return CloudEventBuilder.v1().withId(id).withSource(URI.create("urn:test")).withType("type").build();
+    }
+
+    private static final class FakeReader implements PositionCatchupPipeline.Reader {
+        private final TreeMap<Long, CloudEvent> byPosition = new TreeMap<>();
+        private LongSupplier head = () -> 0L;
+
+        static FakeReader withEventsInRange(long fromInclusive, long toInclusive) {
+            FakeReader reader = new FakeReader();
+            LongStream.rangeClosed(fromInclusive, toInclusive).forEach(position -> reader.byPosition.put(position, event(id(position))));
+            return reader;
+        }
+
+        FakeReader headSupplier(LongSupplier supplier) {
+            this.head = supplier;
+            return this;
+        }
+
+        @Override
+        public long currentHead() {
+            return head.getAsLong();
+        }
+
+        @Override
+        public Stream<CloudEvent> readWindow(long fromExclusive, long toInclusive) {
+            return byPosition.subMap(fromExclusive, false, toInclusive, true).values().stream();
+        }
+    }
+}

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupHandoverTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupHandoverTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.PositionRange;
+import org.occurrent.eventstore.api.SortBy;
+import org.occurrent.eventstore.api.blocking.EventStoreQueries;
+import org.occurrent.eventstore.api.blocking.PositionOrderedReader;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.GlobalCheckpoint;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.StringBasedCheckpoint;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
+import org.occurrent.subscription.api.blocking.Subscription;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Handover-seam tests for the blocking {@link StreamCatchupSubscriptionModel} position path, driven by a fake position
+ * store and a fake live source so the reserve-low-position-commit-late ordering and the during-replay overlap can be
+ * reproduced deterministically. The blocking position path caches only the reconcile-phase ids (its live resume token
+ * is exclusive, so bulk events below the token are not re-delivered), so the deduped overlap here is the events written
+ * during the replay, which the live source re-delivers.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StreamCatchupHandoverTest {
+
+    @Test
+    void a_low_position_event_that_commits_after_the_handover_advanced_past_it_is_still_delivered_exactly_once() {
+        // The bulk read sees positions 1, 3, 4, 5 but position 2 was reserved before commit (ADR 45) and committed late,
+        // after the forward-only replay passed it, so neither bulk nor reconcile reads it. It committed after the
+        // pre-bulk resume token, so the live source delivers it (e2). An id-based dedup delivers it; a position
+        // watermark that dropped live events with position <= 5 would lose it.
+        FakePositionStore store = FakePositionStore.withEventsAt(1, 3, 4, 5).heads(5, 5);
+        FakeLiveModel live = new FakeLiveModel(events("e2"));
+        CopyOnWriteArrayList<String> received = deliver(live, store, 1000);
+
+        assertThat(received).containsExactly("e1", "e3", "e4", "e5", "e2");
+    }
+
+    @Test
+    void an_overlap_larger_than_the_old_1000_cap_delivers_each_event_exactly_once_when_the_ceiling_covers_it() {
+        // Bulk drains 1..1000, then the head advances to 3000, so reconcile drains the 2000 events written during the
+        // replay (an overlap far past the old fixed 1000 cap). The live source re-delivers those 2000, and a ceiling
+        // that covers them dedupes the whole re-delivery, so every event is delivered exactly once.
+        FakePositionStore store = FakePositionStore.withEventsInRange(1, 3000).heads(1000, 3000);
+        FakeLiveModel live = new FakeLiveModel(eventsInRange(1001, 3000));
+        CopyOnWriteArrayList<String> received = deliver(live, store, 5000);
+
+        assertThat(received).hasSize(3000);
+        assertThat(received).doesNotHaveDuplicates();
+        assertThat(Set.copyOf(received)).isEqualTo(idsInRange(1, 3000));
+    }
+
+    @Test
+    void an_overlap_beyond_the_ceiling_may_be_delivered_more_than_once_but_is_never_lost() {
+        // Bulk drains 1..100, then the head advances to 600, so reconcile drains 500 during-replay events. The ceiling
+        // is 100, so the oldest reconcile ids are evicted and re-delivered by the live source. Eviction can only cause
+        // a duplicate, never a loss, so every event still appears at least once.
+        FakePositionStore store = FakePositionStore.withEventsInRange(1, 600).heads(100, 600);
+        FakeLiveModel live = new FakeLiveModel(eventsInRange(101, 600));
+        CopyOnWriteArrayList<String> received = deliver(live, store, 100);
+
+        assertThat(Set.copyOf(received)).isEqualTo(idsInRange(1, 600));
+        assertThat(received.size()).isGreaterThan(600); // duplicates occurred, which is allowed
+    }
+
+    private CopyOnWriteArrayList<String> deliver(FakeLiveModel live, FakePositionStore store, int ceiling) {
+        CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
+        StreamCatchupSubscriptionModel catchup = new StreamCatchupSubscriptionModel(live, store, new CatchupSubscriptionModelConfig(ceiling));
+        boolean started = catchup.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> received.add(cloudEvent.getId()))
+                .waitUntilStarted(Duration.ofSeconds(10));
+        assertThat(started).isTrue();
+        return received;
+    }
+
+    private static List<CloudEvent> events(String... ids) {
+        return java.util.Arrays.stream(ids).map(StreamCatchupHandoverTest::event).toList();
+    }
+
+    private static List<CloudEvent> eventsInRange(long fromInclusive, long toInclusive) {
+        return LongStream.rangeClosed(fromInclusive, toInclusive).mapToObj(position -> event(id(position))).toList();
+    }
+
+    private static Set<String> idsInRange(long fromInclusive, long toInclusive) {
+        return LongStream.rangeClosed(fromInclusive, toInclusive).mapToObj(StreamCatchupHandoverTest::id).collect(java.util.stream.Collectors.toSet());
+    }
+
+    private static String id(long position) {
+        return "e" + position;
+    }
+
+    private static CloudEvent event(String id) {
+        return CloudEventBuilder.v1().withId(id).withSource(URI.create("urn:test")).withType("type").build();
+    }
+
+    // A position-ordered store whose currentPosition answers a scripted sequence of heads (bulk head, then reconcile
+    // snapshot) so a test can make the head advance mid-replay. readInPositionOrder honors the range bounds. The
+    // time-based query paths must never run in position mode, so they fail loudly.
+    private static final class FakePositionStore implements EventStoreQueries, PositionOrderedReader {
+        private final TreeMap<Long, CloudEvent> byPosition = new TreeMap<>();
+        private long[] heads = {0L};
+        private int headIndex = 0;
+
+        static FakePositionStore withEventsAt(long... positions) {
+            FakePositionStore store = new FakePositionStore();
+            for (long position : positions) {
+                store.byPosition.put(position, event(id(position)));
+            }
+            return store;
+        }
+
+        static FakePositionStore withEventsInRange(long fromInclusive, long toInclusive) {
+            FakePositionStore store = new FakePositionStore();
+            LongStream.rangeClosed(fromInclusive, toInclusive).forEach(position -> store.byPosition.put(position, event(id(position))));
+            return store;
+        }
+
+        FakePositionStore heads(long... heads) {
+            this.heads = heads;
+            return this;
+        }
+
+        @Override
+        public synchronized long currentPosition() {
+            long value = heads[Math.min(headIndex, heads.length - 1)];
+            headIndex++;
+            return value;
+        }
+
+        @Override
+        public boolean writesPosition() {
+            return true;
+        }
+
+        @Override
+        public Stream<CloudEvent> readInPositionOrder(Filter filter, PositionRange range) {
+            long fromExclusive = range.afterPosition().orElse(0L);
+            long toInclusive = range.upToPosition().orElse(Long.MAX_VALUE);
+            return byPosition.subMap(fromExclusive, false, toInclusive, true).values().stream();
+        }
+
+        @Override
+        public Stream<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
+            throw new AssertionError("Position mode must not use the time-based query path");
+        }
+
+        @Override
+        public long count(Filter filter) {
+            throw new AssertionError("Position mode must not use the time-based count path");
+        }
+
+        @Override
+        public boolean exists(Filter filter) {
+            throw new AssertionError("Position mode must not use the time-based exists path");
+        }
+    }
+
+    // A live source whose subscribe replays a fixed, finite list to the delivery consumer the catch-up hands it (which
+    // wraps the dedup cache), then returns a started subscription. globalCheckpoint is non-null so the fail-loud
+    // handover proceeds.
+    private static final class FakeLiveModel implements CheckpointAwareSubscriptionModel {
+        private final List<CloudEvent> live;
+
+        private FakeLiveModel(List<CloudEvent> live) {
+            this.live = live;
+        }
+
+        @Override
+        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+            live.forEach(action);
+            return new StartedSubscription(subscriptionId);
+        }
+
+        @Override
+        public @Nullable Checkpoint globalCheckpoint() {
+            return new StringBasedCheckpoint("token");
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public void start(boolean resumeSubscriptionsAutomatically) {
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public boolean isRunning(String subscriptionId) {
+            return true;
+        }
+
+        @Override
+        public boolean isPaused(String subscriptionId) {
+            return false;
+        }
+
+        @Override
+        public Subscription resumeSubscription(String subscriptionId) {
+            return new StartedSubscription(subscriptionId);
+        }
+
+        @Override
+        public void pauseSubscription(String subscriptionId) {
+        }
+
+        @Override
+        public void cancelSubscription(String subscriptionId) {
+        }
+    }
+
+    private record StartedSubscription(String id) implements Subscription {
+        @Override
+        public boolean waitUntilStarted(Duration timeout) {
+            return true;
+        }
+    }
+}

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -74,9 +74,14 @@ class ReactorDcbCatchupSubscriptionModel implements CheckpointAwareSubscriptionM
      */
     public static final long DEFAULT_POSITION_WINDOW_SIZE = 1000;
     /**
-     * Default number of event ids kept to deduplicate the replay-to-live handover seam.
+     * Default ceiling on the number of event ids kept to deduplicate the replay-to-live handover seam. The dedup set
+     * grows to cover the overlap the live change stream re-delivers (bounded by the write volume during the replay,
+     * not by total history) and evicts oldest-first only once it would exceed this ceiling. Exceeding the ceiling
+     * yields extra duplicate deliveries, never loss (delivery is at-least-once), so raise it to cut duplicates on a
+     * large rebuild or lower it to cap memory (each id is a short string). It is well above the previous {@code 1000}
+     * so a rebuild with heavy concurrent writes no longer evicts the overlap before the live stream re-delivers it.
      */
-    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 1000;
+    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
 
     private final CheckpointAwareSubscriptionModel subscriptionModel;
     private final DcbEventStore dcbEventStore;

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/HandoverCache.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/HandoverCache.java
@@ -24,26 +24,32 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * A bounded, insertion-ordered set of recently replayed event ids. The live change stream resumes inclusively and
- * re-delivers events near the captured token that the replay already emitted, and this cache skips those. It only
- * needs the tail the live resume can overlap, not the whole history.
+ * An insertion-ordered set of replayed event ids that the inclusive live resume re-delivers at the handover seam, so
+ * the pipeline can suppress those duplicates. It holds the ids delivered during the replay window (the overlap the
+ * live change stream re-delivers, bounded by the write volume during the replay, not by total history), and grows to
+ * cover that overlap up to {@code ceiling}. Once the set would exceed {@code ceiling} it evicts oldest-first.
+ * <p>
+ * Eviction is loss-safe by construction: dropping an id can only stop a re-delivered live event from being suppressed,
+ * so an overlap larger than {@code ceiling} yields extra duplicate deliveries, never loss. Dedup is by id, never by
+ * position, so a low-position event that commits late (after the handover advanced past its position) and is therefore
+ * absent from the forward-only replay is never in this set and is always delivered by the live change stream.
  */
 @NullMarked
 final class HandoverCache {
-    private final int maxSize;
+    private final int ceiling;
     private final Set<String> ids;
 
-    public HandoverCache(int maxSize) {
-        if (maxSize < 1) {
-            throw new IllegalArgumentException("maxSize must be at least 1, was " + maxSize);
+    public HandoverCache(int ceiling) {
+        if (ceiling < 1) {
+            throw new IllegalArgumentException("ceiling must be at least 1, was " + ceiling);
         }
-        this.maxSize = maxSize;
+        this.ceiling = ceiling;
         this.ids = Collections.synchronizedSet(new LinkedHashSet<>());
     }
 
     public void add(String id) {
         synchronized (ids) {
-            if (ids.add(id) && ids.size() > maxSize) {
+            if (ids.add(id) && ids.size() > ceiling) {
                 Iterator<String> iterator = ids.iterator();
                 iterator.next();
                 iterator.remove();

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipeline.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipeline.java
@@ -35,9 +35,11 @@ import static java.util.Objects.requireNonNull;
  * type, and is reused by both the stream and the DCB catch-up models.
  * <p>
  * The live resume token is captured before the bulk replay, not after, so an event that commits during the replay is
- * still delivered by the live subscription. The replay pages the sequence in {@code position} windows, then a
- * reconciliation pass keeps paging until the head stops advancing so events written during the replay are delivered
- * in order. A bounded id cache dedupes events that both the replay and the live subscription see.
+ * still delivered by the live subscription. The replay pages the sequence in {@code position} windows, then a single
+ * reconciliation pass drains up to a head snapshotted once at reconcile start so events written during the replay are
+ * delivered in order. It does not chase a moving head: under sustained writes that would never terminate, so anything
+ * committed after the snapshot head is left to the live subscription (which resumes from the pre-bulk token), deduped
+ * by the id cache. That cache dedupes events that both the replay and the live subscription see.
  * <p>
  * If the replay runs longer than the change stream history (the MongoDB oplog window), the captured token ages out
  * and the live resume fails loudly rather than silently dropping an event. If the model reports no resume token at
@@ -108,11 +110,13 @@ final class PositionCatchupPipeline {
                 .concatWith(Flux.defer(() -> windows(upTo, toInclusive, cache)));
     }
 
-    // Pages from the bulk head onward, re-reading the head each round, until it stops advancing. This delivers events
-    // written during the bulk replay in position order.
+    // Drains events written during the bulk replay in position order up to a head snapshotted once here. It does not
+    // chase a moving head: under sustained writes re-reading the head would advance forever and the catch-up would
+    // never hand over to live (a livelock). Anything committed after this snapshot head is delivered by the live
+    // change stream, which resumes from the pre-bulk token, deduped by the id cache. Loss-safe: nothing in
+    // (snapshotHead, now] is skipped because live covers it, and nothing in (cursor, snapshotHead] is skipped because
+    // this pass drains it.
     private Flux<CloudEvent> reconcile(long cursor, HandoverCache cache) {
-        return reader.currentHead().flatMapMany(head -> head > cursor
-                ? windows(cursor, head, cache).concatWith(Flux.defer(() -> reconcile(head, cache)))
-                : Flux.empty());
+        return reader.currentHead().flatMapMany(snapshotHead -> windows(cursor, snapshotHead, cache));
     }
 }

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
@@ -93,9 +93,14 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
      */
     public static final long DEFAULT_POSITION_WINDOW_SIZE = 1000;
     /**
-     * Default number of event ids kept to deduplicate the replay-to-live handover seam.
+     * Default ceiling on the number of event ids kept to deduplicate the replay-to-live handover seam. The dedup set
+     * grows to cover the overlap the live change stream re-delivers (bounded by the write volume during the replay,
+     * not by total history) and evicts oldest-first only once it would exceed this ceiling. Exceeding the ceiling
+     * yields extra duplicate deliveries, never loss (delivery is at-least-once), so raise it to cut duplicates on a
+     * large rebuild or lower it to cap memory (each id is a short string). It is well above the previous {@code 1000}
+     * so a rebuild with heavy concurrent writes no longer evicts the overlap before the live stream re-delivers it.
      */
-    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 1000;
+    public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
 
     private final CheckpointAwareSubscriptionModel subscriptionModel;
     private final PositionOrderedReader positionOrderedReader;

--- a/subscription/util/reactor/stream-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipelineTest.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipelineTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.reactor.durable.catchup;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.filter.Filter;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.StreamSubscriptionFilter;
+import org.occurrent.subscription.StringBasedCheckpoint;
+import org.occurrent.subscription.SubscriptionFilter;
+import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Deterministic unit tests for {@link PositionCatchupPipeline} using a fake position reader and a fake live source, so
+ * the reserve-low-position-commit-late ordering and the sustained-write reconcile can be reproduced without a database.
+ * The pipeline owns the whole bulk-reconcile-live handover, so these tests exercise every phase of the no-loss
+ * contract in one place.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PositionCatchupPipelineTest {
+
+    private static final SubscriptionFilter LIVE_FILTER = StreamSubscriptionFilter.filter(Filter.all());
+    private static final Predicate<CloudEvent> DELIVER_EVERYTHING = __ -> true;
+
+    @Test
+    void a_low_position_event_that_commits_after_the_handover_advanced_past_it_is_still_delivered_exactly_once() {
+        // The bulk read sees positions 1..5 but position 2 was reserved before commit (ADR 45) and had not committed
+        // yet when the forward-only replay passed it, so the replay never reads it. The head does not move, so
+        // reconcile adds nothing. The live change stream, resuming from the pre-bulk token, re-delivers the boundary
+        // events (e4, e5, already in the dedup set) and the late e2 (not in the set). A position-watermark dedup that
+        // dropped live events with position <= 5 would drop e2 and lose it. Id-based dedup delivers it exactly once.
+        FakeReader reader = FakeReader.withEventsAt(1, 3, 4, 5).head(5);
+        FakeLiveSource live = new FakeLiveSource(events("e4", "e5", "e2"));
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000, 1000);
+
+        StepVerifier.create(pipeline.catchup(live, LIVE_FILTER, DELIVER_EVERYTHING, 0).map(CloudEvent::getId))
+                .expectNext("e1", "e3", "e4", "e5", "e2")
+                .verifyComplete();
+    }
+
+    @Test
+    void an_overlap_larger_than_the_old_1000_cap_delivers_each_event_exactly_once_when_the_ceiling_covers_it() {
+        // The replay emits 2000 events and the live stream re-delivers the newest 1500 of them, an overlap far past the
+        // old fixed 1000 cap. With a ceiling that covers the overlap the whole re-delivery is deduped, so every event
+        // is delivered exactly once.
+        FakeReader reader = FakeReader.withEventsInRange(1, 2000).head(2000);
+        FakeLiveSource live = new FakeLiveSource(eventsInRange(501, 2000));
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000, 5000);
+
+        List<String> delivered = pipeline.catchup(live, LIVE_FILTER, DELIVER_EVERYTHING, 0).map(CloudEvent::getId).collectList().block();
+
+        assertThat(delivered).hasSize(2000);
+        assertThat(delivered).doesNotHaveDuplicates();
+        assertThat(Set.copyOf(delivered)).isEqualTo(idsInRange(1, 2000));
+    }
+
+    @Test
+    void an_overlap_beyond_the_ceiling_may_be_delivered_more_than_once_but_is_never_lost() {
+        // The overlap (500 re-delivered) exceeds the ceiling (100), so the oldest ids were evicted from the dedup set
+        // and are re-delivered. Eviction can only cause a duplicate, never a loss, so every event still appears at
+        // least once.
+        FakeReader reader = FakeReader.withEventsInRange(1, 500).head(500);
+        FakeLiveSource live = new FakeLiveSource(eventsInRange(1, 500));
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000, 100);
+
+        List<String> delivered = pipeline.catchup(live, LIVE_FILTER, DELIVER_EVERYTHING, 0).map(CloudEvent::getId).collectList().block();
+
+        assertThat(Set.copyOf(delivered)).isEqualTo(idsInRange(1, 500));
+        assertThat(delivered.size()).isGreaterThan(500); // duplicates occurred, which is allowed
+    }
+
+    @Test
+    void reconcile_hands_over_to_live_in_bounded_time_under_continuous_writes_and_loses_nothing() {
+        // currentHead advances by 10 on every call, simulating writes that never stop during the catch-up. The old
+        // reconcile re-read the head after every window and would chase this forever, never handing over to live (a
+        // livelock). The snapshot-bounded reconcile reads the head exactly once, drains up to it, and completes: the
+        // pipeline calls currentHead twice (bulk head 10, reconcile snapshot 20), so the replay drains positions 1..20
+        // and then goes live. Everything past the snapshot is covered by the live stream, so nothing is lost.
+        FakeReader reader = FakeReader.withEventsInRange(1, 40).headSupplier(advancingBy(10));
+        FakeLiveSource live = new FakeLiveSource(events("live-1"));
+        PositionCatchupPipeline pipeline = new PositionCatchupPipeline(reader, 1000, 1000);
+
+        StepVerifier.create(pipeline.catchup(live, LIVE_FILTER, DELIVER_EVERYTHING, 0).map(CloudEvent::getId))
+                .expectNextSequence(idsInRangeList(1, 20))
+                .expectNext("live-1")
+                .verifyComplete();
+    }
+
+    private static LongSupplier advancingBy(long step) {
+        AtomicLong head = new AtomicLong();
+        return () -> head.addAndGet(step);
+    }
+
+    private static List<CloudEvent> events(String... ids) {
+        return java.util.Arrays.stream(ids).map(PositionCatchupPipelineTest::event).collect(Collectors.toList());
+    }
+
+    private static List<CloudEvent> eventsInRange(long fromInclusive, long toInclusive) {
+        return idsInRangeList(fromInclusive, toInclusive).stream().map(PositionCatchupPipelineTest::event).collect(Collectors.toList());
+    }
+
+    private static Set<String> idsInRange(long fromInclusive, long toInclusive) {
+        return Set.copyOf(idsInRangeList(fromInclusive, toInclusive));
+    }
+
+    private static List<String> idsInRangeList(long fromInclusive, long toInclusive) {
+        return LongStream.rangeClosed(fromInclusive, toInclusive).mapToObj(PositionCatchupPipelineTest::id).collect(Collectors.toList());
+    }
+
+    private static String id(long position) {
+        return "e" + position;
+    }
+
+    private static CloudEvent event(String id) {
+        return CloudEventBuilder.v1().withId(id).withSource(URI.create("urn:test")).withType("type").build();
+    }
+
+    // Maps a position to an event and answers head reads from a supplier so a test can hold the head still or keep it
+    // advancing to simulate sustained writes.
+    private static final class FakeReader implements CatchupReader {
+        private final TreeMap<Long, CloudEvent> byPosition = new TreeMap<>();
+        private LongSupplier head = () -> 0L;
+
+        static FakeReader withEventsAt(long... positions) {
+            FakeReader reader = new FakeReader();
+            for (long position : positions) {
+                reader.byPosition.put(position, event(id(position)));
+            }
+            return reader;
+        }
+
+        static FakeReader withEventsInRange(long fromInclusive, long toInclusive) {
+            FakeReader reader = new FakeReader();
+            LongStream.rangeClosed(fromInclusive, toInclusive).forEach(position -> reader.byPosition.put(position, event(id(position))));
+            return reader;
+        }
+
+        FakeReader head(long value) {
+            this.head = () -> value;
+            return this;
+        }
+
+        FakeReader headSupplier(LongSupplier supplier) {
+            this.head = supplier;
+            return this;
+        }
+
+        @Override
+        public Flux<CloudEvent> readWindow(long fromExclusive, long toInclusive) {
+            return Flux.fromIterable(byPosition.subMap(fromExclusive, false, toInclusive, true).values());
+        }
+
+        @Override
+        public Mono<Long> currentHead() {
+            return Mono.fromSupplier(head::getAsLong);
+        }
+    }
+
+    // A live source whose subscribe replays a fixed, finite list so the handover can be verified deterministically. In
+    // production the live stream is unbounded, but a finite list is enough to prove the dedup at the seam.
+    private record FakeLiveSource(List<CloudEvent> live) implements CheckpointAwareSubscriptionModel {
+        @Override
+        public Mono<Checkpoint> globalCheckpoint() {
+            return Mono.just(new StringBasedCheckpoint("token"));
+        }
+
+        @Override
+        public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
+            return Flux.fromIterable(live);
+        }
+    }
+}


### PR DESCRIPTION
Two fixes to the position-ordered catch-up-to-live handover. I applied both consistently to the reactor and blocking stacks, and since the stream and DCB catch-up models share the same pipeline, both modes get them.

The invariant I held onto throughout: the handover must never lose an event. Delivery is at-least-once, so a duplicate is fine and a loss is not. Positions are reserved before commit and outside the transaction (ADR 0045), so a low-position event can commit late, after the handover has already seen a higher position. That event is missed by the forward-only replay and reconcile, and is delivered only by the live change stream. Dedup stays keyed by id, never by position, so that late event is never dropped.

### Fix 1, handover dedup no longer under-sizes the overlap

The dedup id set capped at a fixed size (`1000` in the reactor models, `100` in the blocking models). Once the overlap the live subscription re-delivers grew past that cap, the cache evicted ids the live stream then re-delivered as duplicates. On a large rebuild with heavy concurrent writes that meant a flood of duplicate deliveries.

The set now grows to cover that overlap, which is bounded by the write volume during the replay, not by total history, up to a configurable ceiling that defaults to `100000`. Beyond the ceiling it falls back to the existing oldest-first eviction. That is safe because evicting a dedup entry can only cause a duplicate, never a loss. The ceiling is configurable through the catch-up config, so you can raise it to cut duplicates further or lower it to cap memory.

I also fixed the misleading docstring on `HandoverCache` that claimed it only needs the tail the live resume can overlap.

### Fix 2, reconcile no longer livelocks under sustained writes

The reconcile pass that drains events written during the bulk replay re-read the store head after every window and kept paging until the head stopped advancing. Under a continuous write rate the head never stops advancing, so reconcile never terminated and the catch-up never went live.

It now snapshots the head once at reconcile start, drains from the cursor up to that snapshot, and hands over to live. Anything committed after the snapshot is delivered by the live subscription, which resumes from the pre-bulk token, so nothing is skipped. Nothing in the drained range is skipped either, because reconcile drains it.

### Tests

I added deterministic tests for both stacks, driven by fake readers and fake live sources so the tricky orderings are reproducible without a database.

* The loss guard, the important one. A low-position event that commits after the handover advanced past its position is still delivered exactly once. This is the regression guard a position-watermark approach would have failed.
* Duplicate reduction. An overlap larger than the old `1000` cap delivers each event exactly once when the ceiling covers it.
* Ceiling exceeded. Beyond the ceiling, events may be delivered more than once but every event still appears at least once.
* No livelock. Under continuous writes during reconcile, catch-up reaches live in bounded time and loses nothing.

### Verification

`./mvnw -pl subscription/util -am test` is green (`BUILD SUCCESS`), including the MongoDB integration tests. The new unit tests pass on their own too, 4 in the reactor pipeline and 13 across the blocking catch-up classes.
