### PR TITLE
Rename the saga DSL 'machine core' surface to 'core'

### DIFF
--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/Expectation.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/Expectation.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * One requirement of a {@code join} step: how many events of a given type must arrive (since the step was entered) before
  * the join is fulfilled. The count is fixed at build time. A join with a runtime-varying count is a documented non-goal
- * of the flow layer (drop to the machine-core {@code Saga} for that).
+ * of the flow layer (drop to the core {@code Saga} for that).
  *
  * @param eventType the event type to wait for
  * @param count     how many are required (at least one)

--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSaga.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSaga.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Builds a flow saga: a linear, declarative process of steps, branches, joins and timeouts, which compiles down to the
- * machine-core {@code Saga<E, FlowState<E>, C>} the executor runs. Use it for the common case where a process moves
+ * core {@code Saga<E, FlowState<E>, C>} the executor runs. Use it for the common case where a process moves
  * through a small number of named steps. Drop to {@code Saga.builder(...)} for anything the flow model cannot express
  * (dynamic joins, accumulators, an event valid in every step).
  * <p>

--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
@@ -36,7 +36,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 /**
- * Compiles a flow definition (steps, branches, joins, timeouts) down to the machine-core {@link Saga} the executor runs.
+ * Compiles a flow definition (steps, branches, joins, timeouts) down to the core {@link Saga} the executor runs.
  * The step name is the persisted position, a timer is named {@code "step:" + stepName}, and because a timer lives only in
  * the saga's own state envelope (there is exactly one per name), a re-armed timer replaces the previous one and no
  * separate fencing is needed here.

--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -25,7 +25,7 @@ import java.util.function.Function
 
 /**
  * Marks the flow-saga builder receivers so that, inside a nested `step { }` block, a member of an outer scope (such as
- * `correlate`) does not resolve implicitly. This is a deliberate deviation from the non-nesting projection/machine DSLs,
+ * `correlate`) does not resolve implicitly. This is a deliberate deviation from the non-nesting projection/core DSLs,
  * which do not use a `@DslMarker`.
  */
 @DslMarker

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 /**
  * Covers the Java {@link FlowSaga} builder surface with the same order-fulfillment retry-loop scenario the Kotlin
  * {@code SagaFlowExtensionsTest} covers via the {@code saga { }} DSL, proving the lowering is correct through the
- * machine-core {@link Saga} contract regardless of which surface built it.
+ * core {@link Saga} contract regardless of which surface built it.
  */
 @DisplayName("FlowSaga")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensionsTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensionsTest.kt
@@ -30,7 +30,7 @@ import org.occurrent.dsl.saga.SagaTimeout
 import java.time.Duration
 
 /**
- * Proves that the flow DSL lowers to the machine-core [Saga] contract correctly: every assertion here goes through
+ * Proves that the flow DSL lowers to the core [Saga] contract correctly: every assertion here goes through
  * [Saga.step], [Saga.onStart], [Saga.react] and [Saga.isTerminal], never through some parallel notion of "what the flow
  * should do". [Saga.step] folds [Saga.evolve] and [Saga.react] but deliberately excludes [Saga.onStart] (see its
  * kdoc), so the effects of a start event are computed here as `onStart(s1, e) + react(s1, e)`, exactly as an executor

--- a/dsl/saga-dsl/mongodb-spring/src/main/java/org/occurrent/dsl/saga/mongodb/spring/SpringMongoSagaStateStore.java
+++ b/dsl/saga-dsl/mongodb-spring/src/main/java/org/occurrent/dsl/saga/mongodb/spring/SpringMongoSagaStateStore.java
@@ -54,12 +54,12 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
  * and the dedup watermarks. A top-level indexed {@code nextTimerFiresAt} (the earliest pending timer) makes
  * {@link #findWithDueTimers(Instant, int)} an indexed query.
  * <p>
- * State serialization: a machine-core saga's state is written with the application's {@code MongoConverter}, like the
+ * State serialization: a core saga's state is written with the application's {@code MongoConverter}, like the
  * snapshot store. A flow saga's state ({@code FlowState}) is written field by field, with its received domain events
  * serialized as CloudEvents through the supplied {@link CloudEventConverter} so they round-trip by their stable
  * {@code CloudEventTypeMapper} type rather than a Java class name. A domain event can therefore move to a different
  * package without breaking in-flight flow-saga state. Pass the converter (via the four-argument constructor) for a flow
- * saga, leave it out for a machine-core saga.
+ * saga, leave it out for a core saga.
  * <p>
  * {@link #compareAndSave} is atomic: a new instance is inserted (a duplicate {@code _id} loses), and an update replaces
  * the document only when its stored {@code version} still equals the expected one, via a single {@code findAndReplace}.
@@ -103,7 +103,7 @@ public final class SpringMongoSagaStateStore<S extends @Nullable Object> impleme
     private final @Nullable CloudEventConverter<Object> cloudEventConverter;
 
     /**
-     * Creates a store for a machine-core saga, whose state serializes with the application's {@code MongoConverter}.
+     * Creates a store for a core saga, whose state serializes with the application's {@code MongoConverter}.
      *
      * @param mongoOperations the {@link MongoOperations} used to read and write instance documents
      * @param collectionName  the collection the instances are stored in
@@ -116,7 +116,7 @@ public final class SpringMongoSagaStateStore<S extends @Nullable Object> impleme
     /**
      * Creates a store that, when {@code cloudEventConverter} is supplied, serializes a flow saga's {@code FlowState}
      * received events as CloudEvents so they round-trip by their stable CloudEvent type. Pass {@code null} for a
-     * machine-core saga.
+     * core saga.
      *
      * @param mongoOperations     the {@link MongoOperations} used to read and write instance documents
      * @param collectionName      the collection the instances are stored in
@@ -208,7 +208,7 @@ public final class SpringMongoSagaStateStore<S extends @Nullable Object> impleme
     }
 
     // Serialize the state. A flow saga's FlowState is written field by field with its received events as CloudEvents (see
-    // flowStateToDocument), so events round-trip by their stable CloudEvent type. Any other state (a machine-core saga's
+    // flowStateToDocument), so events round-trip by their stable CloudEvent type. Any other state (a core saga's
     // own model) goes through convertToMongoType, exactly like the snapshot store: a scalar stays a scalar and a
     // POJO/record becomes a sub-document.
     private Object toStateValue(S state) {

--- a/example/saga/order-fulfillment/src/main/java/org/occurrent/example/saga/orderfulfillment/core/OrderFulfillmentSaga.java
+++ b/example/saga/order-fulfillment/src/main/java/org/occurrent/example/saga/orderfulfillment/core/OrderFulfillmentSaga.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.example.saga.orderfulfillment.machine;
+package org.occurrent.example.saga.orderfulfillment.core;
 
 import org.occurrent.dsl.saga.Saga;
 import org.occurrent.dsl.saga.SagaEffect;
@@ -31,7 +31,7 @@ import java.time.Duration;
 import java.util.List;
 
 /**
- * The order-fulfillment process expressed with the machine-core {@link Saga} builder: an explicit, per-event-type fold
+ * The order-fulfillment process expressed with the core {@link Saga} builder: an explicit, per-event-type fold
  * and reaction over {@link OrderSagaState}. See {@code org.occurrent.example.saga.orderfulfillment.flow} for the same
  * process expressed with the declarative flow DSL instead.
  * <p>

--- a/example/saga/order-fulfillment/src/main/java/org/occurrent/example/saga/orderfulfillment/core/OrderSagaState.java
+++ b/example/saga/order-fulfillment/src/main/java/org/occurrent/example/saga/orderfulfillment/core/OrderSagaState.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package org.occurrent.example.saga.orderfulfillment.machine;
+package org.occurrent.example.saga.orderfulfillment.core;
 
 /**
- * The machine-core saga instance state: an order awaiting payment, shipped, or cancelled. The initial state (before
+ * The core saga instance state: an order awaiting payment, shipped, or cancelled. The initial state (before
  * {@code OrderPlaced} is applied) is plain {@code null}, as in {@code Saga.builder(null)}.
  */
 public sealed interface OrderSagaState permits AwaitingPayment, Completed, Cancelled {

--- a/example/saga/order-fulfillment/src/main/kotlin/org/occurrent/example/saga/orderfulfillment/flow/OrderFulfillmentFlowSaga.kt
+++ b/example/saga/order-fulfillment/src/main/kotlin/org/occurrent/example/saga/orderfulfillment/flow/OrderFulfillmentFlowSaga.kt
@@ -31,7 +31,7 @@ import org.occurrent.example.saga.orderfulfillment.ShipOrder
 import java.time.Duration
 
 /**
- * The same order-fulfillment process as [org.occurrent.example.saga.orderfulfillment.machine.OrderFulfillmentSaga],
+ * The same order-fulfillment process as [org.occurrent.example.saga.orderfulfillment.core.OrderFulfillmentSaga],
  * expressed instead with the declarative Kotlin flow `saga { }` block: one step, two branches and a timeout, rather than
  * an explicit per-event-type fold and reaction.
  */

--- a/example/saga/order-fulfillment/src/test/java/org/occurrent/example/saga/orderfulfillment/core/OrderFulfillmentSagaTest.java
+++ b/example/saga/order-fulfillment/src/test/java/org/occurrent/example/saga/orderfulfillment/core/OrderFulfillmentSagaTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.example.saga.orderfulfillment.machine;
+package org.occurrent.example.saga.orderfulfillment.core;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
  * Runs {@link OrderFulfillmentSaga} through {@link SagaRunner}, showing the decider-free dispatch path first (a plain
  * lambda over an {@code ApplicationService}) and the decider adapter as an alternative.
  */
-@DisplayName("Machine-core order-fulfillment saga")
+@DisplayName("Core order-fulfillment saga")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class OrderFulfillmentSagaTest {
 

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Saga.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Saga.java
@@ -55,7 +55,7 @@ import java.lang.annotation.*;
  * The {@link #store()} attribute selects the {@code SagaStateStore} bean by type, {@link #storeName()} by name (or both to
  * disambiguate). With both unset, the store resolves by convention: the unique {@code SagaStateStore} bean, otherwise the
  * default MongoDB implementation (a {@code saga-<id>} collection), whose state type is read from the factory method's
- * generic return type. A machine-core saga's state serializes with the application's {@code MongoConverter}, like the
+ * generic return type. A core saga's state serializes with the application's {@code MongoConverter}, like the
  * snapshot store. A flow saga's received events serialize as CloudEvents through the {@code CloudEventConverter}, so they
  * persist by their stable {@code CloudEventTypeMapper} type and a domain event can move to a different package without
  * breaking in-flight saga state.


### PR DESCRIPTION
Renames the saga DSL's low-level authoring surface from "machine core" to "core", so it reads as the plain counterpart to the flow DSL rather than something mechanical. This matches the docs rename (the "The Core DSL" section on the held `docs/saga-dsl` branch).

It is text and one example package rename, no API change:

- javadoc, kdoc, a comment, and a `@DisplayName` drop "machine-core" for "core" across the saga DSL, the annotations module, the Spring Mongo state store, and the order-fulfillment example.
- the order-fulfillment example's Java package moves from `...orderfulfillment.machine` to `...orderfulfillment.core`, so it pairs with the Kotlin `flow` package. The `OrderFulfillmentFlowSaga` kdoc link that pointed at the old package is updated.

All unreleased (0.31.0), and the package is example-only, so no published coordinate changes and nothing to migrate.

Verified: `mvn -Pexamples-module -DskipTests install` of the saga DSL, annotations, state store, and example modules is green, and the order-fulfillment example tests pass (4/4).
