### PR TITLE
Fix Kotlin Decider state chaining failing to compile under JSpecify null-marking

### DIFF
--- a/dsl/decider/src/main/java/org/occurrent/dsl/decider/Decider.java
+++ b/dsl/decider/src/main/java/org/occurrent/dsl/decider/Decider.java
@@ -34,6 +34,9 @@ import java.util.function.Predicate;
  * @param <S> The state that the decider work
  * @param <E> The type of events that the decider returns
  */
+// State returns below use the plain type variable S so its nullness follows the type argument
+// (parametric nullness). Do not annotate them @Nullable S. That forces the return nullable even when
+// S is a non-null type, which breaks Kotlin callers that feed one decision's state into the next.
 public interface Decider<C, S extends @Nullable Object, E> {
     /**
      * The state a decider starts from, before any events have been applied.
@@ -106,7 +109,7 @@ public interface Decider<C, S extends @Nullable Object, E> {
      * Convenience for {@link #decideOnEvents} that returns only the resulting state.
      */
     @SuppressWarnings("unchecked")
-    default @Nullable S decideOnEventsAndReturnState(List<E> events, C command, C... additionalCommands) {
+    default S decideOnEventsAndReturnState(List<E> events, C command, C... additionalCommands) {
         return decideOnEvents(events, command, additionalCommands).state;
     }
 
@@ -121,7 +124,7 @@ public interface Decider<C, S extends @Nullable Object, E> {
     /**
      * Convenience for {@link #decideOnEvents} that returns only the resulting state.
      */
-    default @Nullable S decideOnEventsAndReturnState(List<E> events, List<C> commands) {
+    default S decideOnEventsAndReturnState(List<E> events, List<C> commands) {
         return decideOnEvents(events, commands).state;
     }
 
@@ -162,7 +165,7 @@ public interface Decider<C, S extends @Nullable Object, E> {
     /**
      * Convenience for {@link #decideOnState} that returns only the resulting state.
      */
-    default @Nullable S decideOnStateAndReturnState(S state, List<C> commands) {
+    default S decideOnStateAndReturnState(S state, List<C> commands) {
         return decideOnState(state, commands).state;
     }
 
@@ -178,7 +181,7 @@ public interface Decider<C, S extends @Nullable Object, E> {
     /**
      * Convenience for {@link #decideOnState} that returns only the resulting state.
      */
-    default @Nullable S decideOnStateAndReturnState(S state, C command, C... additionalCommands) {
+    default S decideOnStateAndReturnState(S state, C command, C... additionalCommands) {
         return decideOnState(state, command, additionalCommands).state;
     }
 
@@ -197,7 +200,7 @@ public interface Decider<C, S extends @Nullable Object, E> {
         return new Decision<>(newState, newEvents);
     }
 
-    private @Nullable S fold(S state, List<E> events) {
+    private S fold(S state, List<E> events) {
         for (E event : events) {
             state = evolve(state, event);
             if (isTerminal(state)) {

--- a/dsl/decider/src/test/kotlin/org/occurrent/dsl/decider/DeciderTest.kt
+++ b/dsl/decider/src/test/kotlin/org/occurrent/dsl/decider/DeciderTest.kt
@@ -73,4 +73,45 @@ class DeciderTest {
             { assertThat(events[0].name()).isEqualTo("Another Name") },
         )
     }
+
+    // Regression: over a non-null state type, one decision's resulting state must feed straight into the
+    // next decide call. A @Nullable S return would type these as SwitchState? and fail to compile under
+    // the module's JSpecify null-marking.
+    @Test
+    fun `chaining decideOnStateAndReturnState compiles and transitions for a non-null state`() {
+        // Given
+        val decider = decider<ToggleCommand, SwitchState, SwitchEvent>(
+            initialState = SwitchState.Off,
+            decide = { _, _ -> listOf(SwitchEvent.Toggled) },
+            evolve = { state, _ ->
+                when (state) {
+                    SwitchState.Off -> SwitchState.On
+                    SwitchState.On -> SwitchState.Off
+                }
+            }
+        )
+
+        // When
+        val state1: SwitchState = decider.decideOnStateAndReturnState(SwitchState.Off, ToggleCommand.Toggle)
+        val state2: SwitchState = decider.decideOnStateAndReturnState(state1, ToggleCommand.Toggle)
+
+        // Then
+        assertAll(
+            { assertThat(state1).isEqualTo(SwitchState.On) },
+            { assertThat(state2).isEqualTo(SwitchState.Off) },
+        )
+    }
+}
+
+private sealed interface SwitchState {
+    object Off : SwitchState
+    object On : SwitchState
+}
+
+private sealed interface ToggleCommand {
+    object Toggle : ToggleCommand
+}
+
+private sealed interface SwitchEvent {
+    object Toggled : SwitchEvent
 }


### PR DESCRIPTION
`Decider`'s `decideOnStateAndReturnState` and `decideOnEventsAndReturnState` returned `@Nullable S` (as did the private `fold`). Once the `dsl/decider` package became null-marked in #287, that types the result as `S?` for a concrete non-null state, so the common Kotlin pattern of feeding one decision's resulting state straight into the next `decide` call stopped compiling.

I changed those returns to the plain type variable `S`, so its nullness follows the type argument: a decider whose state is non-null gets a non-null result and chains cleanly, and a decider that instantiates `S` as a nullable type still gets a nullable result. The `@Nullable Object` bound stays, so a null initial state is still expressible.

No changelog entry, because the break only ever existed on the unreleased 0.30.0 line and no release shipped it. There is a Kotlin regression test that would not compile before this fix.
