### PR TITLE
Add Java facades for running Deciders and DcbDeciders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+### Changelog next version
+
+#### Changes
+
+* Added Java-friendly facades for running a `Decider` or `DcbDecider` through an application service, so Java callers get the same one-call ergonomics the Kotlin `execute(command, decider)` extensions already provide (those are Kotlin `inline`/`reified` and not callable from Java). Construct one around an existing application service and call `execute(command, decider)`. `org.occurrent.dsl.decider.DeciderApplicationService` wraps a blocking `ApplicationService` and runs a stream `Decider`, and `org.occurrent.dsl.dcb.blocking.DcbDeciderApplicationService` and `org.occurrent.dsl.dcb.reactor.DcbDeciderApplicationService` wrap the blocking and reactive DCB application services and run a `DcbDecider` (with `execute`, `executeAndReturnState`, `executeAndReturnEvents`, and `executeAndReturnDecision`). The decider's event type must equal the application service's event type. Widen a narrower feature decider first with `Decider.adapt(...)` or `DcbDecider.adapt(...)`.
+* Added `DcbDecider.criteriaFor(command)` and `criteriaFor(commands)` to resolve the DCB read boundary for one or more commands, rejecting an unrecognized command and requiring all commands in a single execute to share a boundary since they are appended atomically under one condition. The Kotlin DCB decider extensions now delegate to it.
+
 ### 0.30.0 (2026-07-13)
 
 #### Highlights

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationService.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.blocking.dcb.DcbExecuteOptions;
+import org.occurrent.dsl.dcb.DcbDecider;
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A thin facade over a blocking {@link DcbApplicationService} that runs a {@link DcbDecider}, the Java counterpart to
+ * the Kotlin {@code execute(command, dcbDecider)} extension in {@code DcbApplicationServiceDeciderExtensions.kt}.
+ * Construct it once around an existing DCB application service and call {@link #execute} with a command and a decider.
+ * <p>
+ * The {@code DcbDecider} carries all three pieces DCB execution needs: the decision function, the {@link DcbCriteria}
+ * read boundary derived from the command, and the {@link org.occurrent.application.service.dcb.TagGenerator} for the
+ * events it writes. This facade resolves the boundary, routes the decider's tags through {@link DcbExecuteOptions}, and
+ * runs the decision, so a Java caller does not have to wire those by hand.
+ * <p>
+ * The decider's event type must be the same as the application service's event type {@code E}. A feature decider whose
+ * event type is narrower than {@code E} should first be widened with {@link DcbDecider#adapt(DcbDecider, Class, Class)}
+ * (or combined with {@link DcbDecider#compose}, which already yields a decider over {@code E}).
+ */
+@NullMarked
+public final class DcbDeciderApplicationService<E> {
+
+    private final DcbApplicationService<E> applicationService;
+
+    public DcbDeciderApplicationService(DcbApplicationService<E> applicationService) {
+        this.applicationService = Objects.requireNonNull(applicationService, "applicationService cannot be null");
+    }
+
+    /**
+     * Execute a single command using {@code dcbDecider} to resolve the read boundary, decide, and tag the new events.
+     * Returns the {@link DcbAppendResult}, or {@link Optional#empty()} when the decider produced no new events. Throws
+     * {@link IllegalArgumentException} when the command is not recognized by the decider.
+     */
+    public <C, S extends @Nullable Object> Optional<DcbAppendResult> execute(C command, DcbDecider<C, S, E> dcbDecider) {
+        return execute(List.of(command), dcbDecider);
+    }
+
+    /**
+     * Execute {@code commands} in order using {@code dcbDecider}. All commands must resolve to the same read boundary
+     * since they are appended atomically under one condition. Returns the {@link DcbAppendResult}, or
+     * {@link Optional#empty()} when the decider produced no new events.
+     */
+    public <C, S extends @Nullable Object> Optional<DcbAppendResult> execute(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        DcbCriteria criteria = dcbDecider.criteriaFor(commands);
+        DcbExecuteOptions<E> options = DcbExecuteOptions.<E>options().tagGenerator(dcbDecider.tags());
+        return applicationService.execute(criteria, options, events -> dcbDecider.decider().decideOnEventsAndReturnEvents(events, commands));
+    }
+
+    /**
+     * Execute a single command and return the folded state plus the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Decider.Decision<S, E> executeAndReturnDecision(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(List.of(command), dcbDecider);
+    }
+
+    /**
+     * Execute {@code commands} and return the folded state plus the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Decider.Decision<S, E> executeAndReturnDecision(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        DcbCriteria criteria = dcbDecider.criteriaFor(commands);
+        DcbExecuteOptions<E> options = DcbExecuteOptions.<E>options().tagGenerator(dcbDecider.tags());
+        AtomicReference<Decider.Decision<S, E>> decision = new AtomicReference<>();
+        applicationService.execute(criteria, options, events -> {
+            Decider.Decision<S, E> result = dcbDecider.decider().decideOnEvents(events, commands);
+            decision.set(result);
+            return result.events();
+        });
+        return decision.get();
+    }
+
+    /**
+     * Execute a single command and return the folded state after the decision.
+     */
+    public <C, S extends @Nullable Object> S executeAndReturnState(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(command, dcbDecider).state();
+    }
+
+    /**
+     * Execute {@code commands} and return the folded state after the decision.
+     */
+    public <C, S extends @Nullable Object> S executeAndReturnState(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(commands, dcbDecider).state();
+    }
+
+    /**
+     * Execute a single command and return the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> List<E> executeAndReturnEvents(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(command, dcbDecider).events();
+    }
+
+    /**
+     * Execute {@code commands} and return the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> List<E> executeAndReturnEvents(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(commands, dcbDecider).events();
+    }
+}

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationService.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationService.java
@@ -92,7 +92,7 @@ public final class DcbDeciderApplicationService<E> {
             decision.set(result);
             return result.events();
         });
-        return decision.get();
+        return Objects.requireNonNull(decision.get(), "The decider produced no decision");
     }
 
     /**

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbApplicationServiceDeciderExtensions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbApplicationServiceDeciderExtensions.kt
@@ -40,21 +40,8 @@ import java.util.concurrent.atomic.AtomicReference
  * boundary-mismatch one, so the message points at the actual cause.
  */
 @PublishedApi
-internal fun <C : Any, E : Any> dcbCriteriaFor(commands: List<C>, dcbDecider: DcbDecider<C, *, E>): DcbCriteria {
-    require(commands.isNotEmpty()) { "Must supply at least one command" }
-    val first = requireRecognized(commands.first(), dcbDecider)
-    for (i in 1 until commands.size) {
-        val boundary = requireRecognized(commands[i], dcbDecider)
-        require(boundary == first) {
-            "All commands in a single execute must resolve to the same DcbCriteria boundary, they are appended atomically under one condition"
-        }
-    }
-    return first
-}
-
-private fun <C : Any, E : Any> requireRecognized(command: C, dcbDecider: DcbDecider<C, *, E>): DcbCriteria =
-    dcbDecider.criteria().apply(command)
-        ?: throw IllegalArgumentException("The decider does not recognize command $command, so there is no boundary to read and no decision to make")
+internal fun <C : Any, E : Any> dcbCriteriaFor(commands: List<C>, dcbDecider: DcbDecider<C, *, E>): DcbCriteria =
+    dcbDecider.criteriaFor(commands)
 
 /**
  * Execute a decider command. The [dcbDecider] carries the DCB decision boundary and the tags for the events it emits.

--- a/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationServiceTest.java
+++ b/dsl/dcb-dsl/blocking/src/test/java/org/occurrent/dsl/dcb/blocking/DcbDeciderApplicationServiceTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.blocking.dcb.GenericDcbApplicationService;
+import org.occurrent.application.service.dcb.TagGenerator;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.dsl.dcb.DcbDecider;
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.eventstore.api.dcb.Tag;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("DcbApplicationServiceDeciders")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DcbDeciderApplicationServiceTest {
+
+    private InMemoryEventStore eventStore;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private DcbApplicationService<DomainEvent> applicationService;
+    private DcbDeciderApplicationService<DomainEvent> deciderApplicationService;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void create_instances() {
+        eventStore = new InMemoryEventStore();
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        applicationService = new GenericDcbApplicationService<>(
+                eventStore,
+                cloudEventConverter,
+                (DomainEvent event) -> Set.of(tagFor(event)),
+                GenericDcbApplicationService.defaultRetryStrategy()
+        );
+        deciderApplicationService = new DcbDeciderApplicationService<>(applicationService);
+        time = LocalDateTime.now();
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class Execute {
+
+        @Test
+        void appends_the_events_decided_by_the_decider() {
+            // When
+            Optional<DcbAppendResult> result = deciderApplicationService.execute(new DefineName("Jane Doe"), nameDcbDecider());
+
+            // Then
+            assertAll(
+                    () -> assertThat(result).isPresent(),
+                    () -> assertThat(result.orElseThrow().eventCount()).isEqualTo(1),
+                    () -> assertThat(readNameEvents("name")).containsExactly(new NameDefined("event-1", time, "name", "Jane Doe"))
+            );
+        }
+
+        @Test
+        void returns_empty_when_the_decision_produces_no_new_events() {
+            // Given
+            append(new NameDefined("event-0", time, "name", "Jane Doe"));
+
+            // When
+            Optional<DcbAppendResult> result = deciderApplicationService.execute(new DefineName("Jane Doe"), nameDcbDecider());
+
+            // Then
+            assertAll(
+                    () -> assertThat(result).isEmpty(),
+                    () -> assertThat(readNameEvents("name")).containsExactly(new NameDefined("event-0", time, "name", "Jane Doe"))
+            );
+        }
+
+        @Test
+        void appends_events_for_multiple_commands_that_resolve_to_the_same_boundary() {
+            // When
+            Optional<DcbAppendResult> result = deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider());
+
+            // Then
+            assertAll(
+                    () -> assertThat(result).isPresent(),
+                    () -> assertThat(readNameEvents("name")).containsExactly(
+                            new NameDefined("event-1", time, "name", "Jane Doe"),
+                            new NameWasChanged("event-2", time, "name", "John Doe")
+                    )
+            );
+        }
+
+        @Test
+        void throws_IllegalArgumentException_when_the_decider_does_not_recognize_the_command() {
+            // Given
+            var unrecognizingDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> command instanceof DefineName ? nameQuery("name") : null,
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            var thrown = catchThrowable(() -> deciderApplicationService.execute(new ChangeName("John Doe"), unrecognizingDecider));
+
+            // Then
+            assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void throws_IllegalArgumentException_when_commands_in_a_batch_resolve_to_different_boundaries() {
+            // Given
+            var perCommandDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> switch (command) {
+                        case DefineName defineName -> nameQuery(defineName.name());
+                        case ChangeName changeName -> nameQuery(changeName.name());
+                        case NoOp __ -> nameQuery("name");
+                    },
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            var thrown = catchThrowable(() -> deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), perCommandDecider));
+
+            // Then
+            assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnDecision")
+    class ExecuteAndReturnDecision {
+
+        @Test
+        void returns_the_folded_state_plus_the_new_events() {
+            // Given
+            append(new NameDefined("event-0", time, "name", "Jane Doe"));
+
+            // When
+            Decider.Decision<String, DomainEvent> decision = deciderApplicationService.executeAndReturnDecision(new ChangeName("John Doe"), nameDcbDecider());
+
+            // Then
+            assertAll(
+                    () -> assertThat(decision.state()).isEqualTo("John Doe"),
+                    () -> assertThat(decision.events()).containsExactly(new NameWasChanged("event-2", time, "name", "John Doe"))
+            );
+        }
+
+        @Test
+        void throws_IllegalArgumentException_when_the_decider_does_not_recognize_the_command() {
+            // Given
+            var unrecognizingDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> command instanceof DefineName ? nameQuery("name") : null,
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            var thrown = catchThrowable(() -> deciderApplicationService.executeAndReturnDecision(new ChangeName("John Doe"), unrecognizingDecider));
+
+            // Then
+            assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnState")
+    class ExecuteAndReturnState {
+
+        @Test
+        void returns_the_folded_state_after_multiple_commands() {
+            // When
+            deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider());
+            String state = deciderApplicationService.executeAndReturnState(NoOp.INSTANCE, nameDcbDecider());
+
+            // Then
+            assertThat(state).isEqualTo("John Doe");
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnEvents")
+    class ExecuteAndReturnEvents {
+
+        @Test
+        void returns_the_new_events_for_multiple_commands_in_order() {
+            // When
+            List<DomainEvent> newEvents = deciderApplicationService.executeAndReturnEvents(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider());
+
+            // Then
+            assertAll(
+                    () -> assertThat(newEvents).containsExactly(
+                            new NameDefined("event-1", time, "name", "Jane Doe"),
+                            new NameWasChanged("event-2", time, "name", "John Doe")
+                    ),
+                    () -> assertThat(readNameEvents("name")).containsExactlyElementsOf(newEvents)
+            );
+        }
+    }
+
+    // executeAndReturnState cannot carry a null state, so this decider uses a non-null String, with an empty string
+    // for "no name yet".
+    private Decider<NameCommand, String, DomainEvent> nameDecider() {
+        return Decider.create(
+                "",
+                (NameCommand command, String state) -> switch (command) {
+                    case DefineName defineName -> state.isEmpty() ? List.of(new NameDefined("event-1", time, "name", defineName.name())) : List.of();
+                    case ChangeName changeName -> List.of(new NameWasChanged("event-2", time, "name", changeName.name()));
+                    case NoOp __ -> List.of();
+                },
+                (state, event) -> event.name()
+        );
+    }
+
+    private DcbDecider<NameCommand, String, DomainEvent> nameDcbDecider() {
+        return DcbDecider.from(nameDecider(), command -> nameQuery("name"), event -> Set.of(tagFor(event)));
+    }
+
+    private void append(DomainEvent... events) {
+        List<Tag> tags = List.of(Tag.of("name", "name"));
+        var cloudEvents = cloudEventConverter.toCloudEvents(List.of(events)).stream()
+                .map(event -> DcbCloudEvents.withTags(event, tags))
+                .toList();
+        eventStore.append(cloudEvents);
+    }
+
+    private List<DomainEvent> readNameEvents(String nameId) {
+        return cloudEventConverter.toDomainEvents(eventStore.read(nameQuery(nameId)).stream()).toList();
+    }
+
+    private static DcbCriteria nameQuery(String nameId) {
+        return DcbCriteria.tags(Tag.of("name", nameId));
+    }
+
+    private static Tag tagFor(DomainEvent event) {
+        return Tag.of("name", event.userId());
+    }
+
+    private sealed interface NameCommand {
+    }
+
+    private record DefineName(String name) implements NameCommand {
+    }
+
+    private record ChangeName(String name) implements NameCommand {
+    }
+
+    private enum NoOp implements NameCommand {
+        INSTANCE
+    }
+}

--- a/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/DcbDecider.java
+++ b/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/DcbDecider.java
@@ -190,4 +190,36 @@ public record DcbDecider<C, S extends @Nullable Object, E>(
 
         return new DcbDecider<>(composedDecider, composedCriteria, composedTags);
     }
+
+    /**
+     * Resolve the DCB read boundary for a single {@code command}. Throws {@link IllegalArgumentException} if this
+     * decider does not recognize the command (its {@link #criteria} returns {@code null}), since then there is no
+     * boundary to read and no decision to make.
+     */
+    public DcbCriteria criteriaFor(C command) {
+        DcbCriteria boundary = criteria.apply(command);
+        if (boundary == null) {
+            throw new IllegalArgumentException("The decider does not recognize command " + command + ", so there is no boundary to read and no decision to make");
+        }
+        return boundary;
+    }
+
+    /**
+     * Resolve the single DCB read boundary shared by all of {@code commands}. Requires at least one command, and
+     * requires every command to resolve to the same boundary, since the events they produce are appended atomically
+     * under one append condition. Throws {@link IllegalArgumentException} otherwise.
+     */
+    public DcbCriteria criteriaFor(List<C> commands) {
+        if (commands.isEmpty()) {
+            throw new IllegalArgumentException("Must supply at least one command");
+        }
+        DcbCriteria first = criteriaFor(commands.getFirst());
+        for (int i = 1; i < commands.size(); i++) {
+            DcbCriteria boundary = criteriaFor(commands.get(i));
+            if (!boundary.equals(first)) {
+                throw new IllegalArgumentException("All commands in a single execute must resolve to the same DcbCriteria boundary, they are appended atomically under one condition");
+            }
+        }
+        return first;
+    }
 }

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDeciderApplicationService.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbDeciderApplicationService.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.service.reactor.dcb.DcbApplicationService;
+import org.occurrent.application.service.reactor.dcb.DcbExecuteOptions;
+import org.occurrent.dsl.dcb.DcbDecider;
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A thin facade over a reactive {@link DcbApplicationService} that runs a {@link DcbDecider}, the Java counterpart to
+ * the Kotlin {@code execute(command, dcbDecider)} extension in the reactor
+ * {@code DcbApplicationServiceDeciderExtensions.kt}. Construct it once around an existing DCB application service and
+ * call {@link #execute} with a command and a decider.
+ * <p>
+ * The {@code DcbDecider} carries all three pieces DCB execution needs: the decision function, the {@link DcbCriteria}
+ * read boundary derived from the command, and the {@link org.occurrent.application.service.dcb.TagGenerator} for the
+ * events it writes. The decision itself is synchronous, only the read and append are reactive.
+ * <p>
+ * The decider's event type must be the same as the application service's event type {@code E}. A feature decider whose
+ * event type is narrower than {@code E} should first be widened with {@link DcbDecider#adapt(DcbDecider, Class, Class)}
+ * (or combined with {@link DcbDecider#compose}, which already yields a decider over {@code E}).
+ */
+@NullMarked
+public final class DcbDeciderApplicationService<E> {
+
+    private final DcbApplicationService<E> applicationService;
+
+    public DcbDeciderApplicationService(DcbApplicationService<E> applicationService) {
+        this.applicationService = Objects.requireNonNull(applicationService, "applicationService cannot be null");
+    }
+
+    /**
+     * Execute a single command using {@code dcbDecider}. Emits the {@link DcbAppendResult}, or completes empty when the
+     * decider produced no new events. Fails with {@link IllegalArgumentException} when the command is not recognized.
+     */
+    public <C, S extends @Nullable Object> Mono<DcbAppendResult> execute(C command, DcbDecider<C, S, E> dcbDecider) {
+        return execute(List.of(command), dcbDecider);
+    }
+
+    /**
+     * Execute {@code commands} in order using {@code dcbDecider}. All commands must resolve to the same read boundary
+     * since they are appended atomically under one condition.
+     */
+    public <C, S extends @Nullable Object> Mono<DcbAppendResult> execute(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        // Deferred so boundary resolution (and the IllegalArgumentException it may throw) happens per subscription
+        // rather than eagerly when the Mono is built.
+        return Mono.defer(() -> {
+            DcbCriteria criteria = dcbDecider.criteriaFor(commands);
+            DcbExecuteOptions<E> options = DcbExecuteOptions.<E>options().tagGenerator(dcbDecider.tags());
+            return applicationService.execute(criteria, options, events -> dcbDecider.decider().decideOnEventsAndReturnEvents(events, commands));
+        });
+    }
+
+    /**
+     * Execute a single command and emit the folded state plus the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Mono<Decider.Decision<S, E>> executeAndReturnDecision(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(List.of(command), dcbDecider);
+    }
+
+    /**
+     * Execute {@code commands} and emit the folded state plus the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Mono<Decider.Decision<S, E>> executeAndReturnDecision(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        // Deferred so the AtomicReference is created per subscription. A shared reference would let concurrent or
+        // repeat subscribers see each other's decision.
+        return Mono.defer(() -> {
+            DcbCriteria criteria = dcbDecider.criteriaFor(commands);
+            DcbExecuteOptions<E> options = DcbExecuteOptions.<E>options().tagGenerator(dcbDecider.tags());
+            AtomicReference<Decider.Decision<S, E>> decision = new AtomicReference<>();
+            return applicationService.execute(criteria, options, events -> {
+                Decider.Decision<S, E> result = dcbDecider.decider().decideOnEvents(events, commands);
+                decision.set(result);
+                return result.events();
+            }).then(Mono.fromCallable(() -> Objects.requireNonNull(decision.get(), "The decider produced no decision")));
+        });
+    }
+
+    /**
+     * Execute a single command and emit the folded state after the decision. The state is bound to a non-null type
+     * because a {@link Mono} cannot carry a null value, use {@link #executeAndReturnDecision} for a nullable state.
+     */
+    public <C, S> Mono<S> executeAndReturnState(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(command, dcbDecider).map(Decider.Decision::state);
+    }
+
+    /**
+     * Execute {@code commands} and emit the folded state after the decision.
+     */
+    public <C, S> Mono<S> executeAndReturnState(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(commands, dcbDecider).map(Decider.Decision::state);
+    }
+
+    /**
+     * Execute a single command and emit the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Mono<List<E>> executeAndReturnEvents(C command, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(command, dcbDecider).map(Decider.Decision::events);
+    }
+
+    /**
+     * Execute {@code commands} and emit the new events decided by {@code dcbDecider}.
+     */
+    public <C, S extends @Nullable Object> Mono<List<E>> executeAndReturnEvents(List<C> commands, DcbDecider<C, S, E> dcbDecider) {
+        return executeAndReturnDecision(commands, dcbDecider).map(Decider.Decision::events);
+    }
+}

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbApplicationServiceDeciderExtensions.kt
@@ -42,21 +42,8 @@ import java.util.concurrent.atomic.AtomicReference
  * boundary-mismatch one, so the message points at the actual cause.
  */
 @PublishedApi
-internal fun <C : Any, E : Any> dcbCriteriaFor(commands: List<C>, dcbDecider: DcbDecider<C, *, E>): DcbCriteria {
-    require(commands.isNotEmpty()) { "Must supply at least one command" }
-    val first = requireRecognized(commands.first(), dcbDecider)
-    for (i in 1 until commands.size) {
-        val boundary = requireRecognized(commands[i], dcbDecider)
-        require(boundary == first) {
-            "All commands in a single execute must resolve to the same DcbCriteria boundary, they are appended atomically under one condition"
-        }
-    }
-    return first
-}
-
-private fun <C : Any, E : Any> requireRecognized(command: C, dcbDecider: DcbDecider<C, *, E>): DcbCriteria =
-    dcbDecider.criteria().apply(command)
-        ?: throw IllegalArgumentException("The decider does not recognize command $command, so there is no boundary to read and no decision to make")
+internal fun <C : Any, E : Any> dcbCriteriaFor(commands: List<C>, dcbDecider: DcbDecider<C, *, E>): DcbCriteria =
+    dcbDecider.criteriaFor(commands)
 
 /**
  * Execute a decider command. The [dcbDecider] carries the DCB decision boundary and the tags for the events it emits.

--- a/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDeciderApplicationServiceTest.java
+++ b/dsl/dcb-dsl/reactor/src/test/java/org/occurrent/dsl/dcb/reactor/DcbDeciderApplicationServiceTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.dcb.reactor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.dcb.TagGenerator;
+import org.occurrent.application.service.reactor.dcb.DcbApplicationService;
+import org.occurrent.application.service.reactor.dcb.GenericDcbApplicationService;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.dsl.dcb.DcbDecider;
+import org.occurrent.dsl.decider.Decider;
+import org.occurrent.eventstore.api.dcb.DcbAppendResult;
+import org.occurrent.eventstore.api.dcb.DcbCloudEvents;
+import org.occurrent.eventstore.api.dcb.DcbCriteria;
+import org.occurrent.eventstore.api.dcb.Tag;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.testsupport.mongodb.FlushMongoDBExtension;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.eventstore.api.EventStoreCapability.DCB;
+import static org.occurrent.eventstore.api.EventStoreCapability.STREAM;
+
+@Testcontainers
+@DisplayName("DcbApplicationServiceDeciders")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DcbDeciderApplicationServiceTest {
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer;
+
+    static {
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
+        List<String> ports = new ArrayList<>();
+        ports.add("27017:27017");
+        mongoDBContainer.withReuse(true).setPortBindings(ports);
+    }
+
+    @RegisterExtension
+    FlushMongoDBExtension flushMongoDBExtension = new FlushMongoDBExtension(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbappservicedeciders"));
+
+    private ReactorMongoEventStore eventStore;
+    private CloudEventConverter<DomainEvent> converter;
+    private DcbApplicationService<DomainEvent> applicationService;
+    private DcbDeciderApplicationService<DomainEvent> deciderApplicationService;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void create_instances() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".dcbappservicedeciders");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        ReactiveMongoTransactionManager transactionManager = new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName("events")
+                .transactionConfig(transactionManager)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .eventStoreCapabilities(STREAM, DCB)
+                .build();
+        eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        converter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        applicationService = new GenericDcbApplicationService<>(eventStore, converter, (DomainEvent event) -> Set.of(tagFor(event)), GenericDcbApplicationService.defaultRetry());
+        deciderApplicationService = new DcbDeciderApplicationService<>(applicationService);
+        time = LocalDateTime.now();
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class Execute {
+
+        @Test
+        void appends_the_events_decided_by_the_decider() {
+            // When
+            DcbAppendResult result = deciderApplicationService.execute(new DefineName("Jane Doe"), nameDcbDecider()).block();
+
+            // Then
+            assertThat(requireNonNull(result).eventCount()).isEqualTo(1);
+            assertThat(readNameEvents("name")).containsExactly(new NameDefined("event-1", time, "name", "Jane Doe"));
+        }
+
+        @Test
+        void completes_empty_when_the_decision_produces_no_new_events() {
+            // Given
+            append(new NameDefined("event-0", time, "name", "Jane Doe"));
+
+            // When
+            DcbAppendResult result = deciderApplicationService.execute(new DefineName("Jane Doe"), nameDcbDecider()).block();
+
+            // Then
+            assertThat(result).isNull();
+            assertThat(readNameEvents("name")).containsExactly(new NameDefined("event-0", time, "name", "Jane Doe"));
+        }
+
+        @Test
+        void appends_events_for_multiple_commands_that_resolve_to_the_same_boundary() {
+            // When
+            DcbAppendResult result = deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider()).block();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(readNameEvents("name")).containsExactly(
+                    new NameDefined("event-1", time, "name", "Jane Doe"),
+                    new NameWasChanged("event-2", time, "name", "John Doe")
+            );
+        }
+
+        @Test
+        void fails_with_IllegalArgumentException_when_the_decider_does_not_recognize_the_command() {
+            // Given
+            var unrecognizingDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> command instanceof DefineName ? nameQuery("name") : null,
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            Mono<DcbAppendResult> result = deciderApplicationService.execute(new ChangeName("John Doe"), unrecognizingDecider);
+
+            // Then
+            StepVerifier.create(result).expectError(IllegalArgumentException.class).verify();
+        }
+
+        @Test
+        void fails_with_IllegalArgumentException_when_commands_in_a_batch_resolve_to_different_boundaries() {
+            // Given
+            var perCommandDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> switch (command) {
+                        case DefineName defineName -> nameQuery(defineName.name());
+                        case ChangeName changeName -> nameQuery(changeName.name());
+                        case NoOp __ -> nameQuery("name");
+                    },
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            Mono<DcbAppendResult> result = deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), perCommandDecider);
+
+            // Then
+            StepVerifier.create(result).expectError(IllegalArgumentException.class).verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnDecision")
+    class ExecuteAndReturnDecision {
+
+        @Test
+        void emits_the_folded_state_plus_the_new_events() {
+            // Given
+            append(new NameDefined("event-0", time, "name", "Jane Doe"));
+
+            // When
+            Decider.Decision<String, DomainEvent> decision = deciderApplicationService.executeAndReturnDecision(new ChangeName("John Doe"), nameDcbDecider()).block();
+
+            // Then
+            assertThat(requireNonNull(decision).state()).isEqualTo("John Doe");
+            assertThat(decision.events()).containsExactly(new NameWasChanged("event-2", time, "name", "John Doe"));
+        }
+
+        @Test
+        void fails_with_IllegalArgumentException_when_the_decider_does_not_recognize_the_command() {
+            // Given
+            var unrecognizingDecider = DcbDecider.from(
+                    nameDecider(),
+                    (NameCommand command) -> command instanceof DefineName ? nameQuery("name") : null,
+                    (TagGenerator<DomainEvent>) event -> Set.of(tagFor(event))
+            );
+
+            // When
+            Mono<Decider.Decision<String, DomainEvent>> result = deciderApplicationService.executeAndReturnDecision(new ChangeName("John Doe"), unrecognizingDecider);
+
+            // Then
+            StepVerifier.create(result).expectError(IllegalArgumentException.class).verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnState")
+    class ExecuteAndReturnState {
+
+        @Test
+        void emits_the_folded_state_after_multiple_commands() {
+            // Given
+            deciderApplicationService.execute(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider()).block();
+
+            // When
+            String state = deciderApplicationService.executeAndReturnState(NoOp.INSTANCE, nameDcbDecider()).block();
+
+            // Then
+            assertThat(state).isEqualTo("John Doe");
+        }
+    }
+
+    @Nested
+    @DisplayName("executeAndReturnEvents")
+    class ExecuteAndReturnEvents {
+
+        @Test
+        void emits_the_new_events_for_multiple_commands_in_order() {
+            // When
+            List<DomainEvent> newEvents = deciderApplicationService.executeAndReturnEvents(List.of(new DefineName("Jane Doe"), new ChangeName("John Doe")), nameDcbDecider()).block();
+
+            // Then
+            assertThat(newEvents).containsExactly(
+                    new NameDefined("event-1", time, "name", "Jane Doe"),
+                    new NameWasChanged("event-2", time, "name", "John Doe")
+            );
+            assertThat(readNameEvents("name")).containsExactlyElementsOf(newEvents);
+        }
+    }
+
+    // executeAndReturnState cannot carry a null state, so this decider uses a non-null String, with an empty string
+    // for "no name yet".
+    private Decider<NameCommand, String, DomainEvent> nameDecider() {
+        return Decider.create(
+                "",
+                (NameCommand command, String state) -> switch (command) {
+                    case DefineName defineName -> state.isEmpty() ? List.of(new NameDefined("event-1", time, "name", defineName.name())) : List.of();
+                    case ChangeName changeName -> List.of(new NameWasChanged("event-2", time, "name", changeName.name()));
+                    case NoOp __ -> List.of();
+                },
+                (state, event) -> event.name()
+        );
+    }
+
+    private DcbDecider<NameCommand, String, DomainEvent> nameDcbDecider() {
+        return DcbDecider.from(nameDecider(), command -> nameQuery("name"), event -> Set.of(tagFor(event)));
+    }
+
+    private void append(DomainEvent... events) {
+        List<Tag> tags = List.of(Tag.of("name", "name"));
+        var cloudEvents = converter.toCloudEvents(List.of(events)).stream()
+                .map(event -> DcbCloudEvents.withTags(event, tags))
+                .toList();
+        eventStore.append(cloudEvents).block();
+    }
+
+    private List<DomainEvent> readNameEvents(String nameId) {
+        return converter.toDomainEvents(requireNonNull(eventStore.read(nameQuery(nameId)).block()).events().stream()).toList();
+    }
+
+    private static DcbCriteria nameQuery(String nameId) {
+        return DcbCriteria.tags(Tag.of("name", nameId));
+    }
+
+    private static Tag tagFor(DomainEvent event) {
+        return Tag.of("name", event.userId());
+    }
+
+    private sealed interface NameCommand {
+    }
+
+    private record DefineName(String name) implements NameCommand {
+    }
+
+    private record ChangeName(String name) implements NameCommand {
+    }
+
+    private enum NoOp implements NameCommand {
+        INSTANCE
+    }
+}

--- a/dsl/decider/src/main/java/org/occurrent/dsl/decider/DeciderApplicationService.java
+++ b/dsl/decider/src/main/java/org/occurrent/dsl/decider/DeciderApplicationService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.decider;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.eventstore.api.WriteResult;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A thin facade over a blocking {@link ApplicationService} that runs a {@link Decider}, the Java counterpart to the
+ * Kotlin {@code execute(streamId, command, decider)} extension in {@code ApplicationServiceDeciderExtensions.kt}.
+ * Construct it once around an existing application service and call {@link #execute} with a command and a decider.
+ * <p>
+ * The decider's event type must be the same as the application service's event type {@code E}. A feature decider whose
+ * event type is narrower than {@code E} should first be widened with {@link Decider#adapt(Decider, Class, Class)} (or
+ * combined with {@link Decider#compose}, which already yields a decider over {@code E}).
+ */
+@NullMarked
+public final class DeciderApplicationService<E> {
+
+    private final ApplicationService<E> applicationService;
+
+    public DeciderApplicationService(ApplicationService<E> applicationService) {
+        this.applicationService = Objects.requireNonNull(applicationService, "applicationService cannot be null");
+    }
+
+    /**
+     * Execute a single command against {@code streamId}, using {@code decider} to decide the new events.
+     */
+    public <C, S extends @Nullable Object> WriteResult execute(String streamId, C command, Decider<C, S, E> decider) {
+        return execute(streamId, List.of(command), decider);
+    }
+
+    /**
+     * Execute a single command against {@code streamId}, using {@code decider} to decide the new events.
+     */
+    public <C, S extends @Nullable Object> WriteResult execute(UUID streamId, C command, Decider<C, S, E> decider) {
+        return execute(streamId.toString(), command, decider);
+    }
+
+    /**
+     * Execute {@code commands} in order against {@code streamId}, using {@code decider} to decide the new events.
+     */
+    public <C, S extends @Nullable Object> WriteResult execute(String streamId, List<C> commands, Decider<C, S, E> decider) {
+        return applicationService.execute(streamId, events -> decider.decideOnEventsAndReturnEvents(events, commands));
+    }
+
+    /**
+     * Execute {@code commands} in order against {@code streamId}, using {@code decider} to decide the new events.
+     */
+    public <C, S extends @Nullable Object> WriteResult execute(UUID streamId, List<C> commands, Decider<C, S, E> decider) {
+        return execute(streamId.toString(), commands, decider);
+    }
+}

--- a/dsl/decider/src/test/java/org/occurrent/dsl/decider/DeciderApplicationServiceTest.java
+++ b/dsl/decider/src/test/java/org/occurrent/dsl/decider/DeciderApplicationServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.decider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.generic.GenericApplicationService;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("ApplicationServiceDeciders")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeciderApplicationServiceTest {
+
+    private Decider<NameCommand, String, DomainEvent> decider;
+    private InMemoryEventStore eventStore;
+    private CloudEventConverter<DomainEvent> cloudEventConverter;
+    private ApplicationService<DomainEvent> applicationService;
+    private DeciderApplicationService<DomainEvent> deciderApplicationService;
+    private LocalDateTime time;
+
+    @BeforeEach
+    void create_instances() {
+        time = LocalDateTime.now();
+        decider = Decider.create(
+                "",
+                (NameCommand command, String state) -> switch (command) {
+                    case DefineName defineName -> List.of(new NameDefined("event-1", time, "name", defineName.name()));
+                    case ChangeName changeName -> List.of(new NameWasChanged("event-2", time, "name", changeName.name()));
+                },
+                (state, event) -> event.name()
+        );
+        eventStore = new InMemoryEventStore();
+        cloudEventConverter = new JacksonCloudEventConverter.Builder<DomainEvent>(new ObjectMapper(), URI.create("urn:test")).idMapper(DomainEvent::eventId).build();
+        applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
+        deciderApplicationService = new DeciderApplicationService<>(applicationService);
+    }
+
+    @AfterEach
+    void delete_all_events_in_event_store() {
+        eventStore.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class Execute {
+
+        @Test
+        void appends_the_events_decided_for_a_single_command() {
+            // Given
+            var streamId = UUID.randomUUID();
+            var command = new DefineName("Jane Doe");
+
+            // When
+            var result = deciderApplicationService.execute(streamId, command, decider);
+
+            // Then
+            assertThat(result).isEqualTo(new WriteResult(streamId.toString(), 0, 1));
+        }
+
+        @Test
+        void appends_the_events_decided_for_a_single_command_given_a_string_stream_id() {
+            // Given
+            var streamId = UUID.randomUUID().toString();
+            var command = new DefineName("Jane Doe");
+
+            // When
+            var result = deciderApplicationService.execute(streamId, command, decider);
+
+            // Then
+            assertThat(result).isEqualTo(new WriteResult(streamId, 0, 1));
+        }
+
+        @Test
+        void appends_the_events_decided_for_a_list_of_commands_in_order() {
+            // Given
+            var streamId = UUID.randomUUID();
+            var command1 = new DefineName("John");
+            var command2 = new ChangeName("Johan");
+
+            // When
+            var result = deciderApplicationService.execute(streamId, List.of(command1, command2), decider);
+
+            // Then
+            assertAll(
+                    () -> assertThat(result).isEqualTo(new WriteResult(streamId.toString(), 0, 2)),
+                    () -> assertThat(readNameEvents()).containsExactly(
+                            new NameDefined("event-1", time, "name", "John"),
+                            new NameWasChanged("event-2", time, "name", "Johan")
+                    )
+            );
+        }
+    }
+
+    private sealed interface NameCommand {
+    }
+
+    private record DefineName(String name) implements NameCommand {
+    }
+
+    private record ChangeName(String name) implements NameCommand {
+    }
+
+    private List<DomainEvent> readNameEvents() {
+        return eventStore.all().map(cloudEventConverter::toDomainEvent).toList();
+    }
+}

--- a/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/AppointmentSchedulingService.java
+++ b/example/domain/appointment-scheduling/src/main/java/org/occurrent/example/domain/appointmentscheduling/application/AppointmentSchedulingService.java
@@ -17,9 +17,14 @@
 package org.occurrent.example.domain.appointmentscheduling.application;
 
 import org.occurrent.application.service.blocking.dcb.DcbApplicationService;
+import org.occurrent.application.service.dcb.TagGenerator;
+import org.occurrent.application.service.dcb.annotation.AnnotationTagGenerator;
+import org.occurrent.dsl.dcb.DcbDecider;
+import org.occurrent.dsl.dcb.blocking.DcbDeciderApplicationService;
 import org.occurrent.example.domain.appointmentscheduling.event.DomainEvent;
 import org.occurrent.example.domain.appointmentscheduling.model.Appointment;
 import org.occurrent.example.domain.appointmentscheduling.model.Clinician;
+import org.occurrent.example.domain.appointmentscheduling.model.Commands.AppointmentCommand;
 import org.occurrent.example.domain.appointmentscheduling.model.Commands.BookAppointment;
 import org.occurrent.example.domain.appointmentscheduling.model.Commands.CancelAppointment;
 import org.occurrent.example.domain.appointmentscheduling.model.Commands.DefineSlot;
@@ -29,39 +34,44 @@ import org.occurrent.example.domain.appointmentscheduling.model.Patient;
 import org.occurrent.example.domain.appointmentscheduling.model.Slot;
 
 /**
- * Runs each command by reading the events its decider's criteria selects, deciding, and appending. The plain
- * decider does the folding, the criteria defines the DCB read and append boundary, and the application
- * service supplies the optimistic append condition and tags the new events.
+ * Runs each command through a {@link DcbDecider} that bundles the feature's decider, its DCB read boundary, and the
+ * tags for the events it writes. {@link DcbDeciderApplicationService#execute} reads the events the boundary selects,
+ * decides, tags the new events, and appends them under the DCB optimistic condition.
  */
 public class AppointmentSchedulingService {
-    private final DcbApplicationService<DomainEvent> applicationService;
+
+    // The tags are derived from the events themselves via their annotations, so one stateless generator serves every
+    // decider.
+    private static final TagGenerator<DomainEvent> TAGS = new AnnotationTagGenerator<>();
+
+    private static final DcbDecider<RegisterClinician, ?, DomainEvent> CLINICIAN = DcbDecider.from(Clinician.DECIDER, Clinician::criteria, TAGS);
+    private static final DcbDecider<RegisterPatient, ?, DomainEvent> PATIENT = DcbDecider.from(Patient.DECIDER, Patient::criteria, TAGS);
+    private static final DcbDecider<DefineSlot, ?, DomainEvent> SLOT = DcbDecider.from(Slot.DECIDER, Slot::criteria, TAGS);
+    private static final DcbDecider<AppointmentCommand, ?, DomainEvent> APPOINTMENT = DcbDecider.from(Appointment.DECIDER, Appointment::criteria, TAGS);
+
+    private final DcbDeciderApplicationService<DomainEvent> applicationService;
 
     public AppointmentSchedulingService(DcbApplicationService<DomainEvent> applicationService) {
-        this.applicationService = applicationService;
+        this.applicationService = new DcbDeciderApplicationService<>(applicationService);
     }
 
     public void registerClinician(RegisterClinician command) {
-        applicationService.execute(Clinician.criteria(command),
-                events -> Clinician.DECIDER.decideOnEventsAndReturnEvents(events, command));
+        applicationService.execute(command, CLINICIAN);
     }
 
     public void registerPatient(RegisterPatient command) {
-        applicationService.execute(Patient.criteria(command),
-                events -> Patient.DECIDER.decideOnEventsAndReturnEvents(events, command));
+        applicationService.execute(command, PATIENT);
     }
 
     public void defineSlot(DefineSlot command) {
-        applicationService.execute(Slot.criteria(command),
-                events -> Slot.DECIDER.decideOnEventsAndReturnEvents(events, command));
+        applicationService.execute(command, SLOT);
     }
 
     public void bookAppointment(BookAppointment command) {
-        applicationService.execute(Appointment.criteria(command),
-                events -> Appointment.DECIDER.decideOnEventsAndReturnEvents(events, command));
+        applicationService.execute(command, APPOINTMENT);
     }
 
     public void cancelAppointment(CancelAppointment command) {
-        applicationService.execute(Appointment.criteria(command),
-                events -> Appointment.DECIDER.decideOnEventsAndReturnEvents(events, command));
+        applicationService.execute(command, APPOINTMENT);
     }
 }


### PR DESCRIPTION
Running a `Decider` or `DcbDecider` through an application service was only ergonomic from Kotlin, where `execute(command, decider)` is an `inline`/`reified` extension that Java cannot call. Java callers had to hand-wire the pieces, worst for DCB where execution also needs a criteria boundary and a tag generator, not just a decision function.

This adds thin Java facades that wrap an application service and run a decider:

- `DeciderApplicationService` (`dsl/decider`) over a blocking `ApplicationService`.
- `DcbDeciderApplicationService` (`dsl/dcb-dsl` blocking and reactor) over a `DcbApplicationService`, with `execute` plus `executeAndReturnState`/`Events`/`Decision`.

Construct one around an existing application service and call `execute(command, decider)`. The decider's event type must equal the application service's event type, widen a narrower feature decider first with `Decider.adapt(...)` / `DcbDecider.adapt(...)`.

Also adds `DcbDecider.criteriaFor(command)` / `criteriaFor(commands)` to resolve the read boundary (rejecting an unrecognized command, requiring one shared boundary per execute). The Kotlin DCB decider extensions now delegate to it.

Converts the appointment-scheduling Java example to the new facade, and adds Java tests for all three facades (the reactor one is Testcontainers-backed). Targets the next release.
