### PR TITLE
Rename flow-saga goTo continuation to transitionTo

### DIFF
--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/Continuation.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/Continuation.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Where a flow saga goes after a branch, join, or timeout fires. It is data, not a value returned from a user lambda, so
- * the builder can validate the whole step graph (every {@link GoTo} target exists) and the graph can be rendered.
+ * the builder can validate the whole step graph (every {@link TransitionTo} target exists) and the graph can be rendered.
  */
 public sealed interface Continuation {
 
@@ -29,8 +29,8 @@ public sealed interface Continuation {
     }
 
     /** Jump to the named step. A back-edge (including to the current step) models a loop or a retry. */
-    record GoTo(String stepName) implements Continuation {
-        public GoTo {
+    record TransitionTo(String stepName) implements Continuation {
+        public TransitionTo {
             requireNonNull(stepName, "stepName cannot be null");
         }
     }
@@ -45,8 +45,8 @@ public sealed interface Continuation {
     }
 
     /** Jump to the named step. */
-    static Continuation goTo(String stepName) {
-        return new GoTo(stepName);
+    static Continuation transitionTo(String stepName) {
+        return new TransitionTo(stepName);
     }
 
     /** Complete the saga. */

--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSaga.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSaga.java
@@ -55,7 +55,7 @@ public final class FlowSaga {
 
     /**
      * Assembles a flow saga. Not thread-safe, configure it and call {@link #build()} once. {@code build()} validates the
-     * whole step graph: {@code startsOn} is required, every step name is unique, every {@code goTo} target exists, and
+     * whole step graph: {@code startsOn} is required, every step name is unique, every {@code transitionTo} target exists, and
      * every referenced event type has a correlation.
      *
      * @param <E> the domain event type
@@ -158,7 +158,7 @@ public final class FlowSaga {
                 stepsByName.put(step.name(), step);
             }
 
-            validateGoToTargets(stepsByName.keySet());
+            validateTransitionToTargets(stepsByName.keySet());
             Set<Class<? extends E>> eventTypes = collectEventTypes();
             validateCorrelationCoverage(eventTypes);
 
@@ -166,11 +166,11 @@ public final class FlowSaga {
                     correlators, Set.of(startType), eventTypes, historyWindow);
         }
 
-        private void validateGoToTargets(Set<String> stepNamesInGraph) {
+        private void validateTransitionToTargets(Set<String> stepNamesInGraph) {
             for (CompiledStep<E, C> step : steps) {
                 for (Continuation continuation : continuationsOf(step)) {
-                    if (continuation instanceof Continuation.GoTo goTo && !stepNamesInGraph.contains(goTo.stepName())) {
-                        throw new IllegalStateException("step '" + step.name() + "' has goTo(\"" + goTo.stepName()
+                    if (continuation instanceof Continuation.TransitionTo transitionTo && !stepNamesInGraph.contains(transitionTo.stepName())) {
+                        throw new IllegalStateException("step '" + step.name() + "' has transitionTo(\"" + transitionTo.stepName()
                                 + "\") but no such step is defined");
                     }
                 }

--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
@@ -206,7 +206,7 @@ final class FlowSagaImpl<E, C> implements Saga<E, FlowState<E>, C> {
                 }
                 yield new FlowState<>(null, retained, newWindowStart, newStepEntry, true, fromStep, kind, branchIndex);
             }
-            case Continuation.GoTo goTo -> new FlowState<>(goTo.stepName(), retained, newWindowStart, newStepEntry, false, fromStep, kind, branchIndex);
+            case Continuation.TransitionTo transitionTo -> new FlowState<>(transitionTo.stepName(), retained, newWindowStart, newStepEntry, false, fromStep, kind, branchIndex);
             case Continuation.End ignored -> new FlowState<>(null, retained, newWindowStart, newStepEntry, true, fromStep, kind, branchIndex);
         };
     }

--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -97,7 +97,7 @@ class StepScope<E : Any, C : Any> @PublishedApi internal constructor(@PublishedA
     val end: Continuation get() = Continuation.end()
 
     /** Continuation: jump to the named step (a back-edge models a loop or retry). */
-    fun goTo(step: String): Continuation = Continuation.goTo(step)
+    fun transitionTo(step: String): Continuation = Continuation.transitionTo(step)
 
     /** An expectation of [count] events of type [T], for a [join]. */
     inline fun <reified T : E> expect(count: Int = 1): Expectation<E> = Expectation(T::class.java, count)

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
@@ -83,7 +83,7 @@ class FlowSagaTest {
                         .on(PaymentReserved.class, Continuation.end(), p -> List.of(new ShipOrder(p.orderId())))
                         .on(PaymentFailed.class,
                                 (f, received) -> received.count(PaymentFailed.class) < 3,
-                                Continuation.goTo("awaiting-payment"),
+                                Continuation.transitionTo("awaiting-payment"),
                                 f -> List.of(new ReservePayment(f.orderId(), f.amount())))
                         .on(PaymentFailed.class, Continuation.end(), f -> List.of(new CancelOrder(f.orderId())))
                         .timeout(Duration.ofMinutes(30), Continuation.end(),
@@ -277,8 +277,8 @@ class FlowSagaTest {
                     .historyWindow(historyWindow)
                     .startsOn(Begin.class, Begin::id)
                     .correlate(Tick.class, Tick::id)
-                    .step("a", step -> step.on(Tick.class, Continuation.goTo("b"), t -> List.of()))
-                    .step("b", step -> step.on(Tick.class, Continuation.goTo("a"), t -> List.of()))
+                    .step("a", step -> step.on(Tick.class, Continuation.transitionTo("b"), t -> List.of()))
+                    .step("b", step -> step.on(Tick.class, Continuation.transitionTo("a"), t -> List.of()))
                     .build();
         }
 

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/AbsoluteTimeoutFlowSagaTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/AbsoluteTimeoutFlowSagaTest.kt
@@ -44,7 +44,7 @@ class AbsoluteTimeoutFlowSagaTest {
         startsOn<AuctionStarted>(correlatedBy = { it.auctionId })
         correlate<BidPlaced> { it.auctionId }
         step("bidding") {
-            on<BidPlaced>(then = goTo("bidding")) { }
+            on<BidPlaced>(then = transitionTo("bidding")) { }
             timeout(at = { received -> received.initiating<AuctionStarted>().endsAt }, then = end) { received ->
                 issue(CloseAuction(received.initiating<AuctionStarted>().auctionId))
             }

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensionsTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensionsTest.kt
@@ -263,7 +263,7 @@ class SagaFlowExtensionsTest {
             step("awaiting-payment") {
                 on<PaymentReserved>(then = end) { p -> issue(ShipOrder(p.orderId)) }
                 on<PaymentFailed>(
-                    then = goTo("awaiting-payment"),
+                    then = transitionTo("awaiting-payment"),
                     onlyIf = { _, r -> r.count<PaymentFailed>() < 3 }
                 ) { f -> issue(ReservePayment(f.orderId, f.amount)) }
                 on<PaymentFailed>(then = end) { f -> issue(CancelOrder(f.orderId)) }
@@ -482,13 +482,13 @@ class SagaFlowExtensionsTest {
         }
 
         @Test
-        fun `a goTo target that is not a declared step fails to build`() {
+        fun `a transitionTo target that is not a declared step fails to build`() {
             assertThatThrownBy {
                 saga<ValidationEvent, ValidationCommand> {
                     startsOn<Started>({ it.id })
                     correlate<Foo> { it.id }
                     step("first") {
-                        on<Foo>(then = goTo("does-not-exist")) {}
+                        on<Foo>(then = transitionTo("does-not-exist")) {}
                     }
                 }
             }.isInstanceOf(IllegalStateException::class.java)


### PR DESCRIPTION
This renames the flow-saga `goTo` continuation to `transitionTo`: the `Continuation.GoTo` record, its `goTo(..)` factory, and the Kotlin `StepScope.goTo` method. `transitionTo` reads as state-machine vocabulary alongside `next` and `end`, and unlike a lowercase `goto` it does not collide with Java's reserved keyword.

The docs counterpart lives in the held docs PR occurrent-org/occurrent-org.github.io#10.
