### PR TITLE
Stop green runs from reporting two errors that are not there

### DIFF
--- a/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
+++ b/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
@@ -151,7 +151,11 @@ public class NativeMongoCheckpointStorageTest {
                 return;
             }
             if (previous == null) {
-                thread.getThreadGroup().uncaughtException(thread, throwable);
+                // What the JVM itself would do. Handing this to the thread group instead would come straight back
+                // here, because the root group asks Thread.getDefaultUncaughtExceptionHandler for a handler and
+                // that is now this one, so an unexpected exception would recurse until the stack ran out.
+                System.err.print("Exception in thread \"" + thread.getName() + "\" ");
+                throwable.printStackTrace(System.err);
             } else {
                 previous.uncaughtException(thread, throwable);
             }

--- a/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
+++ b/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
@@ -123,14 +123,18 @@ public class NativeMongoCheckpointStorageTest {
 
     @AfterEach
     void shutdown() {
-        subscriptionModel.shutdown();
-        mongoClient.close();
-        // Restored after the shutdown above rather than from a second @AfterEach, because JUnit does not promise
-        // an order between two of them and shutting down must still be covered by the handler.
-        if (replacedDefaultUncaughtExceptionHandler) {
-            Thread.setDefaultUncaughtExceptionHandler(previousDefaultUncaughtExceptionHandler);
-            previousDefaultUncaughtExceptionHandler = null;
-            replacedDefaultUncaughtExceptionHandler = false;
+        // Restored in a finally after the shutdown, rather than from a second @AfterEach, because JUnit does not
+        // promise an order between two of them, shutting down must still be covered by the handler, and a handler
+        // that swallows exceptions must never outlive this test even if shutting down throws.
+        try {
+            subscriptionModel.shutdown();
+            mongoClient.close();
+        } finally {
+            if (replacedDefaultUncaughtExceptionHandler) {
+                Thread.setDefaultUncaughtExceptionHandler(previousDefaultUncaughtExceptionHandler);
+                previousDefaultUncaughtExceptionHandler = null;
+                replacedDefaultUncaughtExceptionHandler = false;
+            }
         }
     }
 

--- a/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
+++ b/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageTest.java
@@ -105,6 +105,8 @@ public class NativeMongoCheckpointStorageTest {
     private ObjectMapper objectMapper;
     private MongoClient mongoClient;
     private MongoDatabase database;
+    private Thread.UncaughtExceptionHandler previousDefaultUncaughtExceptionHandler;
+    private boolean replacedDefaultUncaughtExceptionHandler;
 
     @BeforeEach
     void create_mongo_event_store() {
@@ -123,6 +125,33 @@ public class NativeMongoCheckpointStorageTest {
     void shutdown() {
         subscriptionModel.shutdown();
         mongoClient.close();
+        // Restored after the shutdown above rather than from a second @AfterEach, because JUnit does not promise
+        // an order between two of them and shutting down must still be covered by the handler.
+        if (replacedDefaultUncaughtExceptionHandler) {
+            Thread.setDefaultUncaughtExceptionHandler(previousDefaultUncaughtExceptionHandler);
+            previousDefaultUncaughtExceptionHandler = null;
+            replacedDefaultUncaughtExceptionHandler = false;
+        }
+    }
+
+    // A consumer that throws kills the dispatcher thread when the retry strategy is none, since there is nothing
+    // left to restart it. The JVM's default handler then prints that stack trace, which GitHub Actions turns into
+    // an error annotation, so an otherwise green run reports errors and real ones get easier to miss.
+    // Anything other than the one exception the test asks for still reaches the handler that was installed before.
+    private void expectUncaughtException(Class<? extends Throwable> type, String message) {
+        Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+        previousDefaultUncaughtExceptionHandler = previous;
+        replacedDefaultUncaughtExceptionHandler = true;
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            if (type.isInstance(throwable) && message.equals(throwable.getMessage())) {
+                return;
+            }
+            if (previous == null) {
+                thread.getThreadGroup().uncaughtException(thread, throwable);
+            } else {
+                previous.uncaughtException(thread, throwable);
+            }
+        });
     }
 
     @Test
@@ -281,6 +310,7 @@ public class NativeMongoCheckpointStorageTest {
 
         // Disable retry
         subscriptionModel = newDurableSubscription("events", RFC_3339_STRING, RetryStrategy.none());
+        expectUncaughtException(IllegalArgumentException.class, "Expected");
 
         AtomicInteger counter = new AtomicInteger();
         CopyOnWriteArrayList<CloudEvent> state = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
Every green run reported 2 errors under Annotations, one per JDK, both from the `mongodb-native` shard with the message `Expected`. Nothing was actually failing, which is the problem, since a run that always claims 2 errors trains you to ignore the annotations and a real one then goes unnoticed.

The source is `NativeMongoCheckpointStorageTest`, in the test that disables retry and makes the consumer throw on the first event. With `RetryStrategy.none()` there is nothing left to restart the dispatcher thread, so the exception reaches the JVM's default handler, which prints the stack trace, and GitHub Actions turns that into an error annotation.

I left the production code alone. `NativeMongoSubscriptionModel` logs "Will restart!" and rethrows, and `startSubscription` wraps the runnable in `executeWithRetry`, so with a configured retry strategy it really does restart. With retry explicitly off, letting the exception propagate is the only thing it can do. The test already called Awaitility's `dontCatchUncaughtExceptions`, so the escaping exception was known and intended when it was written.

Instead the test installs a default uncaught exception handler that ignores the one `IllegalArgumentException` it asks for and delegates everything else to whatever handler was installed before, restored after `shutdown()` in the existing `@AfterEach` rather than a second one, since JUnit does not promise an order between two. The injected failure and the assertions are untouched, and the model still logs its warning, so the error path the test exercises still runs.

Checked locally against the same module both ways. `Exception in thread` appears once before this change and not at all after, with 13 tests passing either way. On CI the run is green with zero error annotations, against 2 on every green run before.
