### PR TITLE
Fix keyed on-demand projection reads and fold on-demand reads incrementally

### DIFF
--- a/doc/architecture/decisions/0058-higher-level-read-model-projection-dsl.md
+++ b/doc/architecture/decisions/0058-higher-level-read-model-projection-dsl.md
@@ -82,6 +82,9 @@ the store.
 - The store stays out of the descriptor, so one projection can be materialized into different stores, or folded
   on demand, without changing its definition.
 - Delivery mode is a runner concern, so async, synchronous (ADR 57), and pull all reuse one descriptor.
+- The on-demand `project` now takes an optional instance id: a keyed projection folded without one throws, since
+  blending every instance into a single state on demand would silently produce nonsense, and passing the id folds
+  just that instance.
 - `compose` is not available yet, and read models compose less naturally than deciders to begin with. The
   `@Projection` annotation followed in ADR 59, reusing these same runners rather than a parallel mechanism, so
   catch-up and durable resume were never blocked on the annotation existing.

--- a/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/ProjectionExtensions.kt
@@ -74,9 +74,14 @@ fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String
 /**
  * Folds the events [projection] selects, read on demand, into its view state and returns it: the strongly-consistent,
  * query-driven counterpart to the subscription-fed [Subscriptions.project]. Uses the projection's explicit filter if
- * set, else its handled event types (empty means "all events").
+ * set, else its handled event types (empty means "all events"). Only valid for a single-instance (singleton)
+ * projection; a keyed projection throws, since folding every instance into one blended state on demand would produce
+ * a nonsense result. Use [project] with an `instanceId` for a keyed projection.
  */
 fun <S, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Projection<S, E, ID>): S {
+    require(projection.id() == null) {
+        "projection is keyed; folding every instance into one blended state on demand is not supported, use project(projection, instanceId) to read a single instance, or a singleton projection for one shared state"
+    }
     val explicitFilter = projection.filter()
     val events: Stream<E> = when {
         explicitFilter != null -> query(explicitFilter)
@@ -84,4 +89,23 @@ fun <S, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Projection<
         else -> query(projection.eventTypes().toList())
     }
     return projection.view().evolve(events)
+}
+
+/**
+ * Folds the events [projection] selects for [instanceId], read on demand, into that instance's view state and returns
+ * it: the strongly-consistent, query-driven, single-instance counterpart to the unqualified [project]. Uses the same
+ * filter or handled event types as the unqualified [project] to read candidate events, then keeps only the ones whose
+ * [Projection.id] resolves to [instanceId] before folding. A singleton projection (no id function) has a single
+ * instance regardless of [instanceId], so this folds all selected events, same as the unqualified [project].
+ */
+fun <S, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Projection<S, E, ID>, instanceId: ID): S {
+    val explicitFilter = projection.filter()
+    val events: Stream<E> = when {
+        explicitFilter != null -> query(explicitFilter)
+        projection.eventTypes().isEmpty() -> all()
+        else -> query(projection.eventTypes().toList())
+    }
+    val id = projection.id()
+    val scopedEvents = if (id == null) events else events.filter { id.apply(it) == instanceId }
+    return projection.view().evolve(scopedEvents)
 }

--- a/dsl/projection-dsl/blocking/src/test/kotlin/org/occurrent/dsl/projection/blocking/ProjectionBlockingTest.kt
+++ b/dsl/projection-dsl/blocking/src/test/kotlin/org/occurrent/dsl/projection/blocking/ProjectionBlockingTest.kt
@@ -18,6 +18,7 @@ package org.occurrent.dsl.projection.blocking
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.AfterEach
@@ -150,7 +151,7 @@ class ProjectionBlockingTest {
     }
 
     @Test
-    fun pull_projection_folds_the_matching_events_on_demand_and_matches_the_pushed_state() {
+    fun id_scoped_pull_projection_folds_the_matching_events_on_demand_and_matches_the_pushed_state() {
         val store = ConcurrentHashMap<String, String>()
         val repository = viewStateRepository<String, String>({ store[it] }, { id, s -> store[id] = s })
         subscriptions(subscriptionModel, converter) {
@@ -165,8 +166,29 @@ class ProjectionBlockingTest {
         await untilAsserted { assertThat(store["johan"]).isEqualTo("Johan Haleby") }
 
         val queries = DomainEventQueries(eventStore, converter)
-        val pulled = queries.project(currentNameProjection())
+        val pulled = queries.project(currentNameProjection(), "johan")
 
         assertThat(pulled).isEqualTo("Johan Haleby").isEqualTo(store["johan"])
+    }
+
+    @Test
+    fun id_scoped_pull_projection_folds_only_the_requested_instance_when_multiple_instances_exist() {
+        write("johan", NameDefined(UUID.randomUUID().toString(), Date(), "johan", "Johan"), NameWasChanged(UUID.randomUUID().toString(), Date(), "johan", "Johan Haleby"))
+        write("eve", NameDefined(UUID.randomUUID().toString(), Date(), "eve", "Eve"))
+
+        val queries = DomainEventQueries(eventStore, converter)
+
+        assertThat(queries.project(currentNameProjection(), "johan")).isEqualTo("Johan Haleby")
+        assertThat(queries.project(currentNameProjection(), "eve")).isEqualTo("Eve")
+    }
+
+    @Test
+    fun unqualified_pull_projection_throws_for_a_keyed_projection() {
+        write("johan", NameDefined(UUID.randomUUID().toString(), Date(), "johan", "Johan"))
+
+        val queries = DomainEventQueries(eventStore, converter)
+
+        assertThatThrownBy { queries.project(currentNameProjection()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 }

--- a/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
@@ -97,9 +97,18 @@ fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection:
  * Folds the events [projection] selects, read on demand, into its view state: the strongly-consistent, query-driven
  * counterpart to the subscription-fed [Subscriptions.project]. The returned [Mono] emits the folded state, or completes
  * empty when that state is `null` (Reactor cannot carry a `null` value, so the state type is constrained to be non-null;
- * a nullable-state read model should use the blocking pull or model absence explicitly).
+ * a nullable-state read model should use the blocking pull or model absence explicitly). Only valid for a
+ * single-instance (singleton) projection; a keyed projection errors, since folding every instance into one blended
+ * state on demand would produce a nonsense result. Use [project] with an `instanceId` for a keyed projection.
  */
 fun <S : Any, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Projection<S, E, ID>): Mono<S> {
+    if (projection.id() != null) {
+        return Mono.error(
+            IllegalArgumentException(
+                "projection is keyed; folding every instance into one blended state on demand is not supported, use project(projection, instanceId) to read a single instance, or a singleton projection for one shared state"
+            )
+        )
+    }
     val explicitFilter = projection.filter()
     val events: Flux<E> = when {
         explicitFilter != null -> query(explicitFilter)
@@ -107,4 +116,24 @@ fun <S : Any, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Proje
         else -> query(projection.eventTypes().toList())
     }
     return events.collectList().flatMap { list -> Mono.justOrEmpty(projection.view().evolve(list)) }
+}
+
+/**
+ * Folds the events [projection] selects for [instanceId], read on demand, into that instance's view state: the
+ * strongly-consistent, query-driven, single-instance counterpart to the unqualified [project]. Uses the same filter
+ * or handled event types as the unqualified [project] to read candidate events, then keeps only the ones whose
+ * [Projection.id] resolves to [instanceId] before folding. A singleton projection (no id function) has a single
+ * instance regardless of [instanceId], so this folds all selected events, same as the unqualified [project]. The
+ * returned [Mono] emits the folded state, or completes empty when that state is `null`.
+ */
+fun <S : Any, E : Any, ID : Any> DomainEventQueries<E>.project(projection: Projection<S, E, ID>, instanceId: ID): Mono<S> {
+    val explicitFilter = projection.filter()
+    val events: Flux<E> = when {
+        explicitFilter != null -> query(explicitFilter)
+        projection.eventTypes().isEmpty() -> all()
+        else -> query(projection.eventTypes().toList())
+    }
+    val id = projection.id()
+    val scopedEvents = if (id == null) events else events.filter { id.apply(it) == instanceId }
+    return scopedEvents.collectList().flatMap { list -> Mono.justOrEmpty(projection.view().evolve(list)) }
 }

--- a/dsl/projection-dsl/reactor/src/test/kotlin/org/occurrent/dsl/projection/reactor/ReactorProjectionTest.kt
+++ b/dsl/projection-dsl/reactor/src/test/kotlin/org/occurrent/dsl/projection/reactor/ReactorProjectionTest.kt
@@ -19,6 +19,7 @@ package org.occurrent.dsl.projection.reactor
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.cloudevents.CloudEvent
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
 import org.junit.jupiter.api.Test
@@ -138,14 +139,34 @@ class ReactorProjectionTest {
     }
 
     @Test
-    fun pull_folds_a_query_into_the_same_state_as_push() {
+    fun id_scoped_pull_folds_a_query_into_the_same_state_as_push() {
         val defined = NameDefined(id(), Date(), "johan", "Johan")
         val changed = NameWasChanged(id(), Date(), "johan", "Johan Haleby")
         val queries = DomainEventQueries(InMemoryEventStoreQueries(cloudEvents(defined, changed)), converter)
 
-        val state: String? = queries.project(currentNameProjection()).block()
+        val state: String? = queries.project(currentNameProjection(), "johan").block()
 
         assertThat(state).isEqualTo("Johan Haleby")
+    }
+
+    @Test
+    fun id_scoped_pull_folds_only_the_requested_instance_when_multiple_instances_exist() {
+        val johanDefined = NameDefined(id(), Date(), "johan", "Johan")
+        val johanChanged = NameWasChanged(id(), Date(), "johan", "Johan Haleby")
+        val eveDefined = NameDefined(id(), Date(), "eve", "Eve")
+        val queries = DomainEventQueries(InMemoryEventStoreQueries(cloudEvents(johanDefined, johanChanged, eveDefined)), converter)
+
+        assertThat(queries.project(currentNameProjection(), "johan").block()).isEqualTo("Johan Haleby")
+        assertThat(queries.project(currentNameProjection(), "eve").block()).isEqualTo("Eve")
+    }
+
+    @Test
+    fun unqualified_pull_errors_for_a_keyed_projection() {
+        val defined = NameDefined(id(), Date(), "johan", "Johan")
+        val queries = DomainEventQueries(InMemoryEventStoreQueries(cloudEvents(defined)), converter)
+
+        assertThatThrownBy { queries.project(currentNameProjection()).block() }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     private fun cloudEvents(vararg events: DomainEvent): List<CloudEvent> = events.map { converter.toCloudEvent(it) }

--- a/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotViews.java
+++ b/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotViews.java
@@ -28,6 +28,7 @@ import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.eventstore.api.blocking.EventStore;
 import org.occurrent.eventstore.api.blocking.EventStream;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -60,8 +61,11 @@ public final class SnapshotViews {
 
         SnapshotSupport.Base<S> base = SnapshotSupport.resolveBase(store.findLatest(streamId), snapshotView.schemaVersion(), snapshotView.view()::initialState);
         EventStream<CloudEvent> eventStream = eventStore.read(streamId, SnapshotSupport.requireInt(base.version(), "the snapshot base stream version"), Integer.MAX_VALUE);
-        List<E> tail = converter.toDomainEvents(eventStream.events()).toList();
-        S current = snapshotView.view().evolve(base.state(), tail);
+        // The tail is folded incrementally straight off the stream (evolve(S, Stream) does not buffer it), and the
+        // events are captured into a list as a side effect of that same pass since the policy below needs them (for
+        // example onEvent inspects the tail's event types), so the events are never held in memory twice.
+        List<E> tail = new ArrayList<>();
+        S current = snapshotView.view().evolve(base.state(), converter.toDomainEvents(eventStream.events()).peek(tail::add));
 
         long version = eventStream.version();
         // On the read side the policy sees the tail it folded as the "new events", so always()/onEvent(...) stay meaningful

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotViews.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotViews.java
@@ -26,6 +26,7 @@ import org.occurrent.dsl.snapshot.SnapshotView;
 import org.occurrent.eventstore.api.reactor.EventStore;
 import reactor.core.publisher.Mono;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -58,16 +59,24 @@ public final class ReactiveSnapshotViews {
         Objects.requireNonNull(policy, "policy cannot be null");
 
         return Mono.defer(() -> ReactiveSnapshotSupport.resolveBase(store, streamId, snapshotView.schemaVersion(), snapshotView.view()::initialState).flatMap(base ->
-                eventStore.read(streamId, SnapshotSupport.requireInt(base.version(), "the snapshot base stream version"), Integer.MAX_VALUE).flatMap(eventStream ->
-                        eventStream.events().collectList().flatMap(cloudEvents -> {
-                            List<E> tail = converter.toDomainEvents(cloudEvents.stream()).toList();
-                            S current = snapshotView.view().evolve(base.state(), tail);
-                            long version = eventStream.version();
-                            // On the read side the policy sees the tail it folded as the "new events", so always()/onEvent(...)
-                            // stay meaningful and everyNEvents rides the version delta.
-                            return ReactiveSnapshotSupport.maybeSaveBestEffort(store, streamId, snapshotView.schemaVersion(), policy,
-                                            new SnapshotDecision<>(current, tail, version, SnapshotSupport.requireInt(version - base.version(), "the number of events since the snapshot")))
-                                    .thenReturn(current);
-                        }))));
+                eventStore.read(streamId, SnapshotSupport.requireInt(base.version(), "the snapshot base stream version"), Integer.MAX_VALUE).flatMap(eventStream -> {
+                    // The tail is folded incrementally straight off the event flux with reduce, instead of collecting it
+                    // to a list first. The events are captured into a list as a side effect of that same pass since the
+                    // policy below needs them (for example onEvent inspects the tail's event types), so the events are
+                    // never held in memory twice.
+                    List<E> tail = new ArrayList<>();
+                    return eventStream.events()
+                            .map(converter::toDomainEvent)
+                            .doOnNext(tail::add)
+                            .reduce(base.state(), (state, event) -> snapshotView.view().evolve(state, event))
+                            .flatMap(current -> {
+                                long version = eventStream.version();
+                                // On the read side the policy sees the tail it folded as the "new events", so always()/onEvent(...)
+                                // stay meaningful and everyNEvents rides the version delta.
+                                return ReactiveSnapshotSupport.maybeSaveBestEffort(store, streamId, snapshotView.schemaVersion(), policy,
+                                                new SnapshotDecision<>(current, tail, version, SnapshotSupport.requireInt(version - base.version(), "the number of events since the snapshot")))
+                                        .thenReturn(current);
+                            });
+                })));
     }
 }

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Iterator;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -90,22 +91,30 @@ public interface View<S extends @Nullable Object, E> {
 
     /**
      * Evolve initial state from a lazily-produced stream of events, for example a query result. The stream
-     * is collected and folded into the state.
+     * is folded incrementally, one event at a time, without collecting it into a list first.
      *
      * @return The evolved state
      */
     default S evolve(@NonNull Stream<E> events) {
-        return evolve(events.toList());
+        return evolve(initialState(), events);
     }
 
     /**
-     * Evolve from an explicit state and a lazily-produced stream of events. The stream is collected and
-     * folded into the state.
+     * Evolve from an explicit state and a lazily-produced stream of events. The stream is folded
+     * incrementally, one event at a time, without collecting it into a list first.
      *
      * @return The evolved state
      */
     default S evolve(S state, @NonNull Stream<E> events) {
-        return evolve(state, events.toList());
+        S result = state;
+        try (events) {
+            // Fold sequentially in encounter order, since a view fold is order-dependent and a parallel forEach is not.
+            Iterator<E> iterator = events.iterator();
+            while (iterator.hasNext()) {
+                result = evolve(result, iterator.next());
+            }
+        }
+        return result;
     }
 
     static <S extends @Nullable Object, E> View<S, E> create(S initialState, @NonNull BiFunction<S, E, S> evolve) {

--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/ViewTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/ViewTest.kt
@@ -27,6 +27,7 @@ import org.occurrent.dsl.view.testsupport.NameState
 import org.occurrent.dsl.view.testsupport.nameChanged
 import org.occurrent.dsl.view.testsupport.nameDefined
 import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
 
 @DisplayNameGeneration(DisplayNameGenerator.Simple::class)
 class ViewTest {
@@ -212,6 +213,43 @@ class ViewTest {
 
             // Then
             assertThat(state).isEqualTo(NameState(userId, "name3"))
+        }
+
+        @Test
+        fun `evolve from a java Stream without initial state produces the same result as the List-based fold`() {
+            // Given
+            val userId = UUID.randomUUID().toString()
+            val events = listOf<DomainEvent>(
+                nameDefined(userId, "name1"),
+                nameChanged(userId, "name2"),
+                nameChanged(userId, "name3"),
+                nameChanged(userId, "name4"),
+                nameChanged(userId, "name5")
+            )
+
+            // When
+            val stateFromList = nullableView.evolve(events)
+            val stateFromStream = nullableView.evolve(events.stream())
+
+            // Then
+            assertThat(stateFromStream).isEqualTo(stateFromList)
+        }
+
+        @Test
+        fun `evolve from a java Stream without initial state closes the stream after folding`() {
+            // Given
+            val userId = UUID.randomUUID().toString()
+            val closed = AtomicBoolean(false)
+            val stream = listOf<DomainEvent>(
+                nameDefined(userId, "name1"),
+                nameChanged(userId, "name2")
+            ).stream().onClose { closed.set(true) }
+
+            // When
+            nullableView.evolve(stream)
+
+            // Then
+            assertThat(closed.get()).isTrue()
         }
 
     }
@@ -410,6 +448,43 @@ class ViewTest {
 
             // Then
             assertThat(state).isEqualTo(Defined(NameState(userId, "name2")))
+        }
+
+        @Test
+        fun `evolve from a java Stream with an explicit state produces the same result as the List-based fold`() {
+            // Given
+            val userId = UUID.randomUUID().toString()
+            val events = listOf<DomainEvent>(
+                nameDefined(userId, "name1"),
+                nameChanged(userId, "name2"),
+                nameChanged(userId, "name3"),
+                nameChanged(userId, "name4"),
+                nameChanged(userId, "name5")
+            )
+
+            // When
+            val stateFromList = nonNullableView.evolve(Name.Undefined, events)
+            val stateFromStream = nonNullableView.evolve(Name.Undefined, events.stream())
+
+            // Then
+            assertThat(stateFromStream).isEqualTo(stateFromList)
+        }
+
+        @Test
+        fun `evolve from a java Stream with an explicit state closes the stream after folding`() {
+            // Given
+            val userId = UUID.randomUUID().toString()
+            val closed = AtomicBoolean(false)
+            val stream = listOf<DomainEvent>(
+                nameDefined(userId, "name1"),
+                nameChanged(userId, "name2")
+            ).stream().onClose { closed.set(true) }
+
+            // When
+            nonNullableView.evolve(Name.Undefined, stream)
+
+            // Then
+            assertThat(closed.get()).isTrue()
         }
 
         @Test


### PR DESCRIPTION
The two design-surface items from the review that were kept out of the quick pre-release batch. The catch-up batching (P3) is deferred, see the end.

- On-demand `project(projection)` on a keyed projection folded every instance into one blended state and ignored the projection's id, silently producing a nonsense result (the write-side `materializedView` already rejects this shape). It now fails loud on a keyed projection, and there is a new `project(projection, instanceId)` overload that folds only that instance's events. Fixed on both the stream and DCB pull readers, blocking and reactor. A singleton projection is unaffected. (C4)
- `View.evolve(Stream)` folded by first collecting the whole stream into a list, so an on-demand read over a long history allocated the entire history at once. It now folds incrementally in one pass with no intermediate list, which is the path the on-demand `project()` uses. The snapshot `readState` tail is folded the same way (it still keeps the tail list where the snapshot policy needs to inspect it). (P2)

Deferred: the `@Projection` catch-up per-event read-modify-write (P3). Batching writes during the replay phase needs the catch-up model to tell the projection runner which phase a delivery is in, and that seam does not exist today. Adding it means changing the shared subscription infrastructure that every subscriber uses, which is out of proportion for this change. It is recorded as a follow-up with a concrete design (a delivery-phase signal, or an on-catch-up-complete callback on the catch-up model).

Unreleased, so no changelog.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"johan/post-030-review-dcb-throttle","parentHead":"7647c1ad5f3f985b1696179b6d7046509ea42e49","parentPull":343,"trunk":"main"}
```
-->
