### PR TITLE
Add a native (non-Spring) appointment-scheduling DCB example

### DIFF
--- a/example/domain/appointment-scheduling/README.md
+++ b/example/domain/appointment-scheduling/README.md
@@ -1,0 +1,56 @@
+# Appointment scheduling (DCB, no Spring)
+
+A small clinic scheduler that books appointments across three entities at once: a clinician, a patient, and
+a time slot. Booking has to hold one consistency boundary over all three, which is exactly what Occurrent's
+Dynamic Consistency Boundary (DCB) support is for.
+
+This is the third DCB example in the repository, and it is built deliberately unlike the other two. Where
+`hotel-booking` and `course-enrollment` are Kotlin on Spring Boot and use the `dcbDecider` DSL, this one is:
+
+- **Plain Java, no Spring.** A `main` in [`Bootstrap`](src/main/java/org/occurrent/example/domain/appointmentscheduling/Bootstrap.java)
+  wires everything by hand, and the website is served with Javalin and j2html.
+- **Native MongoDB.** It uses the native-driver `MongoEventStore` with the DCB capability turned on
+  (`eventStoreCapabilities(STREAM, DCB)`), constructed from a plain `MongoClient`.
+- **Plain deciders.** The domain is written as ordinary `Decider`s. There is no `DcbDecider`. The read
+  boundary for each command is a `DcbCriteria` built at the call site in
+  [`AppointmentSchedulingService`](src/main/java/org/occurrent/example/domain/appointmentscheduling/application/AppointmentSchedulingService.java).
+- **Annotation-based tags.** Events carry `@DcbTag` on their id fields, and an `AnnotationTagGenerator`
+  turns each event into its tags, so there is no hand-written event-to-tag function. The small `Tags`
+  helper still exists, but only to build the tags a read criterion matches on, not to tag events.
+
+## The invariants
+
+Booking an appointment enforces, atomically:
+
+- the clinician is registered
+- the patient is registered
+- the slot is defined and not already booked (a slot is booked at most once)
+- the patient is under their appointment limit
+
+The last two are the interesting ones. Slot uniqueness is a fact about the slot, the booking limit is a fact
+about the patient, and a single booking has to respect both at the same time. The command reads
+`DcbCriteria.tagsAnyOf(clinician, patient, slot)`, so the decision sees the clinician's registration, the
+patient's registration and every one of their appointments, and the slot's current state. The append is
+rejected if any matching event was committed since the read, so two people racing for the same slot cannot
+both win, and a patient cannot exceed their limit by booking concurrently.
+
+## Running it
+
+DCB appends use a multi-document transaction, so MongoDB must run as a replica set.
+
+The easy path needs no local MongoDB. Run
+[`LocalLauncher`](src/test/java/org/occurrent/example/domain/appointmentscheduling/LocalLauncher.java), which
+starts a throwaway replica set with Testcontainers and boots the app, then open http://localhost:7000.
+
+To run against your own MongoDB instead, start a replica set on `mongodb://localhost:27017` and run
+`Bootstrap`.
+
+## Tests
+
+[`AppointmentSchedulingTest`](src/test/java/org/occurrent/example/domain/appointmentscheduling/AppointmentSchedulingTest.java)
+drives the use cases against a real native store on a Testcontainers replica set and covers slot uniqueness,
+registration checks, the booking limit, cancellation, and two threads racing for the same slot.
+
+```
+mvn -Pexamples-module -pl example/domain/appointment-scheduling test
+```

--- a/example/domain/appointment-scheduling/pom.xml
+++ b/example/domain/appointment-scheduling/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>example-domain</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>example-domain-appointment-scheduling</artifactId>
+
+    <dependencies>
+        <!-- Native (non-Spring) MongoDB event store with the DCB capability -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-mongodb-native</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- DCB application service (blocking) -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>application-service-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>application-service-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Tags generated from @DcbTag on the events -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>dcb-annotation-taggenerator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>eventstore-api-dcb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>decider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- DCB query DSL for the read side (returns domain events for a DcbCriteria) -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>dcb-dsl-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>query-dsl-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-converter-jackson3</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>cloudevent-type-mapper-reflection</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <!-- Website: Javalin + j2html, the repo's non-Spring web convention -->
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.j2html</groupId>
+            <artifactId>j2html</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/Bootstrap.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/Bootstrap.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.javalin.Javalin;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.blocking.dcb.GenericDcbApplicationService;
+import org.occurrent.application.service.dcb.TagGenerator;
+import org.occurrent.application.service.dcb.annotation.AnnotationTagGenerator;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.mongodb.nativedriver.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
+import org.occurrent.example.domain.appointmentscheduling.application.AppointmentSchedulingService;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.web.WebApi;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+
+/**
+ * Wires the example without Spring: a native-driver MongoDB event store with the DCB capability, a Jackson 3
+ * cloud event converter, an annotation-based tag generator, the DCB application service, and a Javalin server.
+ * <p>
+ * DCB appends use a multi-document transaction, so the MongoDB connection must be a replica set.
+ */
+public final class Bootstrap {
+    private static final String DATABASE_NAME = "appointment-scheduling";
+    private static final String EVENTS_COLLECTION_NAME = "events";
+    private static final URI SOURCE = URI.create("urn:occurrent:domain:appointmentscheduling");
+
+    private final Javalin javalin;
+    private final MongoClient mongoClient;
+
+    private Bootstrap(Javalin javalin, MongoClient mongoClient) {
+        this.javalin = javalin;
+        this.mongoClient = mongoClient;
+    }
+
+    public static void main(String[] args) {
+        Bootstrap application = bootstrap("mongodb://localhost:27017", 7000);
+        Runtime.getRuntime().addShutdownHook(new Thread(application::shutdown));
+    }
+
+    public static Bootstrap bootstrap(String connectionString, int port) {
+        MongoClient mongoClient = MongoClients.create(connectionString);
+
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        MongoEventStore eventStore = new MongoEventStore(mongoClient, DATABASE_NAME, EVENTS_COLLECTION_NAME, config);
+
+        CloudEventConverter<DomainEvent> converter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), SOURCE)
+                .typeMapper(ReflectionCloudEventTypeMapper.simple(DomainEvent.class))
+                .idMapper(event -> event.eventId().toString())
+                .timeMapper(DomainEvent::occurredAt)
+                .build();
+        TagGenerator<DomainEvent> tagGenerator = new AnnotationTagGenerator<>();
+        DcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter, tagGenerator);
+
+        AppointmentSchedulingService service = new AppointmentSchedulingService(applicationService);
+        DcbDomainEventQueries<DomainEvent> dcbQueries = new DcbDomainEventQueries<>(new DomainEventQueries<>(eventStore, converter));
+        SchedulingQueries queries = new SchedulingQueries(dcbQueries);
+
+        Javalin javalin = Javalin.create(cfg -> cfg.showJavalinBanner = false).start(port);
+        WebApi.configureRoutes(javalin, service, queries);
+        return new Bootstrap(javalin, mongoClient);
+    }
+
+    public void shutdown() {
+        javalin.stop();
+        mongoClient.close();
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/AppointmentSchedulingService.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/AppointmentSchedulingService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.application;
+
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.model.Appointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Clinician;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.BookAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.CancelAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.DefineSlot;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterClinician;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterPatient;
+import org.occurrent.example.domain.appointmentscheduling.model.Patient;
+import org.occurrent.example.domain.appointmentscheduling.model.Slot;
+
+/**
+ * Runs each command by reading the events its decider's criteria selects, deciding, and appending. The plain
+ * decider does the folding, the criteria defines the DCB read and append boundary, and the application
+ * service supplies the optimistic append condition and tags the new events.
+ */
+public class AppointmentSchedulingService {
+    private final DcbApplicationService<DomainEvent> applicationService;
+
+    public AppointmentSchedulingService(DcbApplicationService<DomainEvent> applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    public void registerClinician(RegisterClinician command) {
+        applicationService.execute(Clinician.criteria(command),
+                events -> Clinician.DECIDER.decideOnEventsAndReturnEvents(events.toList(), command).stream());
+    }
+
+    public void registerPatient(RegisterPatient command) {
+        applicationService.execute(Patient.criteria(command),
+                events -> Patient.DECIDER.decideOnEventsAndReturnEvents(events.toList(), command).stream());
+    }
+
+    public void defineSlot(DefineSlot command) {
+        applicationService.execute(Slot.criteria(command),
+                events -> Slot.DECIDER.decideOnEventsAndReturnEvents(events.toList(), command).stream());
+    }
+
+    public void bookAppointment(BookAppointment command) {
+        applicationService.execute(Appointment.criteria(command),
+                events -> Appointment.DECIDER.decideOnEventsAndReturnEvents(events.toList(), command).stream());
+    }
+
+    public void cancelAppointment(CancelAppointment command) {
+        applicationService.execute(Appointment.criteria(command),
+                events -> Appointment.DECIDER.decideOnEventsAndReturnEvents(events.toList(), command).stream());
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.application;
+
+import org.jspecify.annotations.Nullable;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.example.domain.appointmentscheduling.event.AppointmentBooked;
+import org.occurrent.example.domain.appointmentscheduling.event.AppointmentCancelled;
+import org.occurrent.example.domain.appointmentscheduling.event.ClinicianRegistered;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.event.PatientRegistered;
+import org.occurrent.example.domain.appointmentscheduling.event.SlotDefined;
+import org.occurrent.example.domain.appointmentscheduling.model.Tags;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Strongly consistent read side. It queries the DCB store through {@link DcbDomainEventQueries}, which hands
+ * back domain events for a criterion, so this class never touches the raw store or the cloud event converter.
+ * Criteria are built from event classes with the query DSL's criteria builder.
+ */
+public class SchedulingQueries {
+    private final DcbDomainEventQueries<DomainEvent> queries;
+
+    public SchedulingQueries(DcbDomainEventQueries<DomainEvent> queries) {
+        this.queries = queries;
+    }
+
+    public Overview overview() {
+        List<AppointmentBooked> active = activeFrom(queries.query(
+                queries.criteria().types(AppointmentBooked.class, AppointmentCancelled.class)).toList());
+        Map<UUID, Long> activeByPatient = active.stream().collect(Collectors.groupingBy(AppointmentBooked::patientId, Collectors.counting()));
+        Set<UUID> bookedSlots = active.stream().map(AppointmentBooked::slotId).collect(Collectors.toSet());
+
+        List<ClinicianView> clinicians = queries.query(queries.criteria().type(ClinicianRegistered.class))
+                .map(ClinicianRegistered.class::cast)
+                .map(e -> new ClinicianView(e.clinicianId(), e.name()))
+                .toList();
+        List<PatientView> patients = queries.query(queries.criteria().type(PatientRegistered.class))
+                .map(PatientRegistered.class::cast)
+                .map(e -> new PatientView(e.patientId(), e.name(), e.maxAppointments(), activeByPatient.getOrDefault(e.patientId(), 0L).intValue()))
+                .toList();
+        List<SlotView> slots = queries.query(queries.criteria().type(SlotDefined.class))
+                .map(SlotDefined.class::cast)
+                .map(e -> new SlotView(e.slotId(), e.startTime(), bookedSlots.contains(e.slotId())))
+                .toList();
+        List<AppointmentView> appointments = active.stream().map(SchedulingQueries::toAppointment).toList();
+        return new Overview(clinicians, patients, slots, appointments);
+    }
+
+    public Optional<ClinicianDetail> clinician(UUID clinicianId) {
+        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.clinician(clinicianId))).toList();
+        return events.stream().filter(ClinicianRegistered.class::isInstance).map(ClinicianRegistered.class::cast).findFirst()
+                .map(registered -> new ClinicianDetail(registered.clinicianId(), registered.name(),
+                        activeFrom(events).stream().map(SchedulingQueries::toAppointment).toList()));
+    }
+
+    public Optional<PatientDetail> patient(UUID patientId) {
+        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.patient(patientId))).toList();
+        return events.stream().filter(PatientRegistered.class::isInstance).map(PatientRegistered.class::cast).findFirst()
+                .map(registered -> new PatientDetail(registered.patientId(), registered.name(), registered.maxAppointments(),
+                        activeFrom(events).stream().map(SchedulingQueries::toAppointment).toList()));
+    }
+
+    public Optional<SlotDetail> slot(UUID slotId) {
+        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.slot(slotId))).toList();
+        return events.stream().filter(SlotDefined.class::isInstance).map(SlotDefined.class::cast).findFirst()
+                .map(defined -> {
+                    List<AppointmentBooked> active = activeFrom(events);
+                    AppointmentView booking = active.isEmpty() ? null : toAppointment(active.get(0));
+                    return new SlotDetail(defined.slotId(), defined.startTime(), booking);
+                });
+    }
+
+    // Folds booked/cancelled in read (sequence) order into the appointments that are currently active.
+    private static List<AppointmentBooked> activeFrom(List<DomainEvent> events) {
+        Map<UUID, AppointmentBooked> bySlot = new LinkedHashMap<>();
+        for (DomainEvent event : events) {
+            if (event instanceof AppointmentBooked booked) {
+                bySlot.put(booked.slotId(), booked);
+            } else if (event instanceof AppointmentCancelled cancelled) {
+                bySlot.remove(cancelled.slotId());
+            }
+        }
+        return List.copyOf(bySlot.values());
+    }
+
+    private static AppointmentView toAppointment(AppointmentBooked booked) {
+        return new AppointmentView(booked.clinicianId(), booked.patientId(), booked.slotId());
+    }
+
+    public record Overview(List<ClinicianView> clinicians, List<PatientView> patients, List<SlotView> slots, List<AppointmentView> appointments) {
+    }
+
+    public record ClinicianView(UUID id, String name) {
+    }
+
+    public record PatientView(UUID id, String name, int maxAppointments, int activeAppointments) {
+        public int remaining() {
+            return maxAppointments - activeAppointments;
+        }
+    }
+
+    public record SlotView(UUID id, OffsetDateTime startTime, boolean booked) {
+    }
+
+    public record AppointmentView(UUID clinicianId, UUID patientId, UUID slotId) {
+    }
+
+    public record ClinicianDetail(UUID id, String name, List<AppointmentView> appointments) {
+    }
+
+    public record PatientDetail(UUID id, String name, int maxAppointments, List<AppointmentView> appointments) {
+        public int remaining() {
+            return maxAppointments - appointments.size();
+        }
+    }
+
+    public record SlotDetail(UUID id, OffsetDateTime startTime, @Nullable AppointmentView booking) {
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/AppointmentBooked.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/AppointmentBooked.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import org.occurrent.annotation.DcbTag;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AppointmentBooked(UUID eventId, OffsetDateTime occurredAt,
+                                @DcbTag("clinician") UUID clinicianId,
+                                @DcbTag("patient") UUID patientId,
+                                @DcbTag("slot") UUID slotId) implements DomainEvent {
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/AppointmentCancelled.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/AppointmentCancelled.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import org.occurrent.annotation.DcbTag;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AppointmentCancelled(UUID eventId, OffsetDateTime occurredAt,
+                                   @DcbTag("clinician") UUID clinicianId,
+                                   @DcbTag("patient") UUID patientId,
+                                   @DcbTag("slot") UUID slotId) implements DomainEvent {
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/ClinicianRegistered.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/ClinicianRegistered.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import org.occurrent.annotation.DcbTag;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ClinicianRegistered(UUID eventId, OffsetDateTime occurredAt,
+                                  @DcbTag("clinician") UUID clinicianId, String name) implements DomainEvent {
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/DomainEvent.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/DomainEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Marker for every domain event in this example. All events live in this package so the reflection-based
+ * cloud event type mapper can round-trip them by simple class name.
+ */
+public interface DomainEvent {
+    UUID eventId();
+
+    OffsetDateTime occurredAt();
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/PatientRegistered.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/PatientRegistered.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import org.occurrent.annotation.DcbTag;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PatientRegistered(UUID eventId, OffsetDateTime occurredAt,
+                                @DcbTag("patient") UUID patientId, String name, int maxAppointments) implements DomainEvent {
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/SlotDefined.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/event/SlotDefined.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.event;
+
+import org.occurrent.annotation.DcbTag;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record SlotDefined(UUID eventId, OffsetDateTime occurredAt,
+                          @DcbTag("slot") UUID slotId, OffsetDateTime startTime) implements DomainEvent {
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Appointment.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Appointment.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.example.domain.appointmentscheduling.event.AppointmentBooked;
+import org.occurrent.example.domain.appointmentscheduling.event.AppointmentCancelled;
+import org.occurrent.example.domain.appointmentscheduling.event.ClinicianRegistered;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.event.PatientRegistered;
+import org.occurrent.example.domain.appointmentscheduling.event.SlotDefined;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.AppointmentCommand;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.BookAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.CancelAppointment;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * The cross-boundary decision. Booking an appointment must hold one consistency boundary across three
+ * entities at once: the clinician and patient must be registered, the slot must be defined and not already
+ * booked, and the patient must be under their booking limit. The read boundary spans all three tags, so the
+ * decision sees the clinician's registration, the patient's registration and every one of their
+ * appointments, and the slot's definition and current booking. Cancelling reads only the slot.
+ */
+public final class Appointment {
+    private Appointment() {
+    }
+
+    public static final Decider<AppointmentCommand, State, DomainEvent> DECIDER = Decider.create(
+            State.initial(), Appointment::decide, Appointment::evolve);
+
+    public static DcbCriteria criteria(AppointmentCommand command) {
+        return switch (command) {
+            case BookAppointment book -> DcbCriteria.tagsAnyOf(Tags.clinician(book.clinicianId()), Tags.patient(book.patientId()), Tags.slot(book.slotId()));
+            case CancelAppointment cancel -> DcbCriteria.tags(Tags.slot(cancel.slotId()));
+        };
+    }
+
+    private static List<DomainEvent> decide(AppointmentCommand command, State state) {
+        return switch (command) {
+            case BookAppointment book -> book(book, state);
+            case CancelAppointment cancel -> cancel(cancel, state);
+        };
+    }
+
+    private static List<DomainEvent> book(BookAppointment command, State state) {
+        if (!state.registeredClinicians().contains(command.clinicianId())) {
+            throw new IllegalArgumentException("Clinician " + command.clinicianId() + " is not registered");
+        }
+        Integer limit = state.patientLimits().get(command.patientId());
+        if (limit == null) {
+            throw new IllegalArgumentException("Patient " + command.patientId() + " is not registered");
+        }
+        if (!state.definedSlots().contains(command.slotId())) {
+            throw new IllegalArgumentException("Slot " + command.slotId() + " is not defined");
+        }
+        if (state.activeBySlot().containsKey(command.slotId())) {
+            throw new IllegalStateException("Slot " + command.slotId() + " is already booked");
+        }
+        int count = state.activeCountByPatient().getOrDefault(command.patientId(), 0);
+        if (count >= limit) {
+            throw new IllegalStateException("Patient " + command.patientId() + " has reached the booking limit of " + limit);
+        }
+        return List.of(new AppointmentBooked(UUID.randomUUID(), OffsetDateTime.now(UTC), command.clinicianId(), command.patientId(), command.slotId()));
+    }
+
+    private static List<DomainEvent> cancel(CancelAppointment command, State state) {
+        State.Booking booking = state.activeBySlot().get(command.slotId());
+        if (booking == null) {
+            throw new IllegalStateException("Slot " + command.slotId() + " has no active appointment to cancel");
+        }
+        return List.of(new AppointmentCancelled(UUID.randomUUID(), OffsetDateTime.now(UTC), booking.clinicianId(), booking.patientId(), command.slotId()));
+    }
+
+    private static State evolve(State state, DomainEvent event) {
+        return switch (event) {
+            case ClinicianRegistered e -> state.withClinician(e.clinicianId());
+            case PatientRegistered e -> state.withPatient(e.patientId(), e.maxAppointments());
+            case SlotDefined e -> state.withSlot(e.slotId());
+            case AppointmentBooked e -> state.withBooking(e.slotId(), e.clinicianId(), e.patientId());
+            case AppointmentCancelled e -> state.withCancellation(e.slotId(), e.patientId());
+            default -> state;
+        };
+    }
+
+    /**
+     * Keyed by entity id so a decision reads only the ids named by its command, which the DCB criteria
+     * guarantees are complete in the folded events.
+     */
+    public record State(Set<UUID> registeredClinicians, Map<UUID, Integer> patientLimits, Set<UUID> definedSlots,
+                        Map<UUID, Booking> activeBySlot, Map<UUID, Integer> activeCountByPatient) {
+
+        public record Booking(UUID clinicianId, UUID patientId) {
+        }
+
+        static State initial() {
+            return new State(Set.of(), Map.of(), Set.of(), Map.of(), Map.of());
+        }
+
+        State withClinician(UUID clinicianId) {
+            return new State(plus(registeredClinicians, clinicianId), patientLimits, definedSlots, activeBySlot, activeCountByPatient);
+        }
+
+        State withPatient(UUID patientId, int maxAppointments) {
+            return new State(registeredClinicians, put(patientLimits, patientId, maxAppointments), definedSlots, activeBySlot, activeCountByPatient);
+        }
+
+        State withSlot(UUID slotId) {
+            return new State(registeredClinicians, patientLimits, plus(definedSlots, slotId), activeBySlot, activeCountByPatient);
+        }
+
+        State withBooking(UUID slotId, UUID clinicianId, UUID patientId) {
+            return new State(registeredClinicians, patientLimits, definedSlots, put(activeBySlot, slotId, new Booking(clinicianId, patientId)), add(activeCountByPatient, patientId, 1));
+        }
+
+        State withCancellation(UUID slotId, UUID patientId) {
+            return new State(registeredClinicians, patientLimits, definedSlots, remove(activeBySlot, slotId), add(activeCountByPatient, patientId, -1));
+        }
+
+        private static <T> Set<T> plus(Set<T> set, T element) {
+            Set<T> copy = new HashSet<>(set);
+            copy.add(element);
+            return Set.copyOf(copy);
+        }
+
+        private static <K, V> Map<K, V> put(Map<K, V> map, K key, V value) {
+            Map<K, V> copy = new HashMap<>(map);
+            copy.put(key, value);
+            return Map.copyOf(copy);
+        }
+
+        private static <K, V> Map<K, V> remove(Map<K, V> map, K key) {
+            Map<K, V> copy = new HashMap<>(map);
+            copy.remove(key);
+            return Map.copyOf(copy);
+        }
+
+        private static <K> Map<K, Integer> add(Map<K, Integer> map, K key, int delta) {
+            Map<K, Integer> copy = new HashMap<>(map);
+            copy.merge(key, delta, Integer::sum);
+            return Map.copyOf(copy);
+        }
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Clinician.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Clinician.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.example.domain.appointmentscheduling.event.ClinicianRegistered;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterClinician;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * Registers a clinician once. The read boundary is the clinician's own registration events.
+ */
+public final class Clinician {
+    private Clinician() {
+    }
+
+    public enum State {NOT_REGISTERED, REGISTERED}
+
+    public static final Decider<RegisterClinician, State, DomainEvent> DECIDER = Decider.create(
+            State.NOT_REGISTERED,
+            (command, state) -> {
+                if (state == State.REGISTERED) {
+                    throw new IllegalStateException("Clinician " + command.clinicianId() + " is already registered");
+                }
+                return List.of(new ClinicianRegistered(UUID.randomUUID(), OffsetDateTime.now(UTC), command.clinicianId(), command.name()));
+            },
+            (state, event) -> event instanceof ClinicianRegistered ? State.REGISTERED : state);
+
+    public static DcbCriteria criteria(RegisterClinician command) {
+        return DcbCriteria.type(ClinicianRegistered.class.getSimpleName()).tags(Tags.clinician(command.clinicianId()));
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Commands.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Commands.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * The commands accepted by the four deciders.
+ */
+public final class Commands {
+    private Commands() {
+    }
+
+    public record RegisterClinician(UUID clinicianId, String name) {
+    }
+
+    public record RegisterPatient(UUID patientId, String name, int maxAppointments) {
+    }
+
+    public record DefineSlot(UUID slotId, OffsetDateTime startTime) {
+    }
+
+    public sealed interface AppointmentCommand {
+        UUID slotId();
+    }
+
+    public record BookAppointment(UUID clinicianId, UUID patientId, UUID slotId) implements AppointmentCommand {
+    }
+
+    public record CancelAppointment(UUID slotId) implements AppointmentCommand {
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Patient.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Patient.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.event.PatientRegistered;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterPatient;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * Registers a patient once, with the maximum number of appointments they may hold at a time.
+ */
+public final class Patient {
+    private Patient() {
+    }
+
+    public enum State {NOT_REGISTERED, REGISTERED}
+
+    public static final Decider<RegisterPatient, State, DomainEvent> DECIDER = Decider.create(
+            State.NOT_REGISTERED,
+            (command, state) -> {
+                if (state == State.REGISTERED) {
+                    throw new IllegalStateException("Patient " + command.patientId() + " is already registered");
+                }
+                if (command.maxAppointments() < 1) {
+                    throw new IllegalArgumentException("maxAppointments must be at least 1");
+                }
+                return List.of(new PatientRegistered(UUID.randomUUID(), OffsetDateTime.now(UTC), command.patientId(), command.name(), command.maxAppointments()));
+            },
+            (state, event) -> event instanceof PatientRegistered ? State.REGISTERED : state);
+
+    public static DcbCriteria criteria(RegisterPatient command) {
+        return DcbCriteria.type(PatientRegistered.class.getSimpleName()).tags(Tags.patient(command.patientId()));
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Slot.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Slot.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.event.SlotDefined;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.DefineSlot;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * Defines a bookable slot once.
+ */
+public final class Slot {
+    private Slot() {
+    }
+
+    public enum State {NOT_DEFINED, DEFINED}
+
+    public static final Decider<DefineSlot, State, DomainEvent> DECIDER = Decider.create(
+            State.NOT_DEFINED,
+            (command, state) -> {
+                if (state == State.DEFINED) {
+                    throw new IllegalStateException("Slot " + command.slotId() + " is already defined");
+                }
+                return List.of(new SlotDefined(UUID.randomUUID(), OffsetDateTime.now(UTC), command.slotId(), command.startTime()));
+            },
+            (state, event) -> event instanceof SlotDefined ? State.DEFINED : state);
+
+    public static DcbCriteria criteria(DefineSlot command) {
+        return DcbCriteria.type(SlotDefined.class.getSimpleName()).tags(Tags.slot(command.slotId()));
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Tags.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/model/Tags.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.model;
+
+import org.occurrent.eventstore.api.dcb.Tag;
+
+import java.util.UUID;
+
+/**
+ * The DCB tags for the three entities. The keys match the {@code @DcbTag} keys on the events, so a criterion
+ * built here selects the events the annotation tag generator produced.
+ */
+public final class Tags {
+    private Tags() {
+    }
+
+    public static Tag clinician(UUID clinicianId) {
+        return Tag.of("clinician", clinicianId.toString());
+    }
+
+    public static Tag patient(UUID patientId) {
+        return Tag.of("patient", patientId.toString());
+    }
+
+    public static Tag slot(UUID slotId) {
+        return Tag.of("slot", slotId.toString());
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/web/WebApi.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/web/WebApi.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling.web;
+
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import j2html.tags.ContainerTag;
+import org.occurrent.example.domain.appointmentscheduling.application.AppointmentSchedulingService;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries.AppointmentView;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries.Overview;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries.SlotView;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.BookAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.CancelAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.DefineSlot;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterClinician;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterPatient;
+
+import java.net.URLEncoder;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.button;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.each;
+import static j2html.TagCreator.form;
+import static j2html.TagCreator.h1;
+import static j2html.TagCreator.h2;
+import static j2html.TagCreator.input;
+import static j2html.TagCreator.label;
+import static j2html.TagCreator.li;
+import static j2html.TagCreator.option;
+import static j2html.TagCreator.p;
+import static j2html.TagCreator.select;
+import static j2html.TagCreator.span;
+import static j2html.TagCreator.ul;
+
+public final class WebApi {
+    private WebApi() {
+    }
+
+    public static void configureRoutes(Javalin javalin, AppointmentSchedulingService service, SchedulingQueries queries) {
+        javalin.get("/", ctx -> ctx.html(overviewPage(queries.overview(), ctx.queryParam("error"))));
+
+        javalin.post("/clinicians", ctx -> submit(ctx, () ->
+                service.registerClinician(new RegisterClinician(UUID.randomUUID(), required(ctx, "name")))));
+
+        javalin.post("/patients", ctx -> submit(ctx, () ->
+                service.registerPatient(new RegisterPatient(UUID.randomUUID(), required(ctx, "name"), Integer.parseInt(required(ctx, "maxAppointments"))))));
+
+        javalin.post("/slots", ctx -> submit(ctx, () ->
+                service.defineSlot(new DefineSlot(UUID.randomUUID(), LocalDateTime.parse(required(ctx, "startTime")).atOffset(UTC)))));
+
+        javalin.post("/appointments", ctx -> submit(ctx, () ->
+                service.bookAppointment(new BookAppointment(formUuid(ctx, "clinicianId"), formUuid(ctx, "patientId"), formUuid(ctx, "slotId")))));
+
+        javalin.post("/appointments/cancel", ctx -> submit(ctx, () ->
+                service.cancelAppointment(new CancelAppointment(formUuid(ctx, "slotId")))));
+
+        javalin.get("/clinician/:id", ctx -> ctx.html(queries.clinician(pathUuid(ctx, "id"))
+                .map(WebApi::clinicianPage).orElseGet(() -> notFoundPage("Clinician"))));
+
+        javalin.get("/patient/:id", ctx -> ctx.html(queries.patient(pathUuid(ctx, "id"))
+                .map(WebApi::patientPage).orElseGet(() -> notFoundPage("Patient"))));
+
+        javalin.get("/slot/:id", ctx -> ctx.html(queries.slot(pathUuid(ctx, "id"))
+                .map(WebApi::slotPage).orElseGet(() -> notFoundPage("Slot"))));
+    }
+
+    private static void submit(Context ctx, Runnable action) {
+        try {
+            action.run();
+            ctx.redirect("/");
+        } catch (Exception e) {
+            String message = e.getMessage() == null ? e.toString() : e.getMessage();
+            ctx.redirect("/?error=" + URLEncoder.encode(message, UTF_8));
+        }
+    }
+
+    private static String overviewPage(Overview overview, String error) {
+        return page(() -> body(
+                h1("Appointment scheduling"),
+                error == null ? span() : div(error).withStyle("color:#b00;font-weight:bold;margin:1em 0;"),
+                cliniciansSection(overview),
+                patientsSection(overview),
+                slotsSection(overview),
+                bookingSection(overview),
+                appointmentsSection(overview)
+        ));
+    }
+
+    private static ContainerTag cliniciansSection(Overview overview) {
+        return div(
+                h2("Clinicians"),
+                form().withMethod("post").withAction("/clinicians").with(
+                        label("Name ").with(input().withName("name").isRequired()),
+                        button("Register clinician").withType("submit")),
+                ul(each(overview.clinicians(), c -> li(a(c.name()).withHref("/clinician/" + c.id()))))
+        );
+    }
+
+    private static ContainerTag patientsSection(Overview overview) {
+        return div(
+                h2("Patients"),
+                form().withMethod("post").withAction("/patients").with(
+                        label("Name ").with(input().withName("name").isRequired()),
+                        label(" Max appointments ").with(input().withName("maxAppointments").withType("number").attr("min", 1).withValue("2").isRequired()),
+                        button("Register patient").withType("submit")),
+                ul(each(overview.patients(), p -> li(
+                        a(p.name()).withHref("/patient/" + p.id()),
+                        span(" (" + p.activeAppointments() + "/" + p.maxAppointments() + " booked, " + p.remaining() + " remaining)"))))
+        );
+    }
+
+    private static ContainerTag slotsSection(Overview overview) {
+        return div(
+                h2("Slots"),
+                form().withMethod("post").withAction("/slots").with(
+                        label("Start time ").with(input().withName("startTime").withType("datetime-local").isRequired()),
+                        button("Define slot").withType("submit")),
+                ul(each(overview.slots(), s -> li(
+                        a(s.startTime().toString()).withHref("/slot/" + s.id()),
+                        span(s.booked() ? " (booked)" : " (free)"))))
+        );
+    }
+
+    private static ContainerTag bookingSection(Overview overview) {
+        List<SlotView> freeSlots = overview.slots().stream().filter(s -> !s.booked()).toList();
+        return div(
+                h2("Book appointment"),
+                form().withMethod("post").withAction("/appointments").with(
+                        label("Clinician ").with(select().withName("clinicianId").with(
+                                each(overview.clinicians(), c -> option(c.name()).withValue(c.id().toString())))),
+                        label(" Patient ").with(select().withName("patientId").with(
+                                each(overview.patients(), p -> option(p.name()).withValue(p.id().toString())))),
+                        label(" Slot ").with(select().withName("slotId").with(
+                                each(freeSlots, s -> option(s.startTime().toString()).withValue(s.id().toString())))),
+                        button("Book").withType("submit"))
+        );
+    }
+
+    private static ContainerTag appointmentsSection(Overview overview) {
+        return div(
+                h2("Appointments"),
+                ul(each(overview.appointments(), a -> li(
+                        span("clinician " + shortId(a.clinicianId()) + ", patient " + shortId(a.patientId()) + ", slot " + shortId(a.slotId()) + " "),
+                        form().withMethod("post").withAction("/appointments/cancel").withStyle("display:inline;").with(
+                                input().withName("slotId").withType("hidden").withValue(a.slotId().toString()),
+                                button("Cancel").withType("submit")))))
+        );
+    }
+
+    private static String clinicianPage(SchedulingQueries.ClinicianDetail detail) {
+        return page(() -> body(
+                h1("Clinician " + detail.name()),
+                appointmentsList(detail.appointments()),
+                backLink()));
+    }
+
+    private static String patientPage(SchedulingQueries.PatientDetail detail) {
+        return page(() -> body(
+                h1("Patient " + detail.name()),
+                p(detail.appointments().size() + " of " + detail.maxAppointments() + " booked, " + detail.remaining() + " remaining"),
+                appointmentsList(detail.appointments()),
+                backLink()));
+    }
+
+    private static String slotPage(SchedulingQueries.SlotDetail detail) {
+        AppointmentView booking = detail.booking();
+        return page(() -> body(
+                h1("Slot " + detail.startTime()),
+                booking == null
+                        ? p("Free")
+                        : p("Booked by clinician " + shortId(booking.clinicianId()) + " for patient " + shortId(booking.patientId())),
+                backLink()));
+    }
+
+    private static ContainerTag appointmentsList(List<AppointmentView> appointments) {
+        return appointments.isEmpty()
+                ? p("No appointments")
+                : ul(each(appointments, a -> li("clinician " + shortId(a.clinicianId()) + ", patient " + shortId(a.patientId()) + ", slot " + shortId(a.slotId()))));
+    }
+
+    private static ContainerTag backLink() {
+        return p(a("Back").withHref("/"));
+    }
+
+    private static String notFoundPage(String what) {
+        return page(() -> body(h1(what + " not found"), backLink()));
+    }
+
+    private static String page(Supplier<ContainerTag> body) {
+        return body.get().withStyle("font-family:sans-serif;max-width:760px;margin:2em auto;").render();
+    }
+
+    private static String required(Context ctx, String name) {
+        return requireNonNull(ctx.formParam(name), name + " is required");
+    }
+
+    private static UUID formUuid(Context ctx, String name) {
+        return UUID.fromString(required(ctx, name));
+    }
+
+    private static UUID pathUuid(Context ctx, String name) {
+        return UUID.fromString(ctx.pathParam(name));
+    }
+
+    private static String shortId(UUID id) {
+        return id.toString().substring(0, 8);
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/resources/logback.xml
+++ b/example/domain/appointment-scheduling/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/example/domain/appointment-scheduling/src/test/java/org/occurrent/example/domain/appointmentscheduling/AppointmentSchedulingTest.java
+++ b/example/domain/appointment-scheduling/src/test/java/org/occurrent/example/domain/appointmentscheduling/AppointmentSchedulingTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.blocking.dcb.GenericDcbApplicationService;
+import org.occurrent.application.service.dcb.annotation.AnnotationTagGenerator;
+import org.occurrent.dsl.dcb.blocking.DcbDomainEventQueries;
+import org.occurrent.dsl.query.blocking.DomainEventQueries;
+import org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException;
+import org.occurrent.eventstore.mongodb.nativedriver.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
+import org.occurrent.example.domain.appointmentscheduling.application.AppointmentSchedulingService;
+import org.occurrent.example.domain.appointmentscheduling.application.SchedulingQueries;
+import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.BookAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.CancelAppointment;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.DefineSlot;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterClinician;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.RegisterPatient;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class AppointmentSchedulingTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:domain:appointmentscheduling");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version", "8.0")).withReplicaSet();
+    }
+
+    private MongoClient mongoClient;
+    private AppointmentSchedulingService service;
+    private SchedulingQueries queries;
+
+    @BeforeEach
+    void wire_the_example_against_a_clean_database() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".appointments");
+        mongoClient = MongoClients.create(connectionString);
+        mongoClient.getDatabase(requireNonNull(connectionString.getDatabase())).drop();
+
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        MongoEventStore eventStore = new MongoEventStore(mongoClient, connectionString.getDatabase(), "events", config);
+        CloudEventConverter<DomainEvent> converter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), SOURCE)
+                .typeMapper(ReflectionCloudEventTypeMapper.simple(DomainEvent.class))
+                .idMapper(event -> event.eventId().toString())
+                .timeMapper(DomainEvent::occurredAt)
+                .build();
+        DcbApplicationService<DomainEvent> applicationService = new GenericDcbApplicationService<>(eventStore, converter, new AnnotationTagGenerator<>());
+        service = new AppointmentSchedulingService(applicationService);
+        queries = new SchedulingQueries(new DcbDomainEventQueries<>(new DomainEventQueries<>(eventStore, converter)));
+    }
+
+    @AfterEach
+    void close_mongo_client() {
+        mongoClient.close();
+    }
+
+    @Test
+    void books_an_appointment_when_the_clinician_patient_and_slot_are_ready() {
+        UUID clinician = registerClinician();
+        UUID patient = registerPatient(2);
+        UUID slot = defineSlot();
+
+        service.bookAppointment(new BookAppointment(clinician, patient, slot));
+
+        assertThat(queries.overview().appointments()).hasSize(1);
+        assertThat(queries.slot(slot).orElseThrow().booking()).isNotNull();
+    }
+
+    @Test
+    void rejects_booking_a_slot_that_is_already_booked() {
+        UUID clinician = registerClinician();
+        UUID firstPatient = registerPatient(2);
+        UUID secondPatient = registerPatient(2);
+        UUID slot = defineSlot();
+        service.bookAppointment(new BookAppointment(clinician, firstPatient, slot));
+
+        assertThatThrownBy(() -> service.bookAppointment(new BookAppointment(clinician, secondPatient, slot)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already booked");
+    }
+
+    @Test
+    void rejects_booking_when_the_clinician_is_not_registered() {
+        UUID patient = registerPatient(2);
+        UUID slot = defineSlot();
+
+        assertThatThrownBy(() -> service.bookAppointment(new BookAppointment(UUID.randomUUID(), patient, slot)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Clinician");
+    }
+
+    @Test
+    void rejects_booking_when_the_patient_is_not_registered() {
+        UUID clinician = registerClinician();
+        UUID slot = defineSlot();
+
+        assertThatThrownBy(() -> service.bookAppointment(new BookAppointment(clinician, UUID.randomUUID(), slot)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Patient");
+    }
+
+    @Test
+    void enforces_the_patient_booking_limit() {
+        UUID clinician = registerClinician();
+        UUID patient = registerPatient(2);
+        UUID slot1 = defineSlot();
+        UUID slot2 = defineSlot();
+        UUID slot3 = defineSlot();
+        service.bookAppointment(new BookAppointment(clinician, patient, slot1));
+        service.bookAppointment(new BookAppointment(clinician, patient, slot2));
+
+        assertThatThrownBy(() -> service.bookAppointment(new BookAppointment(clinician, patient, slot3)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("booking limit");
+    }
+
+    @Test
+    void cancelling_frees_the_slot_and_returns_the_booking_to_the_patient() {
+        UUID clinician = registerClinician();
+        UUID patient = registerPatient(1);
+        UUID slot = defineSlot();
+        service.bookAppointment(new BookAppointment(clinician, patient, slot));
+
+        service.cancelAppointment(new CancelAppointment(slot));
+
+        assertThat(queries.slot(slot).orElseThrow().booking()).isNull();
+        assertThat(queries.patient(patient).orElseThrow().remaining()).isEqualTo(1);
+        // The freed limit lets the patient book again.
+        service.bookAppointment(new BookAppointment(clinician, patient, slot));
+        assertThat(queries.overview().appointments()).hasSize(1);
+    }
+
+    @Test
+    void two_concurrent_bookings_of_the_same_slot_let_exactly_one_win() throws Exception {
+        UUID clinician = registerClinician();
+        UUID firstPatient = registerPatient(1);
+        UUID secondPatient = registerPatient(1);
+        UUID slot = defineSlot();
+
+        CyclicBarrier startTogether = new CyclicBarrier(2);
+        AtomicInteger succeeded = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<Future<?>> futures = List.of(
+                    executor.submit(booking(startTogether, succeeded, clinician, firstPatient, slot)),
+                    executor.submit(booking(startTogether, succeeded, clinician, secondPatient, slot)));
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(succeeded).hasValue(1);
+        assertThat(queries.overview().appointments()).hasSize(1);
+    }
+
+    private Runnable booking(CyclicBarrier startTogether, AtomicInteger succeeded, UUID clinician, UUID patient, UUID slot) {
+        return () -> {
+            try {
+                startTogether.await();
+                service.bookAppointment(new BookAppointment(clinician, patient, slot));
+                succeeded.incrementAndGet();
+            } catch (IllegalStateException | DcbAppendConditionNotFulfilledException e) {
+                // The losing booking either sees the slot already booked after the winner committed, or, if the
+                // optimistic retries are exhausted first, fails the DCB append condition. Either way it did not book.
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    private UUID registerClinician() {
+        UUID clinicianId = UUID.randomUUID();
+        service.registerClinician(new RegisterClinician(clinicianId, "Dr " + shortId(clinicianId)));
+        return clinicianId;
+    }
+
+    private UUID registerPatient(int maxAppointments) {
+        UUID patientId = UUID.randomUUID();
+        service.registerPatient(new RegisterPatient(patientId, "Patient " + shortId(patientId), maxAppointments));
+        return patientId;
+    }
+
+    private UUID defineSlot() {
+        UUID slotId = UUID.randomUUID();
+        service.defineSlot(new DefineSlot(slotId, OffsetDateTime.now(UTC)));
+        return slotId;
+    }
+
+    private static String shortId(UUID id) {
+        return id.toString().substring(0, 8);
+    }
+}

--- a/example/domain/appointment-scheduling/src/test/java/org/occurrent/example/domain/appointmentscheduling/LocalLauncher.java
+++ b/example/domain/appointment-scheduling/src/test/java/org/occurrent/example/domain/appointmentscheduling/LocalLauncher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.example.domain.appointmentscheduling;
+
+import org.testcontainers.mongodb.MongoDBContainer;
+
+/**
+ * Runs the example locally against a throwaway MongoDB replica set started with Testcontainers, so no local
+ * MongoDB is required. Run this {@code main} and open http://localhost:7000.
+ */
+public final class LocalLauncher {
+    private LocalLauncher() {
+    }
+
+    public static void main(String[] args) {
+        MongoDBContainer mongo = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version", "8.0")).withReplicaSet();
+        mongo.start();
+        Bootstrap application = Bootstrap.bootstrap(mongo.getReplicaSetUrl(), 7000);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            application.shutdown();
+            mongo.stop();
+        }));
+        System.out.println("Appointment scheduling is running on http://localhost:7000");
+    }
+}

--- a/example/domain/pom.xml
+++ b/example/domain/pom.xml
@@ -31,6 +31,7 @@
         <module>mastermind</module>
         <module>course-enrollment</module>
         <module>hotel-booking</module>
+        <module>appointment-scheduling</module>
     </modules>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
A third DCB example, built to show the lower-level API rather than the Spring path.

Unlike the Kotlin `hotel-booking` and `course-enrollment` examples, this one uses no Spring. It has a plain `main` in `Bootstrap`, the native-driver `MongoEventStore` with the DCB capability, plain `Decider`s (`Clinician`, `Patient`, `Slot`, `Appointment`) with the read boundary built at the call site, `@DcbTag` plus `AnnotationTagGenerator` for tags, and Javalin with j2html for the website. Reads go through `DcbDomainEventQueries` and are strongly consistent.

The domain is a clinic scheduler where booking an appointment holds one consistency boundary across a clinician, a patient, and a slot: both registered, the slot booked at most once, and the patient under their limit. The integration test covers those invariants plus cancellation and two threads racing for the same slot.

Stacked on #312, which adds the `@DcbTag("...")` shorthand this example uses.
