### PR TITLE
Move ProjectionFilters into an internal package

### DIFF
--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.projection.Projection;
-import org.occurrent.dsl.projection.ProjectionFilters;
+import org.occurrent.dsl.projection.internal.ProjectionFilters;
 import org.occurrent.dsl.view.MaterializedView;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.filter.Filter;

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
  * Internal helper shared by the blocking projection runners (the Kotlin {@code project} extensions and the Java
  * {@code *ProjectionRunner} facades): turning a {@link Projection} plus a {@link ViewStateRepository} into a
  * {@link MaterializedView} that skips events whose id resolves to {@code null}. The plain-{@code Filter} derivation
- * lives in {@code org.occurrent.dsl.projection.ProjectionFilters}, shared with the reactor stack.
+ * lives in {@code org.occurrent.dsl.projection.internal.ProjectionFilters}, shared with the reactor stack.
  */
 @NullMarked
 public final class Projections {

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/internal/ProjectionFilters.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/internal/ProjectionFilters.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package org.occurrent.dsl.projection;
+package org.occurrent.dsl.projection.internal;
 
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.condition.Condition;
+import org.occurrent.dsl.projection.Projection;
 import org.occurrent.filter.Filter;
 
 import java.util.List;

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * Internal helpers shared by the reactor projection runners (the Kotlin {@code project} extensions and the Java
  * {@code Reactive*ProjectionRunner} facades): adapting a blocking view store into the reactive {@code (E) -> Mono<Void>}
  * update the runners consume. The plain-{@code Filter} derivation lives in
- * {@code org.occurrent.dsl.projection.ProjectionFilters}, shared with the blocking stack.
+ * {@code org.occurrent.dsl.projection.internal.ProjectionFilters}, shared with the blocking stack.
  * <p>
  * There is no reactive {@link MaterializedView}/{@link ViewStateRepository} in the view DSL, so a genuinely reactive
  * store should be driven through a caller-supplied {@code (E) -> Mono<Void>} update (the runners' primitive overload).

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.projection.Projection;
-import org.occurrent.dsl.projection.ProjectionFilters;
+import org.occurrent.dsl.projection.internal.ProjectionFilters;
 import org.occurrent.dsl.view.MaterializedView;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.filter.Filter;

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -31,7 +31,7 @@ import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.dcb.DcbEventMetadata;
 import org.occurrent.dsl.dcb.blocking.DcbSubscriptions;
 import org.occurrent.dsl.projection.DcbProjection;
-import org.occurrent.dsl.projection.ProjectionFilters;
+import org.occurrent.dsl.projection.internal.ProjectionFilters;
 import org.occurrent.dsl.projection.blocking.Projections;
 import org.occurrent.dsl.subscription.EventMetadata;
 import org.occurrent.dsl.subscription.blocking.StreamSubscriptions;


### PR DESCRIPTION
`ProjectionFilters` is plumbing shared by the blocking and reactor runners and the `@Projection` registrar, not something callers construct the way they build `Projection` and `DcbProjection`. This moves it from `org.occurrent.dsl.projection` to `org.occurrent.dsl.projection.internal`, so external users can see it is not part of the public API, matching the internal-package convention used across the repo.

Pure move, no behaviour change, and it is unreleased so there is no migration. Verified the affected modules compile.
