### PR TITLE
Add tag and type query shortcuts to DcbDomainEventQueries

### DIFF
--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
@@ -126,9 +126,8 @@ public class DcbDomainEventQueries<E> {
      * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
      */
     public <SUB extends E> Stream<SUB> query(Class<SUB> type) {
-        @SuppressWarnings("unchecked")
-        Stream<SUB> events = (Stream<SUB>) query(criteria().type(type));
-        return events;
+        requireNonNull(type, "Type cannot be null");
+        return query(criteria().type(type)).map(type::cast);
     }
 
     /**

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
@@ -125,7 +125,7 @@ public class DcbDomainEventQueries<E> {
     /**
      * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
      */
-    public <SUB extends E> Stream<SUB> query(Class<SUB> type) {
+    public <SUB extends E> Stream<SUB> types(Class<SUB> type) {
         requireNonNull(type, "Type cannot be null");
         return query(criteria().type(type)).map(type::cast);
     }
@@ -134,7 +134,7 @@ public class DcbDomainEventQueries<E> {
      * Queries DCB events of any of the given types, each mapped to its CloudEvent type string through the converter.
      */
     @SafeVarargs
-    public final Stream<E> query(Class<? extends E> first, Class<? extends E>... rest) {
+    public final Stream<E> types(Class<? extends E> first, Class<? extends E>... rest) {
         return query(criteria().types(first, rest));
     }
 

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueries.java
@@ -25,7 +25,9 @@ import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.DcbEventStream;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.Tag;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -113,6 +115,60 @@ public class DcbDomainEventQueries<E> {
         DcbEventStream eventStream = dcbEventStore.read(query, options);
         List<E> events = domainEventQueries.toDomainEvents(eventStream.stream()).toList();
         return new DcbDomainEventStream<>(events, eventStream.lastSequencePosition(), eventStream.consistencyToken());
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Convenience queries (one-liners over query(criteria), read from the beginning of the DCB sequence).
+    // For read options or mixed criteria, use criteria() together with query(criteria, options).
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
+     */
+    public <SUB extends E> Stream<SUB> query(Class<SUB> type) {
+        @SuppressWarnings("unchecked")
+        Stream<SUB> events = (Stream<SUB>) query(criteria().type(type));
+        return events;
+    }
+
+    /**
+     * Queries DCB events of any of the given types, each mapped to its CloudEvent type string through the converter.
+     */
+    @SafeVarargs
+    public final Stream<E> query(Class<? extends E> first, Class<? extends E>... rest) {
+        return query(criteria().types(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with all the given tags.
+     */
+    public Stream<E> tags(Tag first, Tag... rest) {
+        return query(DcbCriteria.tags(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with all the given tags, each parsed from {@code "key:value"} form.
+     */
+    public Stream<E> tags(String first, String... rest) {
+        return tags(Tag.parse(first), parseTags(rest));
+    }
+
+    /**
+     * Queries DCB events tagged with any of the given tags.
+     */
+    public Stream<E> tagsAnyOf(Tag first, Tag... rest) {
+        return query(DcbCriteria.tagsAnyOf(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with any of the given tags, each parsed from {@code "key:value"} form.
+     */
+    public Stream<E> tagsAnyOf(String first, String... rest) {
+        return tagsAnyOf(Tag.parse(first), parseTags(rest));
+    }
+
+    private static Tag[] parseTags(String[] tags) {
+        return Arrays.stream(tags).map(Tag::parse).toArray(Tag[]::new);
     }
 
     private static DcbEventStore requireDcbEventStore(DomainEventQueries<?> domainEventQueries) {

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
@@ -72,13 +72,13 @@ fun <T : Any> DcbDomainEventQueries<T>.queryForSequenceWithPosition(
  * Queries DCB events of the reified type [T] as a [List].
  */
 inline fun <reified T : Any> DcbDomainEventQueries<in T>.queryForList(): List<T> =
-    query(T::class.java).toList()
+    types(T::class.java).toList()
 
 /**
  * Queries DCB events of the reified type [T] as a [Sequence].
  */
 inline fun <reified T : Any> DcbDomainEventQueries<in T>.queryForSequence(): Sequence<T> =
-    query(T::class.java).asSequence()
+    types(T::class.java).asSequence()
 
 /**
  * Queries DCB events tagged with all the given tags, as a [List].

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesExtensions.kt
@@ -19,6 +19,7 @@ package org.occurrent.dsl.dcb.blocking
 import org.occurrent.eventstore.api.dcb.DcbConsistencyToken
 import org.occurrent.eventstore.api.dcb.DcbCriteria
 import org.occurrent.eventstore.api.dcb.DcbReadOptions
+import org.occurrent.eventstore.api.dcb.Tag
 import kotlin.streams.asSequence
 
 /**
@@ -66,3 +67,39 @@ fun <T : Any> DcbDomainEventQueries<T>.queryForSequenceWithPosition(
     options: DcbReadOptions = DcbReadOptions.fromBeginning()
 ): Triple<Sequence<T>, Long, DcbConsistencyToken> =
     this.queryWithPosition(query, options).let { Triple(it.events().asSequence(), it.lastSequencePosition(), it.consistencyToken()) }
+
+/**
+ * Queries DCB events of the reified type [T] as a [List].
+ */
+inline fun <reified T : Any> DcbDomainEventQueries<in T>.queryForList(): List<T> =
+    query(T::class.java).toList()
+
+/**
+ * Queries DCB events of the reified type [T] as a [Sequence].
+ */
+inline fun <reified T : Any> DcbDomainEventQueries<in T>.queryForSequence(): Sequence<T> =
+    query(T::class.java).asSequence()
+
+/**
+ * Queries DCB events tagged with all the given tags, as a [List].
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForList(firstTag: Tag, vararg moreTags: Tag): List<T> =
+    tags(firstTag, *moreTags).toList()
+
+/**
+ * Queries DCB events tagged with all the given tags (each parsed from `"key:value"`), as a [List].
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForList(firstTag: String, vararg moreTags: String): List<T> =
+    tags(firstTag, *moreTags).toList()
+
+/**
+ * Queries DCB events tagged with any of the given tags, as a [List].
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForListAnyOf(firstTag: Tag, vararg moreTags: Tag): List<T> =
+    tagsAnyOf(firstTag, *moreTags).toList()
+
+/**
+ * Queries DCB events tagged with any of the given tags (each parsed from `"key:value"`), as a [List].
+ */
+fun <T : Any> DcbDomainEventQueries<T>.queryForListAnyOf(firstTag: String, vararg moreTags: String): List<T> =
+    tagsAnyOf(firstTag, *moreTags).toList()

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
@@ -147,13 +147,13 @@ class DcbDomainEventQueriesTest {
     }
 
     @Test
-    void query_by_type_returns_only_events_of_that_type() {
+    void types_returns_only_events_of_the_given_types() {
         NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
         NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
         append("name:1", nameDefined, nameWasChanged);
 
-        List<NameWasChanged> byType = dcbQueries.query(NameWasChanged.class).toList();
-        List<DomainEvent> byTypes = dcbQueries.query(NameDefined.class, NameWasChanged.class).toList();
+        List<NameWasChanged> byType = dcbQueries.types(NameWasChanged.class).toList();
+        List<DomainEvent> byTypes = dcbQueries.types(NameDefined.class, NameWasChanged.class).toList();
 
         assertThat(byType).containsExactly(nameWasChanged);
         assertThat(byTypes).containsExactly(nameDefined, nameWasChanged);

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDomainEventQueriesTest.java
@@ -146,9 +146,53 @@ class DcbDomainEventQueriesTest {
         });
     }
 
+    @Test
+    void query_by_type_returns_only_events_of_that_type() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", nameDefined, nameWasChanged);
+
+        List<NameWasChanged> byType = dcbQueries.query(NameWasChanged.class).toList();
+        List<DomainEvent> byTypes = dcbQueries.query(NameDefined.class, NameWasChanged.class).toList();
+
+        assertThat(byType).containsExactly(nameWasChanged);
+        assertThat(byTypes).containsExactly(nameDefined, nameWasChanged);
+    }
+
+    @Test
+    void tags_returns_events_matching_all_of_the_tags() {
+        NameDefined taggedWithBoth = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged taggedWithNameOnly = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        appendTagged(List.of(Tag.of("name", "1"), Tag.of("tenant", "1")), taggedWithBoth);
+        append("name:1", taggedWithNameOnly);
+
+        assertThat(dcbQueries.tags(Tag.of("name", "1"), Tag.of("tenant", "1")).toList()).containsExactly(taggedWithBoth);
+        assertThat(dcbQueries.tags("name:1", "tenant:1").toList()).containsExactly(taggedWithBoth);
+    }
+
+    @Test
+    void tags_anyOf_returns_events_matching_any_of_the_tags() {
+        NameDefined name = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged other = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", name);
+        append("other:1", other);
+
+        assertThat(dcbQueries.tagsAnyOf(Tag.of("name", "1"), Tag.of("other", "1")).toList()).containsExactly(name, other);
+        assertThat(dcbQueries.tagsAnyOf("name:1", "other:1").toList()).containsExactly(name, other);
+    }
+
+    @Test
+    void a_malformed_string_tag_is_rejected() {
+        assertThatThrownBy(() -> dcbQueries.tags("not-a-tag")).isInstanceOf(IllegalArgumentException.class);
+    }
+
     private void append(String tag, DomainEvent... events) {
+        appendTagged(List.of(Tag.parse(tag)), events);
+    }
+
+    private void appendTagged(List<Tag> tags, DomainEvent... events) {
         List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
-                .map(event -> DcbCloudEvents.withTags(event, List.of(Tag.parse(tag))))
+                .map(event -> DcbCloudEvents.withTags(event, tags))
                 .toList();
         eventStore.append(cloudEvents);
     }

--- a/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
+++ b/dsl/dcb-dsl/blocking/src/test/kotlin/org/occurrent/dsl/dcb/blocking/DcbDslKotlinTest.kt
@@ -85,6 +85,20 @@ class DcbDslKotlinTest {
     }
 
     @Test
+    fun reified_type_and_tag_shortcuts_query_dcb_events() {
+        val nameDefined = NameDefined("eventId1", time, "name", "Some Doe")
+        val nameWasChanged = NameWasChanged("eventId2", time, "name", "Jane Doe")
+        append(listOf("name:1", "tenant:1"), nameDefined)
+        append("name:1", nameWasChanged)
+
+        assertThat(dcbQueries.queryForList<NameDefined>()).containsExactly(nameDefined)
+        assertThat(dcbQueries.queryForSequence<NameWasChanged>().toList()).containsExactly(nameWasChanged)
+        assertThat(dcbQueries.queryForList(Tag.of("name", "1"), Tag.of("tenant", "1"))).containsExactly(nameDefined)
+        assertThat(dcbQueries.queryForList("name:1", "tenant:1")).containsExactly(nameDefined)
+        assertThat(dcbQueries.queryForListAnyOf("name:1", "tenant:1")).containsExactly(nameDefined, nameWasChanged)
+    }
+
+    @Test
     fun queryWithPosition_for_KClass_keeps_the_DCB_sequence_position() {
         val nameDefined = NameDefined("eventId1", time, "name", "Some Doe")
         append("other:1", NameWasChanged("eventId2", time, "name", "Jane Doe"))

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
@@ -23,9 +23,12 @@ import org.occurrent.dsl.query.reactor.DomainEventQueries;
 import org.occurrent.eventstore.api.reactor.EventStoreQueries;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.DcbReadOptions;
+import org.occurrent.eventstore.api.dcb.Tag;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
 
 import static java.util.Objects.requireNonNull;
 
@@ -109,6 +112,60 @@ public class DcbDomainEventQueries<E> {
         return dcbEventStore.read(query, options).flatMap(eventStream ->
                 domainEventQueries.<E>toDomainEvents(Flux.fromStream(eventStream.stream())).collectList()
                         .map(events -> new DcbDomainEventStream<>(events, eventStream.lastSequencePosition(), eventStream.consistencyToken())));
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Convenience queries (one-liners over query(criteria), read from the beginning of the DCB sequence).
+    // For read options or mixed criteria, use criteria() together with query(criteria, options).
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
+     */
+    public <SUB extends E> Flux<SUB> query(Class<SUB> type) {
+        @SuppressWarnings("unchecked")
+        Flux<SUB> events = (Flux<SUB>) query(criteria().type(type));
+        return events;
+    }
+
+    /**
+     * Queries DCB events of any of the given types, each mapped to its CloudEvent type string through the converter.
+     */
+    @SafeVarargs
+    public final Flux<E> query(Class<? extends E> first, Class<? extends E>... rest) {
+        return query(criteria().types(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with all the given tags.
+     */
+    public Flux<E> tags(Tag first, Tag... rest) {
+        return query(DcbCriteria.tags(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with all the given tags, each parsed from {@code "key:value"} form.
+     */
+    public Flux<E> tags(String first, String... rest) {
+        return tags(Tag.parse(first), parseTags(rest));
+    }
+
+    /**
+     * Queries DCB events tagged with any of the given tags.
+     */
+    public Flux<E> tagsAnyOf(Tag first, Tag... rest) {
+        return query(DcbCriteria.tagsAnyOf(first, rest));
+    }
+
+    /**
+     * Queries DCB events tagged with any of the given tags, each parsed from {@code "key:value"} form.
+     */
+    public Flux<E> tagsAnyOf(String first, String... rest) {
+        return tagsAnyOf(Tag.parse(first), parseTags(rest));
+    }
+
+    private static Tag[] parseTags(String[] tags) {
+        return Arrays.stream(tags).map(Tag::parse).toArray(Tag[]::new);
     }
 
     private static DcbEventStore requireDcbEventStore(DomainEventQueries<?> domainEventQueries) {

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
@@ -122,7 +122,7 @@ public class DcbDomainEventQueries<E> {
     /**
      * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
      */
-    public <SUB extends E> Flux<SUB> query(Class<SUB> type) {
+    public <SUB extends E> Flux<SUB> types(Class<SUB> type) {
         requireNonNull(type, "Type cannot be null");
         return query(criteria().type(type)).cast(type);
     }
@@ -131,7 +131,7 @@ public class DcbDomainEventQueries<E> {
      * Queries DCB events of any of the given types, each mapped to its CloudEvent type string through the converter.
      */
     @SafeVarargs
-    public final Flux<E> query(Class<? extends E> first, Class<? extends E>... rest) {
+    public final Flux<E> types(Class<? extends E> first, Class<? extends E>... rest) {
         return query(criteria().types(first, rest));
     }
 

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueries.java
@@ -123,9 +123,8 @@ public class DcbDomainEventQueries<E> {
      * Queries DCB events of the given type, mapped to its CloudEvent type string through the converter.
      */
     public <SUB extends E> Flux<SUB> query(Class<SUB> type) {
-        @SuppressWarnings("unchecked")
-        Flux<SUB> events = (Flux<SUB>) query(criteria().type(type));
-        return events;
+        requireNonNull(type, "Type cannot be null");
+        return query(criteria().type(type)).cast(type);
     }
 
     /**

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
@@ -19,6 +19,7 @@ package org.occurrent.dsl.dcb.reactor
 import org.occurrent.eventstore.api.dcb.DcbConsistencyToken
 import org.occurrent.eventstore.api.dcb.DcbCriteria
 import org.occurrent.eventstore.api.dcb.DcbReadOptions
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
@@ -46,3 +47,9 @@ fun <T : Any> DcbDomainEventQueries<T>.queryForListWithPosition(
     options: DcbReadOptions = DcbReadOptions.fromBeginning()
 ): Mono<Triple<List<T>, Long, DcbConsistencyToken>> =
     this.queryWithPosition(query, options).map { Triple(it.events(), it.lastSequencePosition(), it.consistencyToken()) }
+
+/**
+ * Queries DCB events of the reified type [T] as a [Flux].
+ */
+inline fun <reified T : Any> DcbDomainEventQueries<in T>.query(): Flux<T> =
+    query(T::class.java)

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesExtensions.kt
@@ -51,5 +51,5 @@ fun <T : Any> DcbDomainEventQueries<T>.queryForListWithPosition(
 /**
  * Queries DCB events of the reified type [T] as a [Flux].
  */
-inline fun <reified T : Any> DcbDomainEventQueries<in T>.query(): Flux<T> =
-    query(T::class.java)
+inline fun <reified T : Any> DcbDomainEventQueries<in T>.types(): Flux<T> =
+    types(T::class.java)

--- a/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
@@ -181,13 +181,13 @@ class DcbDomainEventQueriesTest {
     }
 
     @Test
-    void query_by_type_returns_only_events_of_that_type() {
+    void types_returns_only_events_of_the_given_types() {
         NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
         NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
         append("name:1", nameDefined, nameWasChanged);
 
-        List<NameWasChanged> byType = dcbQueries.query(NameWasChanged.class).collectList().block();
-        List<DomainEvent> byTypes = dcbQueries.query(NameDefined.class, NameWasChanged.class).collectList().block();
+        List<NameWasChanged> byType = dcbQueries.types(NameWasChanged.class).collectList().block();
+        List<DomainEvent> byTypes = dcbQueries.types(NameDefined.class, NameWasChanged.class).collectList().block();
 
         assertThat(byType).containsExactly(nameWasChanged);
         assertThat(byTypes).containsExactly(nameDefined, nameWasChanged);

--- a/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
+++ b/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDomainEventQueriesTest.java
@@ -181,6 +181,46 @@ class DcbDomainEventQueriesTest {
     }
 
     @Test
+    void query_by_type_returns_only_events_of_that_type() {
+        NameDefined nameDefined = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged nameWasChanged = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", nameDefined, nameWasChanged);
+
+        List<NameWasChanged> byType = dcbQueries.query(NameWasChanged.class).collectList().block();
+        List<DomainEvent> byTypes = dcbQueries.query(NameDefined.class, NameWasChanged.class).collectList().block();
+
+        assertThat(byType).containsExactly(nameWasChanged);
+        assertThat(byTypes).containsExactly(nameDefined, nameWasChanged);
+    }
+
+    @Test
+    void tags_returns_events_matching_all_of_the_tags() {
+        NameDefined taggedWithBoth = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged taggedWithNameOnly = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        appendTagged(List.of(Tag.of("name", "1"), Tag.of("tenant", "1")), taggedWithBoth);
+        append("name:1", taggedWithNameOnly);
+
+        assertThat(dcbQueries.tags(Tag.of("name", "1"), Tag.of("tenant", "1")).collectList().block()).containsExactly(taggedWithBoth);
+        assertThat(dcbQueries.tags("name:1", "tenant:1").collectList().block()).containsExactly(taggedWithBoth);
+    }
+
+    @Test
+    void tags_anyOf_returns_events_matching_any_of_the_tags() {
+        NameDefined name = new NameDefined("eventId1", time, "name", "Some Doe");
+        NameWasChanged other = new NameWasChanged("eventId2", time, "name", "Jane Doe");
+        append("name:1", name);
+        append("other:1", other);
+
+        assertThat(dcbQueries.tagsAnyOf(Tag.of("name", "1"), Tag.of("other", "1")).collectList().block()).containsExactly(name, other);
+        assertThat(dcbQueries.tagsAnyOf("name:1", "other:1").collectList().block()).containsExactly(name, other);
+    }
+
+    @Test
+    void a_malformed_string_tag_is_rejected() {
+        assertThatThrownBy(() -> dcbQueries.tags("not-a-tag")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void constructor_rejects_a_domain_event_queries_not_backed_by_a_reactive_dcb_event_store() {
         DomainEventQueries<DomainEvent> wrapped = new DomainEventQueries<>(new StreamOnlyEventStoreQueries(), cloudEventConverter);
 
@@ -207,8 +247,12 @@ class DcbDomainEventQueriesTest {
     }
 
     private void append(String tag, DomainEvent... events) {
+        appendTagged(List.of(Tag.parse(tag)), events);
+    }
+
+    private void appendTagged(List<Tag> tags, DomainEvent... events) {
         List<CloudEvent> cloudEvents = cloudEventConverter.toCloudEvents(Stream.of(events))
-                .map(event -> DcbCloudEvents.withTags(event, List.of(Tag.parse(tag))))
+                .map(event -> DcbCloudEvents.withTags(event, tags))
                 .toList();
         eventStore.append(cloudEvents).block();
     }

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
@@ -145,7 +145,7 @@ class DcbReactorDslTest {
         val nameDefined = NameDefined("event-0", time, "name", "Jane Doe")
         append(nameDefined)
 
-        assertThat(queries.query<NameDefined>().collectList().block()).containsExactly(nameDefined)
+        assertThat(queries.types<NameDefined>().collectList().block()).containsExactly(nameDefined)
         assertThat(queries.tags(Tag.of("name", "name")).collectList().block()).containsExactly(nameDefined)
         assertThat(queries.tags("name:name").collectList().block()).containsExactly(nameDefined)
         assertThat(queries.tagsAnyOf("name:name", "other:1").collectList().block()).containsExactly(nameDefined)

--- a/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
+++ b/dsl/dcb-dsl/reactor/src/test/kotlin/org/occurrent/dsl/dcb/reactor/DcbReactorDslTest.kt
@@ -141,6 +141,17 @@ class DcbReactorDslTest {
     }
 
     @Test
+    fun reified_type_and_tag_shortcuts_query_dcb_events() {
+        val nameDefined = NameDefined("event-0", time, "name", "Jane Doe")
+        append(nameDefined)
+
+        assertThat(queries.query<NameDefined>().collectList().block()).containsExactly(nameDefined)
+        assertThat(queries.tags(Tag.of("name", "name")).collectList().block()).containsExactly(nameDefined)
+        assertThat(queries.tags("name:name").collectList().block()).containsExactly(nameDefined)
+        assertThat(queries.tagsAnyOf("name:name", "other:1").collectList().block()).containsExactly(nameDefined)
+    }
+
+    @Test
     fun queryWithPosition_returns_events_position_and_a_usable_consistency_token() {
         append(NameDefined("event-0", time, "name", "Jane Doe"))
 

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
@@ -48,17 +48,17 @@ public class SchedulingQueries {
     }
 
     public Overview overview() {
-        List<AppointmentBooked> active = activeFrom(queries.query(AppointmentBooked.class, AppointmentCancelled.class).toList());
+        List<AppointmentBooked> active = activeFrom(queries.types(AppointmentBooked.class, AppointmentCancelled.class).toList());
         Map<UUID, Long> activeByPatient = active.stream().collect(Collectors.groupingBy(AppointmentBooked::patientId, Collectors.counting()));
         Set<UUID> bookedSlots = active.stream().map(AppointmentBooked::slotId).collect(Collectors.toSet());
 
-        List<ClinicianView> clinicians = queries.query(ClinicianRegistered.class)
+        List<ClinicianView> clinicians = queries.types(ClinicianRegistered.class)
                 .map(e -> new ClinicianView(e.clinicianId(), e.name()))
                 .toList();
-        List<PatientView> patients = queries.query(PatientRegistered.class)
+        List<PatientView> patients = queries.types(PatientRegistered.class)
                 .map(e -> new PatientView(e.patientId(), e.name(), e.maxAppointments(), activeByPatient.getOrDefault(e.patientId(), 0L).intValue()))
                 .toList();
-        List<SlotView> slots = queries.query(SlotDefined.class)
+        List<SlotView> slots = queries.types(SlotDefined.class)
                 .map(e -> new SlotView(e.slotId(), e.startTime(), bookedSlots.contains(e.slotId())))
                 .toList();
         List<AppointmentView> appointments = active.stream().map(SchedulingQueries::toAppointment).toList();

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/SchedulingQueries.java
@@ -48,21 +48,17 @@ public class SchedulingQueries {
     }
 
     public Overview overview() {
-        List<AppointmentBooked> active = activeFrom(queries.query(
-                queries.criteria().types(AppointmentBooked.class, AppointmentCancelled.class)).toList());
+        List<AppointmentBooked> active = activeFrom(queries.query(AppointmentBooked.class, AppointmentCancelled.class).toList());
         Map<UUID, Long> activeByPatient = active.stream().collect(Collectors.groupingBy(AppointmentBooked::patientId, Collectors.counting()));
         Set<UUID> bookedSlots = active.stream().map(AppointmentBooked::slotId).collect(Collectors.toSet());
 
-        List<ClinicianView> clinicians = queries.query(queries.criteria().type(ClinicianRegistered.class))
-                .map(ClinicianRegistered.class::cast)
+        List<ClinicianView> clinicians = queries.query(ClinicianRegistered.class)
                 .map(e -> new ClinicianView(e.clinicianId(), e.name()))
                 .toList();
-        List<PatientView> patients = queries.query(queries.criteria().type(PatientRegistered.class))
-                .map(PatientRegistered.class::cast)
+        List<PatientView> patients = queries.query(PatientRegistered.class)
                 .map(e -> new PatientView(e.patientId(), e.name(), e.maxAppointments(), activeByPatient.getOrDefault(e.patientId(), 0L).intValue()))
                 .toList();
-        List<SlotView> slots = queries.query(queries.criteria().type(SlotDefined.class))
-                .map(SlotDefined.class::cast)
+        List<SlotView> slots = queries.query(SlotDefined.class)
                 .map(e -> new SlotView(e.slotId(), e.startTime(), bookedSlots.contains(e.slotId())))
                 .toList();
         List<AppointmentView> appointments = active.stream().map(SchedulingQueries::toAppointment).toList();
@@ -70,21 +66,21 @@ public class SchedulingQueries {
     }
 
     public Optional<ClinicianDetail> clinician(UUID clinicianId) {
-        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.clinician(clinicianId))).toList();
+        List<DomainEvent> events = queries.tags(Tags.clinician(clinicianId)).toList();
         return events.stream().filter(ClinicianRegistered.class::isInstance).map(ClinicianRegistered.class::cast).findFirst()
                 .map(registered -> new ClinicianDetail(registered.clinicianId(), registered.name(),
                         activeFrom(events).stream().map(SchedulingQueries::toAppointment).toList()));
     }
 
     public Optional<PatientDetail> patient(UUID patientId) {
-        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.patient(patientId))).toList();
+        List<DomainEvent> events = queries.tags(Tags.patient(patientId)).toList();
         return events.stream().filter(PatientRegistered.class::isInstance).map(PatientRegistered.class::cast).findFirst()
                 .map(registered -> new PatientDetail(registered.patientId(), registered.name(), registered.maxAppointments(),
                         activeFrom(events).stream().map(SchedulingQueries::toAppointment).toList()));
     }
 
     public Optional<SlotDetail> slot(UUID slotId) {
-        List<DomainEvent> events = queries.query(queries.criteria().tags(Tags.slot(slotId))).toList();
+        List<DomainEvent> events = queries.tags(Tags.slot(slotId)).toList();
         return events.stream().filter(SlotDefined.class::isInstance).map(SlotDefined.class::cast).findFirst()
                 .map(defined -> {
                     List<AppointmentBooked> active = activeFrom(events);


### PR DESCRIPTION
Querying DCB events meant building a criterion by hand: `query(criteria().tags(Tag.of("course", "212")))`.

This adds one-liners on `DcbDomainEventQueries` (blocking `Stream`, reactor `Flux`) for the common reads: `query(Foo.class)` and `query(Foo.class, Bar.class)` by type, and `tags(...)` / `tagsAnyOf(...)` taking either `Tag`s or `"key:value"` strings. The single-type `query(Foo.class)` returns the narrow element type. Kotlin gets reified type queries and, for blocking, `List`-returning tag shortcuts so callers never touch `java.util.stream.Stream`.

I did not delegate the rest of the `DomainEventQueries` surface (`count`, `exists`, `all`, `queryOne`, `Filter`, paging). Those are stream-oriented reads, a different concern from a DCB read, and stay reachable through `domainEventQueries()`. Tell me if you'd rather have the whole thing delegated.
