### PR TITLE
Show @Projection on a @Component in the course-enrollment example

### DIFF
--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboard.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboard.kt
@@ -42,7 +42,7 @@ const val COURSE_DASHBOARD_ID = "course-dashboard"
 
 /**
  * An in-memory read model of all courses and students, kept current by the `course-dashboard` [org.occurrent.annotation.Projection]
- * (see [CourseDashboardProjectionConfiguration]). It doubles as that projection's [ViewStateRepository]: `findById`/`save`
+ * (see [CourseDashboardProjection]). It doubles as that projection's [ViewStateRepository]: `findById`/`save`
  * read and write the same single-slot [AtomicReference] the query accessors below read from, so there is no separate store
  * to keep in sync. It is eventually consistent with the event store. For a strongly consistent read see the course-detail
  * read model in the enrollment feature.

--- a/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjection.kt
+++ b/example/domain/course-enrollment/src/main/kotlin/org/occurrent/example/domain/courseenrollment/features/coursedashboard/readmodel/CourseDashboardProjection.kt
@@ -29,8 +29,7 @@ import org.occurrent.example.domain.courseenrollment.features.enrollment.model.S
 import org.occurrent.example.domain.courseenrollment.features.enrollment.model.StudentUnenrolledFromCourse
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentDeregistered
 import org.occurrent.example.domain.courseenrollment.features.studentmanagement.model.StudentRegistered
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
 
 /**
  * Registers the `course-dashboard` [Projection] that feeds [CourseDashboard], which also serves as its
@@ -47,10 +46,9 @@ import org.springframework.context.annotation.Configuration
  * in the enrollment controller does. The capability-agnostic subscription receives every matching event regardless of
  * whether it was written through the stream or the DCB API.
  */
-@Configuration(proxyBeanMethods = false)
-class CourseDashboardProjectionConfiguration {
+@Component
+class CourseDashboardProjection {
 
-    @Bean
     @Projection(
         id = COURSE_DASHBOARD_ID,
         startAt = StartPosition.BEGINNING,

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
@@ -38,6 +38,10 @@ import java.lang.annotation.*;
  * The annotated method takes no arguments. The Kotlin DSL equivalent is
  * {@code projection(OrderStatus.EMPTY) { id { it.orderId }; on<OrderPlaced> { s, e -> s.placed(e) } }},
  * and a DCB read model returns a {@code DcbProjection} built with {@code dcbProjection { .. }}.
+ * <p>
+ * The method may live on any Spring bean: a {@code @Bean} factory method in a {@code @Configuration} class, or a
+ * method on a {@code @Component}. The {@code @Component} form is the cleaner choice for a single dedicated projection,
+ * while {@code @Bean} methods group several projections in one configuration class.
  *
  * <h4>Projection Descriptor Type</h4>
  * <p>


### PR DESCRIPTION
A small example and docs refinement, in unreleased code.

A `@Projection` factory method does not have to be a `@Bean` in a `@Configuration` class. The registrar scans every Spring bean's declared methods for `@Projection`, so a plain `@Component` works too. For a single dedicated projection the `@Component` form reads better, and it avoids a minor wart of the `@Bean` form: because the method is a `@Bean`, Spring also registers the returned descriptor as an unused context bean and calls the factory an extra time, whereas the `@Component` form invokes it once.

This moves the course-enrollment dashboard to a `@Component` (renaming `CourseDashboardProjectionConfiguration` to `CourseDashboardProjection`) and adds a note to the `@Projection` Javadoc that the method may live on any Spring bean, with `@Bean` in `@Configuration` still handy for grouping several projections. The docs-site change is in the held draft PR occurrent-org.github.io#7.

Verified: the course-enrollment tests (14) pass.
