### PR TITLE
Gate the DCB @Snapshot maintain path before the range read

### DIFF
--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -654,6 +654,9 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
                     return Mono.<Void>empty(); // already folded (a redelivery), keep folding idempotent
                 }
                 SnapshotSupport.Base<S> base = SnapshotSupport.resolveBase(loaded, schemaVersion, view::initialState);
+                if (position - base.version() < everyNEvents) {
+                    return Mono.<Void>empty(); // throttle before reading, matching events cannot exceed the position gap since the snapshot
+                }
                 return dcbEventStore.read(criteria, DcbReadOptions.between(base.version(), position)).flatMap(eventStream -> {
                     List<E> range = converter.toDomainEvents(eventStream.events().stream()).toList();
                     if (range.size() < everyNEvents) {

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -488,6 +488,9 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
                 return; // already folded (a redelivery), keep folding idempotent
             }
             SnapshotSupport.Base<S> base = SnapshotSupport.resolveBase(loaded, schemaVersion, view::initialState);
+            if (position - base.version() < everyNEvents) {
+                return; // throttle before reading, matching events cannot exceed the position gap since the snapshot
+            }
             List<E> range = converter.toDomainEvents(dcbEventStore.read(criteria, DcbReadOptions.between(base.version(), position)).stream()).toList();
             if (range.size() < everyNEvents) {
                 return; // throttle: too few matching events since the last saved snapshot


### PR DESCRIPTION
The maintained DCB `@Snapshot` path read and materialized the whole boundary since the last snapshot on every delivered event, then threw the work away when the `everyNEvents` throttle was not met. So raising the throttle made the read load worse, not better.

It now gates on the position delta first, since the number of matching events can never exceed `position` minus the snapshot's version, and only reads when that gap reaches the throttle. The exact count check after the read stays, so the snapshot still saves on the same cadence. At the default `everyNEvents` of 1 nothing changes.

This is the throttle-before-read item that was already noted as deferred in the snapshot work. It is unreleased, so no changelog entry.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
