### PR TITLE
Speed up the CI test stage by fixing the drifted shard balance

### DIFF
--- a/.context/ORCHESTRATOR.md
+++ b/.context/ORCHESTRATOR.md
@@ -159,7 +159,7 @@ Build/verify: `rtk mvn -Drevision=0.30.0-SNAPSHOT -pl rewrite -am test`. **Real-
 
 Use `rtk <command>` wherever `rtk` supports it; raw shell only when unsupported. Managed dependency versions live in the root `pom.xml` `<properties>` and imported BOMs (Spring Boot, Reactor, MongoDB driver, Jackson 3, CloudEvents, JobRunr); do not duplicate them here.
 
-CI: `.github/workflows/maven.yml` runs `mvn -B package --file pom.xml` on Temurin Java 21 and 25, with Testcontainers reuse via `$HOME/.testcontainers.properties`.
+CI: `.github/workflows/maven.yml` builds once per JDK (`install -DskipTests`, Temurin 21 and 25) and then runs the tests as 10 shards per JDK, with Testcontainers reuse via `$HOME/.testcontainers.properties`. Shard count is pinned at 10 because the account's GitHub plan allows 20 concurrent jobs; rebalance by moving paths between shards, never by adding one. Each shard reports its per-subtree timings to the run summary and warns when it exceeds `SHARD_BUDGET_SECONDS`, so a shard that grew says so instead of quietly stretching the run.
 
 Local patterns:
 

--- a/.context/ORCHESTRATOR.md
+++ b/.context/ORCHESTRATOR.md
@@ -159,7 +159,7 @@ Build/verify: `rtk mvn -Drevision=0.30.0-SNAPSHOT -pl rewrite -am test`. **Real-
 
 Use `rtk <command>` wherever `rtk` supports it; raw shell only when unsupported. Managed dependency versions live in the root `pom.xml` `<properties>` and imported BOMs (Spring Boot, Reactor, MongoDB driver, Jackson 3, CloudEvents, JobRunr); do not duplicate them here.
 
-CI: `.github/workflows/maven.yml` builds once per JDK (`install -DskipTests`, Temurin 21 and 25) and then runs the tests as 10 shards per JDK, with Testcontainers reuse via `$HOME/.testcontainers.properties`. Shard count is pinned at 10 because the account's GitHub plan allows 20 concurrent jobs; rebalance by moving paths between shards, never by adding one. Each shard reports its per-subtree timings to the run summary and warns when it exceeds `SHARD_BUDGET_SECONDS`, so a shard that grew says so instead of quietly stretching the run.
+CI: `.github/workflows/maven.yml` builds once per JDK (`install -DskipTests`, Temurin 21 and 25) and then runs the tests as 10 shards per JDK, with Testcontainers reuse via `$HOME/.testcontainers.properties`. Shard count is pinned at 10 because the account's GitHub plan allows 20 concurrent jobs; rebalance by moving paths between shards, never by adding one. Each shard reports its per-subtree timings to the run summary and as `shard-timing` log lines, and warns when it exceeds `SHARD_BUDGET_SECONDS`, so a shard that grew says so instead of quietly stretching the run; read them with `gh run view <run-id> --log | grep shard-timing`. Costs are not additive: with Testcontainers reuse the first subtree to boot MongoDB on a runner pays for the container and its neighbours ride along, so a subtree's time changes when it moves shard.
 
 Local patterns:
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,11 @@ env:
   # upload/download-artifact). Unquoted expansion is intentional: the value word-splits into
   # separate mvn arguments.
   MVN: -B -ntp -Dmaven.repo.local=${{ github.workspace }}/.m2repo
+  # Budget for one shard's tests, in seconds. Roughly 20% over the slowest shard the split below
+  # targets, so ordinary runner variance stays quiet and a subtree that actually grew does not.
+  # Exceeding it warns, never fails: nothing here is close to the 20 minute shard timeout, and a
+  # timing gate that can redden an unrelated push would just get ignored.
+  SHARD_BUDGET_SECONDS: 240
 
 jobs:
   # Stage 1: compile and install every module artifact into the local repo, skipping tests.
@@ -94,9 +99,24 @@ jobs:
 
   # Stage 2: run each subtree's tests against the pre-built local repo, one shard per runner
   # (isolated Docker daemon). Within a shard, modules stay sequential (no -T) so the
-  # fixed-port-27017 MongoDB tests never collide. Shards are balanced by MEASURED test time from a
-  # recent CI run (approx seconds shown); the two long poles (subscription ~382s, eventstore
-  # ~242s) are split, the rest merged, so the slowest shard is ~150s of tests instead of ~382s.
+  # fixed-port-27017 MongoDB tests never collide.
+  #
+  # Shard count is pinned at 10 by the concurrency limit, not chosen for tidiness: this account's
+  # GitHub plan allows 20 concurrent jobs, and 10 shards x 2 JDKs is exactly 20. An 11th shard buys
+  # no parallelism, it makes one runner execute two shards back to back, and since every shard is
+  # over 100s that is slower than an imbalanced single wave. Rebalance by moving paths between
+  # shards, not by adding one. Shards run roughly slowest first so that if runners are scarce, the
+  # cheap shards are the ones that wait.
+  #
+  # Balance by measured test time, because the slowest shard sets the whole stage's wall clock.
+  # Measurements are deliberately NOT written down here: that is what went stale last time (#423).
+  # Instead every shard reports its own per-subtree timings to the run summary, and a shard over
+  # SHARD_BUDGET_SECONDS annotates the run, so the live numbers are always one click away and
+  # drift reports itself instead of waiting to be noticed.
+  #
+  # The floor is occurrent-mongodb-spring-boot-starter, ~155s inside a single Maven module. No
+  # arrangement of paths gets the slowest shard below that without splitting one module's tests by
+  # class, which would be the most stale-prone thing in this file.
   #
   # Use -f <subtree>/pom.xml, NOT -pl: -pl on an aggregator does not descend into its children and
   # would run zero tests. We do NOT pass -o: the build job's `install -DskipTests` does not resolve
@@ -113,21 +133,28 @@ jobs:
       matrix:
         java: [ 21, 25 ]
         shard:
+          # Everything reachable without Spring: both native-driver MongoDB stacks, the in-memory
+          # and API modules, and Redis.
+          - { name: mongodb-native,              paths: "eventstore/mongodb/native eventstore/api eventstore/inmemory eventstore/migration eventstore/mongodb/common subscription/mongodb/native subscription/mongodb/common subscription/redis" }
+          # misc is the deliberate junk drawer: whatever is too small to shard on its own. The
+          # reactive Spring Boot starter lives here rather than next to the blocking one because
+          # the blocking starter alone nearly fills a shard.
+          - { name: misc,                        paths: "application rewrite common deadline cloudevents-extension library framework/spring-boot-starter-mongodb-reactive" }
           - { name: eventstore-spring,           paths: "eventstore/mongodb/spring" }
-          - { name: eventstore-rest,             paths: "eventstore/api eventstore/inmemory eventstore/migration eventstore/mongodb/common eventstore/mongodb/native" }
-          - { name: subscription-mongodb-spring, paths: "subscription/mongodb/spring" }
-          - { name: subscription-mongodb-native, paths: "subscription/mongodb/native subscription/mongodb/common subscription/redis" }
-          - { name: subscription-util-blocking,  paths: "subscription/util/blocking subscription/synchronous/blocking subscription/push/blocking" }
-          - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor subscription/synchronous/reactor subscription/push/reactor" }
-          - { name: framework,                   paths: "framework" }
+          # Listed per module, not as the framework aggregator, because the blocking starter is the
+          # single most expensive module in the build and has to sit alone.
+          - { name: framework,                   paths: "framework/spring-boot-starter-mongodb framework/annotations framework/spring-boot-autoconfigure-mongodb-common" }
+          - { name: dsl,                         paths: "dsl" }
           # example modules run real MongoDB replica-set containers with timing-sensitive
           # Awaitility subscription-catchup tests. A single example shard started 12 containers
           # sequentially on one runner, which tipped those waits over. Split by container load
           # (projection+forwarder ~5 vs domain ~7) to cut per-runner churn, keeping an in-run
           # retry as a backstop for residual timing flakiness.
-          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga", args: "-Dsurefire.rerunFailingTestsCount=2" }
           - { name: example-domain,              paths: "example/domain", args: "-Dsurefire.rerunFailingTestsCount=2" }
-          - { name: misc,                        paths: "dsl application rewrite common deadline cloudevents-extension library" }
+          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga", args: "-Dsurefire.rerunFailingTestsCount=2" }
+          - { name: subscription-util-blocking,  paths: "subscription/util/blocking subscription/synchronous/blocking subscription/push/blocking" }
+          - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor subscription/synchronous/reactor subscription/push/reactor" }
+          - { name: subscription-mongodb-spring, paths: "subscription/mongodb/spring" }
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -153,10 +180,29 @@ jobs:
           path: ${{ github.workspace }}/.m2repo/org/occurrent
       - name: Enable Testcontainers reuse on this runner
         run: echo "testcontainers.reuse.enable=true" > "$HOME/.testcontainers.properties"
+      # Each subtree is timed and reported to the run summary, so the shard balance can always be
+      # re-derived from the last green run instead of being measured by hand. Rows are appended as
+      # they complete rather than collected and written at the end, so a shard that fails partway
+      # still leaves the timings it did get behind.
       - name: Run shard tests
         run: |
+          {
+            echo "### ${{ matrix.shard.name }} (java-${{ matrix.java }})"
+            echo
+            echo "| subtree | seconds |"
+            echo "| --- | ---: |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          total=0
           for d in ${{ matrix.shard.paths }}; do
             echo "::group::mvn test -f $d/pom.xml"
+            start=$SECONDS
             mvn $MVN ${{ matrix.shard.args }} --fail-at-end -f "$d/pom.xml" test
+            elapsed=$(( SECONDS - start ))
+            total=$(( total + elapsed ))
+            echo "| \`$d\` | $elapsed |" >> "$GITHUB_STEP_SUMMARY"
             echo "::endgroup::"
           done
+          echo "| **shard total** | **$total** |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$total" -gt "$SHARD_BUDGET_SECONDS" ]; then
+            echo "::warning::Shard ${{ matrix.shard.name }} spent ${total}s on tests, over the ${SHARD_BUDGET_SECONDS}s budget. The slowest shard sets the whole test stage's wall clock, so move a path to a cheaper shard. Per-subtree timings for every shard are in this run's summary."
+          fi

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -211,11 +211,20 @@ jobs:
           for d in ${{ matrix.shard.paths }}; do
             echo "::group::mvn test -f $d/pom.xml"
             start=$SECONDS
-            mvn $MVN ${{ matrix.shard.args }} --fail-at-end -f "$d/pom.xml" test
+            # Take the exit status by hand so a test failure does not abort the step here. Without
+            # this the step dies inside the group above, which leaves the group open and hides the
+            # Maven failure in a collapsed section.
+            status=0
+            mvn $MVN ${{ matrix.shard.args }} --fail-at-end -f "$d/pom.xml" test || status=$?
             elapsed=$(( SECONDS - start ))
+            echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              echo "| \`$d\` | $elapsed (failed) |" >> "$GITHUB_STEP_SUMMARY"
+              echo "shard-timing ${{ matrix.shard.name }} java-${{ matrix.java }} $d ${elapsed}s FAILED"
+              exit "$status"
+            fi
             total=$(( total + elapsed ))
             echo "| \`$d\` | $elapsed |" >> "$GITHUB_STEP_SUMMARY"
-            echo "::endgroup::"
             # Also on stdout, outside the collapsed group: the summary is the readable view, this is
             # the greppable one, so the numbers can be pulled from a run's logs without the UI.
             echo "shard-timing ${{ matrix.shard.name }} java-${{ matrix.java }} $d ${elapsed}s"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -110,9 +110,12 @@ jobs:
   #
   # Balance by measured test time, because the slowest shard sets the whole stage's wall clock.
   # Measurements are deliberately NOT written down here: that is what went stale last time (#423).
-  # Instead every shard reports its own per-subtree timings to the run summary, and a shard over
-  # SHARD_BUDGET_SECONDS annotates the run, so the live numbers are always one click away and
-  # drift reports itself instead of waiting to be noticed.
+  # Instead every shard reports its own per-subtree timings to the run summary and, as
+  # `shard-timing` lines, to its log, and a shard over SHARD_BUDGET_SECONDS annotates the run. So
+  # the live numbers are always one click away, drift reports itself instead of waiting to be
+  # noticed, and the whole picture is one command:
+  #
+  #   gh run view <run-id> --log | grep shard-timing
   #
   # The floor is occurrent-mongodb-spring-boot-starter: one Maven module, and the only unit here
   # that cannot be divided without splitting a single module's tests by class, which would be the
@@ -213,8 +216,12 @@ jobs:
             total=$(( total + elapsed ))
             echo "| \`$d\` | $elapsed |" >> "$GITHUB_STEP_SUMMARY"
             echo "::endgroup::"
+            # Also on stdout, outside the collapsed group: the summary is the readable view, this is
+            # the greppable one, so the numbers can be pulled from a run's logs without the UI.
+            echo "shard-timing ${{ matrix.shard.name }} java-${{ matrix.java }} $d ${elapsed}s"
           done
           echo "| **shard total** | **$total** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "shard-timing ${{ matrix.shard.name }} java-${{ matrix.java }} TOTAL ${total}s budget ${SHARD_BUDGET_SECONDS}s"
           if [ "$total" -gt "$SHARD_BUDGET_SECONDS" ]; then
             echo "::warning::Shard ${{ matrix.shard.name }} spent ${total}s on tests, over the ${SHARD_BUDGET_SECONDS}s budget. The slowest shard sets the whole test stage's wall clock, so move a path to a cheaper shard. Per-subtree timings for every shard are in this run's summary."
           fi

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -114,9 +114,16 @@ jobs:
   # SHARD_BUDGET_SECONDS annotates the run, so the live numbers are always one click away and
   # drift reports itself instead of waiting to be noticed.
   #
-  # The floor is occurrent-mongodb-spring-boot-starter, ~155s inside a single Maven module. No
-  # arrangement of paths gets the slowest shard below that without splitting one module's tests by
-  # class, which would be the most stale-prone thing in this file.
+  # The floor is occurrent-mongodb-spring-boot-starter: one Maven module, and the only unit here
+  # that cannot be divided without splitting a single module's tests by class, which would be the
+  # most stale-prone thing in this file. Any shard above it is a subtree that could be listed as
+  # its own paths instead, so if the floor ever needs chasing, look there first.
+  #
+  # Note that moving a subtree between shards can change what it costs: several of these boot a
+  # MongoDB container, and with Testcontainers reuse on, whichever one runs first on a runner pays
+  # for the container and the rest ride along. A subtree that is cheap next to a neighbour can get
+  # noticeably slower alone. Re-read the summary after moving anything, do not assume the old number
+  # travels with it.
   #
   # Use -f <subtree>/pom.xml, NOT -pl: -pl on an aggregator does not descend into its children and
   # would run zero tests. We do NOT pass -o: the build job's `install -DskipTests` does not resolve
@@ -133,28 +140,33 @@ jobs:
       matrix:
         java: [ 21, 25 ]
         shard:
-          # Everything reachable without Spring: both native-driver MongoDB stacks, the in-memory
-          # and API modules, and Redis.
-          - { name: mongodb-native,              paths: "eventstore/mongodb/native eventstore/api eventstore/inmemory eventstore/migration eventstore/mongodb/common subscription/mongodb/native subscription/mongodb/common subscription/redis" }
-          # misc is the deliberate junk drawer: whatever is too small to shard on its own. The
-          # reactive Spring Boot starter lives here rather than next to the blocking one because
-          # the blocking starter alone nearly fills a shard.
-          - { name: misc,                        paths: "application rewrite common deadline cloudevents-extension library framework/spring-boot-starter-mongodb-reactive" }
+          # A shard's name says what dominates it, not everything in it: filling 10 shards evenly
+          # means some carry a lodger from a subtree that had nowhere cheaper to go. That costs
+          # nothing for triage, because each subtree gets its own ::group:: in the log.
+          #
+          # `application` lodges here: it needs a MongoDB container anyway, so it starts cheaper
+          # next to a subtree that already booted one than it does in a shard of its own.
+          - { name: subscription-mongodb-spring, paths: "subscription/mongodb/spring application" }
           - { name: eventstore-spring,           paths: "eventstore/mongodb/spring" }
+          # Everything that talks to MongoDB through the driver rather than through Spring.
+          - { name: mongodb-native,              paths: "eventstore/mongodb/native subscription/mongodb/native eventstore/api eventstore/mongodb/common subscription/mongodb/common" }
           # Listed per module, not as the framework aggregator, because the blocking starter is the
           # single most expensive module in the build and has to sit alone.
           - { name: framework,                   paths: "framework/spring-boot-starter-mongodb framework/annotations framework/spring-boot-autoconfigure-mongodb-common" }
           - { name: dsl,                         paths: "dsl" }
+          # misc is the deliberate junk drawer: whatever is too small to shard on its own. The
+          # reactive Spring Boot starter is here because the blocking one nearly fills a shard by
+          # itself, so the two cannot share.
+          - { name: misc,                        paths: "framework/spring-boot-starter-mongodb-reactive rewrite common deadline library cloudevents-extension" }
           # example modules run real MongoDB replica-set containers with timing-sensitive
           # Awaitility subscription-catchup tests. A single example shard started 12 containers
           # sequentially on one runner, which tipped those waits over. Split by container load
           # (projection+forwarder ~5 vs domain ~7) to cut per-runner churn, keeping an in-run
           # retry as a backstop for residual timing flakiness.
           - { name: example-domain,              paths: "example/domain", args: "-Dsurefire.rerunFailingTestsCount=2" }
-          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga", args: "-Dsurefire.rerunFailingTestsCount=2" }
+          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga subscription/redis eventstore/migration eventstore/inmemory", args: "-Dsurefire.rerunFailingTestsCount=2" }
           - { name: subscription-util-blocking,  paths: "subscription/util/blocking subscription/synchronous/blocking subscription/push/blocking" }
           - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor subscription/synchronous/reactor subscription/push/reactor" }
-          - { name: subscription-mongodb-spring, paths: "subscription/mongodb/spring" }
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -167,9 +167,12 @@ jobs:
           # (projection+forwarder ~5 vs domain ~7) to cut per-runner churn, keeping an in-run
           # retry as a backstop for residual timing flakiness.
           - { name: example-domain,              paths: "example/domain", args: "-Dsurefire.rerunFailingTestsCount=2" }
-          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga subscription/redis eventstore/migration eventstore/inmemory", args: "-Dsurefire.rerunFailingTestsCount=2" }
+          - { name: example-projection,          paths: "example/projection example/forwarder example/snapshot example/saga", args: "-Dsurefire.rerunFailingTestsCount=2" }
           - { name: subscription-util-blocking,  paths: "subscription/util/blocking subscription/synchronous/blocking subscription/push/blocking" }
-          - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor subscription/synchronous/reactor subscription/push/reactor" }
+          # `args` applies to every path in a shard, so the two `eventstore` lodgers are here rather
+          # than in an `example` shard. Parking them next to a rerun flag they do not need would
+          # retry a genuine failure twice before reporting it.
+          - { name: subscription-rest,           paths: "subscription/api subscription/core subscription/inmemory subscription/util/reactor subscription/synchronous/reactor subscription/push/reactor subscription/redis eventstore/migration eventstore/inmemory" }
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
The shard comment in `.github/workflows/maven.yml` said the split targeted a slowest shard of roughly 150s of tests. It had drifted to 280s, and the two worst shards were not the ones the comment names as the slow ones it split. Nothing ever re-measured it, so it drifted a little further every time a subtree grew (#423).

I repacked the same 10 shards against measured numbers. `dsl` got its own shard, the two Spring Boot starters were separated, and the two non-Spring shards merged to free the slot. Across green runs the slowest shard now measures 186s to 195s instead of 280s, and a full run finishes in 4m40s to 5m10s instead of 6m53s. The spread is runner variance, and part of it is how evenly the 20 jobs get a runner at the start.

Shard count stays at 10 on purpose. This account's GitHub plan allows 20 concurrent jobs and 10 shards across 2 JDKs is exactly 20, so an 11th shard makes one runner execute two shards back to back rather than adding parallelism. Splitting `misc` and `framework` into their own shards, which is the obvious fix and the one #423 proposes, would have left the run no faster. The comment now says so, because "just add a shard" is the tempting wrong move next time.

To stop it drifting again, each shard times every subtree and writes the numbers to the run summary, to its own log as `shard-timing` lines, and to a warning annotation when the shard passes `SHARD_BUDGET_SECONDS`. The workflow comment records the rule and the budget and no measurements at all, since the measurements are what went stale.

Shard costs are not additive, which is worth knowing before moving a path between shards. With Testcontainers reuse the first subtree to start MongoDB on a runner pays for the container and the rest reuse it, so a subtree gets slower when it moves to a shard where nothing has started one yet. My first attempt predicted 200s and measured 237s for exactly that reason, which is what the second commit fixes.
