### PR TITLE
Fix ApplicationContext load failure when occurrent.event-store.stream.position is unset

### DIFF
--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -118,9 +118,9 @@ public class OccurrentMongoAutoConfiguration<E> {
         // The property is only applied when set. true enables position explicitly (kept on even for an unpositioned
         // store), false opts a STREAM-only store out. withoutStreamPosition() is rejected with DCB, so skip it then.
         Boolean streamPosition = eventStoreProperties.getStream().getPosition();
-        if (streamPosition) {
+        if (Boolean.TRUE.equals(streamPosition)) {
             builder.withStreamPosition();
-        } else if (!eventStoreProperties.getCapabilities().contains(EventStoreCapability.DCB)) {
+        } else if (Boolean.FALSE.equals(streamPosition) && !eventStoreProperties.getCapabilities().contains(EventStoreCapability.DCB)) {
             builder.withoutStreamPosition();
         }
         return builder.build();

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
@@ -165,6 +165,39 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
     }
 
     @Test
+    void leaves_stream_position_at_its_default_when_the_position_property_is_unset() {
+        eventStoreConfigContextRunner().run(context -> {
+            EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
+
+            assertThat(eventStoreConfig.streamPositionEnabled).isTrue();
+            assertThat(eventStoreConfig.streamPositionExplicitlyEnabled).isFalse();
+        });
+    }
+
+    @Test
+    void enables_stream_position_explicitly_when_the_position_property_is_true() {
+        eventStoreConfigContextRunner()
+                .withPropertyValues("occurrent.event-store.stream.position=true")
+                .run(context -> {
+                    EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
+
+                    assertThat(eventStoreConfig.streamPositionEnabled).isTrue();
+                    assertThat(eventStoreConfig.streamPositionExplicitlyEnabled).isTrue();
+                });
+    }
+
+    @Test
+    void opts_a_stream_store_out_of_position_when_the_position_property_is_false() {
+        eventStoreConfigContextRunner()
+                .withPropertyValues("occurrent.event-store.stream.position=false")
+                .run(context -> {
+                    EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
+
+                    assertThat(eventStoreConfig.streamPositionEnabled).isFalse();
+                });
+    }
+
+    @Test
     void binds_dcb_only_event_store_capability() {
         contextRunner.withPropertyValues("occurrent.event-store.capabilities=dcb").run(context -> {
             OccurrentProperties properties = context.getBean(OccurrentProperties.class);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfigurationCharacterizationTest.java
@@ -198,6 +198,21 @@ class OccurrentMongoAutoConfigurationCharacterizationTest {
     }
 
     @Test
+    void ignores_a_false_position_property_when_dcb_is_enabled_so_the_context_still_loads() {
+        eventStoreConfigContextRunner()
+                .withPropertyValues(
+                        "occurrent.event-store.capabilities=stream,dcb",
+                        "occurrent.event-store.stream.position=false")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    EventStoreConfig eventStoreConfig = context.getBean(EventStoreConfig.class);
+
+                    // withoutStreamPosition() is rejected with DCB, so a false property is skipped and the default stands.
+                    assertThat(eventStoreConfig.streamPositionEnabled).isTrue();
+                });
+    }
+
+    @Test
     void binds_dcb_only_event_store_capability() {
         contextRunner.withPropertyValues("occurrent.event-store.capabilities=dcb").run(context -> {
             OccurrentProperties properties = context.getBean(OccurrentProperties.class);


### PR DESCRIPTION
The Mongo Spring Boot starter fails to start whenever `occurrent.event-store.stream.position` is left unset, which is the default for most apps. `OccurrentMongoAutoConfiguration` unboxed the property with `if (streamPosition)`, and an unset property is null, so the `EventStoreConfig` bean threw a `NullPointerException` and the whole ApplicationContext failed to load. That is why `main` is currently red on the `framework` and `example-domain` CI shards.

The reactive `OccurrentReactiveMongoAutoConfiguration` already handles this correctly, and the code comment on the blocking side already describes the intended behavior. I brought the blocking code in line: null leaves the `EventStoreConfig` default, `true` enables stream position explicitly, and `false` opts a STREAM-only store out (skipped under DCB).

Added characterization tests for the unset, true, and false cases. I ran the autoconfiguration test locally (25 green). The Mongo integration tests in this module could not run on my machine because of a local Testcontainers socket-mount quirk unrelated to the change, so CI is the check for those.
