### PR TITLE
Document why the DCB snapshot key is derived from the criteria, not the decider

### DIFF
--- a/doc/architecture/decisions/0061-first-class-snapshot-support.md
+++ b/doc/architecture/decisions/0061-first-class-snapshot-support.md
@@ -138,6 +138,45 @@ back to the same or a higher version, without deleting the snapshot, is indistin
 version alone, and the guard trusts it. Version comparison detects one specific shape of reset, it is not a general content
 check. The operational rule stands regardless of the guard: delete the snapshot on every reset.
 
+## Amendment (2026-07-24): the DCB snapshot key is derived from the criteria, not the decider
+
+The original decision stated that the DCB snapshot key defaults to a canonical form of the command's `DcbCriteria`,
+with an override hook, but it did not record why the key is a function of the criteria rather than of the decider.
+This amendment records that reasoning, because keying by the decider is a tempting change that would be a correctness
+regression, not an ergonomic win.
+
+**The decider carries no per-instance identity; the criteria does.** A `DcbDecider` (and the `SnapshotDcbDecider`
+spec that wraps it) is a per-type constant, constructed once and reused for every instance through the one shared
+executor. Per-instance identity enters only through the command, and `DcbDecider.criteriaFor(command)` turns it into a
+per-instance boundary, for example `DcbCriteria.tagsAnyOf(course(command.courseId), student(command.studentId))`. Two
+instances of the same decider resolve to different criteria, hence different canonical keys, hence separate snapshots.
+A key function that received the decider would get the same object for every instance, so it could only produce a
+per-type name, collapsing all instances into one snapshot slot. One instance's folded state would overwrite another's,
+and a resume would load the wrong instance's state. That is silent cross-instance corruption.
+
+**A criteria change is a boundary change, and invalidating the snapshot is the safety behavior, not a flaw.** The
+snapshot is the fold of criteria-matching events up to a stored global position, and a resume reads only the events
+after that position that match the same criteria and folds them onto the snapshot state. If the boundary definition
+changes (a DCB business-rule change), the set of events that fold into the state changes, so the stored fold is over a
+different set. Resuming from it would combine an old-criteria fold up to the stored position with new-criteria events
+after it, producing a silently wrong state. Because the key is derived from the criteria (its types, tags, and excluded
+types), a boundary change yields a new key, the old snapshot is not found, and the state rebuilds from scratch, which
+is correct. A key that stayed stable across a boundary change, such as a decider name or a value taken only from the
+command, would defeat this and resume over the wrong event set. `schemaVersion` does not cover this case: it guards the
+state shape, not which events were folded, so the criteria-derived key is the only automatic guard for a boundary
+change.
+
+**Order-insensitivity keeps this from over-invalidating.** `DcbSnapshotKeys.canonicalKey` sorts every part of the
+criteria, so a cosmetic refactor that resolves to the same tags and types produces the same key and does not rebuild.
+Only a semantically different boundary changes the key.
+
+**Readable keys without losing the guarantee.** The override hook stays a `Function<DcbCriteria, String>`. Because the
+spec is built per type, a caller that wants a human-readable key already knows the type name and can prepend it while
+keeping the full criteria, for example
+`SnapshotDcbDecider.from(decider, store, options, criteria -> "enrollment:" + DcbSnapshotKeys.canonicalKey(criteria))`.
+A custom key that drops the boundary detail for brevity is allowed, but it trades away the automatic boundary-change
+invalidation, so it must be paired with a manual key or `schemaVersion` change when the boundary changes.
+
 ## Consequences
 
 - Snapshots are entirely opt-in. An application that does not use them pays nothing, because `fromStreamVersion` and

--- a/doc/architecture/decisions/0069-programmatic-snapshot-facade-and-per-aggregate-spec.md
+++ b/doc/architecture/decisions/0069-programmatic-snapshot-facade-and-per-aggregate-spec.md
@@ -70,7 +70,9 @@ views.refresh(accountId, accountSource);                                        
 - `SnapshotDcbDecider<C,S,E>` bundles a `DcbDecider` with its `SnapshotStore`, `SnapshotOptions`, and the function that
   turns the resolved `DcbCriteria` into a snapshot key. `from(dcbDecider, store, options)` defaults the key function to
   `DcbSnapshotKeys::canonicalKey`; a four-argument `from` overload takes an explicit one. The key function moved off the
-  executor constructor and onto the spec, since it is per-aggregate.
+  executor constructor and onto the spec, since it is per-aggregate. Its input stays the `DcbCriteria`, not the decider;
+  the 2026-07-24 amendment to [ADR 0061](0061-first-class-snapshot-support.md) records why (per-instance identity and
+  boundary-change invalidation both live in the criteria).
 - `SnapshotViewSource<S,E>` bundles a `SnapshotView` with its `SnapshotStore`. It is named to stay distinct from
   `SnapshotView` (the fold) and `SnapshotViews` (the facade).
 

--- a/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDcbDecider.java
+++ b/dsl/snapshot-dsl/blocking/src/main/java/org/occurrent/dsl/snapshot/blocking/SnapshotDcbDecider.java
@@ -37,6 +37,10 @@ import java.util.function.Function;
  * canonical, order-insensitive rendering of the {@link DcbCriteria} ({@link DcbSnapshotKeys#canonicalKey(DcbCriteria)});
  * use {@link #from(DcbDecider, SnapshotStore, SnapshotOptions, Function)} to override it.
  * <p>
+ * The key is a function of the {@link DcbCriteria}, not of the decider. The criteria carries the per-instance identity
+ * (the decider is a per-type constant reused across instances), and a change to it is the signal to rebuild a stale
+ * snapshot, so a custom key function should stay keyed on the criteria. See ADR 0061 for the full rationale.
+ * <p>
  * Like {@link SnapshotDecider}, this is not a pure value: it holds the {@link SnapshotStore}. The spec stays inert and
  * the {@link SnapshotDcbDeciderApplicationService} performs all I/O.
  *

--- a/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/DcbSnapshotKeys.java
+++ b/dsl/snapshot-dsl/common/src/main/java/org/occurrent/dsl/snapshot/DcbSnapshotKeys.java
@@ -37,6 +37,10 @@ import static java.util.stream.Collectors.joining;
  * encoding injective, so two structurally distinct criteria always produce different keys instead of colliding on one
  * snapshot (for example a single type named {@code "A,B"} and the two types {@code "A"} and {@code "B"}, which would
  * both render as {@code types[A,B]} without the length prefix).
+ * <p>
+ * The DCB snapshot is keyed by the criteria (rather than by the decider) on purpose: the criteria carries the
+ * per-instance identity, and a change to the boundary is what should invalidate and rebuild a stale snapshot. See ADR
+ * 0061 for the full rationale.
  */
 public final class DcbSnapshotKeys {
 

--- a/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDcbDecider.java
+++ b/dsl/snapshot-dsl/reactor/src/main/java/org/occurrent/dsl/snapshot/reactor/ReactiveSnapshotDcbDecider.java
@@ -36,6 +36,10 @@ import java.util.function.Function;
  * ({@link DcbSnapshotKeys#canonicalKey(DcbCriteria)}); use
  * {@link #from(DcbDecider, ReactiveSnapshotStore, SnapshotOptions, Function)} to override it. The spec holds the
  * {@link ReactiveSnapshotStore}, so it is not a pure value; it stays inert and the executor performs all I/O.
+ * <p>
+ * The key is a function of the {@link DcbCriteria}, not of the decider. The criteria carries the per-instance identity
+ * (the decider is a per-type constant reused across instances), and a change to it is the signal to rebuild a stale
+ * snapshot, so a custom key function should stay keyed on the criteria. See ADR 0061 for the full rationale.
  *
  * @param dcbDecider  the decision logic paired with its DCB read boundary and write tags
  * @param store       the snapshot store for this aggregate's state


### PR DESCRIPTION
A question came up about whether the DCB snapshot key function should take the `DcbDecider` instead of the `DcbCriteria`, so a decider could carry a stable, human-readable name that survives criteria changes. It should not, and this records why, so the decision is not quietly reversed later.

The decider is a per-type constant, reused for every instance, so the per-instance identity lives only in the command-derived `DcbCriteria`. Keying by the decider would collapse all instances of a type into one snapshot slot. And a criteria change is a boundary change that alters which events fold into the state, so the criteria-derived key going stale (and rebuilding) is the safety behavior, not a flaw. `schemaVersion` only guards the state shape, not the folded event set.

The rationale lives in a dated amendment to ADR 0061 (which owns the DCB-key decision), with a cross-reference from ADR 0069 and terse "see ADR 0061" pointers in the `SnapshotDcbDecider` / `ReactiveSnapshotDcbDecider` and `DcbSnapshotKeys` javadoc. No API or behavior change: `keyFunction` stays `Function<DcbCriteria, String>`.

A short operational note for users is held separately on the `docs/snapshot-support` docs branch.
