### PR TITLE
Simplify comments in the subscription catch-up and durable models

### DIFF
--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
@@ -139,10 +139,10 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
         StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
         final Checkpoint globalCheckpoint = captureLiveResumeCheckpoint(delegatedStartAt);
 
-        // Page through the DCB sequence from the resume position to the head seen at the start, in windows so a large
+        // Page through the DCB sequence from the resume position to the head seen at start, in windows so a large
         // rebuild does not load the whole matched set at once, then reconcile until the head stops advancing.
-        // position is monotonic and server-assigned, so this needs no count and no time sort. Anything written after
-        // the reconciliation loop stabilises is newer than the live resume position and arrives live.
+        // Position is monotonic and server-assigned, so this needs no count and no time sort. Anything written
+        // after the reconciliation loop stabilises is newer than the live resume position and arrives live.
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
         PositionCatchupPipeline.Reader dcbReader = new PositionCatchupPipeline.Reader() {
             @Override

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModel.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModel.java
@@ -58,7 +58,7 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
     private final AtomicBoolean stoppedByUser = new AtomicBoolean(false);
 
     private final ConcurrentMap<SubscriptionIdAndSubscriberId, CompetingConsumer> competingConsumers = new ConcurrentHashMap<>();
-    // A set that hold which subscriptions whose StartAt position have indicated that they should not use the competing consumer model
+    // Subscriptions whose StartAt position indicated they should not use the competing consumer model
     private final Set<String> nonCompetingConsumersSubscriptions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public CompetingConsumerSubscriptionModel(SubscriptionModel subscriptionModel, CompetingConsumerStrategy strategy) {
@@ -85,9 +85,9 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
         final Subscription subscription;
         if (startAt.get(new SubscriptionModelContext(CompetingConsumerSubscriptionModel.class)) == null) {
             nonCompetingConsumersSubscriptions.add(subscriptionId);
-            // We're not allowed to start the competing consumer subscription, just delegate to parent.
-            // One reason for this might be if we're starting a non-durable in-memory subscription on multiple nodes.
-            // Then typically you want all nodes to receive all events, and thus there's no need for a  CompetingConsumerSubscription.
+            // Not allowed to start the competing consumer subscription, delegate to parent instead. One case: a
+            // non-durable in-memory subscription started on multiple nodes, where every node should receive every
+            // event, so competing consumption is not wanted.
             subscription = getDelegatedSubscriptionModel().subscribe(subscriptionId, filter, startAt, action);
         } else {
             subscription = startCompetingConsumerSubscription(subscriberId, subscriptionId, filter, startAt, action);
@@ -150,14 +150,13 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
         }
 
         if (resumeSubscriptionsAutomatically) {
-            // Note that we deliberately don't start the delegated subscription model here!!
-            // This is because we're not sure that we have the lock. The underlying SM will be started
-            // automatically if required (since it's instructed to do so in the Waiting state supplier).
+            // Deliberately not starting the delegated subscription model here since the lock is not known to be
+            // held. The underlying SM starts automatically if required, per the Waiting state supplier.
             competingConsumers.values().stream()
                     .filter(not(CompetingConsumer::isRunning))
                     .forEach(cc -> {
                                 logDebug("Starting CompetingConsumer subscription (subscriberId={}, subscriptionId={}, state={})", cc.getSubscriberId(), cc.getSubscriptionId(), cc.state.getClass().getSimpleName());
-                                // Only change state if we have permission to consume
+                                // Only change state when permitted to consume
                                 if (cc.isWaiting()) {
                                     // Registering a competing consumer will start the subscription automatically if lock was acquired
                                     competingConsumerStrategy.registerCompetingConsumer(cc.getSubscriptionId(), cc.getSubscriberId());
@@ -221,15 +220,15 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
                             subscription = startWaitingConsumer(competingConsumer);
                         } else {
                             competingConsumers.put(competingConsumer.subscriptionIdAndSubscriberId, competingConsumer.registerRunning());
-                            // This works because we've checked that it's already paused earlier
+                            // Safe because it was already checked to be paused above
                             subscription = delegate.resumeSubscription(subscriptionId);
                         }
                     } else if (registerCompetingConsumer(subscriptionId, subscriberId) && !competingConsumer.isWaiting()) {
-                        // This works because we've checked that it's already paused earlier
+                        // Safe because it was already checked to be paused above
                         competingConsumers.put(competingConsumer.subscriptionIdAndSubscriberId, competingConsumer.registerRunning());
                         subscription = delegate.resumeSubscription(subscriptionId);
                     } else {
-                        // We're not allowed to resume since we don't have the lock.
+                        // Not allowed to resume without the lock
                         subscription = new CompetingConsumerSubscription(subscriptionId, subscriberId);
                     }
                     return subscription;
@@ -293,14 +292,13 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
                 pauseConsumer(competingConsumer, pausedByUser);
                 if (pausedByUser) {
                     logDebug("Will unregister competing consumer because subscription was paused explicitly by user (subscriptionId={}, subscriberId={})", subscriptionId, competingConsumer.getSubscriberId());
-                    // If subscription is paused by user explicitly, then the user needs to resume it again explicitly to start it.
-                    // In these cases, we unregister the competing consumer. This means that it cannot be leader again until the subscription is
-                    // resumed explicitly (it'll re-register the competing consumers).
+                    // A user-paused subscription needs an explicit resume to restart, so unregister the competing
+                    // consumer: it cannot become leader again until the subscription is explicitly resumed.
                     competingConsumerStrategy.unregisterCompetingConsumer(competingConsumer.getSubscriptionId(), competingConsumer.getSubscriberId());
                 } else {
                     logDebug("Will release competing consumer because subscription was paused by system (subscriptionId={}, subscriberId={})", subscriptionId, competingConsumer.getSubscriberId());
-                    // Subscription was not paused by the user, thus we just "release" the competing consumer so that it can re-gain leader status
-                    // later without explicitly resuming the subscription.
+                    // Not paused by the user, so just release the competing consumer so it can re-gain leader
+                    // status later without an explicit resume.
                     competingConsumerStrategy.releaseCompetingConsumer(competingConsumer.getSubscriptionId(), competingConsumer.getSubscriberId());
                 }
             }
@@ -366,14 +364,12 @@ public class CompetingConsumerSubscriptionModel implements DelegatingSubscriptio
 
         if (competingConsumer.isRunning()) {
             logDebug("CompetingConsumer is running, will pause subscription and consumers (subscriberId={}, subscriptionId={})", subscriberId, subscriptionId);
-            // We pause the entire subscription. The reason for this is that we don't want this instance to subscribe to any events at all.
-            // If we don't do this, events will still be sent to the instance. Also, we make use of the "checkpoint" when resuming the
-            // subscription later. If we had not paused the subscription this could happen:
+            // Pausing (not just stopping delivery) is what lets resume later use the checkpoint. Without it:
             // 1. Subscriber 1 loses lock
             // 2. An event is published (A)
             // 3. Subscriber 2 doesn't have lock yet
-            // 4. When we detect that no one has the lock, we resume the subscriber (say Subscriber 2), but now it's too late because we've missed A.
-            // This also make sense since there can only be one subscription with the same id for the same CatchupSubscriptionModel instance.
+            // 4. No one has the lock is detected, Subscriber 2 is resumed, but A was already missed.
+            // Also only one subscription can exist per id per CatchupSubscriptionModel instance.
             pauseSubscription(subscriptionId, false);
         } else if (competingConsumer.isPaused()) {
             logDebug("CompetingConsumer is already paused, won't do anything (subscriberId={}, subscriptionId={})", subscriberId, subscriptionId);

--- a/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModel.java
+++ b/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModel.java
@@ -35,22 +35,14 @@ import static org.occurrent.subscription.CheckpointAwareCloudEvent.getCheckpoint
 import static org.occurrent.subscription.util.predicate.EveryN.everyEvent;
 
 /**
- * Combines  a {@link SubscriptionModel} and with a {@link CheckpointStorage} to automatically persist
- * the checkpoint after each successful call to the "action" method
- * (i.e. when the consumer in this method {@link DurableSubscriptionModel#subscribe(String, Consumer)} has completed successfully),
- * thus making the subscription durable.
+ * Combines a {@link SubscriptionModel} with a {@link CheckpointStorage}, persisting the checkpoint after each
+ * successful call to the action in {@link DurableSubscriptionModel#subscribe(String, Consumer)}.
  *
  * <p>
- * Note that this implementation stores the checkpoint after _every_ action by default. This means one synchronous checkpoint
- * write per delivered event, which roughly doubles the write load of a subscription that's keeping pace with the event store.
- * This default is kept on purpose since changing it would change what happens after a crash: with the default, replay after
- * a restart resumes right after the last delivered event; if checkpoints are written less often, replay resumes from an
- * earlier checkpoint and events already handled before the crash will be re-delivered.
- * <p>
- * If checkpoint-write throughput matters more than minimizing re-delivery after a crash, pass a {@link DurableSubscriptionModelConfig}
- * with {@link org.occurrent.subscription.util.predicate.EveryN#every(int)} as the {@code persistCloudEventPositionPredicate}, for example
- * {@code EveryN.every(10)} to checkpoint every 10th event instead of every single one. The tradeoff is fewer checkpoint writes in
- * exchange for more events being re-delivered (and needing to be handled idempotently) after a crash or restart.
+ * By default the checkpoint is written after every event, doubling write load but resuming right after the
+ * last delivered event on crash. Pass a {@link DurableSubscriptionModelConfig} with
+ * {@link org.occurrent.subscription.util.predicate.EveryN#every(int)} to checkpoint less often, trading fewer
+ * writes for events being re-delivered (must be handled idempotently) after a crash.
  */
 @NullMarked
 public class DurableSubscriptionModel implements CheckpointAwareSubscriptionModel, DelegatingSubscriptionModel {
@@ -94,7 +86,7 @@ public class DurableSubscriptionModel implements CheckpointAwareSubscriptionMode
 
         StartAt startAtToUse = generateStartAtPositionFrom(subscriptionId, startAt);
         if (startAtToUse == null) {
-            // We're not allowed to start this subscription, delegate to wrapped subscription instead
+            // Not allowed to start, delegate to the wrapped subscription instead
             return getDelegatedSubscriptionModel().subscribe(subscriptionId, filter, startAt, action);
         }
 
@@ -114,7 +106,7 @@ public class DurableSubscriptionModel implements CheckpointAwareSubscriptionMode
         if (originalStartAt.isDefault()) {
             StartAt startAtIfNoSubscriptionFound = StartAt.subscriptionModelDefault();
             startAtToUse = StartAt.dynamic(() -> {
-                // It's important that we find the document inside the supplier so that we lookup the latest resume token on retry
+                // Read inside the supplier so a retry picks up the latest checkpoint, not a stale one
                 Checkpoint checkpoint = storage.read(subscriptionId);
                 if (checkpoint == null) {
                     Checkpoint globalCheckpoint = subscriptionModel.globalCheckpoint();

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
@@ -38,11 +38,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Shared plumbing for the mode-specific catch-up subscription models
- * ({@link StreamCatchupSubscriptionModel} and the DCB catch-up model): the wrapped live delegate, the config, the
- * running-catch-up bookkeeping, the shutdown flag, and the lifecycle delegation to the wrapped subscription model.
- * The mode-specific replay and {@code subscribe(...)} routing stays in each subclass. This base is DCB-free so it can
- * live in the stream module that both modes build against.
+ * Shared plumbing for the mode-specific catch-up subscription models ({@link StreamCatchupSubscriptionModel} and the
+ * DCB catch-up model): the live delegate, config, running-catch-up bookkeeping, shutdown flag, and lifecycle
+ * delegation. Replay and {@code subscribe(...)} routing stay in each subclass. DCB-free so it can live in the
+ * stream module both modes build against.
  */
 @NullMarked
 abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, DelegatingSubscriptionModel {
@@ -51,13 +50,12 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     protected final CatchupSubscriptionModelConfig config;
     protected final Class<?> subscriptionModelContextType;
     protected final ConcurrentMap<String, Boolean> runningCatchupSubscriptions = new ConcurrentHashMap<>();
-    // A pause requested for a subscriptionId while its replay is still in-flight (the delegate does not know the id
-    // yet, so pauseSubscription against it would be a no-op or fail). Applied via applyPendingPauseIfAny once the
-    // live delegate subscription for that id exists.
+    // Pause requested for a subscriptionId while its replay is still in-flight, before the delegate knows the id.
+    // Applied via applyPendingPauseIfAny once the live delegate subscription exists.
     protected final ConcurrentMap<String, Boolean> pauseRequestedDuringCatchup = new ConcurrentHashMap<>();
     protected volatile boolean shuttingDown = false;
-    // Set by stop(), cleared by start(...). Checked by the replay loops so stop() interrupts an in-flight replay
-    // instead of only stopping the delegate the replay has not registered with yet.
+    // Set by stop(), cleared by start(...). Checked by the replay loops so stop() interrupts an in-flight
+    // replay, not just the delegate the replay has not registered with yet.
     protected volatile boolean stopped = false;
 
     protected AbstractCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, CatchupSubscriptionModelConfig config, Class<?> subscriptionModelContextType) {
@@ -66,9 +64,8 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
         this.subscriptionModelContextType = Objects.requireNonNull(subscriptionModelContextType, "subscriptionModelContextType cannot be null");
     }
 
-    // Reports subscriptionModelContextType (CatchupSubscriptionModel when wrapped by the dispatcher) so a
-    // StartAt.dynamic supplied by a caller that pattern matches on the public dispatcher type keeps working
-    // regardless of which mode-specific class ends up running the catch-up underneath it.
+    // Reports subscriptionModelContextType (the dispatcher's type when wrapped) so a caller's StartAt.dynamic
+    // pattern-matching on the public dispatcher type keeps working regardless of which subclass runs underneath.
     protected SubscriptionModelContext generateSubscriptionModelContext() {
         return new SubscriptionModelContext(subscriptionModelContextType);
     }
@@ -109,10 +106,9 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     @Override
     public void pauseSubscription(String subscriptionId) {
         if (runningCatchupSubscriptions.containsKey(subscriptionId)) {
-            // The delegate does not know this id yet since the replay has not handed over to it, so record the
-            // request and apply it via applyPendingPauseIfAny once the live delegate subscription for this id
-            // exists. Interrupting the replay itself and resuming it later would need the exact replay cursor to be
-            // persisted, which this class does not do; the replay keeps running until the handover.
+            // Delegate does not know this id yet, so record the request and apply it in applyPendingPauseIfAny
+            // once the live subscription exists. The replay itself keeps running until the handover since
+            // interrupting and resuming it would require persisting the exact replay cursor, which this class does not do.
             pauseRequestedDuringCatchup.put(subscriptionId, true);
         } else {
             getDelegatedSubscriptionModel().pauseSubscription(subscriptionId);
@@ -138,13 +134,12 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, De
     }
 
     /**
-     * Captures the live resume token so an event committed during the replay is still delivered live. Callers
-     * choose when to capture it relative to the bulk replay: {@link StreamCatchupSubscriptionModel}'s position path
-     * captures it before the replay so no in-flight event is missed, while its time-based path captures it after
-     * the replay to keep the token fresh. Returns null when the delegated subscription model must not run
-     * ({@code delegatedStartAt} is null, i.e. the catch-up owns the position entirely). Otherwise fails loudly when
-     * the delegate reports no resume token, mirroring the reactor pipeline's fail-loud handover, instead of silently
-     * falling back to "now" and dropping every event committed during the replay.
+     * Captures the live resume checkpoint handed over to live delivery. Callers choose when: the position path in
+     * {@link StreamCatchupSubscriptionModel} captures it before the bulk replay so no in-flight event is missed;
+     * the time-based path captures it after, to keep the token fresh (avoids oplog ageing).
+     * Returns null when the delegate must not run ({@code delegatedStartAt} null, catch-up owns the position
+     * entirely). Fails loudly if the delegate has no checkpoint rather than silently resuming at "now" and
+     * dropping events committed during replay.
      */
     protected @Nullable Checkpoint captureLiveResumeCheckpoint(@Nullable StartAt delegatedStartAt) {
         if (delegatedStartAt == null) {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -36,13 +36,12 @@ public class CatchupSubscriptionModelConfig {
     static final long DEFAULT_DCB_CATCHUP_POSITION_WINDOW_SIZE = 1000;
 
     /**
-     * Default ceiling on the number of event ids kept to deduplicate the catch-up-to-live handover seam, used by the
-     * convenience constructors that do not take an explicit {@code cacheSize}. The dedup cache grows to cover the
-     * overlap the live subscription re-delivers (bounded by the write volume during the replay, not by total history)
-     * and evicts oldest-first only once it would exceed this ceiling. Exceeding it yields extra duplicate deliveries,
-     * never loss (delivery is at-least-once). It is well above the previous {@code 100} so a rebuild with heavy
-     * concurrent writes no longer evicts the overlap before the live subscription re-delivers it. Each id is a short
-     * string, so lower it to cap memory or raise it to cut duplicates further.
+     * Default ceiling on the number of event ids kept to dedupe the catch-up-to-live handover, used by convenience
+     * constructors without an explicit {@code cacheSize}. The cache grows to cover the replay-to-live overlap
+     * (bounded by write volume during replay, not total history) and evicts oldest-first past this ceiling.
+     * Exceeding it causes extra duplicate deliveries, never loss (at-least-once). Well above the previous
+     * {@code 100} so a rebuild under heavy concurrent writes no longer evicts the overlap before live re-delivers
+     * it. Each id is a short string, so lower it to cap memory or raise it to cut duplicates further.
      */
     public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
 
@@ -91,13 +90,10 @@ public class CatchupSubscriptionModelConfig {
      * @param subscriptionStorageConfig Configures if and how checkpoint persistence should be handled during the catch-up phase.
      */
     public CatchupSubscriptionModelConfig(int cacheSize, CheckpointStorageConfig subscriptionStorageConfig) {
-        // We sort by time but fallback to stream version if time is the same for two events.
-        // While this will _not_ sort the entire in database in insertion order, it at least guarantees
-        // order within a stream. Note that we can't do SortBy.time(ASCENDING).thenNatural(ASCENDING)
-        // since for certain databases (MongoDB) this will prevent sorting from using a "time index" for queries
-        // (see https://docs.mongodb.com/manual/reference/method/cursor.sort/#return-natural-order).
-        // For MongoDB, doing SortBy.time(ASCENDING).then("_id", ASCENDING) would be better,
-        // but "_id" is unique to MongoDB so we cannot use it here.
+        // Sorts by time, falling back to stream version when time ties, which guarantees order within a stream but
+        // not full insertion order. Not SortBy.time(ASCENDING).thenNatural(ASCENDING): on MongoDB that prevents the
+        // sort from using a time index (see https://docs.mongodb.com/manual/reference/method/cursor.sort/#return-natural-order).
+        // SortBy.time(ASCENDING).then("_id", ASCENDING) would be better on MongoDB, but "_id" is Mongo-specific.
         this(cacheSize, subscriptionStorageConfig, SortBy.ascending(TIME, STREAM_VERSION));
     }
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/FixedSizeCache.java
@@ -23,19 +23,18 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * An insertion-ordered cache of delivered event ids that grows to cover the replay-to-live overlap up to {@code size},
- * evicting oldest-first once it would exceed it. Used both to dedupe an overlapping catch-up reconciliation re-read and
- * to skip, in the live consumer, events already delivered during catch-up at the handover seam. Shared by the stream
- * and DCB catch-up paths. The overlap it must cover is bounded by the write volume during the replay (the live change
- * stream resumes from a recent token, not from history), not by total history.
+ * Insertion-ordered cache of delivered event ids covering the replay-to-live overlap up to {@code size}, evicting
+ * oldest-first past that. Dedupes the overlapping reconcile re-read and lets the live consumer skip events already
+ * delivered during catch-up at the handover seam. Shared by the stream and DCB catch-up paths. The overlap is
+ * bounded by write volume during replay, not total history, since the live change stream resumes from a recent
+ * token.
  * <p>
- * Eviction is loss-safe by construction: dropping an id can only stop a re-delivered live event from being suppressed,
- * so an overlap larger than {@code size} yields extra duplicate deliveries, never loss (delivery is at-least-once).
- * Dedup is by id, never by position, so a low-position event that commits late (after the handover advanced past its
- * position) is never in this cache and is always delivered by the live subscription.
+ * Dedup is id-based with a fixed ceiling: exceeding {@code size} evicts entries and causes duplicate delivery,
+ * never loss, since delivery is at-least-once. Never dedupes by position, so a late-committing low-position event
+ * is always delivered live.
  * <p>
- * Written on the catch-up (replay) thread and read on the live delivery thread at the handover seam, so every access
- * is synchronized, matching the reactor {@code HandoverCache}.
+ * Written on the catch-up thread, read on the live thread at the handover seam, so access is synchronized, matching
+ * the reactor {@code HandoverCache}.
  */
 @NullMarked
 final class FixedSizeCache {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/PositionCatchupPipeline.java
@@ -27,15 +27,15 @@ import java.util.stream.Stream;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The bulk-then-reconcile paging shared by every position-ordered blocking catch-up replay. A {@link Reader} supplies
- * the window and head reads, so this pipeline is free of any specific store or query type, and is reused by both the
- * stream and the DCB catch-up models (the blocking counterpart of the reactor {@code PositionCatchupPipeline}).
+ * Bulk-then-reconcile paging shared by every position-ordered blocking catch-up replay. A {@link Reader} supplies
+ * the window and head reads so this pipeline is store-agnostic, reused by both the stream and DCB catch-up models
+ * (blocking counterpart of the reactor {@code PositionCatchupPipeline}).
  * <p>
- * The replay pages the sequence in {@code windowSize} windows, then a single reconciliation pass drains up to a head
- * snapshotted once at reconcile start so events written during the replay are delivered in order. It does not chase a
- * moving head, which under sustained writes would never terminate, so anything committed after the snapshot head is
- * left to the live subscription (resuming from the pre-bulk token), deduped by the caller's cache. The caller supplies
- * the delivery (dedup cache, checkpoint persistence, cancellation) so this class stays a pure paging loop.
+ * The replay pages the sequence in {@code windowSize} windows, then reconciles once, draining up to a head
+ * snapshotted at reconcile start so writes during the replay are delivered in order. It does not chase a moving
+ * head, which would never terminate under sustained writes. Anything committed after the snapshot is left to the
+ * live subscription, deduped by the caller's cache. The caller supplies delivery (dedup, checkpoint persistence,
+ * cancellation), keeping this a pure paging loop.
  */
 @NullMarked
 final class PositionCatchupPipeline {
@@ -80,13 +80,9 @@ final class PositionCatchupPipeline {
         long bulkHead = reader.currentHead();
         long cursor = windows(startPosition, bulkHead, keepRunning, deliver, null);
 
-        // Reconcile events written during the bulk replay by draining up to a head snapshotted once here. It does not
-        // chase a moving head: under sustained writes re-reading the head would advance forever and the catch-up would
-        // never hand over to live (a livelock). Anything committed after this snapshot head is delivered by the live
-        // subscription, which resumes from the pre-bulk token, deduped by the cache. Loss-safe: nothing in
-        // (snapshotHead, now] is skipped because live covers it, and nothing in (cursor, snapshotHead] is skipped
-        // because this pass drains it. Re-reads of the bulk-tail overlap are deduped by the cache (delivery is
-        // at-least-once).
+        // Snapshot the head once and reconcile up to it. Re-reading a moving head would advance forever under
+        // sustained writes and never hand over to live (livelock). Anything after the snapshot is covered by the
+        // live subscription (resumes from the pre-bulk token); the bulk-tail overlap is deduped by the cache.
         long snapshotHead = reader.currentHead();
         cursor = windows(cursor, snapshotHead, keepRunning, deliver, cache);
         return cursor;

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -60,33 +60,30 @@ import static org.occurrent.time.internal.RFC3339.RFC_3339_DATE_TIME_FORMATTER;
 
 /**
  * The blocking stream catch-up path: replays historic stream events (by {@code position} when the store writes one,
- * otherwise by the legacy time/{@code $natural} order) then hands over to a live subscription. This is the stream
- * counterpart split out of {@code CatchupSubscriptionModel} (see ADR 25) so a stream-only application does
- * not need to depend on {@code eventstore-api-dcb}. The dispatcher {@code CatchupSubscriptionModel} in the
- * {@code catchup-subscription} module wraps this class for its stream routing.
+ * otherwise by the legacy time/{@code $natural} order) then hands over to a live subscription. Split out of
+ * {@code CatchupSubscriptionModel} (ADR 25) so a stream-only application does not need {@code eventstore-api-dcb}.
+ * The dispatcher {@code CatchupSubscriptionModel} wraps this class for its stream routing.
  * <p>
- * This class only ever replays and delivers stream-capability events. On a store that has both the {@code STREAM} and
- * {@code DCB} capabilities enabled at once, that promise is enforced, not merely descriptive: a
- * {@link Filter#capability(EventStoreCapability) STREAM-capability filter} is ANDed into both the catch-up-phase reads
- * and the filter handed to the delegated live subscription, so a DCB-tagged event never reaches a subscriber of this
- * class in either phase (see ADR 50). A caller filter is still honored; the capability guard is composed on top of it.
+ * Only ever replays and delivers stream-capability events. On a store with both {@code STREAM} and {@code DCB}
+ * capabilities enabled, this is enforced, not descriptive: a
+ * {@link Filter#capability(EventStoreCapability) STREAM-capability filter} is ANDed into both catch-up reads and
+ * the live-subscription filter, so a DCB-tagged event never reaches a subscriber of this class (ADR 50). A caller
+ * filter is still honored, with the capability guard composed on top.
  * <p>
- * Delivery is at-least-once, with the same catch-up-to-live handover and clock-skew-safe reconciliation guarantees
- * documented on the dispatcher.
+ * Delivery is at-least-once, with the same handover and clock-skew-safe reconciliation guarantees documented on
+ * the dispatcher.
  */
 @NullMarked
 public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
 
-    // Guards every read and every live handover this class performs so a DCB-tagged event is never delivered to a
-    // stream subscriber, even on a store that has both capabilities enabled (see ADR 50). It is store-agnostic: each
-    // Filter-conversion implementation maps this capability to its own storage artifact.
+    // Guards every read and live handover so a DCB-tagged event never reaches a stream subscriber, even when both
+    // capabilities are enabled (ADR 50). Store-agnostic: each Filter-conversion implementation maps this capability
+    // to its own storage artifact.
     private static final Filter STREAM_CAPABILITY_FILTER = Filter.capability(EventStoreCapability.STREAM);
 
     private final EventStoreQueries eventStoreQueries;
-    // The capability guard ANDed into every read and every live handover. It is {@link #STREAM_CAPABILITY_FILTER} for a
-    // stream subscription (so a DCB-tagged event never reaches a stream subscriber, see ADR 50), and {@code null} for a
-    // capability-agnostic subscription, which then filters only by the caller's plain Filter and so delivers events of
-    // every capability.
+    // The capability guard ANDed into every read and live handover: STREAM_CAPABILITY_FILTER for a stream
+    // subscription, null for a capability-agnostic one, which then delivers events of every capability.
     private final @Nullable Filter capabilityScope;
 
     public StreamCatchupSubscriptionModel(CheckpointAwareSubscriptionModel subscriptionModel, EventStoreQueries eventStoreQueries, CatchupSubscriptionModelConfig config) {
@@ -151,8 +148,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         boolean positionMode = streamStoreWritesPosition();
         final StartAt firstStartAt;
         if (startAt.isDefault()) {
-            // By default, we check if there's a subscription position stored for this subscription, if so we resume from there, otherwise,
-            // delegate to the parent subscription model.
+            // Resume from a stored position if there is one, otherwise delegate to the parent subscription model.
             Checkpoint checkpoint = returnIfCheckpointStorageConfigIs(UseCheckpointInStorage.class, cfg -> cfg.storage().read(subscriptionId)).orElse(null);
             if (checkpoint == null) {
                 // Resumed straight to live without a catch-up phase, so scope the delegated subscription the same way
@@ -169,7 +165,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         } else if (startAt.isDynamic()) {
             StartAt startAtGeneratedByDynamic = startAt.get(generateSubscriptionModelContext());
             if (startAtGeneratedByDynamic == null) {
-                // We're not allowed to start this subscription model, defer to parent!
+                // Not allowed to start this subscription model, defer to parent
                 return getDelegatedSubscriptionModel().subscribe(subscriptionId, withCapabilityScope(filter), startAt, action);
             } else {
                 firstStartAt = startAtGeneratedByDynamic;
@@ -196,9 +192,9 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         };
     }
 
-    // The kinds of resolved start a stream subscription can have. Classifying once keeps the routing above an
-    // exhaustive switch, so a new kind forces both switches to handle it and no start can silently fall through to
-    // live delivery, which is the class of bug that once dropped specific-time replay on a position store.
+    // Resolved start kinds for a stream subscription. Classifying once keeps the routing above an exhaustive switch,
+    // so a new kind forces both switches to handle it instead of silently falling through to live delivery, which
+    // once dropped specific-time replay on a position store.
     private enum StreamStart {BEGINNING_OF_TIME, SPECIFIC_TIME, GLOBAL_POSITION, LIVE}
 
     // Resolve the start once, then branch on the resolved checkpoint. Beginning-of-time must be checked before
@@ -254,49 +250,37 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         // Perform the catchup
         runCatchupForStream(eventStoreQueries.query(catchupFilter, config.catchupPhaseSortBy), subscriptionId, action, null);
 
-        // Here we check if the delegated subscription model is allowed to execute. The reason for doing this is that
-        // in certain scenarios, such as when using the @Subscription annotation with settings {@code startAt=BEGINNING_OF_TIME} and
-        // {@code resume=SAME_AS_START_AT}, we instruct the DurableSubscriptionModel (which is typically the delegated subscription model here)
-        // to NOT store the position durably. This because we start at "beginning of time" and we also want to resume at
-        // "beginning of time" and thus we never need to store ANY subscription position (because we always start from "beginning of time"
-        // when application is rebooted). This allows for catching up in-memory projections/views/policies.
-        // We force the wrapping subscription to be a CheckpointAwareSubscriptionModel so that we can capture
-        // where the live subscription should resume. This position is captured *after* the bulk replay so it
-        // stays fresh: capturing it before a long replay would risk the resume token ageing out of the
-        // database change stream (e.g. MongoDB's oplog) before the handover, making the live subscription
-        // unresumable. Events written during the replay are not covered by this position (they were written
-        // before it). They are reconciled separately by the insertion-order delta below. A null resume token from
-        // the delegate fails loudly (captureLiveResumeCheckpoint) instead of silently resuming live at "now" and
-        // dropping every event committed during the replay; see the position path for the same guarantee captured
-        // before its replay instead.
+        // The delegated subscription model may be configured to never store its position durably, e.g. @Subscription
+        // with startAt=BEGINNING_OF_TIME and resume=SAME_AS_START_AT: since every restart replays from beginning of
+        // time anyway, no position needs to be stored. This lets in-memory projections/views/policies catch up.
+        //
+        // The wrapping subscription is forced to be a CheckpointAwareSubscriptionModel to capture where live
+        // delivery should resume. Captured *after* the bulk replay, not before, so the token stays fresh: capturing
+        // it before a long replay risks it ageing out of the change stream (e.g. MongoDB's oplog) before handover.
+        // Events written during the replay are not covered by this checkpoint; they are reconciled separately by
+        // the insertion-order delta below. A null resume token fails loudly (captureLiveResumeCheckpoint) instead
+        // of silently resuming live at "now" and dropping events committed during the replay; the position path
+        // captures its checkpoint before its replay instead, for the same guarantee.
         Class<? extends SubscriptionModel> delegatedSubscriptionModelType = getDelegatedSubscriptionModel().getClass();
         StartAt delegatedStartAt = startAt.get(new SubscriptionModelContext(delegatedSubscriptionModelType));
         final Checkpoint globalCheckpoint = captureLiveResumeCheckpoint(delegatedStartAt);
 
-        // We generate a cache so that events that are streamed at the same time as streaming the events missed
-        // during the catch-up phase are not streamed again.
+        // Cache to avoid re-delivering events already streamed during catch-up when they arrive again live.
         FixedSizeCache catchupPhaseCache = new FixedSizeCache(config.cacheSize);
 
-        // Reconcile events that arrived during the catch-up phase, i.e. those written after the bulk replay started
-        // but at or before the live subscription's resume position (globalCheckpoint). They are, by
-        // definition, the most-recently-inserted matching events, so we read the newest ones in *insertion order*
-        // (SortBy.natural, descending + limit, no skip) and reverse them back to insertion order for delivery.
+        // Reconcile events written after the bulk replay started but at or before the live resume position
+        // (globalCheckpoint): read the newest N in insertion order (SortBy.natural descending + limit, no skip)
+        // and reverse for delivery.
         //
-        // Selecting by insertion order rather than the configurable, time-based catchupPhaseSortBy is what makes this
-        // reconciliation loss-free under clock skew: a during-catch-up event whose "time" is earlier than the replay
-        // cursor's already-passed position would otherwise sort before the already-processed boundary (missed here)
-        // and sit below the live subscription's resume position (missed there too), and would be silently lost.
-        // Reading the newest N in insertion order also reads only the recent tail instead of skipping the whole
-        // backlog, which matters on large event stores.
+        // Selecting by insertion order rather than the configurable catchupPhaseSortBy is what keeps this loss-free
+        // under clock skew (ADR 0014): a during-catch-up event whose time sorts before the already-processed
+        // boundary would be missed by both a time-sorted reconcile and by live delivery. Insertion order also reads
+        // only the recent tail instead of the whole backlog.
         //
-        // The number to read is derived from a count, but more events can be written between that count and the read.
-        // Such a write inflates the store and shifts the "newest N" window forward, pushing the oldest during-catch-up
-        // event out of the read; being at or before globalCheckpoint it would not be re-delivered by the live
-        // subscription either, and would be lost. To close that window we re-read until the matching count stops
-        // growing: each pass reads every event after the pre-catch-up boundary, so a pass during which no new event is
-        // written has necessarily delivered them all. Re-reads re-deliver already-seen events, which are deduped by the
-        // cache (delivery is at-least-once). Any event written after a pass is, by definition, newer than
-        // globalCheckpoint and is therefore covered by the live subscription regardless.
+        // The count to read comes from a count query, but more events can be written before the read runs, shifting
+        // the window and pushing an old during-catch-up event out. Re-read until the matching count stops growing:
+        // a pass with no new event has delivered them all. Re-reads are deduped by the cache (at-least-once).
+        // Anything written after a pass is newer than globalCheckpoint and is covered by live delivery regardless.
         long reconciledThroughCount = numberOfEventsBeforeStartingCatchupSubscription;
         long matchingEventCount = eventStoreQueries.count(catchupFilter);
         while (matchingEventCount > reconciledThroughCount && shouldKeepReplaying(subscriptionId)) {
@@ -319,8 +303,8 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             matchingEventCount = eventStoreQueries.count(catchupFilter);
         }
 
-        // We check if the delegated subscription model is not allowed to subscribe. If so, we remove any temporary subscription position written during the catchup phase
-        // since we're now done with the catch-up.
+        // If the delegate is not allowed to subscribe, remove the temporary position written during catch-up
+        // now that it's done.
         if (delegatedStartAt == null) {
             returnIfCheckpointStorageConfigIs(UseCheckpointInStorage.class, cfg -> {
                 cfg.storage().delete(subscriptionId);
@@ -333,38 +317,30 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
             subscriptionsWasCancelledOrShutdown = false;
             runningCatchupSubscriptions.remove(subscriptionId);
         } else {
-            // When runningCatchupSubscriptions doesn't contain the key at this stage it means that it has been explicitly cancelled.
+            // Key missing from runningCatchupSubscriptions at this stage means it was explicitly cancelled.
             subscriptionsWasCancelledOrShutdown = true;
         }
 
-        // When the catch-up subscription is ready, we store the global position in the position storage so that subscriptions
-        // that have not received _any_ new events during replay will start at the global position if the application is restarted.
-        // Otherwise, nothing will be stored in the "storage" and replay of historic events will take place again on application restart
-        // which is not what we want! The reason for doing this with UseCheckpointInStorage (as opposed to just
-        // PersistCheckpointDuringCatchupPhase) is that if using a "storage" at all in the config, is to accommodate
-        // that the wrapping subscription continues from where we left off.
+        // Store the global position once catch-up is ready so a subscription that got no new events during replay
+        // still resumes from it after a restart, instead of replaying history again. Uses UseCheckpointInStorage
+        // rather than PersistCheckpointDuringCatchupPhase because using storage at all implies the wrapped
+        // subscription should continue from where this left off.
         StartAt startAtToUse = StartAt.dynamic(this.<Supplier<StartAt>, UseCheckpointInStorage>returnIfCheckpointStorageConfigIs(UseCheckpointInStorage.class,
                         cfg -> () -> {
-                            // It's important that we find the document inside the supplier so that we look up the latest resume token on retry
+                            // Read inside the supplier so a retry picks up the latest checkpoint
                             Checkpoint position = cfg.storage().read(subscriptionId);
-                            // If there is no position stored in storage, or if the stored position is time-based
-                            // (i.e. written by the catch-up subscription), we save the globalCheckpoint.
-                            // The reason that we need to write the time-based subscription position in this case
-                            // is that the wrapped subscription might not support time-based subscriptions.
+                            // Nothing stored, or a time-based position from catch-up: save globalCheckpoint, since
+                            // the wrapped subscription may not support time-based positions.
                             if ((position == null || isTimeBasedCheckpoint(position)) && globalCheckpoint != null) {
                                 position = cfg.storage().save(subscriptionId, globalCheckpoint);
                             } else if (position == null) {
-                                // Position can still be null here if globalCheckpoint is null, if so, we start at the "subscriptionModelDefault",
-                                // given that the delegated subscription model is allowed to subscribe (i.e. delegatedStartAt != null).
+                                // globalCheckpoint is also null: start at subscriptionModelDefault if the delegate may subscribe
                                 return delegatedStartAt == null ? startAt : StartAt.subscriptionModelDefault();
                             }
                             return StartAt.checkpoint(position);
                         })
                 .orElse(() -> {
                     if (globalCheckpoint == null) {
-                        // We check if the delegated subscription model is allowed to subscribe (delegatedStartAt != null),
-                        // if so we instruct the subscription model to start from default, otherwise just return the original
-                        // startAt supplied by the user.
                         return delegatedStartAt == null ? startAt : StartAt.subscriptionModelDefault();
                     } else {
                         return StartAt.checkpoint(globalCheckpoint);
@@ -383,7 +359,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         final Subscription subscription;
         if (subscriptionsWasCancelledOrShutdown) {
             doIfCheckpointStorageConfigIs(UseCheckpointInStorage.class, cfg -> {
-                // Only get position if using storage and no position has been stored!
+                // Only get position if using storage and no position has been stored
                 if (!cfg.storage().exists(subscriptionId)) {
                     startAtToUse.get(generateSubscriptionModelContext());
                 }

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -74,12 +74,12 @@ class ReactorDcbCatchupSubscriptionModel implements CheckpointAwareSubscriptionM
      */
     public static final long DEFAULT_POSITION_WINDOW_SIZE = 1000;
     /**
-     * Default ceiling on the number of event ids kept to deduplicate the replay-to-live handover seam. The dedup set
-     * grows to cover the overlap the live change stream re-delivers (bounded by the write volume during the replay,
-     * not by total history) and evicts oldest-first only once it would exceed this ceiling. Exceeding the ceiling
-     * yields extra duplicate deliveries, never loss (delivery is at-least-once), so raise it to cut duplicates on a
-     * large rebuild or lower it to cap memory (each id is a short string). It is well above the previous {@code 1000}
-     * so a rebuild with heavy concurrent writes no longer evicts the overlap before the live stream re-delivers it.
+     * Default ceiling on the number of event ids kept to dedupe the replay-to-live handover. Grows to cover the
+     * replay-to-live overlap (bounded by write volume during replay, not total history) and evicts oldest-first
+     * past this ceiling. Exceeding it causes extra duplicate deliveries, never loss (at-least-once); raise it to
+     * cut duplicates on a large rebuild or lower it to cap memory (each id is a short string). Well above the
+     * previous {@code 1000} so a rebuild under heavy concurrent writes no longer evicts the overlap before live
+     * re-delivers it.
      */
     public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
 

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/HandoverCache.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/HandoverCache.java
@@ -24,15 +24,13 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * An insertion-ordered set of replayed event ids that the inclusive live resume re-delivers at the handover seam, so
- * the pipeline can suppress those duplicates. It holds the ids delivered during the replay window (the overlap the
- * live change stream re-delivers, bounded by the write volume during the replay, not by total history), and grows to
- * cover that overlap up to {@code ceiling}. Once the set would exceed {@code ceiling} it evicts oldest-first.
+ * Insertion-ordered set of replayed event ids the inclusive live resume re-delivers at the handover seam, so the
+ * pipeline can suppress those duplicates. Grows to cover the replay-to-live overlap (bounded by write volume during
+ * replay, not total history) up to {@code ceiling}, then evicts oldest-first.
  * <p>
- * Eviction is loss-safe by construction: dropping an id can only stop a re-delivered live event from being suppressed,
- * so an overlap larger than {@code ceiling} yields extra duplicate deliveries, never loss. Dedup is by id, never by
- * position, so a low-position event that commits late (after the handover advanced past its position) and is therefore
- * absent from the forward-only replay is never in this set and is always delivered by the live change stream.
+ * Dedup is id-based with a fixed ceiling: exceeding it evicts entries and causes duplicate delivery, never loss.
+ * Never dedupes by position, so a late-committing low-position event, absent from the forward-only replay, is
+ * always delivered by the live change stream.
  */
 @NullMarked
 final class HandoverCache {

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipeline.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/PositionCatchupPipeline.java
@@ -30,20 +30,19 @@ import java.util.function.Predicate;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The bulk-then-reconcile-then-live handover shared by every position-ordered reactive catch-up model. A
- * {@link CatchupReader} supplies the window and head reads, so this pipeline is free of any specific store or query
- * type, and is reused by both the stream and the DCB catch-up models.
+ * Bulk-then-reconcile-then-live handover shared by every position-ordered reactive catch-up model. A
+ * {@link CatchupReader} supplies the window and head reads so this pipeline is store-agnostic, reused by both the
+ * stream and DCB catch-up models.
  * <p>
- * The live resume token is captured before the bulk replay, not after, so an event that commits during the replay is
- * still delivered by the live subscription. The replay pages the sequence in {@code position} windows, then a single
- * reconciliation pass drains up to a head snapshotted once at reconcile start so events written during the replay are
- * delivered in order. It does not chase a moving head: under sustained writes that would never terminate, so anything
- * committed after the snapshot head is left to the live subscription (which resumes from the pre-bulk token), deduped
- * by the id cache. That cache dedupes events that both the replay and the live subscription see.
+ * The live resume token is captured before the bulk replay so an event committing during the replay is still
+ * delivered live. The replay pages in {@code position} windows, then reconciles once, draining up to a head
+ * snapshotted at reconcile start so writes during replay are delivered in order. It does not chase a moving head,
+ * which would never terminate under sustained writes; anything after the snapshot is left to the live subscription
+ * (resuming from the pre-bulk token), deduped by the id cache.
  * <p>
- * If the replay runs longer than the change stream history (the MongoDB oplog window), the captured token ages out
- * and the live resume fails loudly rather than silently dropping an event. If the model reports no resume token at
- * all (for example an empty oplog or a restricted cluster), the subscription fails loudly for the same reason.
+ * If the replay runs longer than the change stream history (e.g. the MongoDB oplog window), the captured token ages
+ * out and the handover fails loudly rather than silently dropping events. Same if the model reports no resume token
+ * at all (e.g. an empty oplog or a restricted cluster).
  */
 @NullMarked
 final class PositionCatchupPipeline {
@@ -77,19 +76,17 @@ final class PositionCatchupPipeline {
             throw new IllegalArgumentException("startPosition cannot be negative, was " + startPosition);
         }
         // Capture the live resume token before the bulk replay so an event committing during the replay is still
-        // delivered by the live subscription. If the model reports no token (for example an empty oplog or a
-        // restricted cluster) a no-loss handover to live cannot be guaranteed, so fail loudly instead of silently
-        // dropping the events committed between the end of the replay and going live.
+        // delivered live. If the model reports no token (e.g. an empty oplog or a restricted cluster) a no-loss
+        // handover cannot be guaranteed, so fail loudly instead of silently dropping events.
         return subscriptionModel.globalCheckpoint()
                 .switchIfEmpty(Mono.error(() -> new IllegalStateException("Cannot run a catch-up subscription because the subscription model reported no resume token to hand over to live delivery. The change stream history may be unavailable, for example an empty oplog or a restricted cluster.")))
                 .flatMapMany(liveToken ->
                         reader.currentHead().flatMapMany(bulkHead -> {
                             HandoverCache cache = new HandoverCache(handoverCacheSize);
-                            // Cache the replayed ids, including the bulk tail, because the reactive global
-                            // subscription position resumes inclusively, so the live change stream re-delivers
-                            // boundary events the replay already emitted. Dedup is by id, not by position, so an
-                            // in-flight event below the replay head that was never seen during the replay is still
-                            // delivered once by the live change stream.
+                            // Cache the replayed ids, including the bulk tail, since the reactive global position
+                            // resumes inclusively and the live change stream re-delivers boundary events already
+                            // emitted. Dedup by id, not position, so an in-flight event never seen during the
+                            // replay is still delivered once, live.
                             Flux<CloudEvent> bulk = windows(startPosition, bulkHead, cache);
                             Flux<CloudEvent> reconcile = reconcile(bulkHead, cache);
                             Flux<CloudEvent> live = subscriptionModel.subscribe(liveSubscriptionFilter, StartAt.checkpoint(liveToken))
@@ -110,12 +107,9 @@ final class PositionCatchupPipeline {
                 .concatWith(Flux.defer(() -> windows(upTo, toInclusive, cache)));
     }
 
-    // Drains events written during the bulk replay in position order up to a head snapshotted once here. It does not
-    // chase a moving head: under sustained writes re-reading the head would advance forever and the catch-up would
-    // never hand over to live (a livelock). Anything committed after this snapshot head is delivered by the live
-    // change stream, which resumes from the pre-bulk token, deduped by the id cache. Loss-safe: nothing in
-    // (snapshotHead, now] is skipped because live covers it, and nothing in (cursor, snapshotHead] is skipped because
-    // this pass drains it.
+    // Snapshot the head once and drain events up to it in position order. Re-reading a moving head would advance
+    // forever under sustained writes and never hand over to live (livelock). Anything after the snapshot is
+    // covered by the live change stream (resumes from the pre-bulk token), deduped by the id cache.
     private Flux<CloudEvent> reconcile(long cursor, HandoverCache cache) {
         return reader.currentHead().flatMapMany(snapshotHead -> windows(cursor, snapshotHead, cache));
     }

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
@@ -93,12 +93,12 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
      */
     public static final long DEFAULT_POSITION_WINDOW_SIZE = 1000;
     /**
-     * Default ceiling on the number of event ids kept to deduplicate the replay-to-live handover seam. The dedup set
-     * grows to cover the overlap the live change stream re-delivers (bounded by the write volume during the replay,
-     * not by total history) and evicts oldest-first only once it would exceed this ceiling. Exceeding the ceiling
-     * yields extra duplicate deliveries, never loss (delivery is at-least-once), so raise it to cut duplicates on a
-     * large rebuild or lower it to cap memory (each id is a short string). It is well above the previous {@code 1000}
-     * so a rebuild with heavy concurrent writes no longer evicts the overlap before the live stream re-delivers it.
+     * Default ceiling on the number of event ids kept to dedupe the replay-to-live handover. Grows to cover the
+     * replay-to-live overlap (bounded by write volume during replay, not total history) and evicts oldest-first
+     * past this ceiling. Exceeding it causes extra duplicate deliveries, never loss (at-least-once); raise it to
+     * cut duplicates on a large rebuild or lower it to cap memory (each id is a short string). Well above the
+     * previous {@code 1000} so a rebuild under heavy concurrent writes no longer evicts the overlap before live
+     * re-delivers it.
      */
     public static final int DEFAULT_HANDOVER_CACHE_SIZE = 100_000;
 


### PR DESCRIPTION
Tightens inline comments in the subscription catch-up, durable, and competing-consumer models (blocking and reactor). Cuts narration and ceremony, keeps the load-bearing invariants intact (the insertion-order reconcile that stays loss-free under clock skew, the id-based handover dedup with a ceiling that only ever duplicates and never loses, capture-before-replay). Comments only, no code or behavior change.
