### PR TITLE
Shard CI tests across parallel runners after a shared build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -144,6 +144,6 @@ jobs:
         run: |
           for d in ${{ matrix.shard.paths }}; do
             echo "::group::mvn test -f $d/pom.xml"
-            mvn $MVN -f "$d/pom.xml" test
+            mvn $MVN --fail-at-end -f "$d/pom.xml" test
             echo "::endgroup::"
           done

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -120,7 +120,9 @@ jobs:
           - { name: subscription-util-blocking,  paths: "subscription/util/blocking" }
           - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor" }
           - { name: framework,                   paths: "framework" }
-          - { name: example,                     paths: "example" }
+          # example holds ~25 container-heavy modules with timing-sensitive Awaitility
+          # subscription-catchup tests; retry those in-run so runner load spikes don't red the build.
+          - { name: example,                     paths: "example", args: "-Dsurefire.rerunFailingTestsCount=2" }
           - { name: misc,                        paths: "dsl application rewrite common deadline cloudevents-extension library" }
     steps:
       - uses: actions/checkout@v4
@@ -151,6 +153,6 @@ jobs:
         run: |
           for d in ${{ matrix.shard.paths }}; do
             echo "::group::mvn test -f $d/pom.xml"
-            mvn $MVN --fail-at-end -f "$d/pom.xml" test
+            mvn $MVN ${{ matrix.shard.args }} --fail-at-end -f "$d/pom.xml" test
             echo "::endgroup::"
           done

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -120,9 +120,13 @@ jobs:
           - { name: subscription-util-blocking,  paths: "subscription/util/blocking" }
           - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor" }
           - { name: framework,                   paths: "framework" }
-          # example holds ~25 container-heavy modules with timing-sensitive Awaitility
-          # subscription-catchup tests; retry those in-run so runner load spikes don't red the build.
-          - { name: example,                     paths: "example", args: "-Dsurefire.rerunFailingTestsCount=2" }
+          # example modules run real MongoDB replica-set containers with timing-sensitive
+          # Awaitility subscription-catchup tests. A single example shard started 12 containers
+          # sequentially on one runner, which tipped those waits over. Split by container load
+          # (projection+forwarder ~5 vs domain ~7) to cut per-runner churn, keeping an in-run
+          # retry as a backstop for residual timing flakiness.
+          - { name: example-projection,          paths: "example/projection example/forwarder", args: "-Dsurefire.rerunFailingTestsCount=2" }
+          - { name: example-domain,              paths: "example/domain", args: "-Dsurefire.rerunFailingTestsCount=2" }
           - { name: misc,                        paths: "dsl application rewrite common deadline cloudevents-extension library" }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Cache Maven dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.m2repo
+          # Cache only third-party deps and plugins; this commit's org/occurrent SNAPSHOTs
+          # travel to the test shards via the per-run artifact, so they never linger here.
+          path: |
+            ${{ github.workspace }}/.m2repo
+            !${{ github.workspace }}/.m2repo/org/occurrent
           key: ${{ runner.os }}-m2deps-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2deps-java${{ matrix.java }}-
@@ -128,7 +132,10 @@ jobs:
       - name: Restore Maven dependencies
         uses: actions/cache/restore@v4
         with:
-          path: ${{ github.workspace }}/.m2repo
+          # Only third-party deps come from cache; org/occurrent arrives via the downloaded artifact.
+          path: |
+            ${{ github.workspace }}/.m2repo
+            !${{ github.workspace }}/.m2repo/org/occurrent
           key: ${{ runner.os }}-m2deps-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2deps-java${{ matrix.java }}-

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,33 +5,144 @@ on:
     paths-ignore:
       - '**/*.md'
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
+# Cancel superseded runs on the same ref so pushes don't queue up behind stale builds.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
+env:
+  # Keep the Maven local repository inside the workspace so cache and artifact paths are
+  # deterministic across jobs (avoids '~' expansion differences in actions/cache and
+  # upload/download-artifact). Unquoted expansion is intentional: the value word-splits into
+  # separate mvn arguments.
+  MVN: -B -ntp -Dmaven.repo.local=${{ github.workspace }}/.m2repo
+
+jobs:
+  # Stage 1: compile and install every module artifact into the local repo, skipping tests.
+  # -DskipTests (not -Dmaven.test.skip) still test-compiles, so test-scoped dependencies
+  # (Testcontainers, JUnit, Awaitility) are resolved and cached for the test shards. Runs on
+  # both JDKs to preserve the "compiles on 21 and 25" signal. Compilation is a small fraction of
+  # the old ~13 min single-job build (measured: tests dominate), so this stage is cheap.
+  build:
+    name: build (java-${{ matrix.java }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         java: [ 21, 25 ]
-
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@main
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-
-      - name: Enable Testcontainers reuse on this runner
-        run: |
-          echo "testcontainers.reuse.enable=true" > "$HOME/.testcontainers.properties"
-          cat "$HOME/.testcontainers.properties"
-
-      - name: Cache Maven packages
-        uses: actions/cache@main
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ${{ github.workspace }}/.m2repo
+          key: ${{ runner.os }}-m2deps-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2deps-java${{ matrix.java }}-
+            ${{ runner.os }}-m2deps-
+      - name: Build and install (skip tests)
+        run: mvn $MVN -T1C -DskipTests install
+      # Hand this commit's freshly built SNAPSHOTs to the test shards as an immutable per-run
+      # artifact, so fresh jars never linger in the long-lived dependency cache.
+      - name: Upload project artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: occurrent-m2-java${{ matrix.java }}
+          path: ${{ github.workspace }}/.m2repo/org/occurrent
+          retention-days: 1
+          if-no-files-found: error
 
-      - name: Build with Maven
-        run: mvn -B package --file pom.xml
+  # Guard against silent coverage loss: every module that has tests must fall under exactly one
+  # test shard's paths. Parses the shard paths straight out of this file (no separate list to
+  # keep in sync) and fails if any test-bearing module is not covered, e.g. a newly added module.
+  verify-shard-coverage:
+    name: verify shard coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check every test module is assigned to a shard
+        run: |
+          prefixes=()
+          while IFS= read -r p; do prefixes+=("$p"); done < <(grep -oE 'paths: "[^"]+"' .github/workflows/maven.yml \
+            | sed -E 's/paths: "//; s/"$//' | tr ' ' '\n' | sort -u)
+          echo "Shard path prefixes:"; printf '  %s\n' "${prefixes[@]}"
+          uncovered=()
+          while IFS= read -r d; do
+            covered=0
+            for p in "${prefixes[@]}"; do
+              if [[ "$d" == "$p" || "$d" == "$p/"* ]]; then covered=1; break; fi
+            done
+            [[ $covered -eq 0 ]] && uncovered+=("$d")
+          done < <(find . -type d -path '*/src/test' | sed 's#/src/test##; s#^\./##' | sort)
+          if [[ ${#uncovered[@]} -gt 0 ]]; then
+            echo "::error::These modules have tests but are not covered by any shard:"
+            printf '::error::  %s\n' "${uncovered[@]}"
+            exit 1
+          fi
+          echo "All test modules are covered by a shard."
+
+  # Stage 2: run each subtree's tests against the pre-built local repo, one shard per runner
+  # (isolated Docker daemon). Within a shard, modules stay sequential (no -T) so the
+  # fixed-port-27017 MongoDB tests never collide. Shards are balanced by MEASURED test time from a
+  # recent CI run (approx seconds shown); the two long poles (subscription ~382s, eventstore
+  # ~242s) are split, the rest merged, so the slowest shard is ~150s of tests instead of ~382s.
+  #
+  # Use -f <subtree>/pom.xml, NOT -pl: -pl on an aggregator does not descend into its children and
+  # would run zero tests. We do NOT pass -o: the build job's `install -DskipTests` does not resolve
+  # Surefire's JUnit-platform provider (that happens lazily at test execution), so a fully offline
+  # shard could fail to resolve it on a cold runner. The restored dependency cache + downloaded
+  # project artifacts still supply the bulk; only genuinely missing artifacts fall back to network.
+  test:
+    name: test (${{ matrix.shard.name }}, java-${{ matrix.java }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 21, 25 ]
+        shard:
+          - { name: eventstore-spring,           paths: "eventstore/mongodb/spring" }
+          - { name: eventstore-rest,             paths: "eventstore/api eventstore/inmemory eventstore/migration eventstore/mongodb/common eventstore/mongodb/native" }
+          - { name: subscription-mongodb-spring, paths: "subscription/mongodb/spring" }
+          - { name: subscription-mongodb-native, paths: "subscription/mongodb/native subscription/mongodb/common subscription/redis" }
+          - { name: subscription-util-blocking,  paths: "subscription/util/blocking" }
+          - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor" }
+          - { name: framework,                   paths: "framework" }
+          - { name: misc,                        paths: "dsl application rewrite common deadline example cloudevents-extension library" }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - name: Restore Maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.m2repo
+          key: ${{ runner.os }}-m2deps-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2deps-java${{ matrix.java }}-
+            ${{ runner.os }}-m2deps-
+      - name: Download project artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: occurrent-m2-java${{ matrix.java }}
+          path: ${{ github.workspace }}/.m2repo/org/occurrent
+      - name: Enable Testcontainers reuse on this runner
+        run: echo "testcontainers.reuse.enable=true" > "$HOME/.testcontainers.properties"
+      - name: Run shard tests
+        run: |
+          for d in ${{ matrix.shard.paths }}; do
+            echo "::group::mvn test -f $d/pom.xml"
+            mvn $MVN -f "$d/pom.xml" test
+            echo "::endgroup::"
+          done

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -116,7 +116,8 @@ jobs:
           - { name: subscription-util-blocking,  paths: "subscription/util/blocking" }
           - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor" }
           - { name: framework,                   paths: "framework" }
-          - { name: misc,                        paths: "dsl application rewrite common deadline example cloudevents-extension library" }
+          - { name: example,                     paths: "example" }
+          - { name: misc,                        paths: "dsl application rewrite common deadline cloudevents-extension library" }
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/test/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/TestBootstrap.java
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/test/java/org/occurrent/example/domain/numberguessinggame/mongodb/spring/blocking/TestBootstrap.java
@@ -31,7 +31,7 @@ public class TestBootstrap {
     @Bean
     @ServiceConnection
     public static MongoDBContainer mongoDBContainer() {
-        return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
+        return new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
     }
 
     public static void main(String[] args) {

--- a/example/domain/rps/decider-web/src/test/kotlin/org/occurrent/example/domain/rps/decidermodel/web/TestBootstrap.kt
+++ b/example/domain/rps/decider-web/src/test/kotlin/org/occurrent/example/domain/rps/decidermodel/web/TestBootstrap.kt
@@ -34,7 +34,7 @@ class TestBootstrap {
     @Bean
     @ServiceConnection
     @RestartScope
-    fun mongoDbContainer(): MongoDBContainer = MongoDBContainer("mongo:4.2.8").apply {
+    fun mongoDbContainer(): MongoDBContainer = MongoDBContainer("mongo:4.2.8").withReplicaSet().apply {
         portBindings = listOf("27017:27017")
     }
 }

--- a/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
@@ -16,7 +16,7 @@
 
 package org.occurrent.example.springevent;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import org.assertj.core.api.Assertions;

--- a/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
+++ b/example/forwarder/mongodb-subscription-to-spring-event/src/test/java/org/occurrent/example/springevent/MongoSubscriptionToSpringEventTest.java
@@ -56,7 +56,7 @@ public class MongoSubscriptionToSpringEventTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-adhoc-eventstore-mongodb-queries/src/test/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/SpringAdhocProjectionTest.java
+++ b/example/projection/spring-adhoc-eventstore-mongodb-queries/src/test/java/org/occurrent/example/eventstore/mongodb/spring/projections/adhoc/SpringAdhocProjectionTest.java
@@ -40,7 +40,7 @@ public class SpringAdhocProjectionTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true);
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.setPortBindings(ports);

--- a/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -51,7 +51,7 @@ public class ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-reactor-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/reactor/transactional/ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -19,7 +19,7 @@ package org.occurrent.example.eventstore.mongodb.spring.reactor.transactional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
 import org.occurrent.domain.DomainEvent;
 import org.occurrent.domain.NameDefined;
 import org.occurrent.eventstore.api.reactor.EventStream;
@@ -73,8 +73,7 @@ public class ReactiveTransactionalProjectionsWithSpringAndMongoDBApplicationTest
     @Autowired
     private CurrentNameProjection currentNameProjection;
 
-    @Mock
-    private CurrentNameProjection currentNameProjectionMock;
+    private final CurrentNameProjection currentNameProjectionMock = mock(CurrentNameProjection.class);
 
     @Autowired
     private DomainEventStore eventStore;

--- a/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-subscription-based-mongodb-projections/src/test/java/org/occurrent/example/eventstore/mongodb/spring/changestreamedprojections/SubscriptionProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -45,7 +45,7 @@ public class SubscriptionProjectionsWithSpringAndMongoDBApplicationTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version"));
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet();
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.withReuse(true).setPortBindings(ports);

--- a/example/projection/spring-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/transactional/TransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
+++ b/example/projection/spring-transactional-projection-mongodb/src/test/java/org/occurrent/example/eventstore/mongodb/spring/transactional/TransactionalProjectionsWithSpringAndMongoDBApplicationTest.java
@@ -49,7 +49,7 @@ public class TransactionalProjectionsWithSpringAndMongoDBApplicationTest {
     private static final MongoDBContainer mongoDBContainer;
 
     static {
-        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReuse(true);
+        mongoDBContainer = new MongoDBContainer("mongo:" + System.getProperty("test.mongo.version")).withReplicaSet().withReuse(true);
         List<String> ports = new ArrayList<>();
         ports.add("27017:27017");
         mongoDBContainer.setPortBindings(ports);


### PR DESCRIPTION
CI took ~13-14 min per push, and almost all of that was Testcontainers tests running one after another (compiling the whole reactor is only a small slice of it).

This splits the workflow in two: a cheap `build` job that compiles and installs everything with `-DskipTests` (per JDK), then a matrix of test shards x [21, 25] that each run only their own subtree's tests on their own runner. Separate runners mean separate Docker daemons, so the fixed-port-27017 tests still can't collide. Shards are balanced on measured test time: the two long poles get split (subscription was ~382s, eventstore ~242s), the small stuff is merged, so the slowest shard is ~150s of tests. End to end lands around 5-6 min. A `verify-shard-coverage` job reads the shard paths straight out of the workflow and fails if a module with tests isn't assigned to any shard, so nothing quietly stops running when someone adds a module.

While wiring this up it turned out the `example` subtree was never actually built or tested in CI (the `examples-module` profile is deactivated once `skip-pom-modules-deployment` activates, so `mvn package` skips it). This adds it to the sharded run and fixes the latent test bugs that surfaced once it ran: seven projection/forwarder/bootstrap tests built a `MongoDBContainer` without `.withReplicaSet()` and only worked by piggybacking on another module's shared container; one reactive-transactional test declared `@Mock` with no initializer; and the forwarder test autowired a Jackson 2 `ObjectMapper` while the app now provides a Jackson 3 one.

Note: `CompetingConsumerSubscriptionModelTest` is a pre-existing timing-sensitive flake (5s Awaitility wait) that can fail intermittently on a loaded runner; it passes on retry.
