### PR TITLE
Fix a fail-silent catch-up regression and the seam gaps the #434 reviews found

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -154,7 +154,9 @@ jobs:
           # Everything that talks to MongoDB through the driver rather than through Spring.
           - { name: mongodb-native,              paths: "eventstore/mongodb/native subscription/mongodb/native eventstore/api eventstore/mongodb/common subscription/mongodb/common" }
           # Listed per module, not as the framework aggregator, because the blocking starter is the
-          # single most expensive module in the build and has to sit alone.
+          # single most expensive module in the build. It shares the shard with framework/annotations and
+          # the framework/spring-boot-autoconfigure aggregate (common, blocking, reactor), both cheap
+          # enough to ride along without pushing the shard over budget.
           - { name: framework,                   paths: "framework/spring-boot-starter-mongodb framework/annotations framework/spring-boot-autoconfigure" }
           - { name: dsl,                         paths: "dsl" }
           # misc is the deliberate junk drawer: whatever is too small to shard on its own. The

--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,11 @@
 * `EventMetadata` moves from `org.occurrent.dsl.subscription.EventMetadata` to `org.occurrent.cloudevents.EventMetadata`, and from a Kotlin `data class` to a plain Java class. A 0.30.0 caller referencing the old FQN, importing it, or using its Kotlin-only surface (reified `get<T>`, operator `get`, `copy`, all dropped) updates the reference. The typed accessors are unchanged in name and behavior. The `org.occurrent.UpgradeToOccurrent_0_31` OpenRewrite recipe rewrites every affected reference for you. See the [upgrade guide](doc/migration/upgrading-to-0.31.0.md) and [ADR 71](doc/architecture/decisions/0071-relocate-eventmetadata-to-cloudevents-extension.md).
   * Before: `import org.occurrent.dsl.subscription.EventMetadata`
   * After: `import org.occurrent.cloudevents.EventMetadata`
+* `OccurrentProperties` and the seven other public types in `org.occurrent.springboot.mongo.common` move to `org.occurrent.springboot.common`, and the autoconfigure artifact is renamed from `occurrent-mongodb-spring-boot-autoconfigure` to `occurrent-spring-boot-autoconfigure`. Property keys are unchanged. The `org.occurrent.UpgradeToOccurrent_0_31` OpenRewrite recipe rewrites every affected reference and the module coordinate for you. See the [upgrade guide](doc/migration/upgrading-to-0.31.0.md) and [ADR 72](doc/architecture/decisions/0072-store-neutral-spring-boot-annotation-modules.md).
+  * Before: `import org.occurrent.springboot.mongo.common.OccurrentProperties`
+  * After: `import org.occurrent.springboot.common.OccurrentProperties`
+  * Before artifactId: `occurrent-mongodb-spring-boot-autoconfigure`
+  * After artifactId: `occurrent-spring-boot-autoconfigure`
 
 ### 0.30.0 (2026-07-13)
 

--- a/doc/architecture/decisions/0072-store-neutral-spring-boot-annotation-modules.md
+++ b/doc/architecture/decisions/0072-store-neutral-spring-boot-annotation-modules.md
@@ -54,17 +54,29 @@ Storage conventions travel with the implementation. The `occurrent-snapshot-<id>
 
 The reactive `StartPositionSupport` decided whether history replay was possible by resolving `ReactorMongoEventStore` and calling `writesPosition()`. The store-neutral `PositionOrderedReader` already declares that method, so the capability is reachable without the concrete type.
 
-Resolve `PositionOrderedReader` and narrow to the candidate that is also an `EventStore`. Two details make that the right lookup rather than the obvious one. Resolving `EventStore` directly would be worse, because it is declared `@ConditionalOnMissingBean`, so a user-supplied store gives two candidates and `getIfAvailable()` throws. And resolving `PositionOrderedReader` without narrowing is ambiguous, because a `@Projection(source = PUSH)` application declares its own reader bean. Narrowing to the candidate that is also an `EventStore` reproduces the original "ask the store, not a feed" semantics store-neutrally.
+The rule is: ask the event store, not any reader that happens to be in the context. It lives in one place, `PositionOrderedEventStores.find(ApplicationContext)` in the reactor module, which is public precisely because it is a contract rather than a helper.
 
-This is the one part of the move that is not behavior-preserving: a user-supplied reactive `EventStore` implementing `PositionOrderedReader` now reports position replay as supported, where before only the Mongo store did. Such a store does write positions, so this is a fix.
+**Both the probe and the catch-up wiring must use it, and that is the load-bearing part.** A first attempt had the neutral probe answer "can history be replayed" through the capability while the store starter still composed its catch-up layer from the concrete `ReactorMongoEventStore`. Those two can disagree: a user-supplied reactive `EventStore` implementing `PositionOrderedReader` made the probe say yes while no `ReactorCatchupSubscriptionModel` was wired, so `startAt = BEGINNING` silently did not replay where it used to fail at startup. Fail-loud became fail-silent. `ReactiveCatchupLayerWiringTest` pins it, and reverting the wiring to the concrete lookup fails that test.
 
-### The post-processor becomes public, the registrars stay package-private
+So the seam obligation on a store starter is not just "contribute a `PositionOrderedReader` event store". It is: if your store answers the capability, your catch-up layer must be wired from the same answer.
 
-Each stack exposes exactly one public type, the bean-post-processor, which also carries the `SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME` constant the store starter needs. All four registrars and `StartPositionSupport` remain package-private, keeping the encapsulation #383 established.
+Resolution deliberately goes through bean *names* for `EventStore` and only then checks the `PositionOrderedReader` instance, so no unrelated reader bean is instantiated. Two candidates are handed to the container first, so `@Primary` and `@Fallback` still decide, and only a genuinely unresolvable pair throws, naming the beans. An earlier `getBeanProvider(...).stream()` version was wrong on all three counts: it force-created every matching bean while running mid-refresh, ignored `@Primary`, and silently took the first in registration order.
 
-The alternative was leaving the post-processor package-private and narrowing the `static @Bean` return type to `BeanPostProcessor`. That was tried and it works: Spring resolves `DisposableBean` from the created instance, not from the declared return type, so the destroy callback still fires. The concern that motivated the public type turned out to be unfounded.
+One behavior difference remains and is intended: a user-supplied reactive `EventStore` implementing `PositionOrderedReader` now reports replay as supported, where before only the Mongo store did. Such a store does write positions, and it now also gets the catch-up layer, so the capability and the wiring agree.
 
-Public is still the better choice, for a plainer reason. The store starter needs `SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME` from this class anyway, so the type is already part of the contract between the neutral module and a store starter. Making that explicit beats reaching a constant through a type the declaration pretends is something else.
+### The store-default seams use `@Fallback`, not `@ConditionalOnMissingBean`
+
+`@EnableOccurrent` activates the autoconfiguration through a plain `@Import`, and this repository already documents that `@ConditionalOnMissingBean` can then evaluate before a user's bean is registered and let both through. That is why `TagGenerator` and `CloudEventTypeMapper` use `@Fallback`. The four `Default*Provider` beans do the same, for the same reason.
+
+That makes two provider beans a legitimate state rather than an impossible one, so each resolution site catches `NoUniqueBeanDefinitionException` and reports the annotation, its id, the provider type and the candidate bean names. Without that, the carefully worded provider-absent message was unreachable on ambiguity and users got a bare Spring exception.
+
+### Everything stays package-private except the bean names
+
+The store starter needs one thing from the post-processor: the bean name of the synchronous subscription DSL. That is a constant, not a type, so it lives in `OccurrentBlockingBeanNames` / `OccurrentReactorBeanNames` and both post-processors, all four registrars and both `StartPositionSupport` classes stay package-private. The encapsulation #383 established survives intact.
+
+The complete public surface of the two per-stack modules is therefore: the four `Default*Provider` seams, the two bean-name holders, the two `Occurrent*AnnotationConfiguration` classes a starter imports, and `PositionOrderedEventStores`. Every one of those is something a store starter has to name. Nothing else is reachable.
+
+An earlier attempt made the post-processors public to carry that constant, reasoning that they were already part of the contract. That was more surface than the problem needed. A related worry, that a package-private post-processor declared by a `static @Bean` would lose its `DisposableBean` destroy callback and leak the saga timer poller, was tested and is unfounded: Spring resolves `DisposableBean` from the created instance, not from the declared return type. `AnnotationBeanPostProcessorDestroyCallbackTest` observes the callback directly rather than resting on that inference.
 
 ## Consequences
 

--- a/doc/migration/upgrading-to-0.31.0.md
+++ b/doc/migration/upgrading-to-0.31.0.md
@@ -44,13 +44,13 @@ a nested `ResumeBehavior`/`StartupMode`, for example `Subscription.ResumeBehavio
 `DcbSubscription.ResumeBehavior`, or `Projection.StartupMode`, to the shared top-level
 `org.occurrent.annotation.ResumeBehavior`/`org.occurrent.annotation.StartupMode`. It also rewrites
 `Subscription.StartPosition` and `DcbSubscription.DcbStartPosition` to the shared top-level
-`org.occurrent.annotation.StartPosition`. This covers a fully-qualified reference, an import, and a static import.
-It also composes `org.occurrent.MigrateCoordinates_0_31`, which renames the four checkpoint-storage dependency
-coordinates in your Maven and Gradle build files (see section 3), and rewrites every reference, import, and static
-import of `EventMetadata` from its old package to the new one (see section 4). It also rewrites the Spring Boot
+`org.occurrent.annotation.StartPosition`, and rewrites every reference, import, and static import of
+`EventMetadata` from its old package to the new one (see section 4). This same recipe also rewrites the Spring Boot
 annotation machinery (`OccurrentProperties` and friends) from `org.occurrent.springboot.mongo.common` to
-`org.occurrent.springboot.common`, and the module coordinate from `occurrent-mongodb-spring-boot-autoconfigure` to
-`occurrent-spring-boot-autoconfigure` (see section 5). Safe to run and commit without review.
+`org.occurrent.springboot.common` (see section 5). It also composes `org.occurrent.MigrateCoordinates_0_31`, which
+renames the four checkpoint-storage dependency coordinates (see section 3) and the Spring Boot autoconfigure
+module coordinate, from `occurrent-mongodb-spring-boot-autoconfigure` to `occurrent-spring-boot-autoconfigure`
+(see section 5), in your Maven and Gradle build files. Safe to run and commit without review.
 
 ## 2. What changed
 

--- a/framework/spring-boot-autoconfigure/blocking/pom.xml
+++ b/framework/spring-boot-autoconfigure/blocking/pom.xml
@@ -105,6 +105,12 @@
             <artifactId>occurrent-subscription-catchup-blocking</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- TimeBasedCheckpoint lives here, not in catchup-blocking, even though both share the same package -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-stream-catchup-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-subscription-competing-consumer-blocking</artifactId>
@@ -133,6 +139,12 @@
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-saga-dsl-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- View, MaterializedView and ViewStateRepository are the @Projection read-model store contracts -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-view-dsl</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -47,14 +47,7 @@ import java.util.Set;
  * registrars ({@link SubscriptionAnnotationRegistrar}, {@link ProjectionAnnotationRegistrar},
  * {@link SnapshotAnnotationRegistrar}, {@link SagaAnnotationRegistrar}) built on top of {@link StartPositionSupport}.
  */
-public class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, SmartInitializingSingleton, DisposableBean {
-
-    /**
-     * The bean name of the synchronous {@code Subscriptions} DSL declared by the auto-configuration. Resolved by name
-     * (rather than by type) so it does not collide with the asynchronous {@code Subscriptions} bean, which is of the
-     * same type.
-     */
-    public static final String SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME = "occurrentSynchronousSubscriptionDsl";
+class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, SmartInitializingSingleton, DisposableBean {
 
     private ApplicationContext applicationContext;
     // One shared duplicate-id registry across every registrar: all subscription ids are collected before projections,

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingBeanNames.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingBeanNames.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.blocking;
+
+/**
+ * The bean names a blocking store starter and this module have to agree on. A holder of names keeps the machinery that
+ * uses them package-private, since a starter needs the name rather than the type that resolves it.
+ */
+public final class OccurrentBlockingBeanNames {
+
+    /**
+     * The bean name of the synchronous {@code Subscriptions} DSL declared by the auto-configuration. Resolved by name
+     * (rather than by type) so it does not collide with the asynchronous {@code Subscriptions} bean, which is of the
+     * same type.
+     */
+    public static final String SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME = "occurrentSynchronousSubscriptionDsl";
+
+    private OccurrentBlockingBeanNames() {
+    }
+}

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
@@ -47,6 +47,7 @@ import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.repository.CrudRepository;
 
@@ -125,7 +126,7 @@ class ProjectionAnnotationRegistrar {
             if (synchronous) {
                 // The synchronous subscription model is capability-neutral and applies no DCB criteria, so a DCB
                 // projection receives every synchronously dispatched event and the fold no-ops on unhandled types.
-                Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+                Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
                 synchronousSubscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(Filter.all()), StartAt.subscriptionModelDefault(), false, (metadata, event) -> {
                     materializedView.update(metadata, event);
                     return Unit.INSTANCE;
@@ -150,7 +151,7 @@ class ProjectionAnnotationRegistrar {
             };
             boolean stream = annotation.capability() == org.occurrent.annotation.Capability.STREAM;
             if (synchronous) {
-                Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+                Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
                 synchronousSubscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(eventFilter), StartAt.subscriptionModelDefault(), false, consumer);
                 return;
             }
@@ -242,7 +243,16 @@ class ProjectionAnnotationRegistrar {
     }
 
     private <S, ID> ViewStateRepository<S, ID> defaultProjectionStore(Class<S> stateType, String id) {
-        DefaultProjectionStoreProvider provider = applicationContext.getBeanProvider(DefaultProjectionStoreProvider.class).getIfAvailable();
+        // getIfAvailable() applies @Primary and @Fallback resolution and only throws when the container genuinely
+        // cannot pick, so an ambiguous seam is reported with the annotation id rather than as a bare Spring failure.
+        final DefaultProjectionStoreProvider provider;
+        try {
+            provider = applicationContext.getBeanProvider(DefaultProjectionStoreProvider.class).getIfAvailable();
+        } catch (NoUniqueBeanDefinitionException e) {
+            String[] providerNames = applicationContext.getBeanNamesForType(DefaultProjectionStoreProvider.class);
+            throw new IllegalStateException(("@Projection '%s' found %d DefaultProjectionStoreProvider beans (%s) and cannot pick one to create the zero-config default read-model store. " +
+                    "Declare a MaterializedView, ViewStateRepository or CrudRepository bean, select one with store/storeName, or mark one provider @Primary.").formatted(id, providerNames.length, String.join(", ", providerNames)), e);
+        }
         if (provider == null) {
             throw new IllegalStateException(("@Projection '%s' found no read-model store bean and this starter contributes no zero-config default. " +
                     "Declare a MaterializedView, ViewStateRepository or CrudRepository bean, or select one with store/storeName.").formatted(id));

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrar.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -239,7 +240,16 @@ class SagaAnnotationRegistrar {
         // The state type is reflected first, so a factory that declares none reports that (the actionable fix) rather
         // than a missing provider.
         Class<S> stateType = (Class<S>) reflectSagaStateType(factoryMethod, id);
-        DefaultSagaStateStoreProvider provider = applicationContext.getBeanProvider(DefaultSagaStateStoreProvider.class).getIfAvailable();
+        // getIfAvailable() applies @Primary and @Fallback resolution and only throws when the container genuinely
+        // cannot pick, so an ambiguous seam is reported with the annotation id rather than as a bare Spring failure.
+        final DefaultSagaStateStoreProvider provider;
+        try {
+            provider = applicationContext.getBeanProvider(DefaultSagaStateStoreProvider.class).getIfAvailable();
+        } catch (NoUniqueBeanDefinitionException e) {
+            String[] providerNames = applicationContext.getBeanNamesForType(DefaultSagaStateStoreProvider.class);
+            throw new IllegalStateException(("@Saga '%s' found %d DefaultSagaStateStoreProvider beans (%s) and cannot pick one to create the zero-config default saga state store. " +
+                    "Declare a SagaStateStore bean, select one with store/storeName, or mark one provider @Primary.").formatted(id, providerNames.length, String.join(", ", providerNames)), e);
+        }
         if (provider == null) {
             throw new IllegalStateException(("@Saga '%s' found no SagaStateStore bean and this starter contributes no zero-config default. " +
                     "Declare a SagaStateStore bean, or select one with store/storeName.").formatted(id));

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SnapshotAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SnapshotAnnotationRegistrar.java
@@ -40,6 +40,7 @@ import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.StartAt;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
 import java.lang.reflect.Method;
@@ -145,7 +146,7 @@ class SnapshotAnnotationRegistrar {
 
         boolean stream = annotation.capability() == org.occurrent.annotation.Capability.STREAM;
         if (synchronous) {
-            Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+            Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
             synchronousSubscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(eventFilter), StartAt.subscriptionModelDefault(), false, consumer);
             return;
         }
@@ -230,7 +231,16 @@ class SnapshotAnnotationRegistrar {
         // The state type is reflected first, so a factory that declares none reports that (the actionable fix) rather
         // than a missing provider.
         Class<S> stateType = (Class<S>) reflectSnapshotStateType(factoryMethod, id);
-        DefaultSnapshotStoreProvider provider = applicationContext.getBeanProvider(DefaultSnapshotStoreProvider.class).getIfAvailable();
+        // getIfAvailable() applies @Primary and @Fallback resolution and only throws when the container genuinely
+        // cannot pick, so an ambiguous seam is reported with the annotation id rather than as a bare Spring failure.
+        final DefaultSnapshotStoreProvider provider;
+        try {
+            provider = applicationContext.getBeanProvider(DefaultSnapshotStoreProvider.class).getIfAvailable();
+        } catch (NoUniqueBeanDefinitionException e) {
+            String[] providerNames = applicationContext.getBeanNamesForType(DefaultSnapshotStoreProvider.class);
+            throw new IllegalStateException(("@Snapshot '%s' found %d DefaultSnapshotStoreProvider beans (%s) and cannot pick one to create the zero-config default snapshot store. " +
+                    "Declare a SnapshotStore bean, select one with store/storeName, or mark one provider @Primary.").formatted(id, providerNames.length, String.join(", ", providerNames)), e);
+        }
         if (provider == null) {
             throw new IllegalStateException(("@Snapshot '%s' found no SnapshotStore bean and this starter contributes no zero-config default. " +
                     "Declare a SnapshotStore bean, or select one with store/storeName.").formatted(id));

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SubscriptionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SubscriptionAnnotationRegistrar.java
@@ -156,7 +156,7 @@ class SubscriptionAnnotationRegistrar {
             return Unit.INSTANCE;
         };
 
-        Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+        Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
         // The synchronous subscription model has no lifecycle, start position, or background thread, so there is no
         // start position to resolve and nothing to wait for. Pass the default StartAt (the model ignores it) rather
         // than null to honor the Subscribable contract.

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/AnnotationBeanPostProcessorDestroyCallbackTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/AnnotationBeanPostProcessorDestroyCallbackTest.java
@@ -27,9 +27,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Proves Spring actually calls {@code destroy} on the annotation post-processor when the context shuts down. That
- * method closes every {@code @Saga} timer poller, so if the callback stops firing a poller thread outlives the
- * context and nothing else in the suite notices.
+ * Proves the annotation post-processor is contributed by the store-neutral configuration, that the subscription kill
+ * switch removes it, and that Spring actually calls {@code destroy} on it when the context shuts down.
+ * <p>
+ * The destroy callback is what {@code SagaAnnotationRegistrar.close} hangs off, so a callback that stops firing leaves
+ * poller threads behind. That downstream effect is deliberately NOT asserted here: observing a real {@code @Saga} timer
+ * poller needs a running store, so it belongs to the Docker-gated tests in the store starter. What this file pins is
+ * the callback firing at all.
  * <p>
  * Worth pinning because moving the post-processor between modules changed how its bean is declared. An earlier
  * version of this test asserted the bean definition's recorded type implements {@code DisposableBean}, which turned
@@ -52,6 +56,23 @@ class AnnotationBeanPostProcessorDestroyCallbackTest {
 
         // ApplicationContextRunner closes the context once the lambda returns, so the callback lands after it.
         assertThat(postProcessor.destroyed).isTrue();
+    }
+
+    // The presence half of the pair below. Without it the absence test passes just as happily when the @Bean method is
+    // gone entirely, and the destroy test above registers its own instance so it proves nothing about the wiring.
+    @Test
+    void the_post_processor_is_contributed_by_default() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(OccurrentBlockingAnnotationConfiguration.class))
+                .run(context -> assertThat(context).hasSingleBean(OccurrentBlockingAnnotationBeanPostProcessor.class));
+    }
+
+    @Test
+    void the_post_processor_is_contributed_when_subscriptions_are_explicitly_enabled() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(OccurrentBlockingAnnotationConfiguration.class))
+                .withPropertyValues("occurrent.subscription.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(OccurrentBlockingAnnotationBeanPostProcessor.class));
     }
 
     @Test

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/DefaultStoreProviderSeamTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/DefaultStoreProviderSeamTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.blocking;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.annotation.Projection;
+import org.occurrent.annotation.Saga;
+import org.occurrent.annotation.Snapshot;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.snapshot.SnapshotView;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.subscription.api.blocking.Subscribable;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Characterizes what the blocking stack does when a store-neutral module is used without a store starter: each of the
+ * three zero-config default-store seams ({@link DefaultProjectionStoreProvider}, {@link DefaultSnapshotStoreProvider}
+ * and {@link DefaultSagaStateStoreProvider}) must fail fast naming the annotation id, rather than NPE on a missing
+ * provider or silently drop the store.
+ * <p>
+ * Every factory here declares a concrete generic return type on purpose. A raw return type is rejected one step earlier
+ * by state-type reflection, which is what the sibling {@code *AnnotationValidationTest}s cover, so it never reaches the
+ * provider lookup.
+ * <p>
+ * Container-free, since no store is ever created.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DefaultStoreProviderSeamTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)
+            .withUserConfiguration(ConverterConfiguration.class);
+
+    @Test
+    void projection_without_a_store_bean_and_without_a_default_store_provider_fails_fast() {
+        runner.withUserConfiguration(ProjectionConfiguration.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("projection-default-store")
+                    .hasMessageContaining("found no read-model store bean and this starter contributes no zero-config default");
+        });
+    }
+
+    @Test
+    void snapshot_without_a_store_bean_and_without_a_default_store_provider_fails_fast() {
+        runner.withUserConfiguration(SnapshotConfiguration.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("snapshot-default-store")
+                    .hasMessageContaining("found no SnapshotStore bean and this starter contributes no zero-config default");
+        });
+    }
+
+    @Test
+    void saga_without_a_store_bean_and_without_a_default_store_provider_fails_fast() {
+        runner.withUserConfiguration(SubscribableConfiguration.class, SagaConfiguration.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("saga-default-store")
+                    .hasMessageContaining("found no SagaStateStore bean and this starter contributes no zero-config default");
+        });
+    }
+
+    @Test
+    void projection_with_two_default_store_providers_fails_fast_naming_both_provider_beans() {
+        // The projection seam stands in for all three here: they share the same getIfAvailable/NoUniqueBeanDefinitionException
+        // shape, and this is the one that needs no Subscribable or store fixture beans.
+        runner.withUserConfiguration(TwoProvidersConfiguration.class, ProjectionConfiguration.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(seamFailure(context.getStartupFailure()))
+                    .hasMessageContaining("projection-default-store")
+                    .hasMessageContaining("cannot pick one to create the zero-config default read-model store")
+                    .hasMessageContaining("providerA")
+                    .hasMessageContaining("providerB");
+        });
+    }
+
+    /**
+     * The seam's own {@link IllegalStateException}, not the most specific cause. The ambiguous branch rethrows with
+     * Spring's {@code NoUniqueBeanDefinitionException} as the cause, and that cause names the provider beans too, so
+     * asserting on the cause or on the whole stack trace would pass even if the seam's own message said nothing.
+     */
+    private static Throwable seamFailure(Throwable startupFailure) {
+        for (Throwable current = startupFailure; current != null; current = current.getCause()) {
+            if (current instanceof IllegalStateException && current.getMessage() != null && current.getMessage().startsWith("@Projection")) {
+                return current;
+            }
+        }
+        throw new AssertionError("No @Projection IllegalStateException in the failure chain", startupFailure);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ConverterConfiguration {
+        @Bean
+        CloudEventConverter<TestEvent> cloudEventConverter() {
+            return new CloudEventConverter<>() {
+                @Override
+                public CloudEvent toCloudEvent(TestEvent domainEvent) {
+                    return CloudEventBuilder.v1().withId("id").withSource(URI.create("urn:test")).withType("TestEvent").build();
+                }
+
+                @Override
+                public TestEvent toDomainEvent(CloudEvent cloudEvent) {
+                    return new TestEvent();
+                }
+
+                @Override
+                public String getCloudEventType(Class<? extends TestEvent> type) {
+                    return type.getSimpleName();
+                }
+            };
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SubscribableConfiguration {
+        @Bean
+        Subscribable subscribable() {
+            return mock(Subscribable.class);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TwoProvidersConfiguration {
+        @Bean
+        DefaultProjectionStoreProvider providerA() {
+            return new NeverCalledProjectionStoreProvider();
+        }
+
+        @Bean
+        DefaultProjectionStoreProvider providerB() {
+            return new NeverCalledProjectionStoreProvider();
+        }
+    }
+
+    // Throws rather than returning a store, because an ambiguous seam must be reported before any provider is picked.
+    static class NeverCalledProjectionStoreProvider implements DefaultProjectionStoreProvider {
+        @Override
+        public <S, ID> ViewStateRepository<S, ID> createDefaultProjectionStore(String projectionId, Class<S> stateType) {
+            throw new UnsupportedOperationException("must not be called when two providers exist");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ProjectionConfiguration {
+        @Bean
+        DefaultStoreProjection defaultStoreProjection() {
+            return new DefaultStoreProjection();
+        }
+    }
+
+    static class DefaultStoreProjection {
+        @Projection(id = "projection-default-store")
+        org.occurrent.dsl.projection.Projection<TestState, TestEvent, String> projection() {
+            return org.occurrent.dsl.projection.Projection.<TestState, TestEvent, String>builder(new TestState())
+                    .id(event -> "k")
+                    .on(TestEvent.class, (state, event) -> state)
+                    .build();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SnapshotConfiguration {
+        @Bean
+        DefaultStoreSnapshot defaultStoreSnapshot() {
+            return new DefaultStoreSnapshot();
+        }
+    }
+
+    static class DefaultStoreSnapshot {
+        @Snapshot(id = "snapshot-default-store")
+        SnapshotView<TestState, TestEvent> snapshot() {
+            return SnapshotView.<TestState, TestEvent>builder(new TestState())
+                    .on(TestEvent.class, (state, event) -> state)
+                    .build();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SagaConfiguration {
+        @Bean
+        DefaultStoreSaga defaultStoreSaga() {
+            return new DefaultStoreSaga();
+        }
+    }
+
+    static class DefaultStoreSaga {
+        @Saga(id = "saga-default-store")
+        org.occurrent.dsl.saga.Saga<TestEvent, TestState, TestCommand> saga() {
+            return org.occurrent.dsl.saga.Saga.<TestEvent, TestState, TestCommand>builder(new TestState())
+                    .correlateAll(event -> "k")
+                    .startsOn(TestEvent.class)
+                    .build();
+        }
+    }
+
+    record TestState() {
+    }
+
+    record TestEvent() {
+    }
+
+    record TestCommand() {
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/pom.xml
+++ b/framework/spring-boot-autoconfigure/reactor/pom.xml
@@ -39,6 +39,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
 
         <!-- Occurrent -->
         <dependency>
@@ -66,6 +70,12 @@
             <artifactId>occurrent-eventstore-api-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- EventStoreCapability gates the stream and DCB paths, declared so a transitive trim cannot remove it -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-eventstore-capability</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-eventstore-api-dcb</artifactId>
@@ -89,16 +99,6 @@
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-subscription-durable-reactor</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.occurrent</groupId>
-            <artifactId>occurrent-subscription-catchup-reactor</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.occurrent</groupId>
-            <artifactId>occurrent-subscription-stream-catchup-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -58,14 +58,7 @@ import java.util.Set;
  * registry, and delegates the actual annotation processing to the package-private collaborators built in
  * {@link #setApplicationContext}.
  */
-public class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, SmartInitializingSingleton {
-
-    /**
-     * The bean name of the synchronous {@code Subscriptions} DSL declared by the auto-configuration. Resolved by name
-     * (rather than by type) so it does not collide with the asynchronous {@code Subscriptions} bean, which is of the
-     * same type.
-     */
-    public static final String SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME = "occurrentSynchronousSubscriptions";
+class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, SmartInitializingSingleton {
 
     private ApplicationContext applicationContext;
 

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactorBeanNames.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactorBeanNames.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+/**
+ * The bean names a reactive store starter and this module have to agree on. A holder of names keeps the machinery that
+ * uses them package-private, since a starter needs the name rather than the type that resolves it.
+ */
+public final class OccurrentReactorBeanNames {
+
+    /**
+     * The bean name of the synchronous {@code Subscriptions} DSL declared by the auto-configuration. Resolved by name
+     * (rather than by type) so it does not collide with the asynchronous {@code Subscriptions} bean, which is of the
+     * same type.
+     */
+    public static final String SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME = "occurrentSynchronousSubscriptions";
+
+    private OccurrentReactorBeanNames() {
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/PositionOrderedEventStores.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/PositionOrderedEventStores.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+import org.jspecify.annotations.Nullable;
+import org.occurrent.eventstore.api.reactor.EventStore;
+import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Resolves the reactive event store that can be read in position order, which is what reactive history replay needs.
+ * <p>
+ * This is public because it is a seam between this module and a store starter, not an incidental convenience. Whether
+ * replay is possible is decided here, in {@code StartPositionSupport}, and whether a catch-up subscription model is
+ * layered in is decided by the store starter's auto-configuration. Those two answers must never disagree, since a
+ * subscription that is told replay is supported but runs on a model that cannot replay silently skips history instead
+ * of failing at startup. One resolution used by both is what keeps them from drifting apart.
+ */
+public final class PositionOrderedEventStores {
+
+    private PositionOrderedEventStores() {
+    }
+
+    /**
+     * The event store to ask about position replay, or {@code null} when the context has none that can be read in
+     * position order. Asks the event store rather than any reader that happens to be in the context, since other beans
+     * (an external feed, for example) can read in position order without being the store.
+     *
+     * @throws IllegalStateException when several event stores can be read in position order and none is
+     *                               {@code @Primary}, rather than picking one in registration order.
+     */
+    public static @Nullable PositionOrderedReader find(ApplicationContext applicationContext) {
+        // Narrowed by bean name first so that only an event store is ever instantiated, and never some unrelated
+        // PositionOrderedReader. The reader test is on the instance, because a bean declared as EventStore hides
+        // whether the implementation behind it also reads in position order.
+        Map<String, PositionOrderedReader> candidates = new LinkedHashMap<>();
+        for (String name : applicationContext.getBeanNamesForType(EventStore.class)) {
+            if (applicationContext.getBean(name) instanceof PositionOrderedReader reader) {
+                candidates.put(name, reader);
+            }
+        }
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        if (candidates.size() == 1) {
+            return candidates.values().iterator().next();
+        }
+        // Several: let the container apply its own @Primary resolution before giving up, so an application that has
+        // deliberately marked one store as primary keeps working.
+        try {
+            return applicationContext.getBean(EventStore.class) instanceof PositionOrderedReader reader ? reader : null;
+        } catch (NoUniqueBeanDefinitionException e) {
+            throw new IllegalStateException(("Found %d event store beans that can be read in position order (%s) and cannot pick one to replay history from. " +
+                    "Declare a single reactive EventStore bean, or mark one @Primary.").formatted(candidates.size(), String.join(", ", candidates.keySet())), e);
+        }
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SnapshotAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SnapshotAnnotationRegistrar.java
@@ -38,6 +38,7 @@ import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.StartAt;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import reactor.core.publisher.Mono;
 import kotlin.jvm.functions.Function2;
@@ -151,7 +152,7 @@ class SnapshotAnnotationRegistrar {
 
         boolean stream = annotation.capability() == org.occurrent.annotation.Capability.STREAM;
         if (synchronous) {
-            Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentReactiveAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+            Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentReactorBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
             synchronousSubscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(eventFilter), StartAt.subscriptionModelDefault(), consumer);
             return;
         }
@@ -252,7 +253,16 @@ class SnapshotAnnotationRegistrar {
         // The state type is reflected first, so a factory that declares none reports that (the actionable fix) rather
         // than a missing provider.
         Class<S> stateType = (Class<S>) reflectSnapshotStateType(factoryMethod, id);
-        DefaultReactiveSnapshotStoreProvider provider = applicationContext.getBeanProvider(DefaultReactiveSnapshotStoreProvider.class).getIfAvailable();
+        // getIfAvailable() applies @Primary and @Fallback resolution and only throws when the container genuinely
+        // cannot pick, so an ambiguous seam is reported with the annotation id rather than as a bare Spring failure.
+        final DefaultReactiveSnapshotStoreProvider provider;
+        try {
+            provider = applicationContext.getBeanProvider(DefaultReactiveSnapshotStoreProvider.class).getIfAvailable();
+        } catch (NoUniqueBeanDefinitionException e) {
+            String[] providerNames = applicationContext.getBeanNamesForType(DefaultReactiveSnapshotStoreProvider.class);
+            throw new IllegalStateException(("@Snapshot '%s' found %d DefaultReactiveSnapshotStoreProvider beans (%s) and cannot pick one to create the zero-config default snapshot store. " +
+                    "Declare a ReactiveSnapshotStore bean, select one with store/storeName, or mark one provider @Primary.").formatted(id, providerNames.length, String.join(", ", providerNames)), e);
+        }
         if (provider == null) {
             throw new IllegalStateException(("@Snapshot '%s' found no ReactiveSnapshotStore bean and this starter contributes no zero-config default. " +
                     "Declare a ReactiveSnapshotStore bean, or select one with store/storeName.").formatted(id));

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/StartPositionSupport.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/StartPositionSupport.java
@@ -21,7 +21,6 @@ import org.occurrent.annotation.ResumeBehavior;
 import org.occurrent.annotation.StreamSubscription.StartPosition;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.EventStoreCapability;
-import org.occurrent.eventstore.api.reactor.EventStore;
 import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.springboot.common.StartupWorkaround;
@@ -59,14 +58,10 @@ class StartPositionSupport {
         // End workarounds
     }
 
-    // The event store's own reader. A @Projection(source = PUSH) application declares its own PositionOrderedReader
-    // bean, so the candidate is narrowed to the one that is also an EventStore, keeping the question about the store
-    // rather than about whatever else in the context can read in position order.
+    // Ask the event store, not any reader that happens to be in the context. Shared with the store starter that decides
+    // whether to layer in a catch-up model, so the answer here can never promise a replay the wiring cannot perform.
     private @Nullable PositionOrderedReader eventStoreReader() {
-        return applicationContext.getBeanProvider(PositionOrderedReader.class).stream()
-                .filter(EventStore.class::isInstance)
-                .findFirst()
-                .orElse(null);
+        return PositionOrderedEventStores.find(applicationContext);
     }
 
     // A capability-agnostic subscription replays over the unified global position, so replay is supported whenever the

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SubscriptionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SubscriptionAnnotationRegistrar.java
@@ -163,7 +163,7 @@ class SubscriptionAnnotationRegistrar {
             return invokeMono(method, target, SubscriptionAnnotations.bindArguments(parameters, event, metadata, metadata));
         };
 
-        Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentReactiveAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
+        Subscriptions<E> synchronousSubscriptions = applicationContext.getBean(OccurrentReactorBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME, Subscriptions.class);
         // The synchronous subscription model has no lifecycle, start position, or background subscription, so there is
         // no start position to resolve and nothing to wait for.
         synchronousSubscriptions.subscribe(id, AgnosticSubscriptionFilter.filter(filter), StartAt.subscriptionModelDefault(), consumer);

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/DefaultReactiveSnapshotStoreProviderSeamTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/DefaultReactiveSnapshotStoreProviderSeamTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.annotation.Snapshot;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.snapshot.SnapshotView;
+import org.occurrent.subscription.api.reactor.Subscribable;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Characterizes what the reactive stack does when the store-neutral module is used without a store starter: the
+ * {@link DefaultReactiveSnapshotStoreProvider} seam must fail fast naming the {@code @Snapshot} id, rather than NPE on a
+ * missing provider or silently drop the store.
+ * <p>
+ * The factory declares a concrete generic return type on purpose. A raw return type is rejected one step earlier by
+ * state-type reflection, which {@code ReactiveAnnotationFailFastTest} covers, so it never reaches the provider lookup.
+ * <p>
+ * Container-free, since no store is ever created.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DefaultReactiveSnapshotStoreProviderSeamTest {
+
+    @Test
+    void snapshot_without_a_store_bean_and_without_a_default_store_provider_fails_fast() {
+        new ApplicationContextRunner()
+                .withBean(OccurrentReactiveAnnotationBeanPostProcessor.class, OccurrentReactiveAnnotationBeanPostProcessor::new)
+                .withUserConfiguration(ConverterAndSubscribableConfiguration.class, SnapshotConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()))
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("reactive-snapshot-default-store")
+                            .hasMessageContaining("found no ReactiveSnapshotStore bean and this starter contributes no zero-config default");
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ConverterAndSubscribableConfiguration {
+        @Bean
+        CloudEventConverter<TestEvent> cloudEventConverter() {
+            return new CloudEventConverter<>() {
+                @Override
+                public CloudEvent toCloudEvent(TestEvent domainEvent) {
+                    return CloudEventBuilder.v1().withId("id").withSource(URI.create("urn:test")).withType("TestEvent").build();
+                }
+
+                @Override
+                public TestEvent toDomainEvent(CloudEvent cloudEvent) {
+                    return new TestEvent();
+                }
+
+                @Override
+                public String getCloudEventType(Class<? extends TestEvent> type) {
+                    return type.getSimpleName();
+                }
+            };
+        }
+
+        @Bean
+        Subscribable subscribable() {
+            return mock(Subscribable.class);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SnapshotConfiguration {
+        @Bean
+        DefaultStoreSnapshot defaultStoreSnapshot() {
+            return new DefaultStoreSnapshot();
+        }
+    }
+
+    static class DefaultStoreSnapshot {
+        @Snapshot(id = "reactive-snapshot-default-store")
+        SnapshotView<TestState, TestEvent> snapshot() {
+            return SnapshotView.<TestState, TestEvent>builder(new TestState())
+                    .on(TestEvent.class, (state, event) -> state)
+                    .build();
+        }
+    }
+
+    record TestState() {
+    }
+
+    record TestEvent() {
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationConfigurationTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins that the store-neutral reactive configuration actually contributes the annotation post-processor, and that the
+ * subscription kill switch removes it. Both halves are needed: an absence-only test passes just as happily when the
+ * {@code @Bean} method is gone entirely.
+ * <p>
+ * The reactive twin of {@code AnnotationBeanPostProcessorDestroyCallbackTest} in the blocking module, and the only
+ * container-free coverage of this configuration class (the store starter's equivalent is Docker-gated).
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class OccurrentReactiveAnnotationConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OccurrentReactiveAnnotationConfiguration.class));
+
+    @Test
+    void the_post_processor_is_contributed_by_default() {
+        runner.run(context -> assertThat(context).hasSingleBean(OccurrentReactiveAnnotationBeanPostProcessor.class));
+    }
+
+    @Test
+    void the_post_processor_is_contributed_when_subscriptions_are_explicitly_enabled() {
+        runner.withPropertyValues("occurrent.subscription.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(OccurrentReactiveAnnotationBeanPostProcessor.class));
+    }
+
+    @Test
+    void turning_subscriptions_off_removes_the_post_processor_entirely() {
+        runner.withPropertyValues("occurrent.subscription.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(OccurrentReactiveAnnotationBeanPostProcessor.class));
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveAnnotationFailFastTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveAnnotationFailFastTest.java
@@ -98,7 +98,8 @@ class ReactiveAnnotationFailFastTest {
 
     @Test
     void a_beginning_of_time_stream_subscription_fails_fast_when_history_replay_is_not_supported() {
-        // No ReactorMongoEventStore bean at all, so streamHistoryReplaySupported() is false without needing a store.
+        // No bean that is both a PositionOrderedReader and an EventStore, so streamHistoryReplaySupported() is false
+        // without needing a store at all.
         new ApplicationContextRunner()
                 .withBean(OccurrentReactiveAnnotationBeanPostProcessor.class, OccurrentReactiveAnnotationBeanPostProcessor::new)
                 .withUserConfiguration(ConverterConfiguration.class, BeginningOfTimeStreamSubscriberConfiguration.class)

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StartPositionSupportReaderResolutionTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StartPositionSupportReaderResolutionTest.java
@@ -19,21 +19,26 @@ package org.occurrent.springboot.reactor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.EventStoreCapability;
 import org.occurrent.eventstore.api.reactor.EventStore;
 import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
+import org.occurrent.springboot.common.OccurrentProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 /**
- * Pins how {@link StartPositionSupport} picks the reader it asks about position support. It used to resolve the
- * concrete {@code ReactorMongoEventStore}, which made the lookup store-specific but also guaranteed a single
- * candidate. Resolving the store-neutral {@link PositionOrderedReader} widens it, because a
- * {@code @Projection(source = PUSH)} application declares its own reader bean, so two candidates are reachable in one
- * context and picking the wrong one silently changes whether history is replayed.
+ * Pins how {@link StartPositionSupport} picks the reader it asks about position support: the event store, not any reader
+ * that happens to be in the context. It used to resolve the concrete {@code ReactorMongoEventStore}, which made the
+ * lookup store-specific but also guaranteed a single candidate, so the store-neutral lookup has to reject a reader that
+ * is not the store and refuse to guess between two that are. Picking the wrong one silently changes whether history is
+ * replayed.
  * <p>
  * Container-free: the question is bean selection, so a mock reader answers it and a real MongoDB adds nothing.
  */
@@ -83,6 +88,41 @@ class StartPositionSupportReaderResolutionTest {
                     StartPositionSupport startPositionSupport = new StartPositionSupport(context);
 
                     assertThat(startPositionSupport.positionReplaySupported()).isFalse();
+                });
+    }
+
+    @Test
+    void two_event_stores_that_both_read_in_position_order_fail_loud_instead_of_picking_one() {
+        new ApplicationContextRunner()
+                .withBean("firstEventStore", PositionOrderedReader.class, () -> storeReader(true))
+                .withBean("secondEventStore", PositionOrderedReader.class, () -> storeReader(false))
+                .run(context -> {
+                    StartPositionSupport startPositionSupport = new StartPositionSupport(context);
+
+                    // Registration order would have answered true from the first store, which is a coin flip dressed up
+                    // as a decision, so both names are reported instead.
+                    assertThatThrownBy(startPositionSupport::positionReplaySupported)
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("firstEventStore")
+                            .hasMessageContaining("secondEventStore");
+                });
+    }
+
+    @Test
+    void a_store_that_writes_a_position_without_the_stream_capability_does_not_support_stream_history_replay() {
+        OccurrentProperties occurrentProperties = new OccurrentProperties();
+        occurrentProperties.getEventStore().setCapabilities(Set.of(EventStoreCapability.DCB));
+
+        new ApplicationContextRunner()
+                .withBean("eventStore", PositionOrderedReader.class, () -> storeReader(true))
+                .withBean(OccurrentProperties.class, () -> occurrentProperties)
+                .run(context -> {
+                    StartPositionSupport startPositionSupport = new StartPositionSupport(context);
+
+                    // A DCB-only store writes a position, so the reader alone says yes. Stream replay also needs stream
+                    // events to replay, which this store has none of.
+                    assertThat(startPositionSupport.positionReplaySupported()).isTrue();
+                    assertThat(startPositionSupport.streamHistoryReplaySupported()).isFalse();
                 });
     }
 

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StartPositionSupportReaderResolutionTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StartPositionSupportReaderResolutionTest.java
@@ -95,12 +95,12 @@ class StartPositionSupportReaderResolutionTest {
     void two_event_stores_that_both_read_in_position_order_fail_loud_instead_of_picking_one() {
         new ApplicationContextRunner()
                 .withBean("firstEventStore", PositionOrderedReader.class, () -> storeReader(true))
-                .withBean("secondEventStore", PositionOrderedReader.class, () -> storeReader(false))
+                .withBean("secondEventStore", PositionOrderedReader.class, () -> storeReader(true))
                 .run(context -> {
                     StartPositionSupport startPositionSupport = new StartPositionSupport(context);
 
-                    // Registration order would have answered true from the first store, which is a coin flip dressed up
-                    // as a decision, so both names are reported instead.
+                    // Both write a position, so nothing here depends on writesPosition. The point is that picking by
+                    // registration order is a coin flip dressed up as a decision, so both names are reported instead.
                     assertThatThrownBy(startPositionSupport::positionReplaySupported)
                             .isInstanceOf(IllegalStateException.class)
                             .hasMessageContaining("firstEventStore")

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.occurrent.eventstore.api.dcb.DcbCriteria;
 import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
 import org.occurrent.eventstore.api.reactor.EventStore;
 import org.occurrent.eventstore.api.reactor.EventStoreQueries;
+import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
 import org.occurrent.filter.Filter;
@@ -52,8 +53,9 @@ import org.occurrent.springboot.common.OnMissingCloudEventConverterAndCloudEvent
 import org.occurrent.springboot.common.OnStreamEventStoreCapabilityCondition;
 import org.occurrent.springboot.common.StartupWorkaround;
 import org.occurrent.springboot.reactor.DefaultReactiveSnapshotStoreProvider;
-import org.occurrent.springboot.reactor.OccurrentReactiveAnnotationBeanPostProcessor;
+import org.occurrent.springboot.reactor.OccurrentReactorBeanNames;
 import org.occurrent.springboot.reactor.OccurrentReactiveAnnotationConfiguration;
+import org.occurrent.springboot.reactor.PositionOrderedEventStores;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.reactor.Subscribable;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
@@ -113,9 +115,16 @@ public class OccurrentReactiveMongoAutoConfiguration<E> {
         return () -> applicationContext.getBean(ReactiveMongoOperations.class);
     }
 
-    /** The zero-config MongoDB snapshot store a {@code @Snapshot} falls back to when it declares none. */
+    /**
+     * The zero-config MongoDB snapshot store a {@code @Snapshot} falls back to when it declares none.
+     * <p>
+     * {@code @Fallback} rather than {@code @ConditionalOnMissingBean}: this configuration is activated by
+     * {@code @EnableOccurrentReactive}'s plain {@code @Import}, so the condition can be evaluated before an application's own
+     * provider bean is registered, letting both through. A {@code @Fallback} bean is excluded at dependency-resolution
+     * time instead, which registration order cannot affect. Same reasoning as {@code occurrentTypeMapper()} below.
+     */
     @Bean
-    @ConditionalOnMissingBean(DefaultReactiveSnapshotStoreProvider.class)
+    @Fallback
     DefaultReactiveSnapshotStoreProvider occurrentMongoDefaultReactiveSnapshotStoreProvider(ApplicationContext applicationContext) {
         return new MongoReactiveSnapshotStoreProvider(applicationContext);
     }
@@ -181,29 +190,39 @@ public class OccurrentReactiveMongoAutoConfiguration<E> {
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
     public ReactorDurableSubscriptionModel occurrentDurableSubscriptionModel(ReactiveMongoOperations mongo, CheckpointStorage storage,
                                                                              OccurrentProperties occurrentProperties, ObjectProvider<DcbEventStore> dcbEventStore,
-                                                                             ObjectProvider<ReactorMongoEventStore> reactorEventStore) {
+                                                                             ApplicationContext applicationContext) {
         EventStoreProperties eventStoreProperties = occurrentProperties.getEventStore();
         ReactorMongoSubscriptionModel mongoSubscriptionModel = new ReactorMongoSubscriptionModel(mongo, eventStoreProperties.getCollection(), eventStoreProperties.getTimeRepresentation(),
                 ReactorMongoSubscriptionModelConfig.withConfig().restartSubscriptionsOnChangeStreamHistoryLost(occurrentProperties.getSubscription().isRestartOnChangeStreamHistoryLost()));
-        // A combined store has one ReactorMongoEventStore bean that is both the DCB store and the position-ordered
-        // stream reader, so it fills both roles. DcbCriteria.all() and Filter.all() are shared by every subscription,
-        // which each narrow to their own query or filter in the consumer.
+        return new ReactorDurableSubscriptionModel(composeCatchupLayer(mongoSubscriptionModel, eventStoreProperties, dcbEventStore, applicationContext), storage);
+    }
+
+    /**
+     * Wraps {@code liveModel} in whatever catch-up model the store supports, or returns it unwrapped when the store
+     * supports no replay at all. Package-private rather than inlined above so the composition can be asserted without a
+     * running MongoDB.
+     */
+    static CheckpointAwareSubscriptionModel composeCatchupLayer(CheckpointAwareSubscriptionModel liveModel, EventStoreProperties eventStoreProperties,
+                                                                ObjectProvider<DcbEventStore> dcbEventStore, ApplicationContext applicationContext) {
+        // A combined store has one event store bean that is both the DCB store and the position-ordered stream reader,
+        // so it fills both roles. DcbCriteria.all() and Filter.all() are shared by every subscription, which each narrow
+        // to their own query or filter in the consumer.
         DcbEventStore dcbStore = eventStoreProperties.getCapabilities().contains(DCB) ? dcbEventStore.getIfAvailable() : null;
-        ReactorMongoEventStore streamStore = reactorEventStore.getIfAvailable();
+        // Resolved through the same neutral narrowing the annotation machinery's replay probe uses, so a user-supplied
+        // event store that reads in position order gets a catch-up layer instead of a probe that promises replay over a
+        // bare change stream.
+        PositionOrderedReader streamStore = PositionOrderedEventStores.find(applicationContext);
         // Stream catch-up needs the STREAM capability, not just a position. A DCB-only store also writes position, so
         // gating on writesPosition() alone would wrongly wire stream catch-up for it.
         boolean streamCatchup = eventStoreProperties.getCapabilities().contains(STREAM) && streamStore != null && streamStore.writesPosition();
-        final CheckpointAwareSubscriptionModel inner;
         if (dcbStore != null && streamCatchup) {
-            inner = new ReactorCatchupSubscriptionModel(mongoSubscriptionModel, streamStore, dcbStore, DcbCriteria.all(), Filter.all());
+            return new ReactorCatchupSubscriptionModel(liveModel, streamStore, dcbStore, DcbCriteria.all(), Filter.all());
         } else if (dcbStore != null) {
-            inner = new ReactorCatchupSubscriptionModel(mongoSubscriptionModel, dcbStore, DcbCriteria.all());
+            return new ReactorCatchupSubscriptionModel(liveModel, dcbStore, DcbCriteria.all());
         } else if (streamCatchup) {
-            inner = new ReactorCatchupSubscriptionModel(mongoSubscriptionModel, streamStore, Filter.all());
-        } else {
-            inner = mongoSubscriptionModel;
+            return new ReactorCatchupSubscriptionModel(liveModel, streamStore, Filter.all());
         }
-        return new ReactorDurableSubscriptionModel(inner, storage);
+        return liveModel;
     }
 
     @Bean
@@ -270,8 +289,8 @@ public class OccurrentReactiveMongoAutoConfiguration<E> {
      * so it is given a distinct bean name (and the asynchronous one is {@link Primary}); the annotation processor
      * resolves this one by name.
      */
-    @Bean(OccurrentReactiveAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
-    @ConditionalOnMissingBean(name = OccurrentReactiveAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
+    @Bean(OccurrentReactorBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
+    @ConditionalOnMissingBean(name = OccurrentReactorBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
     public Subscriptions<E> occurrentSynchronousSubscriptions(SynchronousSubscriptionModel synchronousSubscriptionModel, CloudEventConverter<E> cloudEventConverter) {
         return new Subscriptions<>(synchronousSubscriptionModel, cloudEventConverter);

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveCatchupLayerWiringTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveCatchupLayerWiringTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.reactor;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.eventstore.api.dcb.reactor.DcbEventStore;
+import org.occurrent.eventstore.api.reactor.EventStore;
+import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
+import org.occurrent.springboot.common.OccurrentProperties;
+import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
+import org.occurrent.subscription.reactor.durable.catchup.ReactorCatchupSubscriptionModel;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Guards the invariant that ties the neutral replay probe to this starter's wiring: whenever the probe reports that
+ * history replay is supported, a catch-up model must actually have been layered in. A user-supplied reactive event store
+ * used to break it, because the probe asked whether any {@code EventStore} reads in position order while the wiring
+ * asked for the concrete MongoDB store, so replay was promised and then silently skipped over a bare change stream.
+ * <p>
+ * Container-free: the composition is decided from bean types and properties, so mocks answer it and a real MongoDB adds
+ * nothing. The live model is mocked for the same reason.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ReactiveCatchupLayerWiringTest {
+
+    @Test
+    void a_user_supplied_event_store_that_reads_in_position_order_gets_a_catchup_layer() {
+        try (GenericApplicationContext applicationContext = new GenericApplicationContext()) {
+            applicationContext.registerBean("userEventStore", EventStore.class, () -> positionOrderedEventStore(true));
+            applicationContext.refresh();
+
+            CheckpointAwareSubscriptionModel model = OccurrentReactiveMongoAutoConfiguration.composeCatchupLayer(
+                    mock(CheckpointAwareSubscriptionModel.class), new OccurrentProperties().getEventStore(),
+                    applicationContext.getBeanProvider(DcbEventStore.class), applicationContext);
+
+            assertThat(model).isInstanceOf(ReactorCatchupSubscriptionModel.class);
+        }
+    }
+
+    @Test
+    void an_event_store_that_writes_no_position_gets_no_catchup_layer() {
+        CheckpointAwareSubscriptionModel liveModel = mock(CheckpointAwareSubscriptionModel.class);
+
+        try (GenericApplicationContext applicationContext = new GenericApplicationContext()) {
+            applicationContext.registerBean("userEventStore", EventStore.class, () -> positionOrderedEventStore(false));
+            applicationContext.refresh();
+
+            CheckpointAwareSubscriptionModel model = OccurrentReactiveMongoAutoConfiguration.composeCatchupLayer(
+                    liveModel, new OccurrentProperties().getEventStore(),
+                    applicationContext.getBeanProvider(DcbEventStore.class), applicationContext);
+
+            // The other half of the invariant: no replay wired here, and the probe reports none either, so a
+            // BEGINNING_OF_TIME subscription fails at startup rather than losing history.
+            assertThat(model).isSameAs(liveModel);
+        }
+    }
+
+    private static EventStore positionOrderedEventStore(boolean writesPosition) {
+        EventStore eventStore = mock(EventStore.class, withSettings().extraInterfaces(PositionOrderedReader.class));
+        when(((PositionOrderedReader) eventStore).writesPosition()).thenReturn(writesPosition);
+        return eventStore;
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
@@ -51,7 +51,7 @@ import org.occurrent.retry.RetryStrategy;
 import org.occurrent.springboot.blocking.DefaultProjectionStoreProvider;
 import org.occurrent.springboot.blocking.DefaultSagaStateStoreProvider;
 import org.occurrent.springboot.blocking.DefaultSnapshotStoreProvider;
-import org.occurrent.springboot.blocking.OccurrentBlockingAnnotationBeanPostProcessor;
+import org.occurrent.springboot.blocking.OccurrentBlockingBeanNames;
 import org.occurrent.springboot.blocking.OccurrentBlockingAnnotationConfiguration;
 import org.occurrent.springboot.common.*;
 import org.occurrent.springboot.common.OccurrentProperties.EventStoreProperties;
@@ -110,23 +110,30 @@ public class OccurrentMongoAutoConfiguration<E> {
         return () -> applicationContext.getBean(MongoOperations.class);
     }
 
-    /** The zero-config MongoDB read-model store a {@code @Projection} falls back to when it declares none. */
+    /**
+     * The zero-config MongoDB read-model store a {@code @Projection} falls back to when it declares none.
+     * <p>
+     * {@code @Fallback} rather than {@code @ConditionalOnMissingBean}: this configuration is activated by
+     * {@code @EnableOccurrent}'s plain {@code @Import}, so the condition can be evaluated before an application's own
+     * provider bean is registered, letting both through. A {@code @Fallback} bean is excluded at dependency-resolution
+     * time instead, which registration order cannot affect. Same reasoning as {@code occurrentTypeMapper()} below.
+     */
     @Bean
-    @ConditionalOnMissingBean(DefaultProjectionStoreProvider.class)
+    @Fallback
     DefaultProjectionStoreProvider occurrentMongoDefaultProjectionStoreProvider(ApplicationContext applicationContext) {
         return new MongoProjectionStoreProvider(applicationContext);
     }
 
-    /** The zero-config MongoDB snapshot store a {@code @Snapshot} falls back to when it declares none. */
+    /** The zero-config MongoDB snapshot store a {@code @Snapshot} falls back to when it declares none. {@code @Fallback} for the reason above. */
     @Bean
-    @ConditionalOnMissingBean(DefaultSnapshotStoreProvider.class)
+    @Fallback
     DefaultSnapshotStoreProvider occurrentMongoDefaultSnapshotStoreProvider(ApplicationContext applicationContext) {
         return new MongoSnapshotStoreProvider(applicationContext);
     }
 
-    /** The zero-config MongoDB saga state store a {@code @Saga} falls back to when it declares none. */
+    /** The zero-config MongoDB saga state store a {@code @Saga} falls back to when it declares none. {@code @Fallback} for the reason above. */
     @Bean
-    @ConditionalOnMissingBean(DefaultSagaStateStoreProvider.class)
+    @Fallback
     DefaultSagaStateStoreProvider occurrentMongoDefaultSagaStateStoreProvider(ApplicationContext applicationContext) {
         return new MongoSagaStateStoreProvider(applicationContext);
     }
@@ -293,8 +300,8 @@ public class OccurrentMongoAutoConfiguration<E> {
      * so it is given a distinct bean name (and the asynchronous one is {@link Primary}); the annotation processor
      * resolves this one by name.
      */
-    @Bean(OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
-    @ConditionalOnMissingBean(name = OccurrentBlockingAnnotationBeanPostProcessor.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
+    @Bean(OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
+    @ConditionalOnMissingBean(name = OccurrentBlockingBeanNames.SYNCHRONOUS_SUBSCRIPTION_DSL_BEAN_NAME)
     @ConditionalOnProperty(name = "occurrent.subscription.enabled", havingValue = "true", matchIfMissing = true)
     public Subscriptions<E> occurrentSynchronousSubscriptionDsl(SynchronousSubscriptionModel synchronousSubscriptionModel, CloudEventConverter<E> cloudEventConverter) {
         return new Subscriptions<>(synchronousSubscriptionModel, cloudEventConverter);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SagaAnnotationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SagaAnnotationMongoTest.java
@@ -114,6 +114,16 @@ class SagaAnnotationMongoTest {
         });
     }
 
+    @Test
+    void stores_the_state_of_a_saga_that_declares_no_store_in_a_saga_prefixed_collection() {
+        // Pins the collection name, not just that state round-trips: renaming it would orphan every existing saga's
+        // state on upgrade, and observing state through the registry cannot see that.
+        applicationService.execute("order-3", events -> List.of(new OrderPlaced("order-3")));
+
+        await().atMost(ofSeconds(30)).pollInterval(ofMillis(100)).untilAsserted(() ->
+                assertThat(mongoOperations.collectionExists("saga-order-fulfillment")).isTrue());
+    }
+
     private boolean hasLeaseDocument(String id) {
         return mongoOperations.getCollection("competing-consumer-locks").countDocuments(new Document("_id", id)) > 0;
     }

--- a/rewrite/src/main/resources/META-INF/rewrite/annotation-enums.yml
+++ b/rewrite/src/main/resources/META-INF/rewrite/annotation-enums.yml
@@ -77,6 +77,26 @@ recipeList:
       newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties
       ignoreDefinition: true
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.OccurrentProperties$ApplicationServiceProperties
+      newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties$ApplicationServiceProperties
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.OccurrentProperties$CloudEventConverterProperties
+      newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties$CloudEventConverterProperties
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.OccurrentProperties$EventStoreProperties
+      newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties$EventStoreProperties
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.OccurrentProperties$StreamProperties
+      newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties$StreamProperties
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.OccurrentProperties$SubscriptionProperties
+      newFullyQualifiedTypeName: org.occurrent.springboot.common.OccurrentProperties$SubscriptionProperties
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.occurrent.springboot.mongo.common.SubscriptionAnnotations
       newFullyQualifiedTypeName: org.occurrent.springboot.common.SubscriptionAnnotations
       ignoreDefinition: true

--- a/rewrite/src/main/resources/META-INF/rewrite/upgrade-0_31.yml
+++ b/rewrite/src/main/resources/META-INF/rewrite/upgrade-0_31.yml
@@ -22,8 +22,13 @@ description: >-
   ResumeBehavior and StartupMode enums, which moved from being nested inside the Subscription, StreamSubscription,
   DcbSubscription, and Projection annotations to top-level types in org.occurrent.annotation. Also applies the
   Subscription.StartPosition and DcbSubscription.DcbStartPosition move to the shared top-level
-  org.occurrent.annotation.StartPosition. Also renames the four subscription checkpoint-storage artifacts
-  from their -position-storage coordinates to -checkpoint-storage.
+  org.occurrent.annotation.StartPosition. Also rewrites every reference, import, and static import of
+  EventMetadata from org.occurrent.dsl.subscription.EventMetadata to org.occurrent.cloudevents.EventMetadata.
+  Also rewrites OccurrentProperties and the other Spring Boot annotation machinery types from
+  org.occurrent.springboot.mongo.common to org.occurrent.springboot.common. Also renames the four subscription
+  checkpoint-storage artifacts from their -position-storage coordinates to -checkpoint-storage, and the Spring
+  Boot autoconfigure artifact from occurrent-mongodb-spring-boot-autoconfigure to
+  occurrent-spring-boot-autoconfigure.
 recipeList:
   - org.occurrent.MigrateOccurrentRenames_0_31
   - org.occurrent.MigrateCoordinates_0_31

--- a/rewrite/src/test/java/org/occurrent/rewrite/CoordinateRename_0_31Test.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/CoordinateRename_0_31Test.java
@@ -19,13 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 /**
  * Covers the {@code MigrateCoordinates_0_31} recipe: the 0.31.0 rename of the four subscription
- * checkpoint-storage artifacts from -position-storage to -checkpoint-storage. A renamed coordinate and an
- * unrelated Occurrent coordinate (left alone) are both exercised.
+ * checkpoint-storage artifacts from -position-storage to -checkpoint-storage, and the rename of the Spring Boot
+ * autoconfigure artifact from {@code occurrent-mongodb-spring-boot-autoconfigure} to
+ * {@code occurrent-spring-boot-autoconfigure}. A renamed coordinate and an unrelated Occurrent coordinate (left
+ * alone) are both exercised for each.
  */
 class CoordinateRename_0_31Test implements RewriteTest {
 

--- a/rewrite/src/test/java/org/occurrent/rewrite/CoordinateRename_0_31Test.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/CoordinateRename_0_31Test.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/rewrite/src/test/java/org/occurrent/rewrite/SpringBootCommonPackageMoveRenameTest.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/SpringBootCommonPackageMoveRenameTest.java
@@ -68,6 +68,47 @@ class SpringBootCommonPackageMoveRenameTest extends AnnotationEnumRenamesRecipeT
         );
     }
 
+    // A ChangeType on the outer class does NOT rewrite references to its nested classes, verified by removing the
+    // nested entries and watching this fail with "expected to make a change but made no changes". So each nested type
+    // released in 0.30.0 carries its own entry. All five of those are singly nested, which is the case OpenRewrite
+    // requalifies correctly, by importing the outer type. Two levels of nesting does not survive the rewrite (the
+    // import is dropped and the reference left unqualified), but every doubly-nested property group in this class was
+    // added after 0.30.0, so no caller can name one and none gets an entry.
+    @Test
+    void nestedTypeOfOccurrentPropertiesMovesFromSpringbootMongoCommonToSpringbootCommonPackage() {
+        rewriteRun(
+                java(
+                        """
+                        package org.occurrent.springboot.mongo.common;
+                        public class OccurrentProperties {
+                            public static class SubscriptionProperties {
+                            }
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        import org.occurrent.springboot.mongo.common.OccurrentProperties.SubscriptionProperties;
+
+                        class Foo {
+                            SubscriptionProperties properties;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.occurrent.springboot.common.OccurrentProperties;
+
+                        class Foo {
+                            OccurrentProperties.SubscriptionProperties properties;
+                        }
+                        """
+                )
+        );
+    }
+
     @Test
     void occurrentPropertiesMovesFromSpringbootMongoCommonToSpringbootCommonPackageInKotlin() {
         rewriteRun(

--- a/rewrite/src/test/java/org/occurrent/rewrite/Upgrade0_20_5To0_31ChainTest.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/Upgrade0_20_5To0_31ChainTest.java
@@ -26,11 +26,14 @@ import static org.openrewrite.java.Assertions.java;
 /**
  * Proves that a user upgrading straight from Occurrent 0.20.5, who runs both the {@code UpgradeToOccurrent_0_30} and
  * {@code UpgradeToOccurrent_0_31} umbrella recipes, lands on the final 0.31 package rather than stalling on the
- * intermediate 0.30 one. {@code OccurrentProperties} has a 0.30 rename (still 0.20.5 -> 0.30.0, {@code
+ * intermediate 0.30 one. There are two cases in the whole rewrite module where two independently-shipped umbrella
+ * recipes must compose for a type. {@code OccurrentProperties} has a 0.30 rename (still 0.20.5 -> 0.30.0, {@code
  * org.occurrent.springboot.mongo.blocking} -> {@code org.occurrent.springboot.mongo.common}) chained into a 0.31
- * rename (0.30.0 -> 0.31.0, {@code org.occurrent.springboot.mongo.common} -> {@code org.occurrent.springboot.common}),
- * so this is the one case in the whole rewrite module where two independently-shipped umbrella recipes must compose
- * for a type.
+ * rename (0.30.0 -> 0.31.0, {@code org.occurrent.springboot.mongo.common} -> {@code org.occurrent.springboot.common}).
+ * {@code EventMetadata} has the identical two-hop shape: a 0.30 rename (0.20.5 -> 0.30.0, {@code
+ * org.occurrent.dsl.subscription.blocking.EventMetadata} -> {@code org.occurrent.dsl.subscription.EventMetadata})
+ * chained into a 0.31 rename (0.30.0 -> 0.31.0, {@code org.occurrent.dsl.subscription.EventMetadata} -> {@code
+ * org.occurrent.cloudevents.EventMetadata}).
  *
  * <p>The same two-hop shape exists on paper for the Spring Boot autoconfigure module coordinate
  * ({@code MigrateCoordinates_0_30} maps {@code spring-boot-autoconfigure-mongodb-common} to
@@ -82,6 +85,39 @@ class Upgrade0_20_5To0_31ChainTest implements RewriteTest {
 
                         class Foo {
                             OccurrentProperties properties;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void eventMetadataConvergesFromThe0_20_5PackageToTheFinal0_31PackageInOneInvocation() {
+        rewriteRun(
+                java(
+                        """
+                        package org.occurrent.dsl.subscription.blocking;
+                        public class EventMetadata {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        import org.occurrent.dsl.subscription.blocking.EventMetadata;
+
+                        class Foo {
+                            EventMetadata metadata;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.occurrent.cloudevents.EventMetadata;
+
+                        class Foo {
+                            EventMetadata metadata;
                         }
                         """
                 )


### PR DESCRIPTION
Three independent deep reviews of #434 (issue #409) found one behavior regression, several sharp edges on the new capability seams, and gaps in what the new tests actually proved. Nothing needed a revert.

## The regression

The neutral capability probe answered "can history be replayed" from a store-neutral capability, while the reactive starter still composed its catch-up layer from the concrete `ReactorMongoEventStore`. Those disagree for a user-supplied reactive `EventStore` that implements `PositionOrderedReader`: the probe said yes, no `ReactorCatchupSubscriptionModel` got wired, and `startAt = BEGINNING` silently stopped replaying where it used to fail at startup. Fail-loud became fail-silent.

Both sides now go through one rule, `PositionOrderedEventStores.find`, so the probe cannot promise a replay the wiring will not perform. `ReactiveCatchupLayerWiringTest` fails if the wiring goes back to the concrete lookup. The blocking stack was checked rather than assumed and has no equivalent divergence: it has no replay probe, and its catch-up model is gated on the capability properties.

That shared rule also repairs the lookup itself. The first version used `getBeanProvider(PositionOrderedReader.class).stream()`, which force-created every matching bean while running mid-refresh, ignored `@Primary`, and silently took the first in registration order where the old code threw.

## Seam sharp edges

The four `Default*Provider` beans move from `@ConditionalOnMissingBean` to `@Fallback`, because the same files already document that `@ConditionalOnMissingBean` is unreliable under `@EnableOccurrent`'s plain `@Import`, and already adopted `@Fallback` for `TagGenerator`. Two providers is now a legitimate state, so each resolution site reports the annotation, its id and the candidate bean names rather than letting a bare `NoUniqueBeanDefinitionException` escape.

Both bean-post-processors go back to package-private. They were public only to carry a bean-name constant, which now lives in `OccurrentBlockingBeanNames` and `OccurrentReactorBeanNames`. The public surface of the two modules is now exactly what a store starter has to name.

## Tests

The four seam fail-loud paths had no coverage at all, and that is the contract #410 will be written against. Each gets a test, plus one for the ambiguous-provider case. A destroy-callback test that asserted only absence passed vacuously and now asserts presence too. The reactor configuration was never loaded by any test. The `saga-<id>` collection name was pinned by nothing, so renaming it would have orphaned every saga's state with a green build.

Every new test was verified by mutating the production code and confirming it fails. That is worth stating because two tests in this area turned out to be vacuous when checked that way, including one whose assertion was satisfied by the wrapped Spring exception rather than by the seam's own.

## Migration artifacts

The changelog was missing a fourth breaking-changes bullet while the upgrade guide already claimed four. The published recipe description never mentioned `EventMetadata` or this move, which is the text `rewrite:discover` shows.

A `ChangeType` on an outer class does not rewrite references to its nested classes, verified by mutation, so the five nested property groups that shipped in 0.30.0 each get an entry. The three added since do not: no released caller can name them, and two are doubly nested, which OpenRewrite does not rewrite into compiling code. `EventMetadata` turned out to have the same two-hop chain across the 0.30 and 0.31 umbrellas and now has a convergence test as well.

## Also

`dependency:analyze` found four used-undeclared artifacts, now declared, and two genuinely unused ones in the reactor module, now dropped.

## Verification

76 container-free tests across the three modules, up from 66. 38 rewrite tests. `SagaAnnotationMongoTest` green against a real MongoDB. The mongo-neutrality grep still returns nothing for both per-stack modules and their POMs.
