### PR TITLE
Fix correctness and API-hygiene findings from the post-0.30.0 review

### DIFF
--- a/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
+++ b/application/service/blocking/src/main/java/org/occurrent/application/service/blocking/ExecuteOptions.java
@@ -96,7 +96,7 @@ public final class ExecuteOptions<E> {
      * @return New options with filter applied.
      */
     public ExecuteOptions<E> filter(StreamReadFilter filter) {
-        return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null, null, fromStreamVersion);
+        return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null, sideEffect, fromStreamVersion);
     }
 
     /**
@@ -110,7 +110,7 @@ public final class ExecuteOptions<E> {
      * @return New options with execute filter applied.
      */
     public ExecuteOptions<E> filter(ExecuteFilter<? extends E> executeFilter) {
-        return withExecuteFilter(executeFilter);
+        return new ExecuteOptions<>(null, Objects.requireNonNull(executeFilter, "executeFilter cannot be null"), sideEffect, fromStreamVersion);
     }
 
     /**
@@ -178,22 +178,9 @@ public final class ExecuteOptions<E> {
         return fromStreamVersion;
     }
 
-    @SuppressWarnings("rawtypes")
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (ExecuteOptions) obj;
-        return Objects.equals(this.filter, that.filter) &&
-                Objects.equals(this.executeFilter, that.executeFilter) &&
-                Objects.equals(this.sideEffect, that.sideEffect) &&
-                Objects.equals(this.fromStreamVersion, that.fromStreamVersion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(filter, executeFilter, sideEffect, fromStreamVersion);
-    }
+    // Intentionally no equals()/hashCode(): executeFilter and sideEffect are lambda-typed fields, which are compared
+    // by identity, so a structural equals() would almost never consider two functionally-equivalent instances equal.
+    // Falling back to identity equality (the Object default) is less misleading than a partially-structural equals().
 
     @Override
     public String toString() {

--- a/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteOptionsTest.java
+++ b/application/service/blocking/src/test/java/org/occurrent/application/service/blocking/ExecuteOptionsTest.java
@@ -92,6 +92,56 @@ class ExecuteOptionsTest {
     }
 
     @Nested
+    @DisplayName("when withers are composed in any order")
+    class When_withers_are_composed_in_any_order {
+
+        @Test
+        void filter_preserves_a_previously_set_side_effect_and_from_stream_version() {
+            // Given
+            var filter = StreamReadFilter.type(NameDefined.class.getName());
+            var observedNames = new ArrayList<String>();
+
+            // When
+            var executeOptions = ExecuteOptions.<DomainEvent>options()
+                    .fromStreamVersion(5L)
+                    .sideEffect(events -> events.stream().map(DomainEvent::name).forEach(observedNames::add))
+                    .filter(filter);
+
+            executeOptions.sideEffect().accept(List.of(nameDefined("Ada")));
+
+            // Then
+            assertAll(
+                    () -> assertThat(executeOptions.filter()).isEqualTo(filter),
+                    () -> assertThat(executeOptions.fromStreamVersion()).isEqualTo(5L),
+                    () -> assertThat(observedNames).containsExactly("Ada")
+            );
+        }
+
+        @Test
+        void execute_filter_preserves_a_previously_set_side_effect_and_from_stream_version() {
+            // Given
+            var executeFilter = ExecuteFilter.<DomainEvent>type(NameDefined.class);
+            var observedNames = new ArrayList<String>();
+
+            // When
+            var executeOptions = ExecuteOptions.<DomainEvent>options()
+                    .fromStreamVersion(5L)
+                    .sideEffect(events -> events.stream().map(DomainEvent::name).forEach(observedNames::add))
+                    .filter(executeFilter);
+
+            executeOptions.sideEffect().accept(List.of(nameDefined("Ada")));
+
+            // Then
+            assertAll(
+                    () -> assertThat(executeOptions.executeFilter()).isEqualTo(executeFilter),
+                    () -> assertThat(executeOptions.filter()).isNull(),
+                    () -> assertThat(executeOptions.fromStreamVersion()).isEqualTo(5L),
+                    () -> assertThat(observedNames).containsExactly("Ada")
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("when setting fromStreamVersion")
     class When_setting_from_stream_version {
 

--- a/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ExecuteOptions.java
+++ b/application/service/reactor/src/main/java/org/occurrent/application/service/reactor/ExecuteOptions.java
@@ -75,7 +75,7 @@ public final class ExecuteOptions<E> {
      * Set the stream read filter.
      */
     public ExecuteOptions<E> filter(StreamReadFilter filter) {
-        return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null, null, fromStreamVersion);
+        return new ExecuteOptions<>(Objects.requireNonNull(filter, "filter cannot be null"), null, sideEffect, fromStreamVersion);
     }
 
     /**
@@ -83,7 +83,7 @@ public final class ExecuteOptions<E> {
      * execution time.
      */
     public ExecuteOptions<E> filter(ExecuteFilter<? extends E> executeFilter) {
-        return withExecuteFilter(executeFilter);
+        return new ExecuteOptions<>(null, Objects.requireNonNull(executeFilter, "executeFilter cannot be null"), sideEffect, fromStreamVersion);
     }
 
     /**
@@ -145,21 +145,9 @@ public final class ExecuteOptions<E> {
         return fromStreamVersion;
     }
 
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        ExecuteOptions<?> that = (ExecuteOptions<?>) obj;
-        return Objects.equals(this.filter, that.filter) &&
-                Objects.equals(this.executeFilter, that.executeFilter) &&
-                Objects.equals(this.sideEffect, that.sideEffect) &&
-                Objects.equals(this.fromStreamVersion, that.fromStreamVersion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(filter, executeFilter, sideEffect, fromStreamVersion);
-    }
+    // Intentionally no equals()/hashCode(): executeFilter and sideEffect are lambda-typed fields, which are compared
+    // by identity, so a structural equals() would almost never consider two functionally-equivalent instances equal.
+    // Falling back to identity equality (the Object default) is less misleading than a partially-structural equals().
 
     @Override
     public String toString() {

--- a/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/ExecuteOptionsTest.java
+++ b/application/service/reactor/src/test/java/org/occurrent/application/service/reactor/ExecuteOptionsTest.java
@@ -21,14 +21,73 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.occurrent.application.service.ExecuteFilter;
 import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.eventstore.api.StreamReadFilter;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("ExecuteOptions")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ExecuteOptionsTest {
+
+    @Nested
+    @DisplayName("when withers are composed in any order")
+    class When_withers_are_composed_in_any_order {
+
+        @Test
+        void filter_preserves_a_previously_set_side_effect_and_from_stream_version() {
+            // Given
+            var filter = StreamReadFilter.type(NameDefined.class.getName());
+            var sideEffectInvocations = new AtomicInteger();
+
+            // When
+            var executeOptions = ExecuteOptions.<DomainEvent>options()
+                    .fromStreamVersion(5L)
+                    .sideEffect(events -> Mono.fromRunnable(sideEffectInvocations::incrementAndGet))
+                    .filter(filter);
+
+            executeOptions.sideEffect().apply(List.of(nameDefined("Ada"))).block();
+
+            // Then
+            assertAll(
+                    () -> assertThat(executeOptions.filter()).isEqualTo(filter),
+                    () -> assertThat(executeOptions.fromStreamVersion()).isEqualTo(5L),
+                    () -> assertThat(sideEffectInvocations).hasValue(1)
+            );
+        }
+
+        @Test
+        void execute_filter_preserves_a_previously_set_side_effect_and_from_stream_version() {
+            // Given
+            var executeFilter = ExecuteFilter.<DomainEvent>type(NameDefined.class);
+            var sideEffectInvocations = new AtomicInteger();
+
+            // When
+            var executeOptions = ExecuteOptions.<DomainEvent>options()
+                    .fromStreamVersion(5L)
+                    .sideEffect(events -> Mono.fromRunnable(sideEffectInvocations::incrementAndGet))
+                    .filter(executeFilter);
+
+            executeOptions.sideEffect().apply(List.of(nameDefined("Ada"))).block();
+
+            // Then
+            assertAll(
+                    () -> assertThat(executeOptions.executeFilter()).isEqualTo(executeFilter),
+                    () -> assertThat(executeOptions.filter()).isNull(),
+                    () -> assertThat(executeOptions.fromStreamVersion()).isEqualTo(5L),
+                    () -> assertThat(sideEffectInvocations).hasValue(1)
+            );
+        }
+    }
 
     @Nested
     @DisplayName("when setting fromStreamVersion")
@@ -55,5 +114,9 @@ class ExecuteOptionsTest {
                     .hasMessageContaining("Integer.MAX_VALUE")
                     .hasMessageContaining("skip");
         }
+    }
+
+    private static NameDefined nameDefined(String name) {
+        return new NameDefined("event-" + name, LocalDateTime.of(2024, 1, 2, 3, 4), "user", name);
     }
 }

--- a/doc/architecture/decisions/0057-synchronous-subscriptions.md
+++ b/doc/architecture/decisions/0057-synchronous-subscriptions.md
@@ -36,7 +36,10 @@ today) or synchronous, via a separate `@SynchronousSubscription` annotation. The
 id, event types, and a filter, none of the async-only knobs (`startAt`, `resumeBehavior`, `startupMode`) that have no
 meaning for synchronous, at-write-time dispatch. The existing `@Subscription`/`@StreamSubscription`/`@DcbSubscription`
 are unchanged and stay asynchronous, following "mark the exception, not the default": in Occurrent "subscription"
-already denotes the asynchronous mechanism, so only the new special case gets an adjective.
+already denotes the asynchronous mechanism, so only the new special case gets an adjective. ADR 59 later gives
+`@Projection` (and `@Snapshot`) a `mode` attribute instead of a separate annotation. That divergence is intentional,
+not an oversight: a projection is one concept with two delivery timings, while a subscription is Occurrent's name for
+the asynchronous mechanism specifically. See ADR 59 for the reconciling argument.
 
 **A register-only `SynchronousSubscriptionModel` implements the existing `Subscribable`,** so the `Subscriptions`
 DSL and the annotation front-ends target it unchanged. It has no lifecycle, start position, checkpoint, catch-up, or

--- a/doc/architecture/decisions/0058-higher-level-read-model-projection-dsl.md
+++ b/doc/architecture/decisions/0058-higher-level-read-model-projection-dsl.md
@@ -30,7 +30,7 @@ as the branches of the fold, and the view instance id is dug out of the payload 
 ## Decision
 
 **Introduce a read-side descriptor symmetric to `DcbDecider`, and reuse `View` rather than replace it.**
-`Projection<S, E, ID>` is a record that couples a `View` (the pure fold) with the `id` function deriving the view
+`Projection<S, E, ID>` is a final class, built through a builder, that couples a `View` (the pure fold) with the `id` function deriving the view
 instance an event updates, the set of event types the fold handles, and an optional explicit `Filter`.
 `DcbProjection<S, E, ID>` adds the `DcbCriteria` read boundary, the same way `DcbDecider` adds a criteria to a plain
 `Decider`. `View` stays the pure, dependency-light fold it already is, so a caller who only wants to fold events keeps

--- a/doc/architecture/decisions/0059-projection-annotation.md
+++ b/doc/architecture/decisions/0059-projection-annotation.md
@@ -56,6 +56,16 @@ returns for read-your-writes. A synchronous projection has no history to catch u
 from, so `startAt`, `startAtPosition`, and `resumeBehavior` have no meaning there, and the annotation processor
 rejects setting any of them together with `mode = SYNCHRONOUS`.
 
+**This `mode` attribute is not the per-`execute` flag ADR 57 argued against, and `@Snapshot` follows the same choice for
+the same reason.** ADR 57 rejected a `mode` attribute on `@Subscription` because "subscription" already names Occurrent's
+asynchronous delivery mechanism specifically, so async-only knobs such as `startAt` and `resumeBehavior` would be
+meaningless noise on a synchronous variant, and it introduced `@SynchronousSubscription` as the separate, narrower
+annotation instead. A projection is a different shape of problem: it is one concept, a read model kept current from a
+stream of events, with two delivery timings, not two different mechanisms. `@Projection` and `@Snapshot` therefore give
+the read model one annotation with a `mode` attribute, and the processor still makes the illegal combination
+unrepresentable by rejecting `startAt`, `startAtPosition`, and `resumeBehavior` together with `mode = SYNCHRONOUS`, which
+is the same safety ADR 57 gets from a separate annotation, reached by validation instead of by type.
+
 **The same catch-up and durable resume are reachable programmatically, without the Spring starter.** A caller who
 wires their own catch-up-capable subscription model, for example a hand-wired `CatchupSubscriptionModel` over a
 native driver, gets the replay-first-boot-then-resume-from-checkpoint behavior through the new

--- a/doc/architecture/decisions/0060-unify-resumebehavior-and-startupmode-enums.md
+++ b/doc/architecture/decisions/0060-unify-resumebehavior-and-startupmode-enums.md
@@ -34,11 +34,16 @@ per enum family) just to re-derive the same boolean from values that were never 
 their own. This is a plain deduplication: the constants, their names, and their meaning are unchanged, only the
 enclosing type moves.
 
-**The bean post-processors' per-annotation converter methods and `shouldWaitUntilStarted` overloads collapse.**
-With one `ResumeBehavior` and one `StartupMode` shared across every annotation, `toAgnosticResumeBehavior`,
-`toAgnosticStartupMode`, `toDcbResumeBehavior`, and `toDcbStartupMode` have nothing left to convert between, and
-the three `shouldWaitUntilStarted` overloads collapse to one. The bean post-processors keep everything else about
-how `@Projection` picks a stream-style or DCB-style subscription path, only the enum-bridging plumbing goes away.
+**The bean post-processors' per-annotation converter methods go away, and their `shouldWaitUntilStarted` overloads
+now share one `StartupMode` parameter instead of one per enum family.** With one `ResumeBehavior` and one
+`StartupMode` shared across every annotation, `toAgnosticResumeBehavior`, `toAgnosticStartupMode`,
+`toDcbResumeBehavior`, and `toDcbStartupMode` have nothing left to convert between, so they are removed. The reactor
+bean post-processor now needs only one `shouldWaitUntilStarted` method. The blocking bean post-processor still
+overloads on its first parameter's shape, a `StartPositionToUse` for the catch-up path and a plain `boolean` for the
+agnostic path, but both overloads now take the same shared `StartupMode` as their second parameter, so the
+redundant per-enum copies are what collapses, not the overload count itself. The bean post-processors keep
+everything else about how `@Projection` picks a stream-style or DCB-style subscription path, only the
+enum-bridging plumbing goes away.
 
 **This is a source- and binary-breaking change for 0.30.0 callers.** The four enums shipped nested (for example
 `Subscription.ResumeBehavior`, `DcbSubscription.StartupMode`) in the released 0.30.0, so any reference to one of

--- a/doc/architecture/decisions/0061-first-class-snapshot-support.md
+++ b/doc/architecture/decisions/0061-first-class-snapshot-support.md
@@ -32,7 +32,8 @@ that is absent, is treated as no snapshot at all, and execution falls back to a 
 a stale snapshot must never be deserialized into the new shape. Persistence through the DSL executors is best-effort. The
 snapshot is written after the command's events commit, a save failure is logged and never fails the command, and losing a
 snapshot only costs a fuller replay next time. A snapshot that must stay consistent on the write path is maintained instead
-by `@Snapshot(mode = SYNCHRONOUS)` or from a synchronous subscription, which folds it inside the write transaction (ADR 57).
+by a stream `@Snapshot(mode = SYNCHRONOUS)` or from a synchronous subscription, which folds it inside the write transaction
+(ADR 57). A DCB snapshot has no synchronous mode, so DCB write-path consistency comes only from a synchronous subscription.
 
 **Snapshotting lives in the DSL layer where state and folds already live, not in the core application service.** The only
 change to the core is a state-agnostic read offset, `ExecuteOptions.fromStreamVersion(long)` and
@@ -62,8 +63,9 @@ defaults to failing loud rather than doing nothing, so a store that cannot delet
 gone.
 
 **Storage is a small, storage-neutral `SnapshotStore<S>` capability** with `findLatest`, `save`, and `delete`, keyed by a
-`String`. On the stream path the key is the stream id. On the DCB path the key defaults to a deterministic string derived from
-the command's `DcbCriteria` (its record `toString`), with an override hook for callers who want a shorter or custom key. An
+`String`. On the stream path the key is the stream id. On the DCB path the key defaults to a canonical string form of the
+command's `DcbCriteria`, so tag and type order does not change the key, with an override hook for callers who want a shorter
+or custom key. An
 in-memory implementation ships in the common module, and a Spring Data Mongo implementation ships in the starters. The Mongo
 document is a new envelope carrying `state`, `version`, and `schemaVersion`, because the existing `ViewStateRepository` stores
 only the state value with no version marker. The deciders-free path uses a `SnapshotView<S,E>` descriptor and works with no
@@ -85,7 +87,8 @@ maintains one snapshot per stream. A DCB `@Snapshot` (a factory returning a `Dcb
 boundary, keyed by the canonical form of its `DcbCriteria` so tag order does not change the key. The reactor registrar uses
 a `ReactiveSnapshotStore` (a `ReactiveMongoOperations`-backed `ReactiveSpringMongoSnapshotStore` for the zero-config path),
 because a reactive application has no blocking `MongoOperations`. The DSL executors remain the programmatic path for ad-hoc,
-non-annotated use.
+non-annotated use. A DCB `@Snapshot` does not support `mode = SYNCHRONOUS` (that mode is stream only), so a DCB snapshot
+that must be current for read-your-writes is maintained through the DSL executor from a synchronous subscription instead.
 
 ## Consequences
 
@@ -99,8 +102,12 @@ non-annotated use.
   stacks.
 - Snapshot persistence through the DSL executors is best-effort: the snapshot is saved after the write commits, a save
   failure is logged rather than propagated so it never fails an already-committed command, and a lost snapshot only costs a
-  fuller replay. Write-path consistency comes from maintaining the snapshot with `@Snapshot(mode = SYNCHRONOUS)` or a
-  synchronous subscription, which folds inside the write transaction (ADR 57), not from the DSL executors.
+  fuller replay. Write-path consistency comes from maintaining the snapshot with a stream `@Snapshot(mode = SYNCHRONOUS)`
+  or a synchronous subscription, which folds inside the write transaction (ADR 57), not from the DSL executors.
+- A DCB `@Snapshot` does not support `mode = SYNCHRONOUS`. Registering a `DcbSnapshotView` with a synchronous mode is
+  rejected, so a DCB snapshot is always maintained asynchronously through the declarative path. A DCB snapshot that must
+  stay current for read-your-writes is maintained instead through the DSL executor from a synchronous subscription, or
+  by folding it directly inside a synchronous subscription handler.
 - The read-side reader passes the folded tail as the decision's events, so `always()` and `onEvent(...)` behave sensibly on a
   read and `everyNEvents` rides the version delta.
 - One method was added to the public `Decider` API (`evolve(S, List<E>)`) and one option each to `ExecuteOptions` and

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
@@ -28,8 +28,8 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Internal helper shared by the blocking projection runners (the Kotlin {@code project} extensions and the Java
- * {@code *ProjectionRunner} facades): turning a {@link Projection} plus a {@link ViewStateRepository} into a
+ * The public factory for assembling blocking projection runners (the Kotlin {@code project} extensions and the Java
+ * {@code *ProjectionRunner} facades): turns a {@link Projection} plus a {@link ViewStateRepository} into a
  * {@link MaterializedView} that skips events whose id resolves to {@code null}. The plain-{@code Filter} derivation
  * lives in {@code org.occurrent.dsl.projection.internal.ProjectionFilters}, shared with the reactor stack.
  */

--- a/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDcbDeciderApplicationService.java
+++ b/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDcbDeciderApplicationService.java
@@ -26,7 +26,7 @@ import org.occurrent.dsl.snapshot.DcbSnapshotKeys;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotOptions;
 import org.occurrent.dsl.snapshot.SnapshotStore;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.eventstore.api.dcb.DcbAppendResult;
 import org.occurrent.eventstore.api.dcb.DcbCriteria;
 

--- a/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDeciderApplicationService.java
+++ b/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDeciderApplicationService.java
@@ -25,7 +25,7 @@ import org.occurrent.dsl.snapshot.Snapshot;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotOptions;
 import org.occurrent.dsl.snapshot.SnapshotStore;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.eventstore.api.WriteResult;
 
 import java.util.List;

--- a/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotViews.java
+++ b/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotViews.java
@@ -23,7 +23,7 @@ import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotPolicy;
 import org.occurrent.dsl.snapshot.SnapshotStore;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.eventstore.api.blocking.EventStore;
 import org.occurrent.eventstore.api.blocking.EventStream;

--- a/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/SnapshotPolicy.java
+++ b/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/SnapshotPolicy.java
@@ -25,7 +25,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * Decides whether an execute should write a new snapshot, given its {@link SnapshotDecision}. This is the single trigger
  * abstraction for both technical snapshots ({@link #everyNEvents(int)}) and domain-driven ones ({@link #onEvent(Class)},
- * {@link #whenState(Predicate)}, and the decider-backed {@code whenTerminal()} in the blocking and reactor modules).
+ * {@link #whenState(Predicate)}, and the decider-backed {@code SnapshotPolicies.whenTerminal(...)} in this common
+ * module).
  *
  * @param <S> the state type
  * @param <E> the event type

--- a/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/internal/SnapshotSupport.java
+++ b/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/internal/SnapshotSupport.java
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-package org.occurrent.dsl.snapshot;
+package org.occurrent.dsl.snapshot.internal;
 
 import org.jspecify.annotations.Nullable;
+import org.occurrent.dsl.snapshot.Snapshot;
+import org.occurrent.dsl.snapshot.SnapshotDecision;
+import org.occurrent.dsl.snapshot.SnapshotPolicy;
+import org.occurrent.dsl.snapshot.SnapshotStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/internal/package-info.java
+++ b/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.occurrent.dsl.snapshot.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/dsl/snapshot-dsl/common/src/test/java/org/occurrent/dsl/snapshot/SnapshotSupportTest.java
+++ b/dsl/snapshot-dsl/common/src/test/java/org/occurrent/dsl/snapshot/SnapshotSupportTest.java
@@ -19,6 +19,7 @@ package org.occurrent.dsl.snapshot;
 import org.junit.jupiter.api.Test;
 import org.occurrent.dsl.snapshot.LedgerFixture.Deposited;
 import org.occurrent.dsl.snapshot.LedgerFixture.LedgerEvent;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 
 import java.util.List;
 import java.util.Optional;

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDcbDeciderApplicationService.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDcbDeciderApplicationService.java
@@ -90,9 +90,11 @@ public final class ReactiveSnapshotDcbDeciderApplicationService<E> {
     }
 
     /**
-     * Execute {@code command} and return the folded state after the decision (even when nothing was appended).
+     * Execute {@code command} and return the folded state after the decision (even when nothing was appended). The
+     * state is bound to a non-null type because a {@link Mono} cannot carry a null value, use
+     * {@link #executeAndReturnDecision} for a nullable state.
      */
-    public <C, S extends @Nullable Object> Mono<S> executeAndReturnState(C command, DcbDecider<C, S, E> dcbDecider, ReactiveSnapshotStore<S> store, SnapshotOptions<S, E> options) {
+    public <C, S> Mono<S> executeAndReturnState(C command, DcbDecider<C, S, E> dcbDecider, ReactiveSnapshotStore<S> store, SnapshotOptions<S, E> options) {
         return executeAndReturnDecision(command, dcbDecider, store, options).map(Decider.Decision::state);
     }
 

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDeciderApplicationService.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDeciderApplicationService.java
@@ -24,7 +24,7 @@ import org.occurrent.dsl.decider.Decider;
 import org.occurrent.dsl.snapshot.Snapshot;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotOptions;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.eventstore.api.WriteResult;
 import reactor.core.publisher.Mono;
 
@@ -93,9 +93,10 @@ public final class ReactiveSnapshotDeciderApplicationService<E> {
     }
 
     /**
-     * Execute {@code command} and return the folded state after the decision.
+     * Execute {@code command} and return the folded state after the decision. The state is bound to a non-null type
+     * because a {@link Mono} cannot carry a null value, use {@link #executeAndReturnDecision} for a nullable state.
      */
-    public <C, S extends @Nullable Object> Mono<S> executeAndReturnState(String streamId, C command, Decider<C, S, E> decider, ReactiveSnapshotStore<S> store, SnapshotOptions<S, E> options) {
+    public <C, S> Mono<S> executeAndReturnState(String streamId, C command, Decider<C, S, E> decider, ReactiveSnapshotStore<S> store, SnapshotOptions<S, E> options) {
         return executeAndReturnDecision(streamId, command, decider, store, options).map(Decider.Decision::state);
     }
 

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotSupport.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotSupport.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.dsl.snapshot.Snapshot;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotPolicy;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 
 /**
  * The reactive load/resume/persist steps shared by the reactor snapshot executors, mirroring
- * {@code org.occurrent.dsl.snapshot.SnapshotSupport} but composing into a {@link Mono} chain instead of blocking.
+ * {@link SnapshotSupport} but composing into a {@link Mono} chain instead of blocking.
  */
 final class ReactiveSnapshotSupport {
 

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotViews.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotViews.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.dsl.snapshot.SnapshotDecision;
 import org.occurrent.dsl.snapshot.SnapshotPolicy;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.eventstore.api.reactor.EventStore;
 import reactor.core.publisher.Mono;
@@ -44,9 +44,10 @@ public final class ReactiveSnapshotViews {
     /**
      * Read the current state for {@code streamId} by resuming {@code snapshotView} from the snapshot in {@code store} and
      * folding the events written after it. Writes a refreshed snapshot when {@code policy} fires. A loaded snapshot whose
-     * schema version does not match the view is ignored and the state is rebuilt from the whole stream.
+     * schema version does not match the view is ignored and the state is rebuilt from the whole stream. The state is
+     * bound to a non-null type because a {@link Mono} cannot carry a null value.
      */
-    public static <S extends @Nullable Object, E> Mono<S> readState(EventStore eventStore, CloudEventConverter<E> converter, String streamId,
+    public static <S, E> Mono<S> readState(EventStore eventStore, CloudEventConverter<E> converter, String streamId,
                                                                     SnapshotView<S, E> snapshotView, ReactiveSnapshotStore<S> store,
                                                                     SnapshotPolicy<S, E> policy) {
         Objects.requireNonNull(eventStore, "eventStore cannot be null");

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Snapshot.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Snapshot.java
@@ -111,6 +111,11 @@ public @interface Snapshot {
      * 1 saves after every handled event. A larger value trades snapshot freshness for fewer writes: the snapshot then
      * lags by up to {@code n} events, which a snapshot-accelerated read simply folds on top. When a save does happen
      * after skipped events, the intervening events are folded from the store so the saved state stays correct.
+     * <p>
+     * This is the deliberate annotation-level trigger ceiling. The schema version and richer trigger policies (an
+     * event type, a state predicate, or a decider's terminal state, for example the "closing the books" case) live on
+     * the {@code SnapshotView} returned by the factory method, via its builder. Drop to the DSL {@code SnapshotPolicy}
+     * directly for those triggers.
      */
     int everyNEvents() default 1;
 

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/main/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotations.java
@@ -202,12 +202,13 @@ public final class SubscriptionAnnotations {
      * @param startAtSet         whether startAt is set to something other than its default
      * @param startAtPositionSet whether startAtPosition is set
      * @param resumeBehaviorSet  whether resumeBehavior is set to something other than its default
+     * @param startupModeSet     whether startupMode is set to something other than its default
      */
     public static void validateModeStartKnobs(String annotationName, String id, boolean synchronous,
-                                              boolean startAtSet, boolean startAtPositionSet, boolean resumeBehaviorSet) {
-        if (synchronous && (startAtSet || startAtPositionSet || resumeBehaviorSet)) {
+                                              boolean startAtSet, boolean startAtPositionSet, boolean resumeBehaviorSet, boolean startupModeSet) {
+        if (synchronous && (startAtSet || startAtPositionSet || resumeBehaviorSet || startupModeSet)) {
             String noun = annotationName.replace("@", "").toLowerCase(Locale.ROOT);
-            throw new IllegalArgumentException("%s '%s' uses mode = SYNCHRONOUS, which cannot be combined with startAt, startAtPosition, or resumeBehavior (those configure catch-up for an async %s).".formatted(annotationName, id, noun));
+            throw new IllegalArgumentException("%s '%s' uses mode = SYNCHRONOUS, which cannot be combined with startAt, startAtPosition, resumeBehavior, or startupMode (those configure catch-up for an async %s).".formatted(annotationName, id, noun));
         }
         if (startAtSet && startAtPositionSet) {
             throw new IllegalArgumentException("%s '%s' sets both startAt and startAtPosition, which are two ways to express the same start point, so set only one.".formatted(annotationName, id));

--- a/framework/spring-boot-autoconfigure-mongodb-common/src/test/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotationsTest.java
+++ b/framework/spring-boot-autoconfigure-mongodb-common/src/test/java/org/occurrent/springboot/mongo/common/SubscriptionAnnotationsTest.java
@@ -26,7 +26,7 @@ class SubscriptionAnnotationsTest {
 
     @Test
     void synchronous_with_startAt_is_rejected() {
-        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", true, true, false, false))
+        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", true, true, false, false, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("@Projection")
                 .hasMessageContaining("orders")
@@ -35,7 +35,7 @@ class SubscriptionAnnotationsTest {
 
     @Test
     void synchronous_with_startAtPosition_is_rejected() {
-        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", true, false, true, false))
+        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", true, false, true, false, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("@Snapshot")
                 .hasMessageContaining("ledger")
@@ -44,14 +44,24 @@ class SubscriptionAnnotationsTest {
 
     @Test
     void synchronous_with_resumeBehavior_is_rejected() {
-        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", true, false, false, true))
+        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", true, false, false, true, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("mode = SYNCHRONOUS");
     }
 
     @Test
+    void synchronous_with_startupMode_is_rejected() {
+        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", true, false, false, false, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@Snapshot")
+                .hasMessageContaining("ledger")
+                .hasMessageContaining("mode = SYNCHRONOUS")
+                .hasMessageContaining("startupMode");
+    }
+
+    @Test
     void startAt_together_with_startAtPosition_is_rejected() {
-        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", false, true, true, false))
+        assertThatThrownBy(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", false, true, true, false, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("@Snapshot")
                 .hasMessageContaining("ledger")
@@ -60,19 +70,19 @@ class SubscriptionAnnotationsTest {
 
     @Test
     void asynchronous_with_all_catch_up_knobs_except_the_startAt_pair_is_allowed() {
-        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", false, true, false, true))
+        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", false, true, false, true, true))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void synchronous_without_any_start_knob_is_allowed() {
-        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", true, false, false, false))
+        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", "ledger", true, false, false, false, false))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void asynchronous_with_only_startAtPosition_is_allowed() {
-        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", false, false, true, true))
+        assertThatCode(() -> SubscriptionAnnotations.validateModeStartKnobs("@Projection", "orders", false, false, true, true, true))
                 .doesNotThrowAnyException();
     }
 }

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -40,7 +40,7 @@ import org.occurrent.dsl.subscription.reactor.Subscriptions;
 import org.occurrent.dsl.snapshot.DcbSnapshotKeys;
 import org.occurrent.dsl.snapshot.DcbSnapshotView;
 import org.occurrent.dsl.snapshot.Snapshot;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.dsl.snapshot.reactor.ReactiveSnapshotStore;
 import org.occurrent.dsl.view.MaterializedView;
@@ -484,7 +484,8 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         SubscriptionAnnotations.validateModeStartKnobs("@Projection", id, synchronous,
                 annotation.startAt() != org.occurrent.annotation.Projection.StartPosition.DEFAULT,
                 annotation.startAtPosition() >= 0,
-                annotation.resumeBehavior() != ResumeBehavior.DEFAULT);
+                annotation.resumeBehavior() != ResumeBehavior.DEFAULT,
+                annotation.startupMode() != StartupMode.DEFAULT);
 
         CloudEventConverter<E> converter = applicationContext.getBean(CloudEventConverter.class);
         Object descriptor = invokeFactory(method, bean);
@@ -549,7 +550,8 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", id, synchronous,
                 annotation.startAt() != org.occurrent.annotation.Snapshot.StartPosition.BEGINNING,
                 annotation.startAtPosition() >= 0,
-                annotation.resumeBehavior() != ResumeBehavior.DEFAULT);
+                annotation.resumeBehavior() != ResumeBehavior.DEFAULT,
+                annotation.startupMode() != StartupMode.DEFAULT);
 
         CloudEventConverter<E> converter = applicationContext.getBean(CloudEventConverter.class);
         Object descriptor = invokeSnapshotFactory(method, bean);

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveSpringMongoSnapshotStore.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveSpringMongoSnapshotStore.java
@@ -71,7 +71,16 @@ public final class ReactiveSpringMongoSnapshotStore<S extends @Nullable Object> 
     public Mono<Snapshot<S>> findLatest(String key) {
         Objects.requireNonNull(key, "key cannot be null");
         return mongoOperations.findById(key, Document.class, collectionName)
-                .map(document -> {
+                .flatMap(document -> decodeSnapshot(key, document));
+    }
+
+    /**
+     * Decode a stored document into a {@link Snapshot}, degrading to an empty result if the document can no
+     * longer be read. This is scoped to the decode step only, so a connectivity or timeout error from the
+     * preceding {@code findById} call is left to propagate rather than being mistaken for an unreadable snapshot.
+     */
+    private Mono<Snapshot<S>> decodeSnapshot(String key, Document document) {
+        return Mono.fromSupplier(() -> {
                     long version = document.getLong(VERSION);
                     int schemaVersion = document.getInteger(SCHEMA_VERSION);
                     S state = readState(mongoOperations.getConverter(), document.get(STATE));

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -39,7 +39,7 @@ import org.occurrent.dsl.subscription.blocking.Subscriptions;
 import org.occurrent.dsl.snapshot.DcbSnapshotKeys;
 import org.occurrent.dsl.snapshot.DcbSnapshotView;
 import org.occurrent.dsl.snapshot.SnapshotStore;
-import org.occurrent.dsl.snapshot.SnapshotSupport;
+import org.occurrent.dsl.snapshot.internal.SnapshotSupport;
 import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.dsl.view.View;
 import org.occurrent.dsl.view.MaterializedView;
@@ -204,7 +204,8 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         SubscriptionAnnotations.validateModeStartKnobs("@Projection", id, synchronous,
                 annotation.startAt() != org.occurrent.annotation.Projection.StartPosition.DEFAULT,
                 annotation.startAtPosition() >= 0,
-                annotation.resumeBehavior() != ResumeBehavior.DEFAULT);
+                annotation.resumeBehavior() != ResumeBehavior.DEFAULT,
+                annotation.startupMode() != StartupMode.DEFAULT);
 
         CloudEventConverter<E> converter = applicationContext.getBean(CloudEventConverter.class);
         Object descriptor = invokeFactory(method, bean);
@@ -396,7 +397,8 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         SubscriptionAnnotations.validateModeStartKnobs("@Snapshot", id, synchronous,
                 annotation.startAt() != org.occurrent.annotation.Snapshot.StartPosition.BEGINNING,
                 annotation.startAtPosition() >= 0,
-                annotation.resumeBehavior() != ResumeBehavior.DEFAULT);
+                annotation.resumeBehavior() != ResumeBehavior.DEFAULT,
+                annotation.startupMode() != StartupMode.DEFAULT);
 
         CloudEventConverter<E> converter = applicationContext.getBean(CloudEventConverter.class);
         Object descriptor = invokeSnapshotFactory(method, bean);


### PR DESCRIPTION
The low-risk fixes from the review of everything added since 0.30.0. All of it is still unreleased, so there is no changelog entry and no migration.

- The reactive snapshot facades declared a nullable state on methods that return a `Mono`, which cannot carry null, so a null state would have blown up inside Reactor. They now use the same non-null contract the plain reactor DCB facade already documents.
- The stream `ExecuteOptions` filter withers dropped `sideEffect` and `fromStreamVersion` on the way through, so chaining `fromStreamVersion(5).filter(...)` silently lost the snapshot offset. Every wither now carries the unrelated fields, matching the DCB options. The identity-based `equals`/`hashCode` is gone.
- `SnapshotSupport` moved to an `internal` subpackage, matching `ProjectionFilters`.
- The reactive Mongo snapshot store no longer swallows a Mongo timeout as an unreadable snapshot. Only a decode failure degrades to a full replay, which is what the blocking store already does.
- `mode = SYNCHRONOUS` now also rejects `startupMode`, closing the last async-only knob the validation missed.
- ADRs 0057 to 0061 and a few javadoc pointers are corrected to match the shipped code.

Verified locally on JDK 21 with the focused module tests green. CI covers the rest.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
