### PR TITLE
Say that a single-instance @Projection is keyed by its id

### DIFF
--- a/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Projection.java
@@ -80,6 +80,10 @@ public @interface Projection {
     /**
      * The unique identifier of the projection (required, no default). It is the durable checkpoint key and the
      * namespace for the zero-config store, and must be unique across all subscriptions, projections, and snapshots.
+     * <p>
+     * For a single-instance projection it is also the key the one view state is stored under, since such a projection
+     * has no id function to derive a key from. So a read model declared {@code @Projection(id = "is-username-claimed")}
+     * is found under {@code "is-username-claimed"}, not under anything taken from the events.
      */
     String id();
 


### PR DESCRIPTION
The annotation half of #452. PR 459 documents this on the four runner classes, which covers a programmatic caller, and this covers the Spring one. Merge 459 first, the two do not touch the same files.

`Projection.singletonBuilder` and the Kotlin `singletonProjection` already say the single slot is keyed by the projection's runtime identity, and 459 adds it to the runners. `@Projection`'s `id()` still did not, and it described itself only as the durable checkpoint key and the store namespace. That is the entry point a Spring user reads, and guessing wrong gives you a null that looks exactly like a projection that never ran.

I verified the chain rather than assuming it. `ProjectionAnnotationRegistrar` takes `annotation.id()` as the subscription id, and `ProjectionRunner` hands that same id to `Projections.materializedView` as the singleton key.

Documentation only, no behaviour change.

The other two options in #452 do not survive, which is why this is one clause rather than a feature.

Exposing the key would be vacuous. The key is the subscription id, which the caller passed in themselves one line earlier, so an accessor would hand back their own argument.

Rejecting it at registration is not possible. The mistake is in the test, reading `store["johan"]` instead of `store["is-username-claimed"]`. The repository is a map the user supplies, keyed by `String`, and both keys are valid, so Occurrent cannot tell a correct read from a wrong one. The read never goes through Occurrent at all.

Together with 459 this resolves #452.
