### PR TITLE
Simplify the javadoc and kdoc added since 0.30.0

### DIFF
--- a/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/DcbDecider.java
+++ b/dsl/dcb-dsl/common/src/main/java/org/occurrent/dsl/dcb/DcbDecider.java
@@ -32,18 +32,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * A self-describing, composable DCB (Dynamic Consistency Boundary) decision model.
+ * A {@link Decider} paired with the two things DCB execution needs from it: the {@link DcbCriteria} read boundary for a
+ * command, and a {@link TagGenerator} for the events it writes. This keeps a feature's read boundary and write tags
+ * next to its decision logic rather than in whatever application service wires it to the store.
  * <p>
- * A plain {@link Decider} only knows how to decide and evolve. To run it against a DCB event store, a caller must also
- * know which events to read before deciding (the {@link DcbCriteria} read boundary for the incoming command) and which
- * tags to stamp on the events it writes (via a {@link TagGenerator}). {@code DcbDecider} couples those three pieces
- * together so a feature can describe its own read boundary and write tags right next to its decision logic, instead of
- * that knowledge living separately in whatever application service wires the decider to the store.
- * <p>
- * Like {@link Decider}, a {@code DcbDecider} can be widened with {@link #adapt} to a broader command/event type and
- * combined with {@link #compose} into a single decider over several features. Composing preserves the DCB contract:
- * the composed criteria is the union ({@link DcbCriteria#anyOf}) of the boundaries of the children that recognize the
- * command, and the composed tags is the union of tags contributed by whichever child recognizes the event.
+ * Like {@link Decider}, it widens with {@link #adapt} and combines with {@link #compose}. Composing unions the
+ * children's criteria ({@link DcbCriteria#anyOf}) over the commands they recognize, and unions the tags from whichever
+ * child recognizes each event.
  *
  * @param decider  the decision logic: what to do for a command given the current state, and how to fold events into state
  * @param criteria returns the DCB read boundary for a command, or {@code null} if this decider does not apply to that

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
@@ -31,25 +31,18 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Runs a {@link DcbProjection} as an asynchronous, subscription-fed read model over a DCB consistency boundary: it
- * subscribes to the events matching the projection's {@link DcbProjection#criteria() DCB criteria} and updates the
- * materialized view from each one, in a single call. The DCB counterpart to {@link ProjectionRunner}.
+ * subscribes to the events matching the projection's {@link DcbProjection#criteria() criteria} and updates the
+ * materialized view from each. The DCB counterpart to {@link ProjectionRunner}.
  * <p>
- * The read boundary is the descriptor's criteria verbatim (for example the tag filter from {@code dcbProjection { tags(...) }}).
- * Handler-derived event types are not additionally intersected into it: the projection's fold already ignores event
- * types it does not handle, so a criteria broader than the handlers is safe, and narrowing an arbitrary criteria by type
- * cannot be expressed cleanly without risking a change in its OR-of-alternatives semantics. Over-reading only costs a
- * few extra no-op folds, and a tag-scoped boundary reads little to begin with.
+ * The criteria is used verbatim, not intersected with the handler event types: the fold already ignores types it does
+ * not handle, so a broader criteria is safe and over-reading only costs a few no-op folds.
  * <p>
- * <strong>Whether this is live-only or catches up and resumes durably depends on the {@code SubscriptionModel} given
- * to this runner's {@code create} factory</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
- * capable as that model. Given a plain live model with no catch-up support, this runner is live-only. It does not
- * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
- * subscription model, or a hand-wired {@code CatchupSubscriptionModel}), this runner catches up from history and
- * resumes durably across restarts, the same as {@link ProjectionRunner}. For a strongly consistent, complete DCB read
- * model, fold on demand instead with the pull {@code project(...)} (the Kotlin {@code DcbDomainEventQueries.project}
- * extension). For a persistent, declarative DCB read model use the {@code @Projection} annotation. To wire the same
- * catch-up-then-resume behavior by hand without the Spring starter, use
- * {@code ResumeStartPositions.replayThenResumeDcb(...)}.
+ * <strong>Whether this catches up and resumes durably, or is live-only, depends on the {@code SubscriptionModel} passed
+ * to {@link #create}</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as capable as that
+ * model. A catch-up-capable model (the Spring composite, or a hand-wired {@code CatchupSubscriptionModel}) replays
+ * history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on demand
+ * with the pull {@code DcbDomainEventQueries.project(...)}. For a declarative read model use the {@code @Projection}
+ * annotation.
  *
  * @param <E> the domain event type
  */

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
@@ -42,14 +42,12 @@ import static java.util.Objects.requireNonNull;
  * materialized view from every matching event, in one call. The Java counterpart to the Kotlin {@code project(...)}
  * extensions on the subscription DSL, and the read-side mirror of {@code DeciderApplicationService} on the write side.
  * <p>
- * Choose the capability with the factory: {@link #agnostic(Subscribable, CloudEventConverter) agnostic} delivers both
- * stream-written and DCB-appended events (filtered only by the projection's selector), while
- * {@link #stream(Subscribable, CloudEventConverter) stream} scopes delivery to stream-written events. For a DCB
- * consistency-boundary read model use {@link DcbProjectionRunner} instead.
+ * Pick the capability with the factory: {@link #agnostic(Subscribable, CloudEventConverter) agnostic} delivers both
+ * stream-written and DCB-appended events, {@link #stream(Subscribable, CloudEventConverter) stream} only stream-written
+ * ones. For a DCB consistency-boundary read model use {@link DcbProjectionRunner}.
  * <p>
- * The subscription filter is derived from the projection: its explicit {@link Projection#filter() filter} if set, else a
- * type filter over its handled event types (see {@link ProjectionFilters#filterFor}). The returned {@link Subscription} has
- * already been waited on until started.
+ * The subscription filter comes from the projection (its explicit {@link Projection#filter() filter}, else a type filter
+ * over its handled types). The returned {@link Subscription} is already started.
  *
  * @param <E> the domain event type
  */

--- a/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/DcbProjectionExtensions.kt
+++ b/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/DcbProjectionExtensions.kt
@@ -26,17 +26,13 @@ import org.occurrent.subscription.api.blocking.Subscription
 
 /**
  * Runs [dcbProjection] as an asynchronous, subscription-fed read model over its DCB consistency boundary: subscribes to
- * the events matching the projection's [DcbProjection.criteria] and updates [materializedView] from each. The returned
- * [Subscription] has been waited on until started.
+ * the events matching [DcbProjection.criteria] and updates [materializedView] from each. The returned [Subscription] is
+ * already started.
  *
- * Whether this is live-only or catches up and resumes durably depends on the `SubscriptionModel` behind this
- * [DcbSubscriptions] instance. Given a plain live model with no catch-up support, this is live-only. It does not
- * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
- * subscription model, or a hand-wired `CatchupSubscriptionModel`), it catches up from history and resumes durably
- * across restarts, the same as [ProjectionRunner]. For a strongly consistent, complete DCB read model, fold on demand
- * with the pull [project] ([DcbDomainEventQueries.project]). For a persistent, declarative DCB read model use the
- * `@Projection` annotation. To wire the same catch-up-then-resume behavior by hand without the Spring starter, use
- * `ResumeStartPositions.replayThenResumeDcb(...)`.
+ * Whether this catches up and resumes durably, or is live-only, depends on the `SubscriptionModel` behind this
+ * [DcbSubscriptions]. A catch-up-capable model (the Spring composite, or a hand-wired `CatchupSubscriptionModel`)
+ * replays history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on
+ * demand with the pull [DcbDomainEventQueries.project]. For a declarative read model use the `@Projection` annotation.
  */
 fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, materializedView: MaterializedView<E>, startAt: DcbStartAt? = null): Subscription =
     subscribe(subscriptionId, dcbProjection.criteria(), startAt) { e -> materializedView.update(e) }.also { it.waitUntilStarted() }

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/DcbProjection.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/DcbProjection.java
@@ -22,18 +22,12 @@ import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A self-describing DCB (Dynamic Consistency Boundary) read model.
+ * A {@link Projection} paired with the {@link DcbCriteria} that selects which events feed it, usually a tag filter such
+ * as {@code tags("username:bob")}. The read-side mirror of {@code org.occurrent.dsl.dcb.DcbDecider}. The handlers drive
+ * the fold, the criteria drives the read.
  * <p>
- * A {@link Projection} describes a read model in capability-agnostic terms (its fold, its id, its event types). To feed
- * it from a DCB event store, a caller must also know the {@link DcbCriteria} read boundary that selects the events for
- * the model, typically a tag filter such as {@code tags("username:bob")}. {@code DcbProjection} couples the projection
- * with that boundary, mirroring how {@code org.occurrent.dsl.dcb.DcbDecider} adds a {@code DcbCriteria} to a plain
- * {@code Decider} on the write side.
- * <p>
- * The projection's event-type handlers still drive the fold (they no-op on unrecognized events); the {@code criteria}
- * drives which events are read. A single-instance projection parameterized by a key (for example
- * {@code isUsernameClaimedProjection("bob")}) is expressed by closing over the key in the factory that builds the
- * projection and its {@code criteria}, so no per-command boundary function is needed here.
+ * A single-instance projection parameterized by a key (for example {@code isUsernameClaimedProjection("bob")}) closes
+ * over the key in the factory that builds both the projection and its {@code criteria}.
  *
  * @param projection the capability-agnostic read model
  * @param criteria   the DCB read boundary selecting the events that feed the projection

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/DcbProjection.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/DcbProjection.java
@@ -26,8 +26,8 @@ import static java.util.Objects.requireNonNull;
  * as {@code tags("username:bob")}. The read-side mirror of {@code org.occurrent.dsl.dcb.DcbDecider}. The handlers drive
  * the fold, the criteria drives the read.
  * <p>
- * A single-instance projection parameterized by a key (for example {@code isUsernameClaimedProjection("bob")}) closes
- * over the key in the factory that builds both the projection and its {@code criteria}.
+ * A single-instance projection parameterized by a key (for example {@code isUsernameClaimedProjection("bob")}) is built
+ * with {@code dcbSingletonProjection} and closes over the key for its {@code criteria}.
  *
  * @param projection the capability-agnostic read model
  * @param criteria   the DCB read boundary selecting the events that feed the projection

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
@@ -35,20 +35,13 @@ import static java.util.Collections.addAll;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A self-describing, capability-agnostic read model.
+ * A self-describing, capability-agnostic read model: a {@link View} fold plus which view instance an event updates (the
+ * {@code id}) and which events feed it (the handled {@code eventTypes}, or an explicit {@code filter}). It lets a feature
+ * describe its read model next to its fold, and is the read-side mirror of {@code org.occurrent.dsl.dcb.DcbDecider}.
  * <p>
- * A plain {@link View} only knows how to fold events into state. To keep that state up to date from an event stream, a
- * caller must also know which view instance an event updates (the {@code id}) and which events feed the view (the
- * {@code eventTypes} to subscribe to, or an explicit {@code filter}). {@code Projection} couples those pieces together so
- * a feature can describe its read model right next to its fold, instead of that knowledge living separately in whatever
- * subscription or query wires the view to the store. It is the read-side mirror of
- * {@code org.occurrent.dsl.dcb.DcbDecider} on the write side.
- * <p>
- * Build one with the type-safe {@link #builder(Object) handler builder}: register a fold per event type with
- * {@link Builder#on(Class, BiFunction)} and the builder both assembles the {@link View} and records the handled event
- * types, so the subscription filter is derived from exactly the events the fold recognizes. The fold no-ops (returns the
- * state unchanged) for an event type with no registered handler, so it is always safe to feed a {@code Projection} a
- * broader stream than it handles.
+ * Build one with the type-safe {@link #builder(Object) handler builder}, registering a fold per event type with
+ * {@link Builder#on(Class, BiFunction)}. The handled types become the subscription filter, and the fold leaves the state
+ * unchanged for any event type it does not handle, so feeding it a broader stream is safe.
  *
  * @param <S> the state type
  * @param <E> the event type
@@ -76,9 +69,11 @@ public final class Projection<S extends @Nullable Object, E, ID> {
     }
 
     /**
-     * The function deriving which view instance an event updates, or {@code null} for a single-instance projection (the
-     * framework supplies the single key). When present, the function may return {@code null} to skip an event that maps
-     * to no keyed instance.
+     * The function deriving which view instance an event updates, or {@code null} for a single-instance projection. A
+     * single-instance projection folds every event into one view regardless of subject, like a leaderboard built from
+     * all players' events, so it has no per-event key and the framework supplies the single key. A keyed projection has
+     * one instance per key, like a player profile keyed by player id, and its function may return {@code null} to skip
+     * an event that maps to no instance.
      */
     public @Nullable Function<E, @Nullable ID> id() {
         return id;
@@ -107,12 +102,11 @@ public final class Projection<S extends @Nullable Object, E, ID> {
     }
 
     /**
-     * Starts building a single-instance {@code Projection}: one that folds into a single view state rather than one per
-     * key, so it needs no {@code id} function. The single slot is keyed at run time by the projection's own identity
-     * (the subscription id, or the {@code @Projection} id), which is a {@code String}, so a single-instance projection
-     * is always a {@code Projection<S, E, String>}. Register handlers with {@link Builder#on(Class, BiFunction)} and call
-     * {@link Builder#build()}. Use {@link #builder(Object)} with {@link Builder#id(Function)} for a keyed, multi-instance
-     * projection instead. The Kotlin equivalents are {@code singletonProjection}/{@code dcbSingletonProjection}.
+     * Starts building a single-instance {@code Projection}: one view folded from every event, like a leaderboard, rather
+     * than one instance per key, so it needs no {@code id}. The single slot is keyed at run time by the projection's own
+     * identity (the subscription id, or the {@code @Projection} id), a {@code String}, so a single-instance projection is
+     * always a {@code Projection<S, E, String>}. Use {@link #builder(Object)} with {@link Builder#id(Function)} for a
+     * keyed, multi-instance projection. Kotlin: {@code singletonProjection}/{@code dcbSingletonProjection}.
      */
     public static <S extends @Nullable Object, E> Builder<S, E, String> singletonBuilder(S initialState) {
         Builder<S, E, String> builder = new Builder<>(initialState);
@@ -121,10 +115,9 @@ public final class Projection<S extends @Nullable Object, E, ID> {
     }
 
     /**
-     * Widen a {@code Projection} so it can run against a broader event type, mirroring
-     * {@code org.occurrent.dsl.decider.Decider#adapt}. The wrapped fold and id function are widened to ignore events that
-     * are not {@code eventType} (the fold returns the state unchanged, the id returns {@code null} to skip), so the
-     * widened projection can consume a stream carrying other events without touching its state for them.
+     * Widens a {@code Projection} to a broader event type, mirroring {@code Decider#adapt}. The fold and id ignore events
+     * that are not {@code eventType} (the fold leaves the state unchanged, the id returns {@code null}), so the widened
+     * projection can consume a stream carrying other events.
      *
      * @param projection the feature projection to widen
      * @param eventType  the event type the projection understands
@@ -193,17 +186,14 @@ public final class Projection<S extends @Nullable Object, E, ID> {
         }
 
         /**
-         * Registers the fold for a single event type. The handler runs when the evolved event is an instance of
-         * {@code type}; a concrete event with no exact handler falls back to a handler registered for a superclass or
-         * implemented interface (nearest superclass first, then interfaces). Registering the same {@code type} twice
-         * replaces the earlier handler.
+         * Registers the fold for one event type. A concrete event with no exact handler falls back to a handler on a
+         * superclass or interface (nearest superclass first). Registering the same {@code type} twice replaces the
+         * earlier handler.
          * <p>
-         * The registered types also become the projection's {@link Projection#eventTypes()}, which is what a runner
-         * derives the subscription or query filter from when no explicit {@link #filter(Filter) filter} is set. Events
-         * are stored under their concrete runtime type, so register the concrete event types here. A handler keyed on an
-         * abstract supertype or an interface still folds every matching event through the runtime-type dispatch above,
-         * but a type filter derived from that supertype key matches no stored event, so set an explicit
-         * {@link #filter(Filter) filter} whenever you fold by a supertype.
+         * The registered types also become {@link Projection#eventTypes()}, the selector a runner uses when no explicit
+         * {@link #filter(Filter) filter} is set. Register concrete event types: a handler keyed on a supertype still
+         * folds every matching event, but a type filter derived from that supertype key matches no stored event, so set
+         * an explicit {@link #filter(Filter) filter} when you fold by a supertype.
          *
          * @param type    the event type this handler folds
          * @param handler the fold: current state and the event, returning the new state

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/internal/ProjectionFilters.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/internal/ProjectionFilters.java
@@ -38,14 +38,11 @@ public final class ProjectionFilters {
 
     /**
      * The plain {@link Filter} a projection selects on: its explicit {@link Projection#filter() filter} if set,
-     * otherwise a type filter over its {@link Projection#eventTypes() handled event types}, resolved to CloudEvent type
-     * strings through {@code cloudEventConverter}. An empty handled-type set means "all events". It also honours the
-     * descriptor's explicit filter, which the subscription DSL's {@code filterFromEventTypes} does not.
+     * otherwise a type filter over its {@link Projection#eventTypes() handled event types} (resolved to CloudEvent type
+     * strings through {@code cloudEventConverter}, empty means all events).
      * <p>
-     * The type-to-filter mapping is a small, deliberate re-implementation of that {@code filterFromEventTypes}. Reusing
-     * it would make {@code projection-dsl-common} depend on {@code subscription-dsl-common} for a handful of lines and
-     * mean adapting a {@code Set<Class<?>>} to its Kotlin {@code Array<KClass>} parameter, so the copy is the cheaper
-     * side of the tradeoff. Keep this module independent of the subscription stack rather than collapsing the two.
+     * The type-to-filter mapping deliberately re-implements the subscription DSL's {@code filterFromEventTypes} rather
+     * than depend on {@code subscription-dsl-common}, keeping this module independent of the subscription stack.
      */
     public static <E> Filter filterFor(CloudEventConverter<E> cloudEventConverter, Projection<?, E, ?> projection) {
         requireNonNull(cloudEventConverter, "cloudEventConverter cannot be null");

--- a/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
@@ -43,18 +43,18 @@ fun <S, E : Any, ID : Any> projection(initialState: S, block: ProjectionBuilder<
 }
 
 /**
- * Builds a [DcbProjection] with the same type-safe handler block as [projection], plus a DCB read boundary. Supply the
- * boundary with [DcbProjectionBuilder.tags] (the common case, a tag filter such as `tags("username:$username")`) or an
- * explicit [DcbProjectionBuilder.criteria]. With neither, the boundary defaults to [DcbCriteria.all]. For example:
+ * Builds a keyed [DcbProjection] with the same handler block as [projection], plus a DCB read boundary. Supply the
+ * boundary with [DcbProjectionBuilder.tags] (a tag filter such as `tags("kind:account")`) or an explicit
+ * [DcbProjectionBuilder.criteria]. With neither, the boundary defaults to [DcbCriteria.all]. For a single view over all
+ * matching events use [dcbSingletonProjection] instead. For example, one instance per account keyed by account id:
  *
  * ```
- * fun isUsernameClaimedProjection(username: String) =
- *     dcbProjection<Boolean, AccountEvent, String>(initialState = false) {
- *         tags("username:$username")
- *         id { username }
- *         on<AccountRegistered> { _, _ -> true }
- *         on<AccountClosed> { _, _ -> false }
- *         on<UsernameChanged> { _, e -> e.newUsername == username }
+ * fun accountStatus() =
+ *     dcbProjection<Status, AccountEvent, String>(initialState = Status.NEW) {
+ *         tags("kind:account")
+ *         id { it.accountId }
+ *         on<AccountRegistered> { _, _ -> Status.ACTIVE }
+ *         on<AccountClosed> { _, _ -> Status.CLOSED }
  *     }
  * ```
  */

--- a/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/common/src/main/kotlin/org/occurrent/dsl/projection/ProjectionExtensions.kt
@@ -45,7 +45,7 @@ fun <S, E : Any, ID : Any> projection(initialState: S, block: ProjectionBuilder<
 /**
  * Builds a [DcbProjection] with the same type-safe handler block as [projection], plus a DCB read boundary. Supply the
  * boundary with [DcbProjectionBuilder.tags] (the common case, a tag filter such as `tags("username:$username")`) or an
- * explicit [DcbProjectionBuilder.criteria]; with neither, the boundary defaults to [DcbCriteria.all]. For example:
+ * explicit [DcbProjectionBuilder.criteria]. With neither, the boundary defaults to [DcbCriteria.all]. For example:
  *
  * ```
  * fun isUsernameClaimedProjection(username: String) =
@@ -86,7 +86,7 @@ fun <S, E : Any> singletonProjection(initialState: S, block: ProjectionBuilder<S
 
 /**
  * Builds a single-instance [DcbProjection] (see [singletonProjection]) with a DCB read boundary. Supply the boundary
- * with [DcbProjectionBuilder.tags] or an explicit [DcbProjectionBuilder.criteria]; with neither it defaults to
+ * with [DcbProjectionBuilder.tags] or an explicit [DcbProjectionBuilder.criteria]. With neither it defaults to
  * [DcbCriteria.all].
  */
 fun <S, E : Any> dcbSingletonProjection(initialState: S, block: DcbProjectionBuilder<S, E, String>.() -> Unit): DcbProjection<S, E, String> {

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
@@ -34,26 +34,20 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Runs a {@link DcbProjection} as an asynchronous, subscription-fed read model over a DCB consistency boundary on the
- * reactor stack: it subscribes to the events matching the projection's {@link DcbProjection#criteria() DCB criteria} and
- * updates the read model from each one, in a single call. The reactor counterpart to the blocking
- * {@code DcbProjectionRunner}.
+ * reactor stack: it subscribes to the events matching the projection's {@link DcbProjection#criteria() criteria} and
+ * updates the read model from each. The reactor counterpart to the blocking {@code DcbProjectionRunner}.
  * <p>
- * The read boundary is the descriptor's criteria verbatim; handler-derived event types are not additionally intersected
- * into it (the fold already ignores unhandled types, so a broader criteria is safe, and over-reading only costs a few
- * no-op folds). The read model is updated through a reactive {@code (E) -> Mono<Void>} update; the
- * {@link ViewStateRepository}/{@link MaterializedView} overloads drive a blocking view store from the reactive pipeline
- * (scheduled on {@code boundedElastic}; see {@link Projections}).
+ * The criteria is used verbatim, not intersected with the handler event types (the fold ignores types it does not
+ * handle, so a broader criteria is safe). The read model is updated through a reactive {@code (E) -> Mono<Void>}. The
+ * {@link ViewStateRepository}/{@link MaterializedView} overloads drive a blocking view store from the reactive pipeline,
+ * scheduled on {@code boundedElastic} (see {@link Projections}).
  * <p>
- * <strong>Whether this is live-only or catches up and resumes durably depends on the {@code SubscriptionModel} given
- * to this runner's {@code create} factory</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as
- * capable as that model. Given a plain live model with no catch-up support, this runner is live-only. It does not
- * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
- * subscription model, or a hand-wired {@code CatchupSubscriptionModel}), this runner catches up from history and
- * resumes durably across restarts, the same as {@link ReactiveProjectionRunner}. For a strongly consistent, complete
- * DCB read model, fold on demand instead with the pull {@code project(...)} (the Kotlin
- * {@code DcbDomainEventQueries.project} extension). For a persistent, declarative DCB read model use the
- * {@code @Projection} annotation. To wire the same catch-up-then-resume behavior by hand without the Spring starter,
- * use {@code ResumeStartPositions.replayThenResumeDcb(...)}.
+ * <strong>Whether this catches up and resumes durably, or is live-only, depends on the {@code SubscriptionModel} passed
+ * to {@link #create}</strong>, since it subscribes through {@link DcbSubscriptions}, which is only as capable as that
+ * model. A catch-up-capable model (the Spring composite, or a hand-wired {@code CatchupSubscriptionModel}) replays
+ * history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on demand
+ * with the pull {@code DcbDomainEventQueries.project(...)}. For a declarative read model use the {@code @Projection}
+ * annotation.
  *
  * @param <E> the domain event type
  */

--- a/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/DcbProjectionExtensions.kt
+++ b/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/DcbProjectionExtensions.kt
@@ -31,14 +31,10 @@ import reactor.core.publisher.Mono
  * stack: subscribes to the events matching the projection's [DcbProjection.criteria] and applies [update] for each.
  * [update] owns the reactive load-evolve-save, and is also the overload for synchronous read-your-writes dispatch.
  *
- * Whether this is live-only or catches up and resumes durably depends on the `SubscriptionModel` behind this
- * [DcbSubscriptions] instance. Given a plain live model with no catch-up support, this is live-only. It does not
- * replay history and does not resume durably across restarts. Given a catch-up-capable model (the Spring composite
- * subscription model, or a hand-wired `CatchupSubscriptionModel`), it catches up from history and resumes durably
- * across restarts, the same as [ReactiveProjectionRunner]. For a strongly consistent, complete DCB read model, fold
- * on demand with the pull [project] ([DcbDomainEventQueries.project]). For a persistent, declarative DCB read model
- * use the `@Projection` annotation. To wire the same catch-up-then-resume behavior by hand without the Spring
- * starter, use `ResumeStartPositions.replayThenResumeDcb(...)`.
+ * Whether this catches up and resumes durably, or is live-only, depends on the `SubscriptionModel` behind this
+ * [DcbSubscriptions]. A catch-up-capable model (the Spring composite, or a hand-wired `CatchupSubscriptionModel`)
+ * replays history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on
+ * demand with the pull [DcbDomainEventQueries.project]. For a declarative read model use the `@Projection` annotation.
  */
 fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, update: (E) -> Mono<Void>, startAt: DcbStartAt? = null): Subscription =
     subscribeDcb(subscriptionId, dcbProjection.criteria(), startAt) { e -> update(e) }

--- a/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
@@ -32,7 +32,7 @@ import reactor.core.publisher.Mono
 /**
  * Runs [projection] as a capability-agnostic, subscription-fed read model on the reactor stack: creates the subscription
  * (its selector derived from the projection) and applies [update] for every matching event. [update] owns the reactive
- * load-evolve-save against a reactive store; it is also the overload to use for synchronous, in-transaction
+ * load-evolve-save against a reactive store, and is also the overload for synchronous, in-transaction
  * (read-your-writes) dispatch. On a store with both the `STREAM` and `DCB` capabilities this delivers both
  * stream-written and DCB-appended events.
  */

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
@@ -25,21 +25,18 @@ import java.util.OptionalLong;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Options that scope a DCB read. Uses the shared {@link PositionRange} window, the same window used by stream
- * position reads and the query DSL, and optionally caps the number of matching events returned and selects which end
- * of the matching range the cap keeps.
+ * Options that scope a DCB read: the shared {@link PositionRange} window, plus an optional {@code limit} on how many
+ * matching events are returned and a {@code direction} choosing which end of the match the limit keeps.
  * <p>
- * {@code direction} and {@code limit} do not change the order in which events are returned: a {@link DcbEventStream}
- * always lists its events in ascending DCB sequence-position order. They only select <em>which</em> matching events are
- * returned. {@code direction} chooses the end the {@code limit} keeps &mdash; {@link Direction#FORWARD} keeps the
- * lowest-position matches (the oldest), {@link Direction#BACKWARD} keeps the highest-position matches (the newest)
- * &mdash; and {@code limit} caps the count. So {@code fromBeginning().backwards().limit(1)} returns the single
- * highest-position event that matches the criteria, which is how a gapless sequence reads its last entry in one round
- * trip instead of folding the whole stream (see ADR 0056).
+ * Neither {@code direction} nor {@code limit} changes the returned order, a {@link DcbEventStream} always lists events
+ * ascending by DCB position. {@link Direction#FORWARD} keeps the lowest-position (oldest) matches,
+ * {@link Direction#BACKWARD} the highest-position (newest). So {@code fromBeginning().backwards().limit(1)} reads the
+ * single newest matching event in one round trip, how a gapless sequence finds its last entry without folding the whole
+ * stream (ADR 0056).
  * <p>
- * {@code direction} and {@code limit} never affect the {@link DcbEventStream#consistencyToken() consistency token}: the
- * token reflects the whole matching set observed at read time, not the returned page, so a limited read still guards an
- * append against <em>any</em> later matching event.
+ * Neither ever affects the {@link DcbEventStream#consistencyToken() consistency token}, which reflects the whole
+ * matching set observed at read time, not the returned page, so a limited read still guards an append against any later
+ * matching event.
  *
  * @param positionRange the position window to read
  * @param direction     which end of the matching range the {@code limit} keeps; never changes the returned order

--- a/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
+++ b/eventstore/api/dcb/src/main/java/org/occurrent/eventstore/api/dcb/DcbReadOptions.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
  * Options that scope a DCB read: the shared {@link PositionRange} window, plus an optional {@code limit} on how many
  * matching events are returned and a {@code direction} choosing which end of the match the limit keeps.
  * <p>
- * Neither {@code direction} nor {@code limit} changes the returned order, a {@link DcbEventStream} always lists events
+ * Neither {@code direction} nor {@code limit} changes the returned order. A {@link DcbEventStream} always lists events
  * ascending by DCB position. {@link Direction#FORWARD} keeps the lowest-position (oldest) matches,
  * {@link Direction#BACKWARD} the highest-position (newest). So {@code fromBeginning().backwards().limit(1)} reads the
  * single newest matching event in one round trip, how a gapless sequence finds its last entry without folding the whole

--- a/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/dynamicproductprice/ProductPriceDecider.kt
+++ b/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/dynamicproductprice/ProductPriceDecider.kt
@@ -107,7 +107,7 @@ private fun decide(command: ProductPriceCommand, state: ProductPriceState): List
 
 /**
  * The current price at [at] is always valid. The immediately preceding price is also valid if the change to the
- * current price happened within [ProductPricePolicy.GRACE_PERIOD] before [at] - the grace period a shopper who saw
+ * current price happened within [ProductPricePolicy.GRACE_PERIOD] before [at], the grace period a shopper who saw
  * the old price gets to complete their order.
  */
 private fun validPricesAt(priceHistory: List<PricePoint>, at: Instant): Set<BigDecimal> {

--- a/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/dynamicproductprice/ProductPriceDecider.kt
+++ b/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/dynamicproductprice/ProductPriceDecider.kt
@@ -107,8 +107,8 @@ private fun decide(command: ProductPriceCommand, state: ProductPriceState): List
 
 /**
  * The current price at [at] is always valid. The immediately preceding price is also valid if the change to the
- * current price happened within [ProductPricePolicy.GRACE_PERIOD] before [at], the grace period a shopper who saw
- * the old price gets to complete their order.
+ * current price happened within [ProductPricePolicy.GRACE_PERIOD] before [at]. That grace period is the window a
+ * shopper who saw the old price gets to complete their order.
  */
 private fun validPricesAt(priceHistory: List<PricePoint>, at: Instant): Set<BigDecimal> {
     val effective = priceHistory.filter { !it.effectiveFrom.isAfter(at) }.sortedBy { it.effectiveFrom }

--- a/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/invoicenumber/InvoiceService.kt
+++ b/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/invoicenumber/InvoiceService.kt
@@ -34,7 +34,7 @@ data class InvoiceCreated(val eventId: UUID, val occurredAt: Instant, val number
  * Pattern: a gapless, monotonically increasing sequence (invoice numbers, in most jurisdictions, must never skip or
  * repeat). This is the one vignette here that deliberately does NOT go through a [org.occurrent.dsl.dcb.DcbDecider]:
  * a decider folds the entire matching event history on every decision, which is O(n) in the number of invoices ever
- * created - fine for a boundary that is always small (one product, one sign-up), wrong for a boundary that grows
+ * created. That is fine for a boundary that is always small (one product, one sign-up) but wrong for one that grows
  * forever.
  * <p>
  * Instead this talks to the [DcbEventStore] directly:
@@ -42,8 +42,8 @@ data class InvoiceCreated(val eventId: UUID, val occurredAt: Instant, val number
  *    trip, instead of folding every invoice ever created, to learn the last number issued.
  * 2. The append condition is still [DcbCriteria.type] scoped to `InvoiceCreated`, guarded by the read's
  *    [org.occurrent.eventstore.api.dcb.DcbEventStream.consistencyToken]. The token reflects the whole matching set
- *    observed at read time, not just the one returned event, so the append still fails if ANY `InvoiceCreated` -
- *    not just the last one this call happened to see - was committed after the read (see ADR 0056).
+ *    observed at read time, not just the one returned event, so the append still fails if any `InvoiceCreated` (not
+ *    just the last one this call saw) was committed after the read (see ADR 0056).
  * <p>
  * A conflict throws [org.occurrent.eventstore.api.dcb.DcbAppendConditionNotFulfilledException]; the caller decides
  * whether to retry (a retry re-reads the now-current last number, so retrying still produces a gapless sequence, see

--- a/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/optintoken/SignUpDecider.kt
+++ b/example/domain/dcb-patterns/src/main/kotlin/org/occurrent/example/domain/dcbpatterns/optintoken/SignUpDecider.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 /**
  * Pattern: double opt-in with a consume-once, expiring token. [SignUpInitiated] carries the one-time password and
  * when it was issued; [ConfirmSignUp] must arrive with the matching OTP before [SignUpTokenPolicy.TTL] elapses, and
- * only once - a second confirmation with the same OTP is rejected because the boundary already shows the token
+ * only once. A second confirmation with the same OTP is rejected because the boundary already shows the token
  * consumed.
  * <p>
  * The boundary is the pair of tags (email, otp) together (see [criteria]): both tags on [SignUpInitiated]/

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
@@ -20,10 +20,8 @@ package org.occurrent.annotation;
 import java.lang.annotation.*;
 
 /**
- * Marks a factory method that returns a Projection or DcbProjection descriptor, registering it as a
- * persistent read model managed by the framework. The annotation selects between agnostic and
- * stream-based subscriptions and configures how the projection handles event delivery and state
- * management. For example:
+ * Marks a no-arg factory method returning a {@code Projection} or {@code DcbProjection}, registering it as a
+ * persistent, framework-managed read model. For example:
  *
  * <pre lang="java">
  * &#64;Projection(id = "orderStatus")
@@ -35,13 +33,12 @@ import java.lang.annotation.*;
  *         .build();
  * }
  * </pre>
- * The annotated method takes no arguments. The Kotlin DSL equivalent is
- * {@code projection(OrderStatus.EMPTY) { id { it.orderId }; on<OrderPlaced> { s, e -> s.placed(e) } }},
- * and a DCB read model returns a {@code DcbProjection} built with {@code dcbProjection { .. }}.
+ * The Kotlin equivalent is {@code projection(OrderStatus.EMPTY) { id { it.orderId }; on<OrderPlaced> { s, e -> s.placed(e) } }},
+ * and a DCB read model returns a {@code DcbProjection} from {@code dcbProjection { .. }}.
  * <p>
- * The method may live on any Spring bean: a {@code @Bean} factory method in a {@code @Configuration} class, or a
- * method on a {@code @Component}. The {@code @Component} form is the cleaner choice for a single dedicated projection,
- * while {@code @Bean} methods group several projections in one configuration class.
+ * The method may live on any Spring bean: a {@code @Bean} in a {@code @Configuration}, or a method on a
+ * {@code @Component}. Prefer {@code @Component} for a single dedicated projection, {@code @Bean} to group several in
+ * one class.
  *
  * <h4>Projection Descriptor Type</h4>
  * <p>
@@ -52,16 +49,13 @@ import java.lang.annotation.*;
  *
  * <h4>Mode and Startup Behavior</h4>
  * <p>
- * {@link #mode()} controls whether the projection processes events asynchronously (the default, an
- * eventually-consistent subscription that catches up from history) or synchronously (read-your-writes,
- * updated on the write path inside the write transaction). Synchronous mode is mutually exclusive with
- * {@link #startAt()}, {@link #startAtPosition()}, and {@link #resumeBehavior()}, and the framework
- * enforces this constraint during bean post-processing.
+ * {@link #mode()} chooses asynchronous delivery (the default, eventually consistent, catching up from history) or
+ * synchronous (read-your-writes, updated on the write path in the write transaction). Synchronous mode is mutually
+ * exclusive with {@link #startAt()}, {@link #startAtPosition()}, and {@link #resumeBehavior()}.
  * </p>
  * <p>
- * {@link #startupMode()} specifies how the projection behaves at application startup: in the default
- * or background mode it may replay history before becoming live, while {@link StartupMode#WAIT_UNTIL_STARTED}
- * blocks until the projection is fully initialized.
+ * {@link #startupMode()} chooses how startup behaves: the default or background mode may replay history before going
+ * live, while {@link StartupMode#WAIT_UNTIL_STARTED} blocks until the projection is fully started.
  * </p>
  *
  * <h4>State Store</h4>


### PR DESCRIPTION
Simplifies the javadoc and kdoc across the APIs added since 0.30.0, applying the code-comment style: lead with what a type or method is, keep the one load-bearing caveat, and drop the multi-paragraph mechanism narration that had crept in. No code, signatures, or behaviour change.

Covers the projection DSL (`Projection`, `DcbProjection`, the builders and runners on both stacks, `ProjectionFilters`), the `@Projection` annotation, the decider facades and `DcbDecider`, `DcbReadOptions`, and the DCB-pattern and projection example comments. It also adds a concrete leaderboard-vs-per-player example to `Projection`'s `id` documentation so the single-instance-vs-keyed choice is obvious, and fixes a stale example that showed a constant id on the keyed `dcbProjection` builder (that is the single-instance case, which now uses `dcbSingletonProjection`).

Verified the touched modules compile. The matching singleton-vs-keyed guidance is on the held docs PR occurrent-org.github.io#7.
