### PR TITLE
Exclude new aggregate POMs so the 0.30.0 Central release validates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,10 +547,12 @@
                                 <excludeArtifact>cloudevent-converter</excludeArtifact>
                                 <excludeArtifact>cloudevent-type-mapper</excludeArtifact>
                                 <excludeArtifact>common</excludeArtifact>
+                                <excludeArtifact>dcb-dsl</excludeArtifact>
                                 <excludeArtifact>deadline-api</excludeArtifact>
                                 <excludeArtifact>deadline</excludeArtifact>
                                 <excludeArtifact>dsl</excludeArtifact>
                                 <excludeArtifact>eventstore-api</excludeArtifact>
+                                <excludeArtifact>eventstore-migration</excludeArtifact>
                                 <excludeArtifact>eventstore-mongodb-spring</excludeArtifact>
                                 <excludeArtifact>eventstore-mongodb</excludeArtifact>
                                 <excludeArtifact>eventstore</excludeArtifact>


### PR DESCRIPTION
The 0.30.0 Central deployment failed validation on `org.occurrent:eventstore-migration`, an aggregate parent POM with no name, description, url, license, scm, or developers.

Aggregate POMs flatten to empty POMs and are excluded from publishing through the `central-publishing-maven-plugin` exclude list. Two new 0.30.0 aggregators were never added to it: `eventstore-migration` (parent of the position-backfill module) and `dcb-dsl` (parent of the DCB DSL modules). `eventstore-migration` was the one that failed, and `dcb-dsl` would fail the same way on the next attempt, since the deploy aborts on the first invalid artifact.

Added both to the exclude list. Audited every `packaging=pom` module against the list, and these two were the only aggregators missing. The published leaves under them (`occurrent-eventstore-mongodb-position-backfill`, `occurrent-dcb-dsl-common`, `occurrent-dcb-dsl-blocking`, `occurrent-dcb-dsl-reactor`) are unaffected, and `occurrent-bom` stays published.
