### PR TITLE
Fix five example apps silently ignoring their MongoDB settings

### DIFF
--- a/example/domain/course-enrollment/README.md
+++ b/example/domain/course-enrollment/README.md
@@ -20,4 +20,4 @@ A classic aggregate owns a single entity, so holding both rules at once usually 
 
 ## Running
 
-DCB uses MongoDB transactions, so it needs a replica set (a single-node one is fine). The test uses Testcontainers and needs no setup. To run the app yourself, point `spring.data.mongodb.uri` at a replica set.
+DCB uses MongoDB transactions, so it needs a replica set (a single-node one is fine). The test uses Testcontainers and needs no setup. To run the app yourself, point `spring.mongodb.uri` at a replica set.

--- a/example/domain/course-enrollment/src/main/resources/application.yml
+++ b/example/domain/course-enrollment/src/main/resources/application.yml
@@ -7,11 +7,10 @@ occurrent:
     cloud-event-source: urn:occurrent:example:course-enrollment
 
 spring:
-  data:
-    mongodb:
-      # Spring Boot's MongoProperties binds spring.data.mongodb.uri.
-      #
-      # DCB appends run in multi-document transactions, which require a replica set (a single-node replica set is fine
-      # for local development). The Testcontainers-based test starts one automatically; for running the app yourself,
-      # point this at a replica set.
-      uri: mongodb://localhost:27017/course-enrollment?replicaSet=rs0
+  mongodb:
+    # Spring Boot's MongoProperties binds spring.mongodb.uri.
+    #
+    # DCB appends run in multi-document transactions, which require a replica set (a single-node replica set is fine
+    # for local development). The Testcontainers-based test starts one automatically; for running the app yourself,
+    # point this at a replica set.
+    uri: mongodb://localhost:27017/course-enrollment?replicaSet=rs0

--- a/example/domain/hotel-booking/README.md
+++ b/example/domain/hotel-booking/README.md
@@ -35,4 +35,4 @@ WebFlux cancels the underlying DCB subscription automatically when the client di
 
 ## Running
 
-DCB uses MongoDB transactions, so it needs a replica set (a single-node one is fine). The test uses Testcontainers and needs no setup. To run the app yourself, point `spring.data.mongodb.uri` at a replica set, or start `TestBootstrap.main` which boots a Testcontainers replica set for you.
+DCB uses MongoDB transactions, so it needs a replica set (a single-node one is fine). The test uses Testcontainers and needs no setup. To run the app yourself, point `spring.mongodb.uri` at a replica set, or start `TestBootstrap.main` which boots a Testcontainers replica set for you.

--- a/example/domain/hotel-booking/src/main/resources/application.yml
+++ b/example/domain/hotel-booking/src/main/resources/application.yml
@@ -7,11 +7,10 @@ occurrent:
     cloud-event-source: urn:occurrent:example:hotel-booking
 
 spring:
-  data:
-    mongodb:
-      # The reactive ReactiveMongoDatabaseFactory autoconfiguration reads spring.data.mongodb.uri.
-      #
-      # DCB appends run in multi-document transactions, which require a replica set (a single-node replica set is fine
-      # for local development). The Testcontainers-based test starts one automatically; for running the app yourself,
-      # point this at a replica set.
-      uri: mongodb://localhost:27017/hotel-booking?replicaSet=rs0
+  mongodb:
+    # The reactive ReactiveMongoDatabaseFactory autoconfiguration reads spring.mongodb.uri.
+    #
+    # DCB appends run in multi-document transactions, which require a replica set (a single-node replica set is fine
+    # for local development). The Testcontainers-based test starts one automatically; for running the app yourself,
+    # point this at a replica set.
+    uri: mongodb://localhost:27017/hotel-booking?replicaSet=rs0

--- a/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/resources/application.yaml
+++ b/example/domain/number-guessing-game/mongodb/spring/blocking/src/main/resources/application.yaml
@@ -8,9 +8,8 @@ spring:
     name: number-guessing-game
   rabbitmq:
     addresses: amqp://localhost
-  data:
-    mongodb:
-      uri: mongodb://localhost/test
+  mongodb:
+    uri: mongodb://localhost/test
 
 server:
   # Enabled graceful shutdown

--- a/example/domain/rps/decider-web/src/main/resources/application.yaml
+++ b/example/domain/rps/decider-web/src/main/resources/application.yaml
@@ -2,7 +2,7 @@
 spring:
   mongodb:
     representation:
-      uuid: standard # So that Spring MongoDB stores UUID's as strings
+      uuid: standard # So that Spring MongoDB stores UUIDs as strings
   threads:
     virtual:
       enabled: true

--- a/example/domain/rps/decider-web/src/main/resources/application.yaml
+++ b/example/domain/rps/decider-web/src/main/resources/application.yaml
@@ -1,8 +1,8 @@
 #logging.level.org.springframework: DEBUG
 spring:
-  data:
-    mongodb:
-      uuid-representation: standard # So that Spring MongoDB stores UUID's as strings
+  mongodb:
+    representation:
+      uuid: standard # So that Spring MongoDB stores UUID's as strings
   threads:
     virtual:
       enabled: true

--- a/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/resources/application.yaml
+++ b/example/domain/word-guessing-game/mongodb/spring/dcb-autoconfig/src/main/resources/application.yaml
@@ -1,10 +1,10 @@
 spring:
   application:
     name: word-guessing-game-dcb-autoconfig
-  data:
-    mongodb:
-      uri: mongodb://localhost:27017/word-guessing-game-dcb-autoconfig
-      uuid-representation: standard
+  mongodb:
+    uri: mongodb://localhost:27017/word-guessing-game-dcb-autoconfig
+    representation:
+      uuid: standard
   lifecycle:
     timeout-per-shutdown-phase: 30s
   threads:


### PR DESCRIPTION
Spring Boot 4.1 deprecates `spring.data.mongodb.uri` at error level, which means the old name isn't bound at all. Five example configs still used it, so the url they set was ignored and the app connected to Boot's default `mongodb://localhost:27017/test` instead.

I renamed it to `spring.mongodb.uri`, and `uuid-representation` to `spring.mongodb.representation.uuid`, and fixed the two READMEs that name the old property.

The tests never caught this because they get the connection from a `@ServiceConnection` container bean, which contributes a `MongoConnectionDetails` bean rather than a property, so the ignored url never mattered in a test run. It only mattered to someone running an example app against their own MongoDB, which the READMEs tell them to do.

`framework/` and the example test configs still use the old name. I left those alone because #505 already renames them, and it removes some of those config blocks outright.
