### PR TITLE
Create DcbProjectionRunner through a static factory

### DIFF
--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  * few extra no-op folds, and a tag-scoped boundary reads little to begin with.
  * <p>
  * <strong>Whether this is live-only or catches up and resumes durably depends on the {@code SubscriptionModel} given
- * to this runner's constructor</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
+ * to this runner's {@code create} factory</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
  * capable as that model. Given a plain live model with no catch-up support, this runner is live-only. It does not
  * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
  * subscription model, or a hand-wired {@code CatchupSubscriptionModel}), this runner catches up from history and
@@ -58,7 +58,15 @@ public final class DcbProjectionRunner<E> {
 
     private final DcbSubscriptions<E> dcbSubscriptions;
 
-    public DcbProjectionRunner(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+    /**
+     * Creates a runner that subscribes through the given {@code subscriptionModel}, matching the factory style of
+     * {@link ProjectionRunner}.
+     */
+    public static <E> DcbProjectionRunner<E> create(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+        return new DcbProjectionRunner<>(subscriptionModel, cloudEventConverter);
+    }
+
+    private DcbProjectionRunner(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
         this.dcbSubscriptions = new DcbSubscriptions<>(
                 requireNonNull(subscriptionModel, "subscriptionModel cannot be null"),
                 requireNonNull(cloudEventConverter, "cloudEventConverter cannot be null"));

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
@@ -45,7 +45,7 @@ import static java.util.Objects.requireNonNull;
  * (scheduled on {@code boundedElastic}; see {@link Projections}).
  * <p>
  * <strong>Whether this is live-only or catches up and resumes durably depends on the {@code SubscriptionModel} given
- * to this runner's constructor</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
+ * to this runner's {@code create} factory</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
  * capable as that model. Given a plain live model with no catch-up support, this runner is live-only. It does not
  * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
  * subscription model, or a hand-wired {@code CatchupSubscriptionModel}), this runner catches up from history and
@@ -62,7 +62,15 @@ public final class ReactiveDcbProjectionRunner<E> {
 
     private final DcbSubscriptions<E> dcbSubscriptions;
 
-    public ReactiveDcbProjectionRunner(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+    /**
+     * Creates a runner that subscribes through the given {@code subscriptionModel}, matching the factory style of
+     * {@link ReactiveProjectionRunner}.
+     */
+    public static <E> ReactiveDcbProjectionRunner<E> create(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
+        return new ReactiveDcbProjectionRunner<>(subscriptionModel, cloudEventConverter);
+    }
+
+    private ReactiveDcbProjectionRunner(SubscriptionModel subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
         this.dcbSubscriptions = new DcbSubscriptions<>(
                 requireNonNull(subscriptionModel, "subscriptionModel cannot be null"),
                 requireNonNull(cloudEventConverter, "cloudEventConverter cannot be null"));

--- a/example/projection/projection-dsl/src/test/java/org/occurrent/example/projection/dsl/dcbjava/CouponRedemptionProjectionTest.java
+++ b/example/projection/projection-dsl/src/test/java/org/occurrent/example/projection/dsl/dcbjava/CouponRedemptionProjectionTest.java
@@ -72,7 +72,7 @@ class CouponRedemptionProjectionTest {
         ConcurrentHashMap<String, Boolean> store = new ConcurrentHashMap<>();
         ViewStateRepository<Boolean, String> repository = ViewStateRepository.create(store::get, store::put);
 
-        new DcbProjectionRunner<>(subscriptionModel, converter)
+        DcbProjectionRunner.create(subscriptionModel, converter)
                 .project("coupon-redeemed", isCouponRedeemedProjection("SAVE10"), repository);
 
         append("coupon:SAVE10", new CouponIssued("SAVE10"));

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -472,7 +472,7 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
             if (synchronous) {
                 throw new IllegalArgumentException("@Projection '%s' returns a DcbProjection with mode = SYNCHRONOUS, which the reactive stack does not support in this version. Use mode = ASYNC for a DCB read model, or an agnostic Projection for synchronous read-your-writes.".formatted(id));
             }
-            ReactiveDcbProjectionRunner<E> runner = new ReactiveDcbProjectionRunner<>(applicationContext.getBean(SubscriptionModel.class), converter);
+            ReactiveDcbProjectionRunner<E> runner = ReactiveDcbProjectionRunner.create(applicationContext.getBean(SubscriptionModel.class), converter);
             boolean replaysHistory = annotation.startAtPosition() >= 0 || annotation.startAt() == org.occurrent.annotation.Projection.StartPosition.BEGINNING;
             DcbStartAt startAt = generateDcbStartAt(id, toDcbStartPosition(annotation.startAt()), annotation.startAtPosition(), annotation.resumeBehavior());
             applyStartupWorkarounds();


### PR DESCRIPTION
`ProjectionRunner` is created through static factories (`agnostic(...)`/`stream(...)`) but `DcbProjectionRunner` exposed a public constructor, so the two runner families were constructed two different ways. This gives `DcbProjectionRunner` and `ReactiveDcbProjectionRunner` a `create(...)` factory and makes the constructor private, so both families read the same way.

The two runner classes stay split (they handle different descriptor types, `Projection` vs `DcbProjection`, over different subscription backends). This only aligns how they are built. No behaviour change, unreleased so no migration. Verified the affected modules compile and the projection-dsl example test that builds a runner passes.
