### PR TITLE
Move the saga CompetingConsumerStrategy onto the SagaRunner

### DIFF
--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
@@ -161,19 +161,21 @@ public final class SagaRunner<E, C> {
 
         // Register the poller as a competing consumer under its own lease key, then poll only while this instance holds it.
         // hasLock is an in-memory check the strategy's background refresh maintains, so a standby instance costs no query.
-        final CompetingConsumerStrategy strategy = competingConsumerStrategy;
-        final String leaseKey;
-        final String holderId;
+        final @Nullable CompetingConsumerStrategy strategy = competingConsumerStrategy;
+        final @Nullable String leaseKey;
+        final @Nullable String holderId;
         final Runnable pollTask;
         if (strategy != null) {
-            leaseKey = timerLeaseKey(subscriptionId);
-            holderId = UUID.randomUUID().toString();
-            strategy.registerCompetingConsumer(leaseKey, holderId);
+            String key = timerLeaseKey(subscriptionId);
+            String holder = UUID.randomUUID().toString();
+            strategy.registerCompetingConsumer(key, holder);
             pollTask = () -> {
-                if (strategy.hasLock(leaseKey, holderId)) {
+                if (strategy.hasLock(key, holder)) {
                     execution.pollTimers();
                 }
             };
+            leaseKey = key;
+            holderId = holder;
         } else {
             leaseKey = null;
             holderId = null;

--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
@@ -92,21 +92,35 @@ public final class SagaRunner<E, C> {
     private final Subscribable subscriptionModel;
     private final CloudEventConverter<E> cloudEventConverter;
     private final Function<Filter, SubscriptionFilter> toSubscriptionFilter;
+    private final @Nullable CompetingConsumerStrategy competingConsumerStrategy;
 
-    private SagaRunner(Subscribable subscriptionModel, CloudEventConverter<E> cloudEventConverter, Function<Filter, SubscriptionFilter> toSubscriptionFilter) {
+    private SagaRunner(Subscribable subscriptionModel, CloudEventConverter<E> cloudEventConverter, Function<Filter, SubscriptionFilter> toSubscriptionFilter,
+                       @Nullable CompetingConsumerStrategy competingConsumerStrategy) {
         this.subscriptionModel = requireNonNull(subscriptionModel, "subscriptionModel cannot be null");
         this.cloudEventConverter = requireNonNull(cloudEventConverter, "cloudEventConverter cannot be null");
         this.toSubscriptionFilter = requireNonNull(toSubscriptionFilter, "toSubscriptionFilter cannot be null");
+        this.competingConsumerStrategy = competingConsumerStrategy;
     }
 
     /** A runner whose subscription is capability-agnostic: it delivers both stream-written and DCB-appended events. */
     public static <E, C> SagaRunner<E, C> agnostic(Subscribable subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
-        return new SagaRunner<>(subscriptionModel, cloudEventConverter, AgnosticSubscriptionFilter::filter);
+        return new SagaRunner<>(subscriptionModel, cloudEventConverter, AgnosticSubscriptionFilter::filter, null);
     }
 
     /** A runner whose subscription is scoped to the {@code STREAM} capability, excluding DCB-appended events. */
     public static <E, C> SagaRunner<E, C> stream(Subscribable subscriptionModel, CloudEventConverter<E> cloudEventConverter) {
-        return new SagaRunner<>(subscriptionModel, cloudEventConverter, StreamSubscriptionFilter::filter);
+        return new SagaRunner<>(subscriptionModel, cloudEventConverter, StreamSubscriptionFilter::filter, null);
+    }
+
+    /**
+     * Returns a copy of this runner whose saga timer poller is coordinated by {@code strategy}. Only the instance that
+     * currently holds the saga's timer lease polls the store for due timers, the others wake on their interval and do
+     * nothing without querying it. Without a strategy (the default) every instance polls. The lease is released on
+     * {@link SagaSubscription#close()}.
+     */
+    public SagaRunner<E, C> competingConsumerStrategy(CompetingConsumerStrategy strategy) {
+        return new SagaRunner<>(subscriptionModel, cloudEventConverter, toSubscriptionFilter,
+                requireNonNull(strategy, "competingConsumerStrategy cannot be null"));
     }
 
     /** Runs {@code saga} with the default configuration, starting at the subscription model's default position. */
@@ -125,25 +139,13 @@ public final class SagaRunner<E, C> {
     /**
      * Runs {@code saga}. It subscribes with a filter derived from the saga's handled event types, builds per-instance
      * state in {@code stateStore}, dispatches issued commands through {@code commandDispatcher}, and starts a timer
-     * poller that runs on every instance. The returned {@link SagaSubscription} is already started.
+     * poller. If a {@link #competingConsumerStrategy(CompetingConsumerStrategy) competing-consumer strategy} was set on
+     * this runner, only the instance holding the saga's timer lease polls the store, otherwise every instance polls.
+     * The returned {@link SagaSubscription} is already started, and releases the lease on {@link SagaSubscription#close()}.
      */
     public <S extends @Nullable Object> SagaSubscription run(String subscriptionId, Saga<E, S, C> saga,
                                                              SagaStateStore<S> stateStore, CommandDispatcher<C> commandDispatcher,
                                                              @Nullable StartAt startAt, SagaRunnerConfig config) {
-        return run(subscriptionId, saga, stateStore, commandDispatcher, startAt, config, null);
-    }
-
-    /**
-     * Runs {@code saga} with the timer poller coordinated by {@code competingConsumerStrategy}. Only the instance that
-     * currently holds the saga's timer lease polls the store for due timers. The others wake on their interval and do
-     * nothing without querying it. Pass {@code null} to poll on every instance, which is what the shorter overloads do.
-     * The lease is released on {@link SagaSubscription#close()}. Everything else matches
-     * {@link #run(String, Saga, SagaStateStore, CommandDispatcher, StartAt, SagaRunnerConfig)}.
-     */
-    public <S extends @Nullable Object> SagaSubscription run(String subscriptionId, Saga<E, S, C> saga,
-                                                             SagaStateStore<S> stateStore, CommandDispatcher<C> commandDispatcher,
-                                                             @Nullable StartAt startAt, SagaRunnerConfig config,
-                                                             @Nullable CompetingConsumerStrategy competingConsumerStrategy) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(saga, "saga cannot be null");
         requireNonNull(stateStore, "stateStore cannot be null");
@@ -159,15 +161,16 @@ public final class SagaRunner<E, C> {
 
         // Register the poller as a competing consumer under its own lease key, then poll only while this instance holds it.
         // hasLock is an in-memory check the strategy's background refresh maintains, so a standby instance costs no query.
+        final CompetingConsumerStrategy strategy = competingConsumerStrategy;
         final String leaseKey;
         final String holderId;
         final Runnable pollTask;
-        if (competingConsumerStrategy != null) {
+        if (strategy != null) {
             leaseKey = timerLeaseKey(subscriptionId);
             holderId = UUID.randomUUID().toString();
-            competingConsumerStrategy.registerCompetingConsumer(leaseKey, holderId);
+            strategy.registerCompetingConsumer(leaseKey, holderId);
             pollTask = () -> {
-                if (competingConsumerStrategy.hasLock(leaseKey, holderId)) {
+                if (strategy.hasLock(leaseKey, holderId)) {
                     execution.pollTimers();
                 }
             };
@@ -180,7 +183,7 @@ public final class SagaRunner<E, C> {
         ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(daemonThreadFactory("occurrent-saga-timer-" + subscriptionId));
         long intervalMillis = config.timerPollInterval().toMillis();
         poller.scheduleWithFixedDelay(pollTask, intervalMillis, intervalMillis, TimeUnit.MILLISECONDS);
-        return new SagaSubscription(subscription, poller, competingConsumerStrategy, leaseKey, holderId);
+        return new SagaSubscription(subscription, poller, strategy, leaseKey, holderId);
     }
 
     /**

--- a/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/SagaRunnerTest.java
+++ b/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/SagaRunnerTest.java
@@ -516,10 +516,26 @@ class SagaRunnerTest {
 
         private SagaSubscription run(String subscriptionId, SagaStateStore<OrderState> stateStore,
                                     CommandDispatcher<OrderCommand> dispatcher, CompetingConsumerStrategy strategy) {
-            SagaRunner<OrderEvent, OrderCommand> runner = SagaRunner.agnostic(subscriptionModel, converter);
-            SagaSubscription subscription = runner.run(subscriptionId, orderFulfillment(LONG_PAYMENT_TIMEOUT), stateStore, dispatcher, null, FAST, strategy);
+            SagaRunner<OrderEvent, OrderCommand> runner = SagaRunner.<OrderEvent, OrderCommand>agnostic(subscriptionModel, converter)
+                    .competingConsumerStrategy(strategy);
+            SagaSubscription subscription = runner.run(subscriptionId, orderFulfillment(LONG_PAYMENT_TIMEOUT), stateStore, dispatcher, null, FAST);
             subscriptionsToClose.add(subscription);
             return subscription;
+        }
+
+        @Test
+        void competingConsumerStrategy_returns_a_distinct_runner_without_mutating_the_original() {
+            SagaRunner<OrderEvent, OrderCommand> base = SagaRunner.agnostic(subscriptionModel, converter);
+            SagaRunner<OrderEvent, OrderCommand> gated = base.competingConsumerStrategy(new StubStrategy(true));
+            assertThat(gated).isNotSameAs(base);
+        }
+
+        @Test
+        void competingConsumerStrategy_rejects_a_null_strategy() {
+            SagaRunner<OrderEvent, OrderCommand> runner = SagaRunner.agnostic(subscriptionModel, converter);
+            assertThatThrownBy(() -> runner.competingConsumerStrategy(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("competingConsumerStrategy");
         }
 
         @Test

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -754,9 +754,12 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         boolean stream = annotation.capability() == org.occurrent.annotation.Capability.STREAM;
         SagaRunner<E, C> runner = stream ? SagaRunner.stream(subscribable, converter) : SagaRunner.agnostic(subscribable, converter);
         CompetingConsumerStrategy competingConsumerStrategy = resolveSagaCompetingConsumerStrategy();
+        if (competingConsumerStrategy != null) {
+            runner = runner.competingConsumerStrategy(competingConsumerStrategy);
+        }
 
         applyStartupWorkarounds();
-        sagaSubscriptions.add(runner.run(id, saga, stateStore, commandDispatcher, startAt, config, competingConsumerStrategy));
+        sagaSubscriptions.add(runner.run(id, saga, stateStore, commandDispatcher, startAt, config));
     }
 
     // Gate the saga timer poller on the shared competing-consumer lease so only one instance polls, mirroring the


### PR DESCRIPTION
Moves the saga `CompetingConsumerStrategy` off `SagaRunner.run(...)` and onto the runner itself, via a fluent `competingConsumerStrategy(strategy)`:

```kotlin
SagaRunner.agnostic<OrderEvent, OrderCommand>(subscriptionModel, converter)
    .competingConsumerStrategy(strategy)
    .run("order-fulfillment", saga, stateStore, dispatcher)
```

The strategy gates the saga's timer-poller lease. It is infrastructure with a lifecycle, in the same category as the `Subscribable` and the `CloudEventConverter` that already sit on the `agnostic(...)`/`stream(...)` factory, so it belongs to the runner, not to a single `run` call. The old placement, a trailing `@Nullable` argument, also forced a four-overload `run(...)` chain and a seven-argument multi-instance call. The method returns an immutable copy, so a runner stays reusable, and `run(...)` drops from four overloads to three, none carrying the strategy.

The `@Saga` starter applies the strategy through the new method when competing consumers are enabled (`occurrent.saga.competing-consumer.enabled`, default on), and leaves the runner ungated otherwise, exactly as before.

I did not add auto-detection of the strategy from the subscription model. `CompetingConsumerSubscriptionModel` keeps its strategy private with no accessor, so detection would need a new public getter, recursive unwrapping of nested subscription-model decorators, and a new module dependency from the saga DSL, and it would silently leave the poller ungated whenever a wrapper hid the model. Passing it explicitly is clearer and the starter already holds the strategy as a bean.

All unreleased (0.31.0), so no migration. The saga docs on the held `docs/saga-dsl` branch are updated to match.

Verified: `saga-dsl/blocking` 19 tests green (including the rewritten timer-gating tests and a new immutability plus null-rejection test), the blocking Spring starter compiles against the new API, the order-fulfillment example is green, and `mvn -Pexamples-module -DskipTests install` is green.
