### PR TITLE
Document where a single-instance projection stores its state

### DIFF
--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
@@ -68,6 +68,11 @@ public final class DcbProjectionRunner<E> {
     /**
      * Subscribes with the given id and materializes {@code dcbProjection} into {@code repository}, skipping events whose
      * id resolves to {@code null}.
+     *
+     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
+     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
+     * events, so read it back with the same id. One that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
@@ -76,6 +81,11 @@ public final class DcbProjectionRunner<E> {
     /**
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and materializes {@code dcbProjection} into {@code repository}, skipping events whose id resolves to {@code null}.
+     *
+     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
+     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
+     * events, so read it back with the same id. One that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
@@ -69,10 +69,14 @@ public final class DcbProjectionRunner<E> {
      * Subscribes with the given id and materializes {@code dcbProjection} into {@code repository}, skipping events whose
      * id resolves to {@code null}.
      *
-     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
-     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
-     * events, so read it back with the same id. One that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A DCB projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. One that has an id function keys each instance by whatever that function returns
+     * for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
@@ -82,10 +86,14 @@ public final class DcbProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and materializes {@code dcbProjection} into {@code repository}, skipping events whose id resolves to {@code null}.
      *
-     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
-     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
-     * events, so read it back with the same id. One that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A DCB projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. One that has an id function keys each instance by whatever that function returns
+     * for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
@@ -87,10 +87,14 @@ public final class ProjectionRunner<E> {
      * same instance use {@link #project(String, Projection, MaterializedView)} with a store that re-reads and reapplies
      * on conflict, such as the view DSL's {@code materialized(...)}.
      *
-     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
-     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
-     * read it back with the same id. A projection that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. A projection that has an id function keys each instance by whatever that function
+     * returns for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
@@ -101,10 +105,14 @@ public final class ProjectionRunner<E> {
      * and materializes {@code projection} into {@code repository}, skipping events whose id resolves to {@code null}. Pass
      * {@code StartAt.subscriptionModelDefault()} or a specific position to control catch-up.
      *
-     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
-     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
-     * read it back with the same id. A projection that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. A projection that has an id function keys each instance by whatever that function
+     * returns for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return project(subscriptionId, projection, Projections.materializedView(projection, repository, subscriptionId), startAt);

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
@@ -86,6 +86,11 @@ public final class ProjectionRunner<E> {
      * the event. This overload adds no fine-grained optimistic-locking retry of its own, so for concurrent writers to the
      * same instance use {@link #project(String, Projection, MaterializedView)} with a store that re-reads and reapplies
      * on conflict, such as the view DSL's {@code materialized(...)}.
+     *
+     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
+     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
+     * read it back with the same id. A projection that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
@@ -95,6 +100,11 @@ public final class ProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and materializes {@code projection} into {@code repository}, skipping events whose id resolves to {@code null}. Pass
      * {@code StartAt.subscriptionModelDefault()} or a specific position to control catch-up.
+     *
+     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
+     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
+     * read it back with the same id. A projection that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return project(subscriptionId, projection, Projections.materializedView(projection, repository, subscriptionId), startAt);

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
@@ -113,10 +113,14 @@ public final class ReactiveDcbProjectionRunner<E> {
      * Subscribes with the given id and materializes {@code dcbProjection} into the blocking {@code repository} (scheduled
      * on {@code boundedElastic}), skipping events whose id resolves to {@code null}.
      *
-     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
-     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
-     * events, so read it back with the same id. One that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A DCB projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. One that has an id function keys each instance by whatever that function returns
+     * for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
@@ -127,10 +131,14 @@ public final class ReactiveDcbProjectionRunner<E> {
      * and materializes {@code dcbProjection} into the blocking {@code repository} (scheduled on {@code boundedElastic}),
      * skipping events whose id resolves to {@code null}.
      *
-     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
-     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
-     * events, so read it back with the same id. One that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A DCB projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. One that has an id function keys each instance by whatever that function returns
+     * for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
@@ -112,6 +112,11 @@ public final class ReactiveDcbProjectionRunner<E> {
     /**
      * Subscribes with the given id and materializes {@code dcbProjection} into the blocking {@code repository} (scheduled
      * on {@code boundedElastic}), skipping events whose id resolves to {@code null}.
+     *
+     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
+     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
+     * events, so read it back with the same id. One that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
@@ -121,6 +126,11 @@ public final class ReactiveDcbProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and materializes {@code dcbProjection} into the blocking {@code repository} (scheduled on {@code boundedElastic}),
      * skipping events whose id resolves to {@code null}.
+     *
+     * <p>A DCB projection whose {@code projection().id()} is {@code null} is single-instance: it has one
+     * slot, and that slot is stored under {@code subscriptionId} rather than under a key derived from the
+     * events, so read it back with the same id. One that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
@@ -111,10 +111,14 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id and materializes {@code projection} into the blocking {@code repository} (scheduled on
      * {@code boundedElastic}), skipping events whose id resolves to {@code null}.
      *
-     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
-     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
-     * read it back with the same id. A projection that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. A projection that has an id function keys each instance by whatever that function
+     * returns for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
@@ -125,10 +129,14 @@ public final class ReactiveProjectionRunner<E> {
      * and materializes {@code projection} into the blocking {@code repository} (scheduled on {@code boundedElastic}),
      * skipping events whose id resolves to {@code null}.
      *
-     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
-     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
-     * read it back with the same id. A projection that resolves an id keys each instance by that id
-     * instead.</p>
+     * <p>A projection with no id function is single-instance: it has one slot, and that slot is
+     * stored under {@code subscriptionId} rather than under a key derived from the events, so read it back
+     * with the same id. A projection that has an id function keys each instance by whatever that function
+     * returns for an event.</p>
+     *
+     * <p>Those are two different nulls, which is worth keeping apart. No id function at all means
+     * single-instance. An id function that returns {@code null} for one event means that event is skipped,
+     * and the projection is still keyed.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return projectWithMetadata(subscriptionId, projection, Projections.reactiveUpdateWithMetadata(projection, repository, subscriptionId), startAt);

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
@@ -110,6 +110,11 @@ public final class ReactiveProjectionRunner<E> {
     /**
      * Subscribes with the given id and materializes {@code projection} into the blocking {@code repository} (scheduled on
      * {@code boundedElastic}), skipping events whose id resolves to {@code null}.
+     *
+     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
+     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
+     * read it back with the same id. A projection that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
@@ -119,6 +124,11 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and materializes {@code projection} into the blocking {@code repository} (scheduled on {@code boundedElastic}),
      * skipping events whose id resolves to {@code null}.
+     *
+     * <p>A projection whose {@code id()} is {@code null} is single-instance: it has one slot, and that
+     * slot is stored under {@code subscriptionId} rather than under a key derived from the events, so
+     * read it back with the same id. A projection that resolves an id keys each instance by that id
+     * instead.</p>
      */
     public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return projectWithMetadata(subscriptionId, projection, Projections.reactiveUpdateWithMetadata(projection, repository, subscriptionId), startAt);


### PR DESCRIPTION
A projection whose `id()` is `null` is single-instance. It has one slot, and that slot is stored under the subscription id, not under a key derived from the events.

That was not written down on the methods you actually call, so reading the state back by a domain key returns `null`. That looks exactly like a projection that never ran, which sends you looking at the subscription and the filter instead of at the key. The repository's own test already carries a comment explaining it, which is the tell that it catches people.

I added the rule to all 8 `project(..., ViewStateRepository, ...)` overloads across the 4 runners, blocking and reactor, with and without DCB.

All 4 go through the same two helpers, `Projections.materializedView` for the blocking runners and `reactiveUpdateWithMetadata` for the reactive ones, and both behave identically. Documenting only the blocking pair would leave the same problem in the other three DSLs.

Javadoc only. No behavior or signature change, and no changelog entry, since `AGENTS.md` exempts documentation-only edits.

Closes #452
