### PR TITLE
Simplify comments in the MongoDB subscription models

### DIFF
--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
@@ -188,11 +188,9 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Consumer<St
                 return cloudEvent -> matchesFilter(cloudEvent, f);
             }
             case DcbSubscriptionFilter dcbSubscriptionFilter -> {
-                // Match the DCB query in process and require the event to be a DCB-written event, so a non-Mongo
-                // subscribable filters DCB events without a server-side change stream match. The discriminator is
-                // isDcbEvent (the presence of the DCB tags extension), not a positive position: with stream position on by
-                // default, stream events also carry a global position, so a "position > 0" guard would leak stream events
-                // into a DCB subscription.
+                // Requires isDcbEvent (the DCB tags extension) rather than a positive position, since with
+                // stream position on by default, stream events also carry a global position. A "position > 0"
+                // guard would leak stream events into a DCB subscription.
                 DcbCriteria query = dcbSubscriptionFilter.criteria();
                 return cloudEvent -> DcbCloudEvents.isDcbEvent(cloudEvent) && DcbCloudEvents.matches(cloudEvent, query);
             }

--- a/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCommons.java
+++ b/subscription/mongodb/common/base/src/main/java/org/occurrent/subscription/mongodb/internal/MongoCommons.java
@@ -116,13 +116,11 @@ public class MongoCommons {
                 BsonTimestamp operationTime = document.get(OPERATION_TIME, BsonTimestamp.class);
                 withStartPositionApplied = applyOperationTime.apply(t, operationTime);
             } else {
-                // We don't recognize the start position, but instead of throwing an exception we just start at "subscription model default"/now which
-                // means returning t. The reason for not throwing is that subscription models that wraps _this_ subscription (which doesn't understand the
-                // "changeStreamPositionString") may have custom understanding of the change stream position. For example, in the case of a CatchupSubscription,
-                // it adds a "TimeBasedCheckpoint" which no other subscription model understands. In the case where the CatchupSubscription cannot get a global position,
-                // for example if we run on Atlas free-tier, it may write the "TimeBasedCheckpoint" to the position storage impl. If no event has been received after
-                // the subscription has caught-up, the "TimeBasedCheckpoint" will be retained in storage. If a restart happens before a new event has been received,
-                // then the CatchupSubscription will kick in again and understand the "TimeBasedCheckpoint", thus preventing reading the events from the event store again.
+                // Unrecognized start position: return t (subscription model default/now) instead of throwing,
+                // since a wrapping subscription model may understand a position this one doesn't. For example
+                // CatchupSubscription's "TimeBasedCheckpoint" (written when it can't get a global position,
+                // e.g. on Atlas free-tier): if no event arrives after catch-up and a restart happens first,
+                // CatchupSubscription reads it back instead of replaying from the event store.
                 return t;
             }
         }

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoLeaseCompetingConsumerStrategySupport.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoLeaseCompetingConsumerStrategySupport.java
@@ -187,7 +187,6 @@ public class MongoLeaseCompetingConsumerStrategySupport {
                 boolean stillHasLock = MongoListenerLockService.commit(collection, clock, retryStrategy, leaseTime, cc.subscriptionId, cc.subscriberId);
                 if (!stillHasLock) {
                     logDebug("Lost lock! (subscriberId={}, subscriptionId={})", cc.subscriberId, cc.subscriptionId);
-                    // Lock was lost!
                     competingConsumers.put(cc, Status.LOCK_NOT_ACQUIRED);
                     competingConsumerListeners.forEach(listener -> listener.onConsumeProhibited(cc.subscriptionId, cc.subscriberId));
                     logDebug("Completed calling onConsumeProhibited for all listeners (subscriberId={}, subscriptionId={})", cc.subscriberId, cc.subscriptionId);

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
@@ -98,7 +98,7 @@ class MongoListenerLockService {
                 final ErrorCategory errorCategory = ErrorCategory.fromErrorCode(e.getErrorCode());
 
                 if (errorCategory.equals(DUPLICATE_KEY)) {
-                    // This happens frequently, so we don't log it
+                    // Happens frequently, not logged.
                     return Optional.empty();
                 }
 

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -204,12 +204,11 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
         cloudEventDispatcher.execute(executeWithRetry(internalSubscription, NOT_SHUTDOWN, retryStrategy));
     }
 
-    // currentStartAt tracks the position of the last change-stream document read (updated below, whether or not it
-    // produced a delivered CloudEvent), shared with the outer executeWithRetry(internalSubscription, ...) wrapper in
-    // startSubscription so that a restart (rethrown below) or a resume (see resumeSubscription) continues gap-free
-    // from there instead of the original StartAt.
-    // The try block spans opening the cursor too, not just iterating it, since a change-stream error (e.g. history lost,
-    // a failover) can just as well surface when the cursor is (re-)opened as while iterating it.
+    // currentStartAt tracks the last change-stream document read (updated below, even without a delivered
+    // CloudEvent), shared with startSubscription's executeWithRetry wrapper so a restart or resume continues
+    // gap-free from there instead of the original StartAt.
+    // The try block spans opening the cursor too: a change-stream error (history lost, failover) can surface
+    // there just as well as while iterating.
     private void newInternalSubscription(String subscriptionId, SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Consumer<CloudEvent> action, CountDownLatch subscriptionStartedLatch) {
         InternalSubscription internalSubscription = null;
         try {
@@ -335,13 +334,12 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
     public Checkpoint globalCheckpoint() {
         BsonTimestamp currentOperationTime;
         try {
-            // Note that we increase the "increment" by 1 in order to not clash with an existing event in the event store.
-            // This is so that we can avoid duplicates in certain rare cases when replaying events.
+            // Increment by 1 to avoid clashing with an existing event, preventing duplicates in rare replay cases.
             currentOperationTime = MongoCommons.getServerOperationTime(database.runCommand(new Document("hostInfo", 1)), 1);
         } catch (MongoCommandException e) {
             log.warn(cannotFindGlobalCheckpointErrorMessage(e));
-            // This can if the server doesn't allow to get the operation time since "db.adminCommand( { "hostInfo" : 1 } )" is prohibited.
-            // This is the case on for example shared Atlas clusters. If this happens we return the current time of the client instead.
+            // Happens when the server prohibits "hostInfo" (e.g. shared Atlas clusters), falls back to the
+            // client's current time.
             return null;
         }
         return new MongoOperationTimeCheckpoint(currentOperationTime);
@@ -397,8 +395,8 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
         running = true;
 
         CountDownLatch startedLatch = new CountDownLatch(1);
-        // Reuses the same currentStartAt reference so a resume continues from the position of the last change-stream
-        // document read before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
+        // Reuses the same currentStartAt reference so a resume continues from the last change-stream document
+        // read before the subscription was paused, not the original StartAt.
         Runnable newSubscription = () -> newInternalSubscription(subscriptionId, internalSubscription.filter,
                 internalSubscription.currentStartAt, internalSubscription.action, startedLatch);
         startSubscription(newSubscription);

--- a/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
+++ b/subscription/mongodb/spring/blocking-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
@@ -133,11 +133,10 @@ public class SpringMongoCheckpointStorage implements CheckpointStorage {
     }
 
     void persistDocumentStreamPosition(String subscriptionId, Document document) {
-        // "document" carries no $-prefixed update operators, so Spring Data applies it as a full-document
-        // replacement rather than a field-level merge. Any field absent from "document" is therefore dropped,
-        // including the legacy "subscriptionPosition" field written before the SubscriptionPosition -> Checkpoint
-        // rename: the first save after upgrade rewrites the document under the new "checkpoint" field and the legacy
-        // field does not survive. This is the same replacement behaviour the native adapter gets from replaceOne.
+        // "document" has no $-prefixed operators, so Spring Data applies it as a full-document replacement,
+        // not a field-level merge. That drops the legacy "subscriptionPosition" field (from before the
+        // SubscriptionPosition -> Checkpoint rename) on the first save after upgrade, same as the native
+        // adapter's replaceOne.
         mongoOperations.upsert(query(where(ID).is(subscriptionId)),
                 Update.fromDocument(document),
                 checkpointCollection);

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
@@ -91,18 +91,14 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
     private final MongoOperations mongoOperations;
     private final RetryStrategy retryStrategy;
     private final boolean restartSubscriptionsOnChangeStreamHistoryLost;
-    // Shared executor for restart loops so a persistently failing subscription backs off (via retryStrategy)
-    // instead of spawning a new thread for every single restart attempt. One virtual thread is occupied per
-    // subscription that is currently restarting, not per attempt, and it's released as soon as the subscription
-    // recovers, is paused/cancelled, or the model is shut down. Virtual threads are used (rather than a cached
-    // platform-thread pool) because "restartOnce" blocks on "failureSignal.join()" for the entire time the
-    // subscription is restarting, which can be a long time for a persistently failing subscription. A blocked
-    // virtual thread unmounts from its carrier while parked, so this doesn't pin a platform thread for that
-    // duration the way a cached thread pool would.
+    // Shared executor for restart loops so a failing subscription backs off (via retryStrategy) instead of
+    // spawning a thread per restart attempt. One virtual thread per currently-restarting subscription,
+    // released on recovery, pause/cancel, or shutdown. Virtual threads matter because restartOnce() blocks
+    // on failureSignal.join() for the whole restart duration, and a blocked virtual thread unmounts from
+    // its carrier instead of pinning a platform thread.
     private final ExecutorService restartExecutor;
-    // Tracks the in-flight "wait for the next failure (or a stop signal)" future for a subscription that is
-    // currently being restarted, so pauseSubscription/cancelSubscription/shutdown can wake up a blocked restart
-    // loop instead of leaving its thread parked forever.
+    // Tracks the in-flight "wait for next failure or stop signal" future for a restarting subscription, so
+    // pause/cancel/shutdown can wake a blocked restart loop instead of leaving it parked forever.
     private final ConcurrentMap<String, CompletableFuture<@Nullable RestartSignal>> activeRestartSignal;
 
     private volatile boolean shutdown = false;
@@ -165,12 +161,9 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
 
         logDebug("Subscribing ({})", subscriptionId);
 
-        // We wrap the creation of ChangeStreamRequestOptions in a supplier since otherwise the "startAtSupplier"
-        // would be supplied only once, here, during initialization. When using a supplier here, the "startAtSupplier"
-        // is called again when pausing and resuming a subscription. Take the case when a subscription is started with "StartAt.now()".
-        // If we hadn't used a supplier and a subscription is paused and later resumed, it'll be resumed from the _initial_ "StartAt.now()" position,
-        // and not the position the "StartAt.now()" position of when the subscription was resumed. This will lead to historic events being
-        // replayed which is (most likely) not what the user expects.
+        // Wraps ChangeStreamRequestOptions creation in a supplier so it's recomputed on pause/resume, not just
+        // once at subscribe time. Without this, a subscription started with StartAt.now() would resume from
+        // the _initial_ now() position instead of the resume-time position, replaying historic events.
         Function<@Nullable StartAt, ChangeStreamRequestOptions> requestOptionsFunction = overridingStartAt -> {
             var subscriptionModelContext = new StartAt.SubscriptionModelContext(SpringMongoSubscriptionModel.class);
             // TODO We should change builder::resumeAt to builder::startAtOperationTime once Spring adds support for it (see https://jira.spring.io/browse/DATAMONGO-2607)
@@ -242,16 +235,15 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
 
     @Override
     public @Nullable Checkpoint globalCheckpoint() {
-        // Note that we increase the "increment" by 1 in order to not clash with an existing event in the event store.
-        // This is so that we can avoid duplicates in certain rare cases when replaying events.
+        // Increment by 1 to avoid clashing with an existing event, preventing duplicates in rare replay cases.
         BsonTimestamp currentOperationTime;
         try {
             currentOperationTime = MongoCommons.getServerOperationTime(mongoOperations.executeCommand(new Document("hostInfo", 1)), 1);
         } catch (UncategorizedMongoDbException e) {
             if (e.getCause() instanceof MongoCommandException) {
                 log.warn(cannotFindGlobalCheckpointErrorMessage(e.getCause()));
-                // This can if the server doesn't allow to get the operation time since "db.adminCommand( { "hostInfo" : 1 } )" is prohibited.
-                // This is the case on for example shared Atlas clusters. If this happens we return the current time of the client instead.
+                // Happens when the server prohibits "hostInfo" (e.g. shared Atlas clusters), falls back to
+                // the client's current time.
                 return null;
             } else {
                 throw e;
@@ -395,16 +387,15 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         });
     }
 
-    // Carries what a restart attempt should do next: reconnect at "startAt" because "cause" was the triggering
-    // error. A completed future holding "null" instead of a RestartSignal means "stop restarting" (the
-    // subscription was paused/cancelled/shut down, or history was lost and restarting is disabled).
+    // Carries what a restart attempt should do next: reconnect at "startAt" because "cause" triggered it. A
+    // completed future holding null instead means "stop restarting" (paused/cancelled/shut down, or history
+    // lost with restarting disabled).
     private record RestartSignal(StartAt startAt, Throwable cause) {
     }
 
-    // Delivers the outcome of a change-stream error to whichever restart loop is currently responsible for this
-    // subscription: if a restart loop is already waiting for the next failure, wake it up with the signal;
-    // otherwise this is the first failure since subscribe/resume, so start a new restart loop on the shared
-    // restart executor instead of spawning a dedicated thread for this one attempt.
+    // Delivers a change-stream error to whichever restart loop is responsible for this subscription: wakes
+    // an already-waiting loop, or starts a new one on the shared restart executor if this is the first
+    // failure since subscribe/resume.
     private void reportFailure(String subscriptionId, @Nullable CompletableFuture<@Nullable RestartSignal> failureSignal, @Nullable RestartSignal signal) {
         if (failureSignal != null) {
             failureSignal.complete(signal);
@@ -413,10 +404,9 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         }
     }
 
-    // Runs on the shared restart executor: retries restarting the subscription with the backoff configured by
-    // "retryStrategy", the same strategy already used elsewhere in this class, instead of restarting immediately
-    // and unconditionally like the previous thread-per-attempt implementation did. The loop ends (without
-    // throwing) as soon as a restart attempt reports "no further restart needed".
+    // Runs on the shared restart executor, retrying with the backoff from "retryStrategy" instead of
+    // restarting immediately and unconditionally. Ends without throwing once a restart attempt reports no
+    // further restart needed.
     private void runRestartLoop(String subscriptionId, RestartSignal firstSignal) {
         AtomicReference<RestartSignal> next = new AtomicReference<>(firstSignal);
         try {
@@ -431,9 +421,9 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
                 throw outcome.cause() instanceof RuntimeException runtimeException ? runtimeException : new RuntimeException(outcome.cause());
             }, __ -> !shutdown, retryStrategy).run();
         } catch (RuntimeException e) {
-            // A backoff sleep that's interrupted (restart executor shut down) restores the thread's interrupt
-            // status before rethrowing, see RetryExecution. Report that distinctly from genuine retry exhaustion,
-            // and don't clear the interrupt status since the executor thread is being torn down.
+            // An interrupted backoff sleep (executor shutting down) restores the thread's interrupt status
+            // before rethrowing, see RetryExecution. Reported distinctly from retry exhaustion, and the
+            // interrupt status isn't cleared since the executor thread is being torn down.
             if (Thread.currentThread().isInterrupted()) {
                 log.warn("Restart loop for subscription {} was interrupted, likely because the restart executor is shutting down", subscriptionId, e);
             } else if (shutdown) {
@@ -444,9 +434,8 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         }
     }
 
-    // Performs a single restart attempt, then blocks (without holding the model's lock) until either the
-    // freshly (re)registered subscription fails again or the loop is told to stop. Returns the signal describing
-    // the next failure so the caller can retry, or null if no further restart is needed.
+    // Performs one restart attempt, then blocks (without the model's lock) until the subscription fails
+    // again or is told to stop. Returns the next failure signal for the caller to retry, or null if done.
     private @Nullable RestartSignal restartOnce(String subscriptionId, RestartSignal signal) {
         CompletableFuture<@Nullable RestartSignal> failureSignal = new CompletableFuture<>();
         synchronized (this) {
@@ -470,8 +459,8 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         }
     }
 
-    // Wakes up a restart loop that's currently blocked waiting for the next failure of "subscriptionId", if any,
-    // so pausing/cancelling/shutting down doesn't leave a restart-executor thread parked forever.
+    // Wakes a restart loop blocked on the next failure of "subscriptionId", if any, so pause/cancel/shutdown
+    // doesn't leave a restart-executor thread parked forever.
     private void stopRestartLoop(String subscriptionId) {
         CompletableFuture<@Nullable RestartSignal> pending = activeRestartSignal.remove(subscriptionId);
         if (pending != null) {
@@ -483,8 +472,8 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
         return throwable instanceof IllegalStateException && throwable.getMessage().startsWith("Cursor") && throwable.getMessage().endsWith("is not longer open.");
     }
 
-    // Model that hold both the spring subscription and the change stream request so that we can pause the subscription
-    // (by removing it and starting it again)
+    // Holds both the spring subscription and the change stream request so a subscription can be paused (by
+    // removing it) and resumed (by starting a new one).
     private record InternalSubscription(SpringMongoSubscription occurrentSubscription, Function<@Nullable StartAt, ChangeStreamRequest<Document>> changeStreamRequestBuilder) {
 
         InternalSubscription copy(org.springframework.data.mongodb.core.messaging.Subscription springSubscription) {

--- a/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
+++ b/subscription/mongodb/spring/reactor-position-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
@@ -90,11 +90,10 @@ public class ReactorCheckpointStorage implements CheckpointStorage {
     }
 
     private Mono<UpdateResult> persistDocumentStreamPosition(String subscriptionId, Document document) {
-        // "document" carries no $-prefixed update operators, so Spring Data applies it as a full-document
-        // replacement rather than a field-level merge. Any field absent from "document" is therefore dropped,
-        // including the legacy "subscriptionPosition" field written before the SubscriptionPosition -> Checkpoint
-        // rename: the first save after upgrade rewrites the document under the new "checkpoint" field and the legacy
-        // field does not survive. This is the same replacement behaviour the native adapter gets from replaceOne.
+        // "document" has no $-prefixed operators, so Spring Data applies it as a full-document replacement,
+        // not a field-level merge. That drops the legacy "subscriptionPosition" field (from before the
+        // SubscriptionPosition -> Checkpoint rename) on the first save after upgrade, same as the native
+        // adapter's replaceOne.
         return mongo.upsert(query(where(ID).is(subscriptionId)),
                 Update.fromDocument(document),
                 checkpointCollection);

--- a/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
@@ -121,13 +121,10 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
     @Override
     public Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt) {
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
-        // currentStartAt tracks the position of the last change-stream document read (updated eagerly for every
-        // document changeStream(...) reads below, whether or not it produced a delivered CloudEvent), read again by
-        // resilientChangeStream(...) on every resubscribe that retryWhen triggers, so recovery from an error
-        // continues gap-free instead of replaying or skipping events. This is safe here because the caller owns
-        // consumption of the returned Flux directly, unlike the named-subscription path below, which defers
-        // tracking to actual action completion since it interposes its own buffering stage.
-        // Flux.defer gives each subscriber to the returned Flux its own tracked position.
+        // currentStartAt tracks the last change-stream document read (even if it produced no delivered
+        // CloudEvent), so a resubscribe from retryWhen resumes gap-free. Safe here since the caller consumes
+        // the Flux directly. The buffered named-subscription path below advances only on action completion.
+        // Flux.defer gives each subscriber its own tracked position.
         return Flux.defer(() -> {
             AtomicReference<StartAt> currentStartAt = new AtomicReference<>(startAt);
             return resilientChangeStream(filter, currentStartAt, currentStartAt::set, null);
@@ -151,23 +148,22 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
 
     private Subscription startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Function<CloudEvent, Mono<Void>> action) {
         if (!running) {
-            // The model is stopped: don't subscribe at all, so waitUntilStarted() doesn't complete successfully for
-            // a subscription that won't deliver anything until start(true)/resumeSubscription actually starts it.
+            // Model stopped: don't subscribe, so waitUntilStarted() doesn't complete for a subscription that
+            // won't deliver anything until start(true)/resumeSubscription actually starts it.
             InternalSubscription internalSubscription = new InternalSubscription(Disposables.disposed(), currentStartAt, filter, action, Mono.never());
             pausedSubscriptions.put(subscriptionId, internalSubscription);
             return new ReactorMongoSubscription(subscriptionId, internalSubscription.started);
         }
         Sinks.Empty<Void> startedSink = Sinks.empty();
-        // A placeholder goes in before subscribing, since a synchronously-failing subscribe (e.g. building the
-        // change stream options itself throws) runs the error handler below before subscribe() even returns,
-        // which would otherwise try to remove an entry that was never put in yet.
+        // Placeholder goes in before subscribing: a synchronously-failing subscribe (e.g. building the change
+        // stream options throws) runs the error handler below before subscribe() returns, which would
+        // otherwise remove an entry never put in.
         runningSubscriptions.put(subscriptionId, new InternalSubscription(Disposables.disposed(), currentStartAt, filter, action, startedSink.asMono()));
-        // The change stream's own eager, per-document-read tracking (used by the plain subscribe(...) above) is not
-        // used here: concatMap(action) can have several documents already read out of the change stream and
-        // buffered ahead of a slow action, and tracking eagerly would let a pause/cancel or a change-stream error
-        // resume past one of those buffered documents without ever handing it to action, losing it for good.
-        // Advancing currentStartAt only once action() completes means pausing, cancelling, or an automatic retry
-        // can at most redeliver the in-flight event, never skip one.
+        // Eager per-document tracking (used by plain subscribe(...) above) isn't used here: concatMap(action)
+        // can buffer several documents ahead of a slow action, and tracking eagerly would let a pause/cancel
+        // or retry resume past a buffered document without ever handing it to action, losing it. Advancing
+        // currentStartAt only once action() completes means retry/pause/cancel can at most redeliver the
+        // in-flight event, never skip one.
         Disposable disposable = resilientChangeStream(filter, currentStartAt, __ -> {
                 }, startedSink)
                 .concatMap(cloudEvent -> action.apply(cloudEvent)
@@ -175,18 +171,17 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
                 .subscribe(unused -> {
                         }, throwable -> {
                             log.error("Subscription {} terminated with an unrecoverable error", subscriptionId, throwable);
-                            // No-op if doOnSubscribe already completed the sink successfully, but if the change
-                            // stream never got that far (e.g. building the change stream options itself threw),
-                            // this is what keeps waitUntilStarted() from hanging forever.
+                            // No-op if the sink already completed successfully, otherwise (e.g. building the
+                            // change stream options threw) this keeps waitUntilStarted() from hanging forever.
                             startedSink.tryEmitError(throwable);
-                            // A dead subscription must not still count as running, or isRunning(id) would lie and
-                            // the id couldn't be reused without an explicit cancelSubscription() call.
+                            // A dead subscription must not count as running, or isRunning(id) would lie and the
+                            // id couldn't be reused without an explicit cancelSubscription().
                             runningSubscriptions.remove(subscriptionId);
                         });
         InternalSubscription internalSubscription = new InternalSubscription(disposable, currentStartAt, filter, action, startedSink.asMono());
         if (runningSubscriptions.replace(subscriptionId, internalSubscription) == null) {
-            // The placeholder was already removed by a synchronous error above, so this subscription is already
-            // dead. Dispose defensively, matching what the error handler does for the same subscription otherwise.
+            // Placeholder already removed by a synchronous error above, so this subscription is dead,
+            // dispose defensively to match what the error handler otherwise does.
             disposable.dispose();
         }
         return new ReactorMongoSubscription(subscriptionId, internalSubscription.started);
@@ -206,9 +201,9 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
             ChangeStreamOptionsBuilder builder = MongoCommons.applyStartPosition(ChangeStreamOptions.builder(), ChangeStreamOptionsBuilder::startAfter, ChangeStreamOptionsBuilder::resumeAt, currentStartAt.get(), subscriptionModelContext);
             final ChangeStreamOptions changeStreamOptions = ApplyFilterToChangeStreamOptionsBuilder.applyFilter(timeRepresentation, filter, builder);
             Flux<ChangeStreamEvent<Document>> changeStream = mongo.changeStream(eventCollection, changeStreamOptions, Document.class);
-            // "Started" only means the change stream Flux has been subscribed to, not that the server has
-            // acknowledged the command and the cursor is positioned. This is weaker than NativeMongoSubscriptionModel's
-            // latch, which only fires after that blocking round trip has already completed.
+            // "Started" only means the change stream Flux was subscribed to, not that the server acknowledged
+            // the command and the cursor is positioned. Weaker than NativeMongoSubscriptionModel's latch,
+            // which only fires after that round trip completes.
             if (startedSink != null) {
                 changeStream = changeStream.doOnSubscribe(subscription -> startedSink.tryEmitEmpty());
             }
@@ -216,15 +211,15 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
                     .flatMap(changeEvent -> {
                         ChangeStreamDocument<Document> raw = changeEvent.getRaw();
                         if (raw == null) {
-                            // Mirrors SpringMongoSubscriptionModel's same defensive check. Not expected to ever
-                            // happen, but skipping this one event beats an NPE that retries the whole subscription.
+                            // Mirrors SpringMongoSubscriptionModel's defensive check. Not expected, but skipping
+                            // this event beats an NPE that retries the whole subscription.
                             log.error("Internal error: ChangeStreamEvent for collection {} had a null raw document", eventCollection);
                             return Mono.empty();
                         }
                         MongoResumeTokenCheckpoint checkpoint = new MongoResumeTokenCheckpoint(requireNonNull(raw.getResumeToken()));
-                        // Advance the tracked position for every change-stream document received, even if it
-                        // doesn't deserialize into a delivered CloudEvent, mirroring NativeMongoSubscriptionModel,
-                        // so a resubscribe after an error resumes gap-free.
+                        // Advances the tracked position for every document received, even ones that don't
+                        // deserialize into a delivered CloudEvent, mirroring NativeMongoSubscriptionModel, so
+                        // a resubscribe resumes gap-free.
                         onDocumentRead.accept(StartAt.checkpoint(checkpoint));
                         return MongoCloudEventsToJsonDeserializer.deserializeToCloudEvent(raw, timeRepresentation)
                                 .map(cloudEvent -> new CheckpointAwareCloudEvent(cloudEvent, checkpoint))
@@ -234,10 +229,9 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
         });
     }
 
-    // Classifies the error a change-stream Flux terminated with. ChangeStreamHistoryLost (286) restarts from
-    // StartAt.now() only when configured to; everything else (a failover, a transient network error, or anything
-    // else the driver itself could not resume) restarts from the tracked position. Mirrors the classification in
-    // NativeMongoSubscriptionModel and SpringMongoSubscriptionModel.
+    // ChangeStreamHistoryLost (286) restarts from StartAt.now() only when configured to. Everything else
+    // (failover, transient network error, anything the driver itself couldn't resume) restarts from the
+    // tracked position. Mirrors NativeMongoSubscriptionModel and SpringMongoSubscriptionModel.
     private boolean shouldRestart(Throwable throwable, AtomicReference<StartAt> currentStartAt) {
         if (isChangeStreamHistoryLost(throwable)) {
             if (config.restartSubscriptionsOnChangeStreamHistoryLost) {
@@ -260,14 +254,14 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
 
     @Override
     public Mono<Checkpoint> globalCheckpoint() {
-        // Increase the "increment" by 1 so the resume position lands after the most recently
-        // written event, matching SpringMongoSubscriptionModel and avoiding replaying it.
+        // Increment by 1 so the resume position lands after the most recently written event, matching
+        // SpringMongoSubscriptionModel, avoiding a replay.
         return mongo.executeCommand(new Document("hostInfo", 1))
                 .map(document -> MongoCommons.getServerOperationTime(document, 1))
                 .onErrorResume(UncategorizedMongoDbException.class, throwable -> {
                     if (throwable.getCause() instanceof MongoCommandException) {
-                        // This can if the server doesn't allow to get the operation time since "db.adminCommand( { "hostInfo" : 1 } )" is prohibited.
-                        // This is the case on for example shared Atlas clusters. If this happens we return the current time of the client instead.
+                        // Happens when the server prohibits "hostInfo" (e.g. shared Atlas clusters), falls
+                        // back to the client's current time.
                         log.warn(cannotFindGlobalCheckpointErrorMessage(throwable.getCause()));
                         return Mono.empty();
                     } else {
@@ -308,8 +302,8 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
         }
 
         running = true;
-        // Reuses the same currentStartAt reference so resume continues from the position of the last event
-        // delivered before the subscription was paused, rather than replaying (or skipping) from the original StartAt.
+        // Reuses the same currentStartAt reference so resume continues from the last delivered event, not
+        // the original StartAt.
         return startInternalSubscription(subscriptionId, internalSubscription.filter, internalSubscription.currentStartAt, internalSubscription.action);
     }
 


### PR DESCRIPTION
Tightens inline comments in the MongoDB subscription models (native, Spring blocking, Spring reactor), the in-memory model, `MongoCommons`, the checkpoint storage adapters, and the competing-consumer support. Cuts restated code and first-person narration, keeps the non-obvious reasons (resume-token handling, restart classification, the `checkpoint` field with its legacy `subscriptionPosition` read fallback). Comments only, no code or behavior change.
