### PR TITLE
Fix metadata-keyed projections mis-keying every replayed event on the reactor stack

### DIFF
--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
@@ -95,7 +95,7 @@ class CatchupProjectionFeedTest {
     }
 
     @Test
-    void a_live_domain_event_is_folded_with_empty_metadata_so_a_metadata_keyed_projection_fails_loud() {
+    void a_live_domain_event_is_folded_with_empty_metadata_so_a_stream_id_keyed_projection_throws() {
         InMemoryEventStore store = new InMemoryEventStore();
         CloudEventConverter<Counted> converter = countedConverter();
         store.write("s", converter.toCloudEvents(List.of(new Counted("1"), new Counted("2"))));
@@ -111,9 +111,10 @@ class CatchupProjectionFeedTest {
         feed.catchUp();
 
         // Metadata exists only where an event arrives as a CloudEvent. A live domain event has none, so it folds with
-        // EventMetadata.empty() and a projection keyed off metadata fails loud here rather than writing a wrong key.
-        // Pinned deliberately: driving a metadata-keyed projection from a domain-event feed is not supported live, and
-        // the reactor feed behaves identically. Change this test only alongside a decision to support it.
+        // EventMetadata.empty(). Keying on getStreamId() throws, because that accessor requires the extension to be
+        // present. This is not a general "fails loud" guarantee: getPosition() returns null on empty metadata, and a
+        // null id means "skip this event", so a position-keyed projection drops every live event silently instead.
+        // Both are the same unsupported combination, tracked in issue 389. The reactor feed behaves identically.
         assertThatThrownBy(() -> feed.accept(new Counted("3")))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("streamId extension is absent");

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.eventstore.api.PositionRange;
@@ -41,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -84,9 +86,37 @@ class CatchupProjectionFeedTest {
 
         feed.catchUp();
 
-        // The instance is keyed under the stream id "s" (from metadata) and holds a real, non-null position.
-        assertThat(repo).containsKey("s");
-        assertThat(repo.get("s")).isNotNull();
+        // Keyed under the stream id "s" from the metadata, folded to the last replayed event's position rather than to
+        // the 0 that an empty-metadata fold would leave behind.
+        long lastPosition = store.read("s").eventList().stream()
+                .mapToLong(cloudEvent -> EventMetadata.from(cloudEvent).getPosition()).max().orElseThrow();
+        assertThat(repo).containsOnlyKeys("s");
+        assertThat(repo.get("s")).isEqualTo(lastPosition);
+    }
+
+    @Test
+    void a_live_domain_event_is_folded_with_empty_metadata_so_a_metadata_keyed_projection_fails_loud() {
+        InMemoryEventStore store = new InMemoryEventStore();
+        CloudEventConverter<Counted> converter = countedConverter();
+        store.write("s", converter.toCloudEvents(List.of(new Counted("1"), new Counted("2"))));
+
+        ConcurrentHashMap<String, Long> repo = new ConcurrentHashMap<>();
+        ViewStateRepository<Long, String> repository = ViewStateRepository.create(repo::get, repo::put);
+        Projection<Long, Counted, String> projection = Projection.<Long, Counted, String>builder(0L)
+                .id((metadata, event) -> metadata.getStreamId())
+                .on(Counted.class, (state, metadata, event) -> metadata.getPosition())
+                .build();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "positions", projection, repository, store, converter, Counted::eventId, null);
+        feed.catchUp();
+
+        // Metadata exists only where an event arrives as a CloudEvent. A live domain event has none, so it folds with
+        // EventMetadata.empty() and a projection keyed off metadata fails loud here rather than writing a wrong key.
+        // Pinned deliberately: driving a metadata-keyed projection from a domain-event feed is not supported live, and
+        // the reactor feed behaves identically. Change this test only alongside a decision to support it.
+        assertThatThrownBy(() -> feed.accept(new Counted("3")))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("streamId extension is absent");
     }
 
     @Test

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeed.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeed.java
@@ -16,9 +16,11 @@
 
 package org.occurrent.dsl.projection.reactor;
 
+import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.projection.internal.BoundedIdCache;
 import org.occurrent.dsl.projection.internal.ProjectionFilters;
@@ -38,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -55,6 +58,11 @@ import java.util.function.Function;
  * Contract (see ADR 62): catch-up is Occurrent's job, live-resume is the broker's. A live event's {@code accept}
  * {@link Mono} completes only after its handler runs, so the listener can acknowledge after processing. Delivery is
  * at-least-once, so the fold must be idempotent. The buffer is bounded and fails loud on overflow.
+ * <p>
+ * The replay decodes CloudEvents, so {@link EventMetadata} is available there and is folded with the event. A live
+ * domain event arrives with no CloudEvent behind it and is folded with {@link EventMetadata#empty()}. A projection
+ * keyed by metadata therefore resolves its instance from the metadata during the replay and from the event alone once
+ * live, the same split as the blocking {@code CatchupProjectionFeed}.
  */
 @NullMarked
 public final class CatchupProjectionFeed<E> {
@@ -62,13 +70,14 @@ public final class CatchupProjectionFeed<E> {
     public static final int DEFAULT_DEDUP_CACHE_SIZE = 10_000;
     public static final int DEFAULT_MAX_BUFFERED_EVENTS = 100_000;
 
-    private final Function<E, Mono<Void>> fold;
+    private final BiFunction<EventMetadata, E, Mono<Void>> fold;
     private final Filter replayFilter;
     private final PositionOrderedReader reader;
     private final CloudEventConverter<E> converter;
     private final Function<E, String> eventId;
     private final @Nullable CheckpointStorage catchupMarker;
     private final String id;
+    private final int maxBufferedEvents;
     private final BoundedIdCache deliveredIds;
     private final Sinks.Many<Item<E>> liveSink;
     // Acks of live events buffered but not yet folded, so a catch-up failure fails them rather than leaving the
@@ -76,7 +85,7 @@ public final class CatchupProjectionFeed<E> {
     private final Set<MonoSink<Void>> pendingLiveAcks = ConcurrentHashMap.newKeySet();
     private final AtomicReference<Throwable> terminalError = new AtomicReference<>();
 
-    private CatchupProjectionFeed(String id, Function<E, Mono<Void>> fold, Filter replayFilter, PositionOrderedReader reader,
+    private CatchupProjectionFeed(String id, BiFunction<EventMetadata, E, Mono<Void>> fold, Filter replayFilter, PositionOrderedReader reader,
                                         CloudEventConverter<E> converter, Function<E, String> eventId,
                                         @Nullable CheckpointStorage catchupMarker, int dedupCacheSize, int maxBufferedEvents) {
         this.id = id;
@@ -89,6 +98,7 @@ public final class CatchupProjectionFeed<E> {
         this.converter = converter;
         this.eventId = eventId;
         this.catchupMarker = catchupMarker;
+        this.maxBufferedEvents = maxBufferedEvents;
         this.deliveredIds = new BoundedIdCache(dedupCacheSize);
         this.liveSink = Sinks.many().unicast().onBackpressureBuffer(new ArrayBlockingQueue<>(maxBufferedEvents));
     }
@@ -115,7 +125,10 @@ public final class CatchupProjectionFeed<E> {
             @Nullable CheckpointStorage catchupMarker, int dedupCacheSize, int maxBufferedEvents) {
         Objects.requireNonNull(projection, "projection cannot be null");
         Objects.requireNonNull(repository, "repository cannot be null");
-        Function<E, Mono<Void>> fold = Projections.reactiveUpdate(projection, repository, id);
+        // The metadata-aware fold, so a projection keyed by metadata (a stream id, say) resolves the same instance during
+        // the replay as it does live. reactiveUpdate(...) would hardwire EventMetadata.empty() and mis-key every
+        // replayed event.
+        BiFunction<EventMetadata, E, Mono<Void>> fold = Projections.reactiveUpdateWithMetadata(projection, repository, id);
         Filter filter = ProjectionFilters.filterFor(converter, projection);
         return create(id, fold, filter, reader, converter, eventId, catchupMarker, dedupCacheSize, maxBufferedEvents);
     }
@@ -139,6 +152,15 @@ public final class CatchupProjectionFeed<E> {
      */
     public static <E> CatchupProjectionFeed<E> create(
             String id, Function<E, Mono<Void>> fold, Filter replayFilter,
+            PositionOrderedReader reader, CloudEventConverter<E> converter, Function<E, String> eventId,
+            @Nullable CheckpointStorage catchupMarker, int dedupCacheSize, int maxBufferedEvents) {
+        Objects.requireNonNull(fold, "fold cannot be null");
+        // A caller-supplied one-argument fold has no metadata channel, so the replay drops the metadata it decoded.
+        return create(id, (metadata, event) -> fold.apply(event), replayFilter, reader, converter, eventId, catchupMarker, dedupCacheSize, maxBufferedEvents);
+    }
+
+    private static <E> CatchupProjectionFeed<E> create(
+            String id, BiFunction<EventMetadata, E, Mono<Void>> fold, Filter replayFilter,
             PositionOrderedReader reader, CloudEventConverter<E> converter, Function<E, String> eventId,
             @Nullable CheckpointStorage catchupMarker, int dedupCacheSize, int maxBufferedEvents) {
         Objects.requireNonNull(id, "id cannot be null");
@@ -180,9 +202,10 @@ public final class CatchupProjectionFeed<E> {
                 ackSink.error(failure);
                 return;
             }
-            Sinks.EmitResult result = liveSink.tryEmitNext(new Item<>(event, ackSink));
+            Sinks.EmitResult result = liveSink.tryEmitNext(new Item<>(EventMetadata.empty(), event, ackSink));
             if (result.isFailure()) {
-                ackSink.error(new IllegalStateException("Live event buffer overflowed during catch-up replay. "
+                ackSink.error(new IllegalStateException("Live event buffer overflowed during catch-up replay (cap "
+                        + maxBufferedEvents + "). "
                         + "The history is too large to buffer the live feed across a full replay. Rebuild offline from "
                         + "the event store instead of catching up over a live feed. Emit result: " + result));
             }
@@ -206,7 +229,7 @@ public final class CatchupProjectionFeed<E> {
                 .flatMapMany(done -> done
                         ? Flux.empty()
                         : reader.readInPositionOrder(replayFilter, PositionRange.fromBeginning())
-                        .map(converter::toDomainEvent).map(this::replayedItem));
+                        .map(this::replayedItem));
         Flux<Item<E>> markerThenLive = Flux.concat(
                 alreadyDone.flatMap(done -> done ? Mono.<Void>empty() : markCaughtUp()).thenMany(Flux.<Item<E>>empty()),
                 Mono.<Item<E>>fromRunnable(catchupDone::tryEmitEmpty),
@@ -238,7 +261,7 @@ public final class CatchupProjectionFeed<E> {
             }
             // Mono.defer so a synchronous throw from the fold becomes an onError signal onErrorResume can catch, rather
             // than aborting the whole pipeline.
-            return Mono.defer(() -> fold.apply(event))
+            return Mono.defer(() -> fold.apply(item.metadata(), event))
                     .doOnSuccess(v -> {
                         deliveredIds.add(key);
                         ack.success();
@@ -248,7 +271,7 @@ public final class CatchupProjectionFeed<E> {
                         return Mono.empty();
                     });
         }
-        return Mono.defer(() -> fold.apply(event)).doOnSuccess(v -> deliveredIds.add(key));
+        return Mono.defer(() -> fold.apply(item.metadata(), event)).doOnSuccess(v -> deliveredIds.add(key));
     }
 
     // A null id would collapse every such event to one de-dup key and silently drop deliveries, so fail loud instead.
@@ -269,11 +292,11 @@ public final class CatchupProjectionFeed<E> {
                 .then();
     }
 
-    private Item<E> replayedItem(E event) {
-        return new Item<>(event, null);
+    private Item<E> replayedItem(CloudEvent cloudEvent) {
+        return new Item<>(EventMetadata.from(cloudEvent), converter.toDomainEvent(cloudEvent), null);
     }
 
     // A replayed event has a null ack; a live event carries the MonoSink whose completion lets the listener acknowledge.
-    private record Item<E>(E event, @Nullable MonoSink<Void> ack) {
+    private record Item<E>(EventMetadata metadata, E event, @Nullable MonoSink<Void> ack) {
     }
 }

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
@@ -80,9 +80,33 @@ class CatchupProjectionFeedTest {
 
         feed.catchUp().block();
 
-        // The instance is keyed under the stream id "s" (from metadata) and holds a real, non-null position.
-        assertThat(repo).containsKey("s");
-        assertThat(repo.get("s")).isNotNull();
+        // Keyed under the stream id "s" from the metadata, folded to the last replayed event's position (2), not to the
+        // 0 that an empty-metadata fold would leave behind.
+        assertThat(repo).containsOnlyKeys("s");
+        assertThat(repo.get("s")).isEqualTo(2L);
+    }
+
+    @Test
+    void a_live_domain_event_is_folded_with_empty_metadata_so_a_metadata_keyed_projection_fails_loud() {
+        CloudEventConverter<Counted> converter = countedConverter();
+        ConcurrentHashMap<String, Long> repo = new ConcurrentHashMap<>();
+        ViewStateRepository<Long, String> repository = ViewStateRepository.create(repo::get, repo::put);
+        Projection<Long, Counted, String> projection = Projection.<Long, Counted, String>builder(0L)
+                .id((metadata, event) -> metadata.getStreamId())
+                .on(Counted.class, (state, metadata, event) -> metadata.getPosition())
+                .build();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "positions", projection, repository, metadataReader("1", "2"), converter, Counted::eventId, null);
+        feed.catchUp().block();
+
+        // Metadata exists only where an event arrives as a CloudEvent. A live domain event has none, so it folds with
+        // EventMetadata.empty() and a projection keyed off metadata fails loud here rather than writing a wrong key.
+        // Pinned deliberately: driving a metadata-keyed projection from a domain-event feed is not supported live, and
+        // the blocking feed behaves identically. Change this test only alongside a decision to support it.
+        StepVerifier.create(feed.accept(new Counted("3")))
+                .verifyErrorSatisfies(e -> assertThat(e)
+                        .isInstanceOf(NullPointerException.class)
+                        .hasMessageContaining("streamId extension is absent"));
     }
 
     @Test

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.eventstore.api.PositionRange;
@@ -34,6 +35,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,6 +62,27 @@ class CatchupProjectionFeedTest {
 
         feed.accept(new Counted("3")).block();
         await().atMost(ofSeconds(5)).untilAsserted(() -> assertThat(repo.get("counter")).isEqualTo(3));
+    }
+
+    @Test
+    void catch_up_threads_event_metadata_into_the_fold() {
+        CloudEventConverter<Counted> converter = countedConverter();
+        ConcurrentHashMap<String, Long> repo = new ConcurrentHashMap<>();
+        ViewStateRepository<Long, String> repository = ViewStateRepository.create(repo::get, repo::put);
+        // Keyed by the stream id from the metadata and folding the global position: both come from the replayed
+        // CloudEvent, so if the catch-up did not thread the metadata, keying on getStreamId() would fail on empty metadata.
+        Projection<Long, Counted, String> projection = Projection.<Long, Counted, String>builder(0L)
+                .id((metadata, event) -> metadata.getStreamId())
+                .on(Counted.class, (state, metadata, event) -> metadata.getPosition())
+                .build();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "positions", projection, repository, metadataReader("1", "2"), converter, Counted::eventId, null);
+
+        feed.catchUp().block();
+
+        // The instance is keyed under the stream id "s" (from metadata) and holds a real, non-null position.
+        assertThat(repo).containsKey("s");
+        assertThat(repo.get("s")).isNotNull();
     }
 
     @Test
@@ -211,6 +234,39 @@ class CatchupProjectionFeedTest {
             @Override
             public Flux<CloudEvent> readInPositionOrder(Filter filter, PositionRange range) {
                 return Flux.fromIterable(List.of(eventIds)).map(CatchupProjectionFeedTest::cloudEvent);
+            }
+
+            @Override
+            public Mono<Long> currentPosition() {
+                return Mono.just((long) eventIds.length);
+            }
+
+            @Override
+            public boolean writesPosition() {
+                return true;
+            }
+        };
+    }
+
+    // A reader whose history carries real stream metadata (stream id "s", a stream version, and a global position),
+    // unlike reader(...) above which builds bare CloudEvents with no extensions. Needed to prove the catch-up threads
+    // the decoded EventMetadata into the fold rather than EventMetadata.empty().
+    private static PositionOrderedReader metadataReader(String... eventIds) {
+        return new PositionOrderedReader() {
+            @Override
+            public Flux<CloudEvent> readInPositionOrder(Filter filter, PositionRange range) {
+                List<CloudEvent> events = new ArrayList<>();
+                for (int i = 0; i < eventIds.length; i++) {
+                    long version = i + 1;
+                    CloudEvent event = CloudEventBuilder.v1()
+                            .withId(eventIds[i])
+                            .withSource(SOURCE)
+                            .withType("Counted")
+                            .withExtension(OccurrentCloudEventExtension.occurrent("s", version))
+                            .build();
+                    events.add(OccurrentCloudEventExtension.withPosition(event, version));
+                }
+                return Flux.fromIterable(events);
             }
 
             @Override

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeedTest.java
@@ -87,7 +87,7 @@ class CatchupProjectionFeedTest {
     }
 
     @Test
-    void a_live_domain_event_is_folded_with_empty_metadata_so_a_metadata_keyed_projection_fails_loud() {
+    void a_live_domain_event_is_folded_with_empty_metadata_so_a_stream_id_keyed_projection_throws() {
         CloudEventConverter<Counted> converter = countedConverter();
         ConcurrentHashMap<String, Long> repo = new ConcurrentHashMap<>();
         ViewStateRepository<Long, String> repository = ViewStateRepository.create(repo::get, repo::put);
@@ -100,9 +100,10 @@ class CatchupProjectionFeedTest {
         feed.catchUp().block();
 
         // Metadata exists only where an event arrives as a CloudEvent. A live domain event has none, so it folds with
-        // EventMetadata.empty() and a projection keyed off metadata fails loud here rather than writing a wrong key.
-        // Pinned deliberately: driving a metadata-keyed projection from a domain-event feed is not supported live, and
-        // the blocking feed behaves identically. Change this test only alongside a decision to support it.
+        // EventMetadata.empty(). Keying on getStreamId() throws, because that accessor requires the extension to be
+        // present. This is not a general "fails loud" guarantee: getPosition() returns null on empty metadata, and a
+        // null id means "skip this event", so a position-keyed projection drops every live event silently instead.
+        // Both are the same unsupported combination, tracked in issue 389. The blocking feed behaves identically.
         StepVerifier.create(feed.accept(new Counted("3")))
                 .verifyErrorSatisfies(e -> assertThat(e)
                         .isInstanceOf(NullPointerException.class)


### PR DESCRIPTION
A projection keyed by event metadata caught up correctly on the blocking stack and silently mis-keyed every replayed event on the reactor stack.

The reactor `CatchupProjectionFeed` folded replayed events through a `Function<E, Mono<Void>>` built by `Projections.reactiveUpdate`, which hardwires `EventMetadata.empty()`. So a projection using `Projection.idWithMetadata()` (keyed by stream id, say) resolved its instance from empty metadata during the replay. The blocking twin has always folded with `EventMetadata.from(cloudEvent)`, and `Projections.reactiveUpdateWithMetadata` already existed, so this was a wiring gap rather than a missing capability.

The internal fold is now `BiFunction<EventMetadata, E, Mono<Void>>`, and the projection-based `create(...)` overloads wire `reactiveUpdateWithMetadata`. A live domain event has no CloudEvent behind it, so it still folds with `EventMetadata.empty()`, which is what the blocking feed does too. The public `create(id, Function, ...)` overload keeps its signature and wraps into the metadata-aware form, because a caller who hands in a one-argument fold never had a metadata channel to lose.

I found this while sweeping the unreleased API surface, and it is worth noting how it stayed hidden: the blocking test class already had a `catch_up_threads_event_metadata_into_the_fold` test, and the reactor class simply had no equivalent. The missing test was the tell. The reactor test is added here, so the pair is symmetric and a future divergence in either direction fails.

I verified the test catches the real bug rather than a hypothetical one by reverting the fix and confirming it fails with `NullPointerException: streamId extension is absent`, then restoring it. Both suites pass: 29 blocking, 28 reactor.

The reactor overflow message also regains the `(cap N)` fragment that the other three catch-up implementations include.

No changelog entry. This refines a feature that has not shipped, and the existing Projection DSL bullet already promises metadata-keyed projections, so the code now matches what was already written.
