### PR TITLE
Simplify comments in the event store implementations

### DIFF
--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -74,12 +74,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     private final Map<String, CopyOnWriteArrayList<CloudEvent>> state = Collections.synchronizedMap(new LinkedHashMap<>());
     private final AtomicLong nextPosition = new AtomicLong(1);
 
-    // Global, monotonically increasing insertion order assigned to each event at write time, keyed by the
-    // event's "id + source" (the same uniqueness key used by validateNoDuplicateEventExists). This is what
-    // SortBy.natural relies on so that "natural order" means *global* insertion order (matching MongoDB's
-    // $natural), rather than the per-stream grouping that results from iterating "state". Sequences are
-    // assigned inside the "state.compute" critical section in write(...), so they reflect the actual
-    // serialized insertion order across all streams.
+    // Global insertion order assigned to each event at write time, keyed by "id + source" (same key as
+    // validateNoDuplicateEventExists). Backs SortBy.natural, so natural order means global insertion order
+    // (matching MongoDB's $natural), not the per-stream grouping from iterating "state".
     private final AtomicLong insertionSequence = new AtomicLong();
     private final Map<String, Long> insertionOrderByEventKey = new ConcurrentHashMap<>();
 
@@ -223,8 +220,8 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         });
     }
 
-    // Call from inside the "state.compute" critical section so positions are drawn from the same nextPosition counter,
-    // under the same lock, that DCB uses, keeping stream and DCB writes on one shared sequence.
+    // Call from inside the "state.compute" critical section so positions come from the same nextPosition
+    // counter, under the same lock, that DCB uses, keeping stream and DCB writes on one shared sequence.
     private List<CloudEvent> applyStreamWriteExtensions(Stream<CloudEvent> events, String streamId, long streamVersion) {
         List<CloudEvent> withStreamMetadata = zip(LongStream.iterate(streamVersion + 1, i -> i + 1).boxed(), events, Pair::new)
                 .map(pair -> modifyCloudEvent(e -> e.withExtension(new OccurrentCloudEventExtension(streamId, pair.t1))).apply(pair.t2))
@@ -239,8 +236,8 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         return withPosition;
     }
 
-    // Must be called from inside the "state.compute" critical section so that sequence numbers reflect the
-    // serialized insertion order across all streams.
+    // Must run inside the "state.compute" critical section so sequence numbers reflect the serialized
+    // insertion order across all streams.
     private void assignInsertionOrder(List<CloudEvent> events) {
         for (CloudEvent event : events) {
             insertionOrderByEventKey.put(insertionKey(event), insertionSequence.getAndIncrement());
@@ -324,9 +321,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = validateDcbEvents(events);
-        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
-        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
-        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        // Place by the condition's boundary tags when it constrains tags, so the same boundary always lands
+        // in the same partition regardless of per-event tags. Otherwise fall back to the events' tags, so
+        // tagless boundaries do not all collapse onto one hot partition.
         Set<Tag> conditionTags = condition == null ? Set.of() : DcbCloudEvents.tagsOf(condition.query());
         Set<Tag> placementTags = conditionTags.isEmpty() ? tagsOf(eventsToAppend) : conditionTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
@@ -335,8 +332,8 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         DcbAppendResult result;
         synchronized (state) {
             if (condition != null) {
-                // The in-memory store assigns positions and commits atomically under the lock, so its read head is a
-                // sound concurrency boundary: the token value is simply the position observed by the read.
+                // Positions are assigned and committed atomically under the lock, so the read head is a sound
+                // concurrency boundary. The token value is simply the position observed at read time.
                 long afterPosition = condition.consistencyToken().map(DcbConsistencyToken::value).orElse(0L);
                 boolean fulfilled = allEvents()
                         .filter(event -> position(event) > afterPosition)
@@ -510,10 +507,10 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
         Objects.requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
         Objects.requireNonNull(sortBy, SortBy.class.getSimpleName() + " cannot be null");
 
-        // Snapshot the per-stream event lists under the lock, then filter and sort outside it. The stream returned
-        // to the caller is consumed lazily, so iterating state.values() outside the lock could race with a concurrent
-        // write() that structurally modifies the backing map and throw ConcurrentModificationException. Each value is
-        // a CopyOnWriteArrayList that write() replaces atomically, so iterating a snapshotted reference stays safe.
+        // Snapshot the per-stream lists under the lock, then filter and sort outside it. The returned stream is
+        // consumed lazily, so iterating state.values() outside the lock could race with a concurrent write()
+        // and throw ConcurrentModificationException. Each value is a CopyOnWriteArrayList that write() replaces
+        // atomically, so iterating the snapshotted reference stays safe.
         final List<CopyOnWriteArrayList<CloudEvent>> snapshot;
         synchronized (state) {
             snapshot = new ArrayList<>(state.values());
@@ -626,9 +623,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     }
 
     /**
-     * Rejects any DCB-tagged event on the stream write path, regardless of which capabilities are enabled. A
-     * dcbtags-carrying event written through write(...) would bypass the DCB append path, so it would be silently
-     * invisible to DCB reads. Enforcing this keeps the dcbtags extension the reliable DCB discriminator.
+     * Rejects DCB-tagged events on the stream write path. A dcbtags-carrying event written through write(...)
+     * would bypass the DCB append path and stay invisible to DCB reads, so this keeps dcbtags a reliable
+     * DCB discriminator.
      */
     private static void rejectDcbTaggedEvents(List<CloudEvent> events) {
         if (events.stream().anyMatch(DcbCloudEvents::isDcbEvent)) {
@@ -671,10 +668,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
     private Comparator<CloudEvent> toComparator(SortBy sortBy) {
         final Comparator<CloudEvent> comparator;
         if (sortBy instanceof NaturalImpl) {
-            // "Natural" order is global insertion order (see insertionOrderByEventKey), so it matches MongoDB's
-            // $natural and is monotonic with insertion regardless of the events' "time", both standalone and as
-            // a tie-breaker step. This is what the CatchupSubscriptionModel relies on to reconcile events written
-            // during the catch-up phase.
+            // "Natural" order is global insertion order (see insertionOrderByEventKey), matching MongoDB's
+            // $natural. Monotonic with insertion regardless of the events' "time", both standalone and as a
+            // tie-breaker step.
             Comparator<CloudEvent> byInsertionOrder = comparing((CloudEvent cloudEvent) -> insertionOrderByEventKey.getOrDefault(insertionKey(cloudEvent), Long.MAX_VALUE));
             comparator = ((NaturalImpl) sortBy).direction == DESCENDING ? byInsertionOrder.reversed() : byInsertionOrder;
         } else if (sortBy instanceof SingleFieldImpl) {

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventReader.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventReader.java
@@ -53,7 +53,6 @@ public class DocumentCloudEventReader implements CloudEventReader {
 
         V writer = cloudEventWriterFactory.create(specVersion);
 
-        // Let's deal with attributes first
         Set<String> allCloudEventAttributes = specVersion.getAllAttributes();
         for (String attributeName : allCloudEventAttributes) {
             if (Objects.equals(attributeName, SPEC_VERSION_ATTRIBUTE_NAME)) {
@@ -66,17 +65,15 @@ public class DocumentCloudEventReader implements CloudEventReader {
             }
         }
 
-        // Let's deal with extensions
         for (Map.Entry<String, Object> extension : document.entrySet()) {
             if (allCloudEventAttributes.contains(extension.getKey())) {
                 continue;
             }
             if (extension.getKey().equals("data")) {
-                // data handled later
+                // data is handled separately below
                 continue;
             }
 
-            // Switch on types document support
             if (extension.getValue() instanceof Integer integer) {
                 writer.withContextAttribute(extension.getKey(), integer);
             } else if (extension.getValue() instanceof Boolean bool) {
@@ -86,7 +83,6 @@ public class DocumentCloudEventReader implements CloudEventReader {
             }
         }
 
-        // Let's handle data
         Object data = document.get(DATA_ATTRIBUTE_NAME);
         if (data != null) {
             Object contentType = document.get(CONTENT_TYPE_ATTRIBUTE_NAME);
@@ -112,7 +108,6 @@ public class DocumentCloudEventReader implements CloudEventReader {
     private static CloudEventData convertJsonData(Object data) {
         final CloudEventData ceData;
         if (data instanceof Document document) {
-            // Best case, it's a document
             ceData = PojoCloudEventData.wrap(document, DocumentCloudEventReader::convertDocumentToBytes);
         } else if (data instanceof String json) {
             if (json.trim().startsWith(JSON_OBJECT_PREFIX)) {

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventWriter.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/cloudevent/DocumentCloudEventWriter.java
@@ -97,9 +97,8 @@ public class DocumentCloudEventWriter implements CloudEventWriterFactory<Documen
             String text = convertToString(cloudEventData);
             document.put("data", text);
         } else {
-            // Note that we cannot convert the data to DocumentCloudEventData even if content-type is json.
-            // This is because json data can be an array (or just a string) and this thus
-            // not necessarily representable as a "map" (and thus not as a org.bson.Document)
+            // Data cannot become a DocumentCloudEventData even when content-type is json, since json data
+            // can be an array or a bare string, not necessarily representable as a map (org.bson.Document).
             document.put("data", cloudEventData.toBytes());
         }
         return document;

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/MongoExceptionTranslator.java
@@ -49,10 +49,8 @@ public class MongoExceptionTranslator {
                     .map(RuntimeException.class::cast)
                     .orElse(e);
         } else if (e instanceof MongoCommandException && e.getCode() == 112) {
-            // See https://github.com/johanhaleby/occurrent/issues/85
-            // We increase version by 1 since this error only happens when two or more clients write to the same stream at the same time
-            // while also have read the same previous event stream version. This means that one of these write "have won" and the
-            // version has increased by at least one.
+            // This error only happens when two or more clients write to the same stream at the same time after
+            // reading the same previous version, so one of the writes won and the version increased by at least one.
             long eventStreamVersion = ctx.eventStreamVersion + 1;
             runtimeException = new WriteConditionNotFulfilledException(ctx.eventStreamId, eventStreamVersion, ctx.writeCondition,
                     String.format("%s was not fulfilled. Expected version %s but was %s.", WriteCondition.class.getSimpleName(), ctx.writeCondition.toString(), eventStreamVersion));
@@ -91,9 +89,6 @@ public class MongoExceptionTranslator {
     private static final String STREAM_VERSION_INDEX_NAME = OccurrentCloudEventExtension.STREAM_ID + "_1_" + OccurrentCloudEventExtension.STREAM_VERSION + "_1";
 
     private static boolean referencesStreamVersion(String message) {
-        // The duplicate-key message names the offending index, e.g. "index: streamid_1_streamversion_1". Matching
-        // the index name (rather than a bare "streamversion" substring) avoids misclassifying an id+source
-        // duplicate whose source value happens to contain that text.
         return message != null && message.contains("index: " + STREAM_VERSION_INDEX_NAME);
     }
 

--- a/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
+++ b/eventstore/mongodb/common/src/main/java/org/occurrent/eventstore/mongodb/internal/OccurrentCloudEventMongoDocumentMapper.java
@@ -58,7 +58,7 @@ public class OccurrentCloudEventMongoDocumentMapper {
                         " or convert the " + OffsetDateTime.class.getSimpleName() + " to UTC using e.g. \"offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC)\".");
             }
 
-            // Convert date string to a date in order to be able to perform date/time queries on the "time" property name
+            // Store as a Date (not a string) so date/time queries against the "time" property work.
             Date date = Date.from(time.toInstant());
             cloudEventDocument.put("time", date);
         }
@@ -71,7 +71,7 @@ public class OccurrentCloudEventMongoDocumentMapper {
         document.remove("_id");
 
         if (timeRepresentation == DATE) {
-            Object time = document.get("time"); // Be a bit nice and don't enforce Date here if TimeRepresentation has been changed
+            Object time = document.get("time"); // Guard against a non-Date value in case TimeRepresentation changed after storage
             if (time instanceof Date timeAsDate) {
                 OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(timeAsDate.toInstant(), UTC);
                 String format = RFC_3339_DATE_TIME_FORMATTER.format(offsetDateTime);
@@ -80,7 +80,7 @@ public class OccurrentCloudEventMongoDocumentMapper {
         }
 
         CloudEvent cloudEvent = DocumentCloudEventReader.toCloudEvent(document);
-        // When converting to JSON (document.toJson()) the stream version is interpreted as an int in Jackson, we convert it manually to long afterwards.
+        // document.toJson() has Jackson interpret the stream version as an int, so convert it back to long here.
         return CloudEventBuilder.v1(cloudEvent).withExtension(OccurrentCloudEventExtension.STREAM_VERSION, document.getLong(OccurrentCloudEventExtension.STREAM_VERSION)).build();
     }
 }

--- a/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/PositionDocumentMapper.java
+++ b/eventstore/mongodb/dcb-common/src/main/java/org/occurrent/eventstore/mongodb/dcb/internal/PositionDocumentMapper.java
@@ -25,8 +25,8 @@ import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 
 /**
  * Adds and reads back the {@value org.occurrent.cloudevents.OccurrentCloudEventExtension#POSITION} field on a stored
- * MongoDB document. Extracted so that both the DCB write path (which uses it today) and, in the future, the stream
- * write path can add a position to a document without duplicating the field-name and type-coercion contract.
+ * MongoDB document. Extracted so write paths that add a position to a document share one field-name and
+ * type-coercion contract instead of duplicating it.
  */
 @NullMarked
 public final class PositionDocumentMapper {

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -194,8 +194,8 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
             return new EventStreamImpl<>(streamId, 0, Stream.empty());
         }
 
-        // We use "lte" currentStreamVersion so that we don't have the start transactions on read. This means that even
-        // if another thread has inserted more events after we've read "currentStreamVersion" it doesn't matter.
+        // Uses "lte" currentStreamVersion instead of a transaction on read, so an event another thread inserts
+        // after currentStreamVersion is read does not matter.
         Bson query = streamIdAndStreamVersionLessThanOrEqualTo(streamId, currentStreamVersion);
         if (streamReadFilter != null) {
             StreamReadFilterValidator.validate(streamReadFilter);
@@ -405,9 +405,9 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = DcbMarkerModel.validateDcbEvents(events);
-        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
-        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
-        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        // Place by the condition's boundary tags when it constrains tags, so the same boundary always lands
+        // in the same partition regardless of per-event tags. Otherwise fall back to the events' tags, so
+        // tagless boundaries do not all collapse onto one hot partition.
         Set<Tag> conditionTags = condition == null ? Set.of() : DcbCloudEvents.tagsOf(condition.query());
         Set<Tag> placementTags = conditionTags.isEmpty() ? DcbMarkerModel.tagsOf(eventsToAppend) : conditionTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
@@ -426,11 +426,10 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
                     if (condition != null) {
                         enforceAppendCondition(clientSession, condition, eventsToAppend, lastPosition);
                     } else {
-                        // An unconditional append still increments its events' markers so a concurrent conditional append on an
-                        // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
-                        // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
-                        // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
-                        // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                        // An unconditional append still increments its events' markers, so a concurrent conditional append
+                        // on an overlapping tag or type shares a marker, serializes against it, and its consistency-token
+                        // check observes it. Without this, nothing forces a write-write conflict and a concurrent
+                        // conditional append's snapshot could miss this append (write skew). See ADR 0021.
                         incrementConflictMarkers(clientSession, DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
                     }
 
@@ -458,39 +457,39 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         Optional<DcbConsistencyToken> expectedToken = condition.consistencyToken();
         final boolean conflict;
         if (expectedToken.isPresent()) {
-            // Token-carrying check: the condition carries the consistency token the command observed when it read the
-            // query (DcbEventStream.consistencyToken()). If the query's markers have advanced since, an append matching
-            // the query committed after the read, so the condition is not fulfilled. Unlike a position-based existence
-            // check this is immune to read-watermark overshoot, because marker versions are bumped inside the append
-            // transaction (at commit), not when positions are reserved (ADR 0021).
+            // The condition carries the consistency token the command observed when it read the query
+            // (DcbEventStream.consistencyToken()). If the query's markers have advanced since, a matching append
+            // committed after the read, so the condition fails. This is immune to read-watermark overshoot,
+            // unlike a position-based check, because marker versions bump inside the append transaction at
+            // commit, not when positions are reserved (ADR 0021).
             conflict = consistencyToken(clientSession, condition.query()) != expectedToken.get().value();
         } else {
-            // No token: an absolute "fail if any matching event exists" guard. Check the live events rather than the
-            // marker versions, so this means "currently exists" (matching the in-memory store, and surviving deletes and
-            // marker pruning) rather than "ever appended". The marker increments below still serialize concurrent
-            // unconditional guards on the same boundary so two of them cannot both pass.
+            // No token: an absolute "fail if any matching event exists" guard. Checks the live events rather than
+            // marker versions, so it means "currently exists" (surviving deletes and marker pruning) rather than
+            // "ever appended". The marker increments below still serialize concurrent unconditional guards on the
+            // same boundary, so two of them cannot both pass.
             conflict = eventCollection.find(clientSession, toDcbBsonQuery(condition.query(), 0, Long.MAX_VALUE)).limit(1).first() != null;
         }
         if (conflict) {
             throw new DcbAppendConditionNotFulfilledException(condition, currentPosition(), "Append condition was not fulfilled.");
         }
-        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increments
-        // force a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs this
-        // check against the winner's committed increment. Always increment the query's markers so a concurrent matching
-        // append is serialized even when this append's own events do not match the query.
+        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increment
+        // forces a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs
+        // this check against the winner's committed increment. The query's markers are always incremented, so a
+        // concurrent matching append is serialized even when this append's own events do not match the query.
         TreeSet<String> markerKeys = new TreeSet<>(DcbMarkerModel.queryMarkerKeys(condition.query()));
         markerKeys.addAll(DcbMarkerModel.eventMarkerKeys(eventsToAppend));
         incrementConflictMarkers(clientSession, markerKeys, lastPosition);
     }
 
-    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker (per
-    // ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
-    // monotonically increasing version is also the optimistic-concurrency token: a reader snapshots the versions of a
-    // query's markers (see consistencyToken), and an append fails if any of them changed since. The stored lastPosition
-    // is informational.
-    // The marker collection holds one document per distinct tag and per distinct type that has taken part in an append,
-    // and nothing reclaims them automatically, so a high-cardinality tag (a tag per entity) grows the collection without
-    // bound. An operator can prune markers during quiescence (a later append recreates any it still needs).
+    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker
+    // (ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
+    // monotonically increasing version is also the optimistic-concurrency token (see consistencyToken): a reader
+    // snapshots a query's marker versions, and an append fails if any changed since. The stored lastPosition is
+    // informational.
+    // The marker collection holds one document per distinct tag and type that has taken part in an append, and
+    // nothing reclaims them automatically, so a high-cardinality tag (a tag per entity) grows the collection
+    // without bound. An operator can prune markers during quiescence, a later append recreates any it still needs.
     private void incrementConflictMarkers(ClientSession clientSession, Set<String> markerKeys, long lastPosition) {
         if (markerKeys.isEmpty()) {
             return;
@@ -506,18 +505,18 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
     }
 
     // The optimistic-concurrency token for a query: the sum of the versions of its conflict markers. The sum is
-    // monotonically increasing (every append increments at least one marker by one), so it changes if and only if some
-    // append touched at least one of the query's markers since the reader observed it. Because the versions are bumped
-    // inside the append transaction (not when positions are reserved), this token reflects only committed appends and is
-    // therefore immune to the read-watermark overshoot that a position-based check suffers (ADR 0021).
+    // monotonically increasing (every append increments at least one marker), so it changes if and only if some
+    // append touched one of the query's markers since the reader observed it. Because versions bump inside the
+    // append transaction, not when positions are reserved, this token reflects only committed appends and is
+    // immune to the read-watermark overshoot a position-based check suffers (ADR 0021).
     private long consistencyToken(@Nullable ClientSession clientSession, DcbCriteria query) {
         Set<String> markerKeys = DcbMarkerModel.queryMarkerKeys(query);
         if (markerKeys.isEmpty()) {
             return 0;
         }
-        // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading them
-        // one by one could tear across a concurrent append and capture a sum that matches a later state, masking a real
-        // conflict (ADR 31).
+        // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading
+        // them one by one could tear across a concurrent append and capture a sum that masks a real conflict
+        // (ADR 0031).
         List<String> markerIds = markerKeys.stream().map(DcbMarkerModel::markerId).toList();
         Bson markerFilter = in(ID, markerIds);
         FindIterable<Document> markers = clientSession == null ? dcbCheckpointCollection.find(markerFilter) : dcbCheckpointCollection.find(clientSession, markerFilter);
@@ -577,9 +576,9 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
             if (isTransientTransactionError(e)) {
                 throw e;
             }
-            // Two disjoint DCB boundaries that hash to the same partition stream race on the next stream version and one
-            // loses on the unique streamid+streamversion index. This is not a duplicate CloudEvent, so rethrow the raw
-            // duplicate-key error and let executeWithTransientRetry rerun the read-decide-append cycle.
+            // Two disjoint DCB boundaries that hash to the same partition stream race on the next stream version,
+            // and one loses on the unique streamid+streamversion index. This is not a duplicate CloudEvent, so
+            // rethrow the raw duplicate-key error and let executeWithTransientRetry rerun the read-decide-append cycle.
             if (isDuplicateKeyErrorOnStreamVersionIndex(e)) {
                 throw e;
             }
@@ -756,19 +755,17 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
             mongoDatabase.createCollection(dcbCheckpointCollectionName);
         }
 
-        // Cloud spec defines id + source must be unique!
+        // The CloudEvent spec requires id + source to be unique.
         eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true));
-        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up the
-        // current stream version per partition (currentStreamVersion), so it needs the same compound index to avoid a
-        // collection scan. The index is unique for both capabilities: DCB-only writes assign sequential per-partition
-        // stream versions, so uniqueness holds there too. The only way two events collide on the same
-        // streamId+streamVersion is two disjoint DCB boundaries hashing to the same partition stream, which
-        // insertAllDcb already treats as a retryable transient (re-reads and re-assigns a fresh version) rather than a
-        // duplicate error. Creating the identical unique index for STREAM and DCB also means no capability combination
-        // or DCB-only to STREAM+DCB upgrade ever hits an IndexOptionsConflict.
+        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up
+        // the current stream version per partition, so it needs the same compound index to avoid a collection
+        // scan. The index stays unique for DCB too, since DCB-only writes assign sequential per-partition stream
+        // versions. The only collision is two disjoint DCB boundaries hashing to the same partition stream, which
+        // insertAllDcb treats as a retryable transient rather than a duplicate error. One identical unique index
+        // for STREAM and DCB also means no capability combination or upgrade ever hits an IndexOptionsConflict.
         if (eventStoreCapabilities.contains(STREAM) || dcbEnabled) {
-            // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
-            // Note also that this index supports when sorting both ascending and descending since MongoDB can traverse an index in both directions.
+            // This compound index also covers queries on stream id alone, and MongoDB can traverse it in either
+            // direction, so it serves both ascending and descending sorts.
             createStreamVersionIndex(eventStoreCollection, new IndexOptions().unique(true));
         }
         // The position index is created whenever position is written, since DCB and stream writes share the same
@@ -779,28 +776,24 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         if (dcbEnabled) {
             eventStoreCollection.createIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true));
             // A type-only DcbCriteria has no tags to hit the dcbTags index with, so it falls back to the position
-            // index with type checked as a residual FETCH filter, examining every DCB event in the position range to
-            // find the (possibly rare) matches. A (type, position) compound index lets the planner satisfy both the
-            // type equality and the position sort directly from the index, so keysExamined tracks nReturned instead
-            // of the full position range. Evidence: explain("executionStats") on a 50k/50 skewed dataset showed
-            // docsExamined=50050 for nReturned=50 without this index.
+            // index with type checked as a residual FETCH filter, examining every DCB event in the position range.
+            // A (type, position) compound index lets the planner satisfy the type equality and position sort
+            // directly from the index, so keysExamined tracks nReturned instead of the full position range.
+            // Evidence: explain("executionStats") on a 50k/50 skewed dataset showed docsExamined=50050 for
+            // nReturned=50 without this index.
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending("type"), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true));
             // The multikey dcbTags index alone cannot provide the position sort order, so a tag boundary read falls
             // back to an in-memory (or, on MongoDB 6.0+, disk-spilling) SORT after fetching every matching document.
-            // Evidence: explain("executionStats") on a 5,000-of-305,000 skewed dataset (a plausible "popular tag"
-            // boundary, not a pathological one) showed a winning SORT stage over the dcbTags index. A (dcbTags,
-            // position) compound index lets the planner read matches in position order directly, avoiding the sort.
+            // A (dcbTags, position) compound index lets the planner read matches in position order directly instead.
+            // Evidence: explain("executionStats") on a 5,000-of-305,000 skewed dataset (a plausible popular-tag
+            // boundary) showed a winning SORT stage over the dcbTags index without this compound index.
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true));
         }
     }
 
-    // IndexOptionsConflict (error code 85) and IndexKeySpecsConflict (error code 86) both mean an index with this name
-    // already exists with a specification incompatible with the one Occurrent requests. Older MongoDB (4.x) reports the
-    // non-unique-vs-unique clash as 85, while MongoDB 7.0+ reports the same clash as 86. Occurrent always requests the
-    // unique streamId+streamVersion index for both STREAM and DCB, so normal capability combinations and upgrades never
-    // conflict. A conflict here therefore means an operator manually created an incompatible (e.g. non-unique) index.
-    // Occurrent never drops or replaces an existing index, and running on a non-unique index would silently lose the
-    // uniqueness guarantee stream and DCB writes rely on, so this fails startup instead of swallowing the conflict.
+    // The streamid+streamversion index already exists with options that clash with the unique one Occurrent needs
+    // (older MongoDB reports this as error 85, 7.0+ as 86). Occurrent never replaces an index, so fail rather than
+    // run without the uniqueness that stream and DCB writes depend on.
     private static void createStreamVersionIndex(MongoCollection<Document> eventStoreCollection, IndexOptions indexOptions) {
         try {
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), indexOptions);
@@ -964,10 +957,10 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
         } else if (sortBy instanceof MultipleSortStepsImpl) {
             List<SortBy> steps = ((MultipleSortStepsImpl) sortBy).steps;
             // A natural sort step is already a total ordering, so combining it with other sort steps in a compound
-            // sort is semantically incoherent, and Occurrent never builds such a sort itself. MongoDB 7.0+ also
-            // rejects $natural inside a compound sort server-side (BadValue: "$natural sort cannot be set to a value
-            // other than -1 or 1"), so reject it here instead of silently degrading it, which is what older MongoDB
-            // (4.x) did by applying pure natural order and ignoring the other keys.
+            // sort is incoherent. MongoDB 7.0+ also rejects $natural inside a compound sort server-side (BadValue:
+            // "$natural sort cannot be set to a value other than -1 or 1"), so reject it here instead of silently
+            // degrading it, which is what older MongoDB (4.x) did by applying pure natural order and ignoring the
+            // other keys.
             if (steps.stream().anyMatch(NaturalImpl.class::isInstance)) {
                 throw new IllegalArgumentException("A natural sort step cannot be combined with other sort steps, since natural order is already a total ordering. Use natural sort alone.");
             }

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/EventStoreConfig.java
@@ -94,7 +94,7 @@ public class EventStoreConfig {
         if (streamPositionOptedOut && eventStoreCapabilities.contains(EventStoreCapability.DCB)) {
             throw new IllegalArgumentException("Cannot disable stream position when the DCB capability is enabled; a combined store must position everything.");
         }
-        // Note that we deliberately allow the WriteConcern to be null in order to be able to use the default MongoTemplate settings
+        // WriteConcern may be null, so the default MongoTemplate settings apply.
         this.eventStoreCollectionName = eventStoreCollectionName;
         this.transactionTemplate = transactionTemplate;
         this.timeRepresentation = timeRepresentation;

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -174,7 +174,6 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             firstReservedPosition = 0;
         }
 
-        // The actual write logic for the cloud events
         TransactionCallback<StreamVersionDiff> writeLogic = transactionStatus -> {
             long currentStreamVersion = currentStreamVersion(streamId);
 
@@ -344,7 +343,6 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return requireNonNull(transactionTemplate.execute(__ -> logic.apply(updateFunction)));
     }
 
-    // Queries
     @Override
     public Stream<CloudEvent> query(Filter filter, int skip, int limit, SortBy sortBy) {
         requireStreamCapability();
@@ -373,9 +371,9 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
 
     private DcbAppendResult appendDcb(List<CloudEvent> events, @Nullable DcbAppendCondition condition) {
         List<CloudEvent> eventsToAppend = DcbMarkerModel.validateDcbEvents(events);
-        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in
-        // the same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all
-        // condition) fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        // Place by the condition's boundary tags when it constrains tags, so the same boundary always lands
+        // in the same partition regardless of per-event tags. Otherwise fall back to the events' tags, so
+        // tagless boundaries do not all collapse onto one hot partition.
         Set<Tag> conditionTags = condition == null ? Set.of() : DcbCloudEvents.tagsOf(condition.query());
         Set<Tag> placementTags = conditionTags.isEmpty() ? DcbMarkerModel.tagsOf(eventsToAppend) : conditionTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
@@ -392,11 +390,10 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             if (condition != null) {
                 enforceAppendCondition(condition, eventsToAppend, lastPosition);
             } else {
-                // An unconditional append still increments its events' markers so a concurrent conditional append on an
-                // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
-                // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
-                // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
-                // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                // An unconditional append still increments its events' markers, so a concurrent conditional append
+                // on an overlapping tag or type shares a marker, serializes against it, and its consistency-token
+                // check observes it. Without this, nothing forces a write-write conflict and a concurrent
+                // conditional append's snapshot could miss this append (write skew). See ADR 0021.
                 incrementConflictMarkers(DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
             }
 
@@ -413,12 +410,12 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
      * retried here: it propagates to the application service, which re-reads and retries the whole command.
      */
     private static <T> T executeWithTransientRetry(Supplier<T> action) {
-        // Exponential backoff with generous attempts: several appends placed in the same partition stream serialize on
-        // stream_version, so the last writer can need to retry past all the others before it commits.
+        // Exponential backoff with generous attempts, since several appends placed in the same partition stream
+        // serialize on stream_version, so the last writer can need to retry past all the others before it commits.
         // Retry a transient transaction conflict, and also a DuplicateKeyException. That duplicate is either two
-        // transactions first-creating the same conflict marker at once, or two disjoint DCB boundaries hashing to the
-        // same partition stream and losing on the unique streamid+streamversion index. Both are safe to rerun. A genuine
-        // duplicate CloudEvent is translated to a domain exception in insertAllDcb and never reaches here.
+        // transactions first-creating the same conflict marker at once, or two disjoint DCB boundaries hashing to
+        // the same partition stream and losing on the unique streamid+streamversion index. Both are safe to rerun.
+        // A genuine duplicate CloudEvent is translated to a domain exception in insertAllDcb and never reaches here.
         return RetryStrategy.exponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(500), 2.0f)
                 .maxAttempts(15)
                 .retryIf(throwable -> isTransientTransactionError(throwable) || isDuplicateKeyError(throwable))
@@ -466,41 +463,39 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         Optional<DcbConsistencyToken> expectedToken = condition.consistencyToken();
         final boolean conflict;
         if (expectedToken.isPresent()) {
-            // Token-carrying check: the condition carries the consistency token the command observed when it read the
-            // query (DcbEventStream.consistencyToken()). If the query's markers have advanced since, an append matching
-            // the query committed after the read, so the condition is not fulfilled. Unlike a position-based existence
-            // check this is immune to read-watermark overshoot, because marker versions are bumped inside the append
-            // transaction (at commit), not when positions are reserved (ADR 0021).
+            // The condition carries the consistency token the command observed when it read the query
+            // (DcbEventStream.consistencyToken()). If the query's markers have advanced since, a matching append
+            // committed after the read, so the condition fails. This is immune to read-watermark overshoot,
+            // unlike a position-based check, because marker versions bump inside the append transaction at
+            // commit, not when positions are reserved (ADR 0021).
             conflict = consistencyToken(condition.query()) != expectedToken.get().value();
         } else {
-            // No token: an absolute "fail if any matching event exists" guard. Check the live events rather than the
-            // marker versions, so this means "currently exists" (matching the in-memory store, and surviving deletes and
-            // marker pruning) rather than "ever appended". The marker increments below still serialize concurrent
-            // unconditional guards on the same boundary so two of them cannot both pass.
+            // No token: an absolute "fail if any matching event exists" guard. Checks the live events rather than
+            // marker versions, so it means "currently exists" (surviving deletes and marker pruning) rather than
+            // "ever appended". The marker increments below still serialize concurrent unconditional guards on the
+            // same boundary, so two of them cannot both pass.
             conflict = mongoTemplate.exists(toDcbMongoQuery(condition.query(), 0, Long.MAX_VALUE), eventStoreCollectionName);
         }
         if (conflict) {
             throw new DcbAppendConditionNotFulfilledException(condition, currentPosition(), "Append condition was not fulfilled.");
         }
-        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increments
-        // force a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs this
-        // check against the winner's committed increment. Always increment the query's markers so a concurrent matching
-        // append is serialized even when this append's own events do not match the query.
+        // Increment a marker per key for the union of the query's keys and the appended events' keys. The increment
+        // forces a write-write conflict that serializes concurrent appends sharing a marker, so the loser re-runs
+        // this check against the winner's committed increment. The query's markers are always incremented, so a
+        // concurrent matching append is serialized even when this append's own events do not match the query.
         TreeSet<String> markerKeys = new TreeSet<>(DcbMarkerModel.queryMarkerKeys(condition.query()));
         markerKeys.addAll(DcbMarkerModel.eventMarkerKeys(eventsToAppend));
         incrementConflictMarkers(markerKeys, lastPosition);
     }
 
-    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker (per
-    // ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
-    // monotonically increasing version is also the optimistic-concurrency token: a reader snapshots the versions of a
-    // query's markers (see consistencyToken), and an append fails if any of them changed since. The stored lastPosition
-    // is informational.
-    // The marker collection holds one document per distinct tag and per distinct type that has taken part in an append,
-    // and nothing reclaims them automatically, so a high-cardinality tag (a tag per entity) grows the collection without
-    // bound. An operator can prune markers during quiescence (a later append recreates any it still needs). Automatic
-    // reclamation is deferred: safe reclamation needs proof that no in-flight append references a marker, which is its
-    // own concurrency problem and out of proportion to the need today.
+    // Increment a conflict marker per key. Two appends that can match a common event share at least one marker
+    // (ADR 0021), so the in-transaction increment forces a MongoDB write-write conflict and they serialize. The
+    // monotonically increasing version is also the optimistic-concurrency token (see consistencyToken): a reader
+    // snapshots a query's marker versions, and an append fails if any changed since. The stored lastPosition is
+    // informational.
+    // The marker collection holds one document per distinct tag and type that has taken part in an append, and
+    // nothing reclaims them automatically, so a high-cardinality tag (a tag per entity) grows the collection
+    // without bound. An operator can prune markers during quiescence, a later append recreates any it still needs.
     private void incrementConflictMarkers(Set<String> markerKeys, long lastPosition) {
         if (markerKeys.isEmpty()) {
             return;
@@ -517,18 +512,18 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     // The optimistic-concurrency token for a query: the sum of the versions of its conflict markers. The sum is
-    // monotonically increasing (every append increments at least one marker by one), so it changes if and only if some
-    // append touched at least one of the query's markers since the reader observed it. Because the versions are bumped
-    // inside the append transaction (not when positions are reserved), this token reflects only committed appends and is
-    // therefore immune to the read-watermark overshoot that a position-based check suffers (ADR 0021).
+    // monotonically increasing (every append increments at least one marker), so it changes if and only if some
+    // append touched one of the query's markers since the reader observed it. Because versions bump inside the
+    // append transaction, not when positions are reserved, this token reflects only committed appends and is
+    // immune to the read-watermark overshoot a position-based check suffers (ADR 0021).
     private long consistencyToken(DcbCriteria query) {
         Set<String> markerKeys = DcbMarkerModel.queryMarkerKeys(query);
         if (markerKeys.isEmpty()) {
             return 0;
         }
-        // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading them
-        // one by one could tear across a concurrent append and capture a sum that matches a later state, masking a real
-        // conflict (ADR 31).
+        // Read the query's markers in one query so their versions come from a single consistent snapshot. Reading
+        // them one by one could tear across a concurrent append and capture a sum that masks a real conflict
+        // (ADR 0031).
         List<String> markerIds = markerKeys.stream().map(DcbMarkerModel::markerId).toList();
         long sum = 0;
         for (Document marker : mongoTemplate.find(new Query(where(ID).in(markerIds)), Document.class, dcbCheckpointCollectionName)) {
@@ -543,7 +538,7 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     /**
      * Reserves a contiguous block of {@code eventCount} DCB positions by incrementing one global counter document. Every
      * DCB append passes through this single document, so it is a serialization point and an inherent throughput ceiling
-     * for the store as a whole under very high append rates. It is kept outside the append transaction (ADR 21) so it
+     * for the store as a whole under very high append rates. It is kept outside the append transaction (ADR 0021) so it
      * does not turn into transaction conflicts, but the global monotonic sequence cannot be sharded away.
      */
     private long reservePositions(int eventCount) {
@@ -607,7 +602,6 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     @NullUnmarked
-    // Data structures etc
     private static class EventStreamImpl<T> implements EventStream<T> {
         private String _id;
         private long version;
@@ -702,7 +696,6 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return LongConditionEvaluator.evaluate(condition, currentStreamVersion);
     }
 
-    // Read
     private static Query streamIdEqualTo(String streamId) {
         return Query.query(streamIdEqualToCriteria(streamId));
     }
@@ -743,8 +736,8 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             return new EventStreamImpl<>(streamId, 0, Stream.empty());
         }
 
-        // We use "lte" currentStreamVersion so that we don't have the start transactions on read. This means that even
-        // if another thread has inserted more events after we've read "currentStreamVersion" it doesn't matter.
+        // Uses "lte" currentStreamVersion instead of a transaction on read, so an event another thread inserts
+        // after currentStreamVersion is read does not matter.
         Query query = Query.query(streamIdEqualToCriteria(streamId).and(STREAM_VERSION).lte(currentStreamVersion));
 
         if (streamReadFilter != null) {
@@ -780,7 +773,6 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         return autoClose(mongoTemplate.stream(query.with(sort), Document.class, eventStoreCollectionName));
     }
 
-    // Initialization
     private static void initializeEventStore(String eventStoreCollectionName, String dcbPositionCollectionName, String dcbCheckpointCollectionName, Set<EventStoreCapability> eventStoreCapabilities, boolean streamPositionEnabled, MongoTemplate mongoTemplate) {
         if (!mongoTemplate.collectionExists(eventStoreCollectionName)) {
             mongoTemplate.createCollection(eventStoreCollectionName);
@@ -798,35 +790,33 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
         }
 
         MongoCollection<Document> eventStoreCollection = mongoTemplate.getCollection(eventStoreCollectionName);
-        // Cloud spec defines id + source must be unique!
+        // The CloudEvent spec requires id + source to be unique.
         eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(CloudEventV1.ID), Indexes.ascending(CloudEventV1.SOURCE)), new IndexOptions().unique(true));
-        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up the
-        // current stream version per partition (currentStreamVersion), so it needs the same compound index to avoid a
-        // collection scan. The index is unique for both capabilities: DCB-only writes assign sequential per-partition
-        // stream versions, so uniqueness holds there too. The only way two events collide on the same
-        // streamId+streamVersion is two disjoint DCB boundaries hashing to the same partition stream, which the DCB
-        // append path already treats as a retryable transient (re-reads and re-assigns a fresh version) rather than a
-        // duplicate error. Creating the identical unique index for STREAM and DCB also means no capability combination
-        // or DCB-only to STREAM+DCB upgrade ever hits an IndexOptionsConflict.
+        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up
+        // the current stream version per partition, so it needs the same compound index to avoid a collection
+        // scan. The index stays unique for DCB too, since DCB-only writes assign sequential per-partition stream
+        // versions. The only collision is two disjoint DCB boundaries hashing to the same partition stream, which
+        // the DCB append path treats as a retryable transient rather than a duplicate error. One identical unique
+        // index for STREAM and DCB also means no capability combination or upgrade ever hits an IndexOptionsConflict.
         if (eventStoreCapabilities.contains(STREAM) || dcbEnabled) {
-            // Create a streamId + streamVersion ascending index (note that we don't need to index stream id separately since it's covered by this compound index)
-            // Note also that this index supports sorting both ascending and descending since MongoDB can traverse an index in both directions.
+            // This compound index also covers queries on stream id alone, and MongoDB can traverse it in either
+            // direction, so it serves both ascending and descending sorts.
             createStreamVersionIndex(eventStoreCollection, new IndexOptions().unique(true));
         }
         if (dcbEnabled) {
             eventStoreCollection.createIndex(Indexes.ascending(DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true));
             // A type-only DcbCriteria has no tags to hit the dcbTags index with, so it falls back to the position
-            // index with type checked as a residual FETCH filter, examining every DCB event in the position range to
-            // find the (possibly rare) matches. A (type, position) compound index lets the planner satisfy both the
-            // type equality and the position sort directly from the index, so keysExamined tracks nReturned instead
-            // of the full position range. Evidence: explain("executionStats") on a 50k/50 skewed dataset showed
-            // docsExamined=50050 for nReturned=50 without this index.
+            // index with type checked as a residual FETCH filter, examining every DCB event in the position range.
+            // A (type, position) compound index lets the planner satisfy the type equality and position sort
+            // directly from the index, so keysExamined tracks nReturned instead of the full position range.
+            // Evidence: explain("executionStats") on a 50k/50 skewed dataset showed docsExamined=50050 for
+            // nReturned=50 without this index.
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(CloudEventV1.TYPE), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true));
             // The multikey dcbTags index alone cannot provide the position sort order, so a tag boundary read falls
             // back to an in-memory (or, on MongoDB 6.0+, disk-spilling) SORT after fetching every matching document.
-            // Evidence: explain("executionStats") on a 5,000-of-305,000 skewed dataset (a plausible "popular tag"
-            // boundary, not a pathological one) showed a winning SORT stage over the dcbTags index. A (dcbTags,
-            // position) compound index lets the planner read matches in position order directly, avoiding the sort.
+            // A (dcbTags, position) compound index lets the planner read matches in position order directly instead.
+            // Evidence: explain("executionStats") on a 5,000-of-305,000 skewed dataset (a plausible popular-tag
+            // boundary) showed a winning SORT stage over the dcbTags index without this compound index.
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(DCB_TAGS_INDEX_FIELD), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true));
         }
         // The position index is created whenever the store writes a position, so position-ordered reads and catch-up
@@ -835,18 +825,14 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
             eventStoreCollection.createIndex(Indexes.ascending(OccurrentCloudEventExtension.POSITION), new IndexOptions().unique(true).sparse(true));
         }
 
-        // SessionSynchronization need to be "ALWAYS" in order for TransactionTemplate to work with mongo template!
-        // See https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions.transaction-template
+        // SessionSynchronization must be ALWAYS for TransactionTemplate to work with MongoTemplate. See
+        // https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions.transaction-template
         mongoTemplate.setSessionSynchronization(ALWAYS);
     }
 
-    // IndexOptionsConflict (error code 85) and IndexKeySpecsConflict (error code 86) both mean an index with this name
-    // already exists with a specification incompatible with the one Occurrent requests. Older MongoDB (4.x) reports the
-    // non-unique-vs-unique clash as 85, while MongoDB 7.0+ reports the same clash as 86. Occurrent always requests the
-    // unique streamId+streamVersion index for both STREAM and DCB, so normal capability combinations and upgrades never
-    // conflict. A conflict here therefore means an operator manually created an incompatible (e.g. non-unique) index.
-    // Occurrent never drops or replaces an existing index, and running on a non-unique index would silently lose the
-    // uniqueness guarantee stream and DCB writes rely on, so this fails startup instead of swallowing the conflict.
+    // The streamid+streamversion index already exists with options that clash with the unique one Occurrent needs
+    // (older MongoDB reports this as error 85, 7.0+ as 86). Occurrent never replaces an index, so fail rather than
+    // run without the uniqueness that stream and DCB writes depend on.
     private static void createStreamVersionIndex(MongoCollection<Document> eventStoreCollection, IndexOptions indexOptions) {
         try {
             eventStoreCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION)), indexOptions);

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -229,7 +229,6 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         return convertToCloudEvent(timeRepresentation, eventStream);
     }
 
-    // DCB
     @Override
     public Mono<DcbEventStream> read(DcbCriteria query, DcbReadOptions options) {
         if (!eventStoreCapabilities.contains(DCB)) {
@@ -237,11 +236,11 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         }
         requireNonNull(query, "Query cannot be null");
         requireNonNull(options, "Read options cannot be null");
-        // Snapshot the consistency token BEFORE reading the events. If an append commits between these two reads, the
-        // events may include it while the token does not, which only makes a later conditional append over-cautious (a
-        // false conflict that retries) rather than miss the conflict (ADR 0031). The token read and the position read
-        // are independent of each other (neither is derived from the other's result), so zip them concurrently rather
-        // than sequencing them, while keeping both strictly before the event read below.
+        // Snapshot the consistency token BEFORE reading the events. If an append commits between these two reads,
+        // the events may include it while the token does not, which only makes a later conditional append
+        // over-cautious (a false conflict that retries) rather than miss the conflict (ADR 0031). The token read
+        // and the position read are independent, so zip them concurrently rather than sequencing them, while
+        // keeping both strictly before the event read below.
         return Mono.zip(consistencyToken(query), currentPosition())
                 .flatMap(tokenAndHighWatermark -> {
                     long token = tokenAndHighWatermark.getT1();
@@ -306,9 +305,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         } catch (RuntimeException e) {
             return Mono.error(e);
         }
-        // Place by the condition's boundary tags when it constrains on tags, so the same boundary always lands in the
-        // same partition regardless of per-event tags. Otherwise (no condition, or a type-only/match-all condition)
-        // fall back to the events' tags so tagless boundaries do not all collapse onto one hot partition.
+        // Place by the condition's boundary tags when it constrains tags, so the same boundary always lands
+        // in the same partition regardless of per-event tags. Otherwise fall back to the events' tags, so
+        // tagless boundaries do not all collapse onto one hot partition.
         Set<Tag> conditionTags = condition == null ? Set.of() : DcbCloudEvents.tagsOf(condition.query());
         Set<Tag> placementTags = conditionTags.isEmpty() ? DcbMarkerModel.tagsOf(eventsToAppend) : conditionTags;
         String streamId = requireNonNull(dcbStreamIdGenerator.generateStreamId(placementTags), "DcbStreamIdGenerator returned a null stream id");
@@ -326,11 +325,10 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
                         if (condition != null) {
                             conditionAndMarkers = enforceAppendCondition(condition, eventsToAppend, lastPosition);
                         } else {
-                            // An unconditional append still increments its events' markers so a concurrent conditional append on an
-                            // overlapping tag/type shares a marker and serializes against it, and so the conditional append's
-                            // consistency-token check observes it. Without this, an unconditional append touches no marker, nothing
-                            // forces a write-write conflict, and a concurrent conditional append's snapshot can miss this append
-                            // under MongoDB snapshot isolation (write skew). See ADR 0021.
+                            // An unconditional append still increments its events' markers, so a concurrent conditional
+                            // append on an overlapping tag or type shares a marker, serializes against it, and its
+                            // consistency-token check observes it. Without this, nothing forces a write-write conflict
+                            // and a concurrent conditional append's snapshot could miss this append (write skew). See ADR 0021.
                             conditionAndMarkers = incrementConflictMarkers(DcbMarkerModel.eventMarkerKeys(eventsToAppend), lastPosition);
                         }
                         return conditionAndMarkers.then(Mono.defer(() -> {
@@ -351,10 +349,10 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         Optional<DcbConsistencyToken> expectedToken = condition.consistencyToken();
         final Mono<Boolean> conflictMono;
         if (expectedToken.isPresent()) {
-            // Token-carrying check: the condition carries the consistency token the command observed when it read the
-            // query. If the query's markers have advanced since, an append matching the query committed after the read,
-            // so the condition is not fulfilled. Immune to read-watermark overshoot because marker versions are bumped
-            // inside the append transaction (ADR 0021).
+            // The condition carries the consistency token the command observed when it read the query. If the
+            // query's markers have advanced since, a matching append committed after the read, so the condition
+            // fails. Immune to read-watermark overshoot because marker versions bump inside the append
+            // transaction (ADR 0021).
             conflictMono = consistencyToken(condition.query()).map(actual -> actual != expectedToken.get().value());
         } else {
             // No token: an absolute "fail if any matching event exists" guard. The marker increments below still
@@ -585,12 +583,11 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         return new Criteria().andOperator(criteria);
     }
 
-    // Read
     private Mono<EventStreamImpl> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
         return currentStreamVersion(streamId)
                 .flatMap(currentStreamVersion -> {
-                    // We use "lte" currentStreamVersion so that we don't have the start transactions on read. This means that even
-                    // if another thread has inserted more events after we've read "currentStreamVersion" it doesn't matter.
+                    // Uses "lte" currentStreamVersion instead of a transaction on read, so an event another thread
+                    // inserts after currentStreamVersion is read does not matter.
                     Query query = streamIdAndStreamVersionLessThanOrEqualTo(streamId, currentStreamVersion);
                     if (streamReadFilter != null) {
                         StreamReadFilterValidator.validate(streamReadFilter);
@@ -682,24 +679,21 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         return oldestEvent != null && !oldestEvent.containsKey(OccurrentCloudEventExtension.POSITION);
     }
 
-    // Initialization
     private Mono<Void> initializeEventStore(String eventStoreCollectionName, String dcbPositionCollectionName, String dcbCheckpointCollectionName, Set<EventStoreCapability> eventStoreCapabilities, ReactiveMongoTemplate mongoTemplate) {
         boolean dcbEnabled = eventStoreCapabilities.contains(DCB);
         boolean writesPosition = writesPosition();
 
-        // Cloud spec defines id + source must be unique!
+        // The CloudEvent spec requires id + source to be unique.
         Mono<Void> chain = createCollection(eventStoreCollectionName, mongoTemplate)
                 .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending("id"), Indexes.ascending("source")), new IndexOptions().unique(true)))
                 .then();
 
-        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up the
-        // current stream version per partition (currentStreamVersion), so it needs the same compound index to avoid a
-        // collection scan. The index is unique for both capabilities: DCB-only writes assign sequential per-partition
-        // stream versions, so uniqueness holds there too. The only way two events collide on the same
-        // streamId+streamVersion is two disjoint DCB boundaries hashing to the same partition stream, which the DCB
-        // append path already treats as a retryable transient (re-reads and re-assigns a fresh version) rather than a
-        // duplicate error. Creating the identical unique index for STREAM and DCB also means no capability combination
-        // or DCB-only to STREAM+DCB upgrade ever hits an IndexOptionsConflict.
+        // streamId + streamVersion uniqueness is a stream-mode invariant, but the DCB append path also looks up
+        // the current stream version per partition, so it needs the same compound index to avoid a collection
+        // scan. The index stays unique for DCB too, since DCB-only writes assign sequential per-partition stream
+        // versions. The only collision is two disjoint DCB boundaries hashing to the same partition stream, which
+        // the DCB append path treats as a retryable transient rather than a duplicate error. One identical unique
+        // index for STREAM and DCB also means no capability combination or upgrade ever hits an IndexOptionsConflict.
         if (eventStoreCapabilities.contains(STREAM) || dcbEnabled) {
             chain = chain.then(createStreamVersionIndex(eventStoreCollectionName, mongoTemplate, new IndexOptions().unique(true))).then();
         }
@@ -719,18 +713,17 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
                     .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), new IndexOptions().sparse(true)))
                     // A type-only DcbCriteria has no tags to hit the dcbTags index with, so it falls back to the
                     // position index with type checked as a residual FETCH filter, examining every DCB event in the
-                    // position range to find the (possibly rare) matches. A (type, position) compound index lets the
-                    // planner satisfy both the type equality and the position sort directly from the index, so
-                    // keysExamined tracks nReturned instead of the full position range. Evidence:
-                    // explain("executionStats") on a 50k/50 skewed dataset showed docsExamined=50050 for nReturned=50
-                    // without this index.
+                    // position range. A (type, position) compound index lets the planner satisfy the type equality
+                    // and position sort directly from the index, so keysExamined tracks nReturned instead of the
+                    // full position range. Evidence: explain("executionStats") on a 50k/50 skewed dataset showed
+                    // docsExamined=50050 for nReturned=50 without this index.
                     .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending("type"), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true)))
                     // The multikey dcbTags index alone cannot provide the position sort order, so a tag boundary read
                     // falls back to an in-memory (or, on MongoDB 6.0+, disk-spilling) SORT after fetching every
-                    // matching document. Evidence: explain("executionStats") on a 5,000-of-305,000 skewed dataset (a
-                    // plausible "popular tag" boundary, not a pathological one) showed a winning SORT stage over the
-                    // dcbTags index. A (dcbTags, position) compound index lets the planner read matches in position
-                    // order directly, avoiding the sort.
+                    // matching document. A (dcbTags, position) compound index lets the planner read matches in
+                    // position order directly instead. Evidence: explain("executionStats") on a 5,000-of-305,000
+                    // skewed dataset (a plausible popular-tag boundary) showed a winning SORT stage over the dcbTags
+                    // index without this compound index.
                     .then(createIndex(eventStoreCollectionName, mongoTemplate, Indexes.compoundIndex(Indexes.ascending(DcbDocumentMapper.DCB_TAGS_INDEX_FIELD), Indexes.ascending(OccurrentCloudEventExtension.POSITION)), new IndexOptions().sparse(true)))
                     .then();
         }
@@ -739,8 +732,8 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
             chain = chain.then(warnIfUnpositionedEventsExist(eventStoreCollectionName, mongoTemplate));
         }
 
-        // SessionSynchronization need to be "ALWAYS" in order for TransactionTemplate to work with mongo template!
-        // See https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions.transaction-template
+        // SessionSynchronization must be ALWAYS for TransactionTemplate to work with MongoTemplate. See
+        // https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions.transaction-template
         mongoTemplate.setSessionSynchronization(ALWAYS);
 
         return chain;
@@ -779,13 +772,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
         return mongoTemplate.getCollection(eventStoreCollectionName).flatMap(collection -> Mono.from(collection.createIndex(index, indexOptions)));
     }
 
-    // IndexOptionsConflict (error code 85) and IndexKeySpecsConflict (error code 86) both mean an index with this name
-    // already exists with a specification incompatible with the one Occurrent requests. Older MongoDB (4.x) reports the
-    // non-unique-vs-unique clash as 85, while MongoDB 7.0+ reports the same clash as 86. Occurrent always requests the
-    // unique streamId+streamVersion index for both STREAM and DCB, so normal capability combinations and upgrades never
-    // conflict. A conflict here therefore means an operator manually created an incompatible (e.g. non-unique) index.
-    // Occurrent never drops or replaces an existing index, and running on a non-unique index would silently lose the
-    // uniqueness guarantee stream and DCB writes rely on, so this fails startup instead of swallowing the conflict.
+    // The streamid+streamversion index already exists with options that clash with the unique one Occurrent needs
+    // (older MongoDB reports this as error 85, 7.0+ as 86). Occurrent never replaces an index, so fail rather than
+    // run without the uniqueness that stream and DCB writes depend on.
     private static Mono<String> createStreamVersionIndex(String eventStoreCollectionName, ReactiveMongoTemplate mongoTemplate, IndexOptions indexOptions) {
         Bson index = Indexes.compoundIndex(Indexes.ascending(STREAM_ID), Indexes.ascending(STREAM_VERSION));
         return createIndex(eventStoreCollectionName, mongoTemplate, index, indexOptions)


### PR DESCRIPTION
Tightens inline comments in the event store implementations (in-memory and the four MongoDB stores, plus the shared mappers and exception translator). Cuts restated code and version archaeology, keeps the non-obvious reasons (the index-conflict 85/86 handling, the `dcbtags` extension versus the derived `dcbTags` array, the consistency-token-before-read ordering, the partition-collision race, the sparse-index rationale). Comments only, no code or behavior change.
