### PR TITLE
Re-enable the RFC_3339_STRING time range test that has been disabled since 2020

### DIFF
--- a/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/blocking/src/test/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStoreTest.java
@@ -224,7 +224,6 @@ public class SpringMongoEventStoreTest {
                 assertThat(deserialize(events)).containsExactly(nameDefined, nameWasChanged1);
             }
 
-            @Disabled
             @Test
             void query_filter_by_time_range_has_a_range_smaller_as_persisted_time_range_when_rfc_3339() {
                 // Given


### PR DESCRIPTION
One deletion: the bare `@Disabled` that has kept this test out of every run since 2020, whose commit message was "Disabling flaky test" and which carried no inline comment, so that message was the only surviving record of why.

#488 asked for one of two things to settle it, repeated CI runs or a demonstration of the mechanism. The mechanism is the better answer here, because the varying input is `LocalDateTime.now()` and it only rarely produces the string shapes that used to break, so a green run proves less than it looks.

The test queries a time range against a store using `TimeRepresentation.RFC_3339_STRING`. Before ADR 79 the stored value came from `OffsetDateTime.toString()`, which is variable width, while the filter operand came from a formatter that wrote a different shape, and MongoDB compares those strings byte by byte. Both sides now render through `RFC_3339_FIXED_WIDTH_DATE_TIME_FORMATTER`, the write path in `DocumentCloudEventWriter` and the filter in `SpecialFilterHandling`, so the ordering is correct whatever `now()` happens to look like. That is why the 2020 flakiness cannot come back for this reason.

I ran it 100 times locally as confirmation rather than as the argument, and the module now reports 260 tests with nothing skipped, where it reported one skip before.

No changelog entry: nothing here changes behaviour, a public API, or the build.

One thing I noticed and did not touch. `HederligOccurrentTest.kt:57` has the same shape, a bare `@Disabled` since 2023 with the commit message "Disabled the hederlig test" and no reason recorded. It sits next to a TODO about introducing a bootstrap function, so it may be documenting an unfinished idea rather than hiding a defect, which makes it a different question from this one. Worth its own look rather than riding along here.

The other `@Disabled` uses in the repository are not this pattern: one carries a recorded reason, "Only for local testing and tweaking", and the rest sit on support classes in test directories to keep Surefire from collecting them.

Resolves #488.
