### PR TITLE
Fix DeciderCommandHandlersTest waiting for a word hint that can never appear

### DIFF
--- a/example/domain/word-guessing-game/model/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/writemodel/WordHintCharacterRevelationEdgeCasesTest.kt
+++ b/example/domain/word-guessing-game/model/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/writemodel/WordHintCharacterRevelationEdgeCasesTest.kt
@@ -55,4 +55,35 @@ class WordHintCharacterRevelationEdgeCasesTest {
         // Then
         Assertions.assertThat(events).isEmpty()
     }
+
+    @Test
+    fun `reveal character in word hint when player guessed the wrong word doesn't reveal any character when only two characters remain obfuscated`() {
+        // Given
+        val wordHintData = WordHintData(UUID.randomUUID(), "pear", currentlyRevealedPositions = setOf(1, 2))
+
+        // When
+        val events = WordHintCharacterRevelation.revealCharacterInWordHintWhenPlayerGuessedTheWrongWord(wordHintData).toList()
+
+        // Then
+        Assertions.assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `reveal character in word hint when player guessed the wrong word reveals one character when three characters remain obfuscated`() {
+        // Given
+        val wordHintData = WordHintData(UUID.randomUUID(), "apple", currentlyRevealedPositions = setOf(1, 2))
+
+        // When
+        val events = WordHintCharacterRevelation.revealCharacterInWordHintWhenPlayerGuessedTheWrongWord(wordHintData).toList()
+
+        // Then
+        Assertions.assertThat(events).hasSize(1)
+        val e1 = events.single()
+        assertAll(
+                { Assertions.assertThat(e1.character).isIn(wordHintData.wordToGuess.toCharArray().asIterable()) },
+                { Assertions.assertThat(e1.character).isNotEqualTo(WordHintCharacterRevelation.dash) },
+                { Assertions.assertThat(e1.characterPositionInWord).isNotIn(wordHintData.currentlyRevealedPositions) },
+                { Assertions.assertThat(e1.characterPositionInWord - 1).isIn(wordHintData.wordToGuess.indices) },
+        )
+    }
 }

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/AnnotationPoliciesAndDcbReadPathsTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/AnnotationPoliciesAndDcbReadPathsTest.kt
@@ -147,6 +147,9 @@ class AnnotationPoliciesAndDcbReadPathsTest {
         assertThat(events<PlayerWasAwardedPointsForGuessingTheRightWord>(GameDcbQueries.pointsCriteria(gameId))).hasSize(1)
     }
 
+    // Every word needs at least five characters. The domain keeps two characters obfuscated, so a wrong guess
+    // reveals nothing once only two remain, and this test waits for a reveal after a wrong guess - a shorter word
+    // would make that wait unsatisfiable. See WordHintCharacterRevelationEdgeCasesTest for the rule.
     private fun wordList() = WordList(
         WordCategory("test"),
         listOf(Word("alpha"), Word("bravo"), Word("crane"), Word("delta"))

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/DeciderCommandHandlersTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/autoconfig/features/gameplay/usecases/DeciderCommandHandlersTest.kt
@@ -152,8 +152,12 @@ class DeciderCommandHandlersTest {
     private inline fun <reified E : GameEvent> events(criteria: DcbCriteria): List<E> =
         domainEventQueries.queryForList(criteria).filterIsInstance<E>()
 
+    // Every word needs at least five characters. The domain keeps two characters obfuscated, so a wrong guess
+    // reveals nothing once only two remain, and this test waits for a reveal after a wrong guess. StartGame draws
+    // the word at random and WordList requires at least four words, so the draw cannot be removed - keeping every
+    // word the same length makes it irrelevant instead. See WordHintCharacterRevelationEdgeCasesTest for the rule.
     private fun wordList(): WordList = WordList(
         WordCategory("test"),
-        listOf(Word("apple"), Word("banana"), Word("orange"), Word("pear"))
+        listOf(Word("apple"), Word("grape"), Word("mango"), Word("peach"))
     )
 }

--- a/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/usecases/GameplayUsecasesAndPoliciesTest.kt
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb/src/test/kotlin/org/occurrent/example/domain/wordguessinggame/mongodb/spring/dcb/features/gameplay/usecases/GameplayUsecasesAndPoliciesTest.kt
@@ -121,6 +121,9 @@ class GameplayUsecasesAndPoliciesTest {
         assertThat(gameWasWon.winnerId).isEqualTo(playerId)
     }
 
+    // Every word needs at least five characters. The domain keeps two characters obfuscated, so a wrong guess
+    // reveals nothing once only two remain, and this test waits for a reveal after a wrong guess - a shorter word
+    // would make that wait unsatisfiable. See WordHintCharacterRevelationEdgeCasesTest for the rule.
     private fun wordList() = WordList(
         WordCategory("test"),
         listOf(Word("alpha"), Word("bravo"), Word("crane"), Word("delta"))


### PR DESCRIPTION
`DeciderCommandHandlersTest` waits for a third `CharacterInWordHintWasRevealed` event after a wrong guess. The domain keeps two characters obfuscated, so a four-letter word gets `min(2, 4 - 2) = 2` hints on the initial reveal and then `min(1, 2 - 2) = 0` on a wrong guess. The third hint never exists.

`pear` was in a list of otherwise longer words, so one run in four could never satisfy that wait, and raising the Awaitility budget could not have helped.

The list now has four five-letter words. `StartGame` draws the word at random and `WordList` requires at least four words, so the draw can't be removed, but uniform lengths make it irrelevant.

`revealCharacterInWordHintWhenPlayerGuessedTheWrongWord` had no direct test coverage at all. Both existing test classes only cover the initial reveal, so this rule reached CI only as a random draw through a Spring Boot and MongoDB test. I added tests for both sides of the boundary in the model module, and noted the constraint in the two sibling tests whose word lengths matter for the same reason.

Fixes #391
