### PR TITLE
Reject duplicate projection builder calls and simplify the course dashboard

### DIFF
--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
@@ -124,9 +124,12 @@ public record Projection<S extends @Nullable Object, E, ID>(
 
         /**
          * Sets the function deriving the view-instance id from an event. Return {@code null} for an event that maps to no
-         * instance and should be skipped. Required.
+         * instance and should be skipped. Required, and can be set only once.
          */
         public Builder<S, E, ID> id(Function<E, @Nullable ID> id) {
+            if (this.id != null) {
+                throw new IllegalStateException("id(...) has already been set and can only be set once");
+            }
             this.id = requireNonNull(id, "id cannot be null");
             return this;
         }
@@ -160,9 +163,13 @@ public record Projection<S extends @Nullable Object, E, ID>(
         /**
          * Sets an explicit selector that overrides the event-type-derived one. Use it to select on more than event type
          * (subject, source, data, time). A filter broader than the registered handlers is safe (the fold no-ops on
-         * events it does not handle); a filter narrower than the handlers deliberately starves those handlers.
+         * events it does not handle); a filter narrower than the handlers deliberately starves those handlers. Can be
+         * set only once.
          */
         public Builder<S, E, ID> filter(Filter filter) {
+            if (this.filter != null) {
+                throw new IllegalStateException("filter(...) has already been set and can only be set once");
+            }
             this.filter = requireNonNull(filter, "filter cannot be null");
             return this;
         }

--- a/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
@@ -120,8 +120,9 @@ class DcbProjectionBuilder<S, E : Any, ID : Any> @PublishedApi internal construc
         tags.addAll(tag)
     }
 
-    /** Sets the DCB read boundary explicitly, overriding any [tags]. */
+    /** Sets the DCB read boundary explicitly, overriding any [tags]. Can be set only once. */
     fun criteria(criteria: DcbCriteria) {
+        check(explicitCriteria == null) { "criteria(...) has already been set and can only be set once" }
         this.explicitCriteria = criteria
     }
 

--- a/dsl/projection-dsl/common/src/test/java/org/occurrent/dsl/projection/ProjectionTest.java
+++ b/dsl/projection-dsl/common/src/test/java/org/occurrent/dsl/projection/ProjectionTest.java
@@ -189,6 +189,27 @@ class ProjectionTest {
             assertThatThrownBy(() -> projection.eventTypes().clear())
                     .isInstanceOf(UnsupportedOperationException.class);
         }
+
+        @Test
+        void id_cannot_be_set_twice() {
+            Projection.Builder<Boolean, AccountEvent, String> builder = Projection.<Boolean, AccountEvent, String>builder(false)
+                    .id(AccountEvent::accountId);
+
+            assertThatThrownBy(() -> builder.id(event -> "other"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("id");
+        }
+
+        @Test
+        void filter_cannot_be_set_twice() {
+            Projection.Builder<Boolean, AccountEvent, String> builder = Projection.<Boolean, AccountEvent, String>builder(false)
+                    .id(AccountEvent::accountId)
+                    .filter(Filter.all());
+
+            assertThatThrownBy(() -> builder.filter(Filter.all()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("filter");
+        }
     }
 
     @Nested

--- a/dsl/projection-dsl/common/src/test/kotlin/org/occurrent/dsl/projection/ProjectionKotlinTest.kt
+++ b/dsl/projection-dsl/common/src/test/kotlin/org/occurrent/dsl/projection/ProjectionKotlinTest.kt
@@ -17,6 +17,7 @@
 package org.occurrent.dsl.projection
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.occurrent.eventstore.api.dcb.DcbCriteria
@@ -132,6 +133,20 @@ class ProjectionKotlinTest {
             }
 
             assertThat(projection.criteria()).isEqualTo(explicit)
+        }
+
+        @Test
+        fun `criteria cannot be set twice`() {
+            assertThatThrownBy {
+                dcbProjection<Int, AccountEvent, String>(initialState = 0) {
+                    criteria(DcbCriteria.all())
+                    criteria(DcbCriteria.type("SomethingHappened"))
+                    id { it.accountId }
+                    on<AccountRegistered> { state, _ -> state + 1 }
+                }
+            }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("criteria")
         }
     }
 }

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjectionConfiguration.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjectionConfiguration.kt
@@ -20,8 +20,8 @@ import org.occurrent.annotation.Projection
 import org.occurrent.annotation.Projection.Mode
 import org.occurrent.annotation.ResumeBehavior
 import org.occurrent.annotation.Projection.StartPosition
-import org.occurrent.dsl.projection.DcbProjection
-import org.occurrent.dsl.projection.dcbProjection
+import org.occurrent.dsl.projection.Projection as ProjectionModel
+import org.occurrent.dsl.projection.projection
 import org.occurrent.example.domain.courseenrollment.common.DomainEvent
 import org.occurrent.example.domain.courseenrollment.features.coursemanagement.model.CourseCancelled
 import org.occurrent.example.domain.courseenrollment.features.coursemanagement.model.CourseDefined
@@ -40,9 +40,12 @@ import org.springframework.context.annotation.Configuration
  * combines [StartPosition.BEGINNING] with [ResumeBehavior.SAME_AS_START_AT]: BEGINNING alone would replay only the
  * first time and then resume from the stored position on later restarts, which would leave the in-memory model missing
  * all history before that position. SAME_AS_START_AT replays from the beginning on every boot (and keeps no checkpoint).
- * There is a single dashboard instance for the whole module, so [dcbProjection]'s `id` block returns the constant
- * [COURSE_DASHBOARD_ID] regardless of which event is being folded. The projection subscribes to all six event types it
- * folds and applies no further tag boundary, mirroring the event-type-only DCB subscription it replaces.
+ * There is a single dashboard instance for the whole module, so the [projection] `id` block returns the constant
+ * [COURSE_DASHBOARD_ID] regardless of which event is being folded. The dashboard folds a global mix of events across
+ * features with no tag boundary, so it is a capability-agnostic [projection], not a [org.occurrent.dsl.projection.dcbProjection].
+ * A DCB projection earns its place only when the read model needs a DCB tag boundary, as the per-course live subscription
+ * in the enrollment controller does. The capability-agnostic subscription receives every matching event regardless of
+ * whether it was written through the stream or the DCB API.
  */
 @Configuration(proxyBeanMethods = false)
 class CourseDashboardProjectionConfiguration {
@@ -55,8 +58,8 @@ class CourseDashboardProjectionConfiguration {
         mode = Mode.ASYNC,
         store = "courseDashboard"
     )
-    fun courseDashboardProjection(): DcbProjection<DashboardState, DomainEvent, String> =
-        dcbProjection(initialState = DashboardState.EMPTY) {
+    fun courseDashboardProjection(): ProjectionModel<DashboardState, DomainEvent, String> =
+        projection(initialState = DashboardState.EMPTY) {
             id { COURSE_DASHBOARD_ID }
 
             on<CourseDefined> { state, event ->

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjectionConfiguration.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjectionConfiguration.kt
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Configuration
  * Registers the `course-dashboard` [Projection] that feeds [CourseDashboard], which also serves as its
  * [org.occurrent.dsl.view.ViewStateRepository] (bean name `courseDashboard`, matched by [Projection.store]).
  *
- * The read model is in-memory only, so it must be rebuilt from the whole DCB history on every boot. That is why this
+ * The read model is in-memory only, so it must be rebuilt from the whole event history on every boot. That is why this
  * combines [StartPosition.BEGINNING] with [ResumeBehavior.SAME_AS_START_AT]: BEGINNING alone would replay only the
  * first time and then resume from the stored position on later restarts, which would leave the in-memory model missing
  * all history before that position. SAME_AS_START_AT replays from the beginning on every boot (and keeps no checkpoint).


### PR DESCRIPTION
Two small follow-ups on the Projection DSL, both in code that is unreleased.

**Reject duplicate builder calls.** The `Projection.Builder` `id` and `filter` setters and the Kotlin `DcbProjectionBuilder` `criteria` setter used to silently overwrite a prior value when called twice, so calling `id { a }` and then `id { b }` quietly kept the last one. Each now throws `IllegalStateException` on a second call. The per-event-type `on(...)` handler and the additive `tags(...)` stay repeatable, since those are meant to be called more than once.

**Drop needless DCB from the course dashboard.** The dashboard folds a global mix of events with no tag boundary, so its `dcbProjection` defaulted the criteria to `all()` and gained nothing from the DCB read path. It is now a capability-agnostic `projection`, which receives every matching event whether it was written through the stream or the DCB API. A `DcbProjection` now earns its place in the example only where there is a real tag boundary, as the per-course live subscription in the enrollment controller has.

Verified: the projection-dsl common tests (23) and the course-enrollment tests (14) pass locally.
