### PR TITLE
Simplify javadoc/kdoc across everything added since 0.31.0

### DIFF
--- a/application/command-dispatch-dcb/src/main/java/org/occurrent/command/dcb/DcbInvocation.java
+++ b/application/command-dispatch-dcb/src/main/java/org/occurrent/command/dcb/DcbInvocation.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The DCB twin of {@link org.occurrent.command.Invocation}: a command that carries its own handling logic, bounded by
+ * The DCB twin of {@link org.occurrent.command.Invocation}. It carries its own handling logic, scoped by
  * a {@link DcbCriteria} read boundary instead of a stream id. Dispatch it with
  * {@link DcbCommandDispatchers#invocation(org.occurrent.application.service.blocking.dcb.DcbApplicationService)}.
  * <p>
@@ -37,7 +37,8 @@ import static java.util.Objects.requireNonNull;
  * As with the stream form, two invocations are equal only when they hold the same boundary and the very same function
  * instance, so assert on what {@link #decision()} does rather than on the value.
  *
- * @param criteria     the read boundary to fold, and the condition the decided events are appended under
+ * @param criteria     the read boundary whose events {@code decision} runs over, and the condition the decided events
+ *                     are appended under
  * @param tagGenerator tags for the decided events, or {@code null} to use the application service's global generator
  * @param decision     a <i>pure</i> function from the events inside the boundary to the events to append
  * @param <E>          the event type of the write model

--- a/application/command-dispatch/src/main/java/org/occurrent/command/Invocation.java
+++ b/application/command-dispatch/src/main/java/org/occurrent/command/Invocation.java
@@ -22,8 +22,8 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A command that carries its own handling logic: a stream id, and the function to run against that stream's events.
- * Dispatch it with {@link CommandDispatchers#invocation(org.occurrent.application.service.blocking.ApplicationService)}.
+ * A command that carries its own handling logic. It holds a stream id, and the function to run against that stream's
+ * events. Dispatch it with {@link CommandDispatchers#invocation(org.occurrent.application.service.blocking.ApplicationService)}.
  * <p>
  * In a saga, the command type becomes {@code Invocation<E>} and no command records are needed at all:
  * <pre>{@code

--- a/application/command-dispatch/src/main/java/org/occurrent/command/internal/CommandGrouping.java
+++ b/application/command-dispatch/src/main/java/org/occurrent/command/internal/CommandGrouping.java
@@ -39,12 +39,12 @@ public final class CommandGrouping {
      * contractually in order, so {@code [a, b, a]} is three runs rather than two.
      * <p>
      * {@code keyOf} is applied to every item up front, exactly once each, before {@code action} runs for the first
-     * time. That is load-bearing rather than an optimisation. Resolving a key can fail (a missing
-     * {@code @TargetStreamId}, a decider that does not recognise a command), and resolving lazily would throw partway
-     * through, after earlier runs had already been written. Doing it up front means such a batch fails having written
-     * nothing. It also keeps a key derivation that allocates, or is otherwise not free, to one call per item.
+     * time. Resolving a key can fail (a missing {@code @TargetStreamId}, a decider that does not recognise a
+     * command), and resolving lazily would throw partway through, after earlier runs had already been written. Doing
+     * it up front instead means such a batch fails having written nothing. It also keeps a key derivation that
+     * allocates, or is otherwise not free, to one call per item.
      * <p>
-     * An empty list does nothing. Callers rely on that: a saga reaction that only arms a timer still reaches
+     * An empty list does nothing. Callers rely on that. A saga reaction that only arms a timer still reaches
      * {@code dispatchAll} with an empty list.
      *
      * @param items  the batch to split, must not contain null

--- a/common/inmemory/filter-matching-jackson/src/main/java/org/occurrent/inmemory/filtermatching/jackson/JacksonDataFieldReader.java
+++ b/common/inmemory/filter-matching-jackson/src/main/java/org/occurrent/inmemory/filtermatching/jackson/JacksonDataFieldReader.java
@@ -30,9 +30,9 @@ import java.util.Optional;
 /**
  * A {@link DataFieldReader} that parses the event payload as JSON using Jackson.
  * <p>
- * Only a payload the event itself claims is JSON gets parsed, the same rule MongoDB follows: a missing
+ * Only a payload the event itself claims is JSON gets parsed. That follows the same rule MongoDB uses. A missing
  * {@code datacontenttype} means JSON per the CloudEvents spec, and a content type naming {@code json} (for example
- * {@code application/json} or a {@code +json} suffix) means JSON. Anything else, for example {@code text/plain}, is
+ * {@code application/json} or a {@code +json} suffix) also means JSON. Anything else, for example {@code text/plain}, is
  * left alone even if the bytes happen to look like JSON, so a plain-text payload that happens to contain braces never
  * matches a data filter here when it would not match on MongoDB either.
  * <p>

--- a/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/DataFieldReader.java
+++ b/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/DataFieldReader.java
@@ -25,19 +25,19 @@ import java.util.Optional;
  * Reads a field out of a CloudEvent's {@code data} payload, so an in-process store can answer
  * {@link org.occurrent.filter.Filter#data(String, org.occurrent.condition.Condition)}.
  * <p>
- * This is a seam rather than a built-in because reading a payload means parsing it, and the matching module has no
- * parser and no opinion about which one you use. Occurrent ships a Jackson-backed implementation. A store handed no
- * reader keeps refusing a data filter, which is what {@link #refusing()} does.
+ * This is a pluggable interface rather than a built-in parser because reading a payload means parsing it, and the
+ * matching module has no parser and no opinion about which one you use. Occurrent ships a Jackson-backed
+ * implementation. A store handed no reader keeps refusing a data filter, which is what {@link #refusing()} does.
  * <p>
  * <strong>The path is a dotted path, the same one MongoDB resolves.</strong> {@code Filter.data("person.city", ..)}
  * arrives here as {@code person.city}, without the leading {@code data.}. An implementation should return:
  * <ul>
- *     <li>the value at that path, as a plain Java value: a {@link String}, a {@link Number}, a {@link Boolean}, or a
- *     {@link java.util.List} when the field holds an array</li>
+ *     <li>the value at that path, as a plain Java value, for example a {@link String}, a {@link Number}, a
+ *     {@link Boolean}, or a {@link java.util.List} when the field holds an array</li>
  *     <li>{@link Optional#empty()} when the path reaches nothing, including a payload that is not a JSON object, a
  *     field that is absent, and a path that continues past a value that has no fields</li>
  * </ul>
- * Returning the list rather than a match decision is deliberate: the matcher compares an array field by asking whether
+ * Returning the list rather than a match decision is deliberate. The matcher compares an array field by asking whether
  * any element satisfies the condition, the way MongoDB does, and it can only do that if it sees the elements.
  * <p>
  * A value must not be converted to text on the way out. A payload holding {@code {"amount":42}} answers with a number,

--- a/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/PayloadConditions.java
+++ b/common/inmemory/filter-matching/src/main/java/org/occurrent/inmemory/filtermatching/PayloadConditions.java
@@ -47,8 +47,8 @@ final class PayloadConditions {
      * Returns {@code filter} with every condition on a {@code data} payload field replaced by one that matches
      * anything, so the rest of the filter still decides.
      * <p>
-     * Replaced rather than removed, which is the part worth reading twice. Removing a payload condition from an
-     * {@code OR} would change what the filter means: {@code type = X OR data.amount = 42} would become
+     * Replaced rather than removed. Removing a payload condition from an
+     * {@code OR} would change what the filter means. {@code type = X OR data.amount = 42} would become
      * {@code type = X} and discard an event that matched only on the amount. Matching anything is correct under both
      * {@code AND} and {@code OR}.
      */

--- a/doc/migration/upgrading-to-0.32.0.md
+++ b/doc/migration/upgrading-to-0.32.0.md
@@ -2,7 +2,7 @@
 
 Three things break, and only if you use the features they belong to.
 
-**At compile time**, if you write reactive subscriptions, one type was renamed: the reactor `SubscriptionModel` is now
+**At compile time**, if you write reactive subscriptions, one type was renamed. The reactor `SubscriptionModel` is now
 `FluxSubscriptionModel`. The recipe below rewrites it for you. Read
 [section 5](#5-the-reactor-subscriptionmodel-is-now-fluxsubscriptionmodel).
 
@@ -32,7 +32,7 @@ third thing you can ask for:
 | no equivalent | `occurrent.subscription.mode=manual` | Every subscription is registered, none of them runs until you start it |
 
 The old property still works and is deprecated, so nothing breaks if you upgrade without touching your configuration.
-It is removed in the release after next. Setting both is allowed while they agree, which is deliberate: a rewritten
+It is removed in the release after next. Setting both is allowed while they agree, which is deliberate. A rewritten
 configuration file plus a leftover environment variable should not fail your application. Setting both so they
 contradict each other fails at startup, naming both values.
 
@@ -107,7 +107,7 @@ It is now always written in one shape, with seconds and with nine fractional dig
 Nanosecond precision is unaffected. The only difference is that parts which used to be omitted are now written out.
 
 That representation stores `time` as a string, so MongoDB compares it character by character. A single shape is what
-makes those comparisons behave, which fixes two things: an exact filter such as `Filter.time(instant)` now matches an
+makes those comparisons behave, which fixes two things. An exact filter such as `Filter.time(instant)` now matches an
 event written at that instant even when its timestamp falls on a whole minute, and range filters now order correctly.
 Both applied to MongoDB subscriptions as well, since they convert their filters through the same code.
 
@@ -177,7 +177,7 @@ Rationale in [ADR 79](../architecture/decisions/0079-canonical-fixed-width-time-
 There is no recipe for this one, because it is a change to a bean topology rather than a rename a recipe could apply.
 
 `PushSubscriptionModel` and `DomainEventFeed` used to fan one received message out to every consumer registered on
-them. A broker message carries one acknowledgement decision, so those consumers shared it: a consumer that kept failing
+them. A broker message carries one acknowledgement decision, so those consumers shared it. A consumer that kept failing
 held up every consumer behind it on every redelivery, and once the broker gave up and dead-lettered the message they
 never saw it at all. That breaks the isolation Occurrent now holds itself to, so the shared configuration is no longer
 expressible. [ADR 90](../architecture/decisions/0090-a-push-sink-feeds-one-consumer.md) has the full reasoning.
@@ -230,11 +230,11 @@ Projection<ShipmentView, DomainEvent, String> shipments() { ... }
 A `DomainEventFeed` migrates the same way, with one bean per projection.
 
 Then give each sink its own queue on the broker, so that a message one projection cannot handle stops only that
-projection. A single queue behind two sinks still couples them, just at the transport rather than in Occurrent: only
+projection. A single queue behind two sinks still couples them, just at the transport rather than in Occurrent. Only
 one of the two consumers would receive any given message. Whether that means a queue per consumer on a fanout exchange,
 a consumer group per projection, or something else is your broker's vocabulary rather than Occurrent's.
 
-If you drive the sinks yourself rather than through `@Projection`, the same applies: construct one per consumer and
+If you drive the sinks yourself rather than through `@Projection`, the same applies. Construct one per consumer and
 call `accept(...)` on each from your listener.
 
 ## 4. A synchronous subscription no longer stops at the first failing handler
@@ -385,7 +385,7 @@ catch-up model has nothing underneath to delegate the live half to, and refuses 
 
 Before this release the same composition ran through the durable model's own delivery loop, which retried nothing and
 validated nothing, the gap [#547](https://github.com/johanhaleby/occurrent/issues/547) records. The remediation is in
-the message: implement the reactor `SubscriptionModel` on your model, the way every model shipped by Occurrent now
+the message. Implement the reactor `SubscriptionModel` on your model, the way every model shipped by Occurrent now
 does, and the composition inherits its retry and validation. If you cannot, subscribe to the catch-up model's cold
 `Flux` directly and manage the delivery yourself, which is what the old path silently did for you without the
 resilience you probably assumed it had.
@@ -407,7 +407,7 @@ window arrives.
 
 The same position is used when a subscription restarts after a change-stream error, where the model also used to
 reconnect at the present. A subscription whose change stream history is no longer in the oplog still restarts at the
-present, and still only if you asked for that with `restartSubscriptionsOnChangeStreamHistoryLost`; without it, such a
+present, and still only if you asked for that with `restartSubscriptionsOnChangeStreamHistoryLost`. Without it, such a
 subscription stops and says so rather than silently skipping ahead, which is what that setting has always promised.
 
 ### What this asks of you
@@ -419,7 +419,7 @@ subscription it holds, so `stop()` followed by `start()` is the same case. Three
   returns, so pausing mid-handler means that event is handed over again on resume.
 - An event whose handler threw. The position does not advance past an event nobody processed, so the subscription
   restarts on it rather than moving past it. This one is not new in spirit, since the checkpoint never advanced past
-  a failed event either, but it is new in the moment it happens: the retry used to wait for the next application
+  a failed event either, but it is new in the moment it happens. The retry used to wait for the next application
   restart, and now it happens straight away. With `RetryStrategy.none()` the handler therefore sees the event a
   second time before the subscription gives up.
 - Every event another consumer of the same subscription id handled while this one was paused. A competing consumer is
@@ -447,8 +447,8 @@ out, and the right one depends on what the subscription is for:
 
 ### Why the trade goes this way
 
-Both answers cost something: resuming at the present loses events, resuming from the position read repeats them. They
-are not equally bad. A lost event is unrecoverable and violates the isolation rule Occurrent is designed around, while
+Both answers cost something. Resuming at the present loses events, and resuming from the position read repeats them.
+They are not equally bad. A lost event is unrecoverable and violates the isolation rule Occurrent is designed around, while
 a repeat is absorbed by an idempotent handler, and every wrapper above these models already delivers at least once.
 [ADR 94](../architecture/decisions/0094-the-subscription-tck-declares-three-differences-and-waits-deterministically.md)
 records the measurement this was decided against, including the competing-consumer case where it costs the most.

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Catchup.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Catchup.java
@@ -19,21 +19,21 @@ package org.occurrent.annotation;
 
 /**
  * Whether a {@link Source#PUSH} subscription is backfilled from the event store before it takes live events. Applies
- * only to a push source: a {@link Source#EVENT_STORE} subscription chooses how much history it reads with
+ * only to a push source. A {@link Source#EVENT_STORE} subscription chooses how much history it reads with
  * {@code startAt} instead. Read by both {@code @Saga} and {@code @Projection}.
  */
 public enum Catchup {
     /**
-     * The default: replay the event store from the beginning once, then hand over to the live feed, so a subscription
-     * that has never run works through the stored history before it starts reacting to live events. The replay reads
-     * the local event store, so that store has to hold the events the feed carries. It records that it finished, so a
-     * restart skips it and lets the broker resume.
+     * The default. It replays the event store from the beginning once, then hands over to the live feed, so a
+     * subscription that has never run works through the stored history before it starts reacting to live events. The
+     * replay reads the local event store, so that store has to hold the events the feed carries. It records that it
+     * finished, so a restart skips it and lets the broker resume.
      */
     FROM_EVENT_STORE,
     /**
      * Take live events only, from whatever the feed delivers next, with no replay and no event store involved.
      * <p>
-     * This is what a subscription fed by another application's broker needs: the local event store does not hold
+     * This is what a subscription fed by another application's broker needs. The local event store does not hold
      * those events, so a replay would find nothing, or worse, apply unrelated events that happen to live there. It is
      * also the option when the history is simply not wanted.
      * <p>

--- a/framework/annotations/src/main/java/org/occurrent/annotation/Catchup.java
+++ b/framework/annotations/src/main/java/org/occurrent/annotation/Catchup.java
@@ -24,7 +24,7 @@ package org.occurrent.annotation;
  */
 public enum Catchup {
     /**
-     * The default. It replays the event store from the beginning once, then hands over to the live feed, so a
+     * By default it replays the event store from the beginning once, then hands over to the live feed, so a
      * subscription that has never run works through the stored history before it starts reacting to live events. The
      * replay reads the local event store, so that store has to hold the events the feed carries. It records that it
      * finished, so a restart skips it and lets the broker resume.

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ManualStartPushSources.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ManualStartPushSources.java
@@ -27,9 +27,9 @@ import java.util.Objects;
 /**
  * Holds the startup work a {@code source = PUSH} registration would otherwise have run at boot, withheld because
  * {@code occurrent.subscription.mode} is {@code manual}. That covers a {@code @Projection(source = PUSH)} and a
- * {@code @Saga(source = PUSH)} alike: both are fed by a {@code PushSubscriptionModel} or {@code DomainEventFeed} bean
+ * {@code @Saga(source = PUSH)} alike. Both are fed by a {@code PushSubscriptionModel} or {@code DomainEventFeed} bean
  * the application supplies, not by the framework's own {@code SubscriptionModel}, so the withholding that mode applies
- * to that bean never reaches them. This registry is what withholds them instead: inject it and bring one up with
+ * to that bean never reaches them. This registry is what withholds them instead. Inject it and bring one up with
  * {@link #start(String)}, or every withheld one with {@link #startAll()}, once the application is ready to run them.
  * <p>
  * One registry rather than one per annotation, because the reason a registration lands here is the push feed and not

--- a/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/BackgroundCatchupFailures.java
+++ b/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/BackgroundCatchupFailures.java
@@ -27,16 +27,16 @@ import java.util.Optional;
  * The catch-up failures of {@code @Projection(source = PUSH, startupMode = BACKGROUND)} projections, so an application
  * can see them.
  * <p>
- * Under {@code BACKGROUND} the whole point is that nobody waits for the replay, so a failure has nowhere to be thrown:
- * the context refreshed long before it happened. The projection is left with no history folded and no live events, and
+ * Under {@code BACKGROUND} the whole point is that nobody waits for the replay, so a failure has nowhere to be thrown.
+ * The context refreshed long before it happened. The projection is left with no history applied and no live events, and
  * the application starts healthy on top of an empty read model. That is the trade {@code BACKGROUND} makes, and this
- * is what makes it observable rather than silent. The failure is also logged at {@code ERROR}, which stays the
- * backstop for an application that injects nothing.
+ * is what makes it observable rather than silent. The failure is also logged at {@code ERROR}, so an application that
+ * never injects this bean still sees it in the logs.
  * <p>
  * Written by the annotation processor and read by the application, the same shape as the blocking starter's
  * {@code ManualStartPushSources}. Inject it and check it from a health indicator or a readiness probe. It only ever
  * holds ids that were started in the background, so an empty result means either that every background catch-up is
- * still running or succeeded, or that there were none: it is not by itself a statement that a projection is caught up.
+ * still running or succeeded, or that there were none. By itself that is not a statement that a projection is caught up.
  * <p>
  * One class for both stacks, since a background catch-up failure means the same thing on each and the bean carries
  * nothing stack-specific. Each starter contributes it, so an application on either one injects the same type.

--- a/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/OnSubscriptionsNotDisabledCondition.java
+++ b/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/OnSubscriptionsNotDisabledCondition.java
@@ -24,8 +24,8 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
- * Matches unless subscriptions are {@link SubscriptionMode#DISABLED}. Gates every subscription bean, so
- * {@link SubscriptionMode#MANUAL} keeps them all while leaving them stopped.
+ * Matches unless subscriptions are {@link SubscriptionMode#DISABLED}. Applies to every subscription bean, so
+ * {@link SubscriptionMode#MANUAL} still creates them all, just stopped.
  */
 public class OnSubscriptionsNotDisabledCondition implements Condition {
 

--- a/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/SubscriptionMode.java
+++ b/framework/spring-boot-autoconfigure/common/src/main/java/org/occurrent/springboot/common/SubscriptionMode.java
@@ -19,7 +19,8 @@ package org.occurrent.springboot.common;
 import org.jspecify.annotations.Nullable;
 
 /**
- * How much of the subscription machinery an application wants, set with {@code occurrent.subscription.mode}.
+ * Controls which subscription beans Occurrent creates and whether they start automatically, set with
+ * {@code occurrent.subscription.mode}.
  */
 public enum SubscriptionMode {
     /**
@@ -33,7 +34,7 @@ public enum SubscriptionMode {
      * with {@code start()} or one at a time with {@code resumeSubscription(id)}. Use this to bring subscriptions up
      * behind a leader election or a health check, or in a test that chooses which subscriptions run.
      * <p>
-     * A synchronous subscription is affected too, and that is worth knowing before you use this in production: a write
+     * A synchronous subscription is affected too, and that is worth knowing before you use this in production. A write
      * succeeds while its synchronous projection does not run, because the projection is stopped rather than deferred.
      */
     MANUAL,

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ManualStartPushSources.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ManualStartPushSources.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  * {@code occurrent.subscription.mode} is {@code manual}. Such a projection is fed by a
  * {@code PushSubscriptionModel} or {@code DomainEventFeed} bean the application supplies, not by the framework's own
  * subscription model, so the withholding that mode applies to that bean never reaches it. This registry is what
- * withholds it instead: inject it and bring one projection up with {@link #start(String)}, or every withheld one with
+ * withholds it instead. Inject it and bring one projection up with {@link #start(String)}, or every withheld one with
  * {@link #startAll()}, once the application is ready to run them.
  * <p>
  * Starting an id a second time, or one that was never withheld (for example because {@code occurrent.subscription.mode}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
@@ -47,9 +47,9 @@ import static java.util.Objects.requireNonNull;
  * <b>Where a subscription starts from.</b> A subscription that has run before resumes from its stored checkpoint and
  * loses nothing. One that has never run has no checkpoint to resume from, and would otherwise start wherever the
  * wrapped model's default points at the moment it is started, silently skipping everything written since. Give this
- * model a position source and a checkpoint storage and it pins that position when the subscription is registered
- * instead, so starting late withholds events rather than losing them. Without them, a first run starts from the moment
- * it is started.
+ * model a position source and a checkpoint storage and it saves that position as the checkpoint when the subscription
+ * is registered, instead of waiting until it starts. That way, starting a subscription late still delivers the events
+ * written since registration instead of skipping them. Without them, a first run starts from the moment it is started.
  *
  * @see #stoppedByDefault(SubscriptionModel)
  */
@@ -79,7 +79,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, De
      * A model that registers subscriptions without starting them. A subscription running for the first time will start
      * from wherever {@code delegate} starts by default at the moment it is started, so events written between
      * registration and that moment do not reach it. Use
-     * {@link #stoppedByDefault(SubscriptionModel, CheckpointAwareSubscriptionModel, CheckpointStorage)} to pin the
+     * {@link #stoppedByDefault(SubscriptionModel, CheckpointAwareSubscriptionModel, CheckpointStorage)} to record the
      * position at registration instead.
      *
      * @param delegate The subscription model to register with once a subscription is started.
@@ -89,12 +89,13 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, De
     }
 
     /**
-     * A model that registers subscriptions without starting them, and pins where a subscription running for the first
-     * time will start from, so that starting it later withholds events rather than losing them.
+     * A model that registers subscriptions without starting them, and records where a subscription running for the
+     * first time will start from, so that starting it later still delivers the events written since registration
+     * instead of skipping them.
      *
      * @param delegate          The subscription model to register with once a subscription is started.
-     * @param positionSource    Supplies the position to pin. Typically the innermost model, the one reading the feed.
-     * @param checkpointStorage Where the pinned position is written, which must be the storage the wrapped models read.
+     * @param positionSource    Supplies the position to record. Typically the innermost model, the one reading the feed.
+     * @param checkpointStorage Where the recorded position is written, which must be the storage the wrapped models read.
      */
     public static ManualStartSubscriptionModel stoppedByDefault(SubscriptionModel delegate, CheckpointAwareSubscriptionModel positionSource,
                                                                 CheckpointStorage checkpointStorage) {
@@ -105,7 +106,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, De
 
     /**
      * Register a subscription. While this model is withholding, nothing is passed to the wrapped model and the returned
-     * {@link Subscription} is a placeholder standing for the registration: its {@code waitUntilStarted} returns
+     * {@link Subscription} is a placeholder standing for the registration. Its {@code waitUntilStarted} returns
      * immediately, because registering is all that has been asked for. Once the subscription is started,
      * {@link #resumeSubscription(String)} returns the wrapped model's own subscription.
      *

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/FluxSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/FluxSubscriptionModel.java
@@ -26,10 +26,9 @@ import reactor.core.publisher.Flux;
 
 /**
  * The bare reactive subscription primitive. {@link #subscribe(SubscriptionFilter, StartAt)} hands back a {@link Flux}
- * of cloud events that starts when the caller subscribes to it and stops when the caller disposes it. The purpose of a
- * subscription is to read events from an event store and react to these events. Typically a subscription will forward
- * the event to another piece of infrastructure such as a message bus or to create views from the events (such as
- * projections, sagas, snapshots etc).
+ * of cloud events that starts when the caller subscribes to it and stops when the caller disposes it. A subscription
+ * reads events from an event store and reacts to them, typically by forwarding each event to another piece of
+ * infrastructure such as a message bus, or by using it to build a view such as a projection, saga, or snapshot.
  * <p>
  * This is the counterpart to {@link SubscriptionModel}, which tracks a subscription by id so it can be paused, resumed
  * and cancelled. A model fed by a push source rather than by reading a change stream cannot honour this primitive, so
@@ -39,18 +38,17 @@ import reactor.core.publisher.Flux;
 public interface FluxSubscriptionModel {
 
     /**
-     * Stream events from the event store as they arrive and provide a function which allows to configure the
-     * {@link SubscriptionFilter} that is used. Use this method if want to start streaming from a specific
-     * position.
+     * Stream events from the event store as they arrive, matching {@code filter} and starting from {@code startAt}.
+     * Use this overload when you need to both filter events and choose a specific start position.
      *
-     * @return A {@link Flux} with cloud events.
+     * @return A {@link Flux} of cloud events.
      */
     Flux<CloudEvent> subscribe(@Nullable SubscriptionFilter filter, StartAt startAt);
 
     /**
-     * Stream events from the event store as they arrive but filter only events that matches the <code>filter</code>.
+     * Stream events from the event store as they arrive, matching {@code filter} only.
      *
-     * @return A {@link Flux} with cloud events which also includes the {@link Checkpoint} that can be used to resume the stream from the current position.
+     * @return A {@link Flux} of cloud events, each carrying the {@link Checkpoint} you can use to resume the stream from that position.
      */
     default Flux<CloudEvent> subscribe(SubscriptionFilter filter) {
         return subscribe(filter, StartAt.subscriptionModelDefault());
@@ -58,18 +56,18 @@ public interface FluxSubscriptionModel {
 
 
     /**
-     * Stream events from the event store as they arrive from the given start position ({@code startAt}).
+     * Stream events from the event store as they arrive, starting from {@code startAt}.
      *
-     * @return A {@link Flux} with cloud events which also includes the {@link Checkpoint} that can be used to resume the stream from the current position.
+     * @return A {@link Flux} of cloud events, each carrying the {@link Checkpoint} you can use to resume the stream from that position.
      */
     default Flux<CloudEvent> subscribe(StartAt startAt) {
         return subscribe(null, startAt);
     }
 
     /**
-     * Stream events from the event store as they arrive.
+     * Stream every event from the event store as it arrives.
      *
-     * @return A {@link Flux} with cloud events which also includes the {@link Checkpoint} that can be used to resume the stream from the current position.
+     * @return A {@link Flux} of cloud events, each carrying the {@link Checkpoint} you can use to resume the stream from that position.
      */
     default Flux<CloudEvent> subscribe() {
         return subscribe(null, StartAt.subscriptionModelDefault());

--- a/subscription/core/src/main/java/org/occurrent/subscription/internal/SingleConsumerMessages.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/internal/SingleConsumerMessages.java
@@ -21,8 +21,9 @@ package org.occurrent.subscription.internal;
  * sites (the blocking and reactor push subscription models, and the blocking and reactor domain-event feeds) cannot
  * drift. See ADR 90 for why the sinks are single-consumer.
  * <p>
- * This message is the migration path for the change, so it has to carry the whole story: there is no OpenRewrite
- * recipe for a bean topology, and a startup failure naming both consumers is more useful than one would be.
+ * This message is the migration path for the change, so it has to carry the whole story. There is no OpenRewrite
+ * recipe for a bean topology, and a startup failure that names both consumers is the most useful thing this class can
+ * offer instead.
  */
 public final class SingleConsumerMessages {
 

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorage.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorage.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  * subpackage mirrors how {@code org.occurrent.subscription.api.blocking} and {@code org.occurrent.subscription.api.reactor}
  * already name their halves.
  * <p>
- * Every returned {@code Mono} is cold: nothing is read, stored or deleted until it is subscribed to. Arguments are
+ * Every returned {@code Mono} is cold, so nothing is read, stored, or deleted until it is subscribed to. Arguments are
  * still validated eagerly, so a {@code null} fails the calling code and not a subscriber far away.
  */
 @NullMarked

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/NamedCatchupSupport.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/NamedCatchupSupport.java
@@ -43,34 +43,34 @@ import static java.util.Objects.requireNonNull;
 /**
  * The named-subscription half of a reactive catch-up model, shared by the stream and DCB models and the routing
  * dispatcher so the replay logic exists once. The cold {@code Flux} path keeps using {@link PositionCatchupPipeline}
- * directly; this class composes the same replay with a <em>delegated</em> live half instead of a cold one: the live
+ * directly. This class composes the same replay with a <em>delegated</em> live half instead of a cold one. The live
  * subscription is handed to the wrapped model's own named {@code subscribe(..)}, so everything the wrapped model does
- * for a named subscription is inherited, the retry of a failing action and the synchronous refusal of an unsupported
- * filter included. That is the point of the promotion (issues #547 and #550).
+ * for a named subscription is inherited, including the retry of a failing action and the synchronous refusal of an
+ * unsupported filter. That is the point of the promotion (issues #547 and #550).
  * <p>
- * A failing action during the replay is deliberately not retried: the blocking catch-up models do not retry there
+ * A failing action during the replay is deliberately not retried. The blocking catch-up models do not retry there
  * either, and the replay failure reaches whoever waits on {@link Subscription#waitUntilStarted()} rather than being
  * logged and swallowed. Live delivery, where retry matters, is the wrapped model's.
  * <p>
  * The wrapped model must itself manage named subscriptions (implement {@link SubscriptionModel}). A catch-up model
  * over a cold-only wrapped model refuses the named {@code subscribe} paths loudly, because the alternative is a
  * second copy of the named-over-cold driver that {@code ReactorDurableSubscriptionModel} already owns. The model-wide
- * life-cycle calls stay safe on such a composition (no-ops, {@code isRunning()} answering {@code false}): a Spring
- * context close calls {@code shutdown()} and a health check calls {@code isRunning()} regardless of whether the
- * application ever subscribed by name, and a late {@link IllegalStateException} there would fail an application for
- * a capability it never used.
+ * life-cycle calls stay safe on such a composition, with no-ops and {@code isRunning()} answering {@code false}. A
+ * Spring context close calls {@code shutdown()} and a health check calls {@code isRunning()} regardless of whether
+ * the application ever subscribed by name, and a late {@link IllegalStateException} there would fail an application
+ * for a capability it never used.
  * <p>
- * Life-cycle semantics for a subscription still replaying: a pause does not abort the replay, the subscription hands
+ * Life-cycle semantics for a subscription still replaying. A pause does not abort the replay, the subscription hands
  * over to the wrapped model paused (blocking parity). A stop aborts the replay WITHOUT handing over, and parks the
- * subscription; {@code start(..)} relaunches the replay from its original start position, so replayed events may be
+ * subscription. {@code start(..)} relaunches the replay from its original start position, so replayed events may be
  * delivered again (the composition is at-least-once anyway). A subscription created while the model is stopped parks
  * the same way and replays only once the model starts. This is deliberately safer than the blocking catch-up model,
- * which abandons a stop-interrupted replay outright; the blocking COMPOSITION never notices because its durable model
- * parks subscriptions before the catch-up model sees them, a gate the delegating path here does not run through.
- * Cancelling or shutting down aborts in-flight replays; waiting on a subscription cancelled before its handover
- * completes successfully, the blocking {@code CancelledSubscription} contract: there is nothing left to start.
- * Model-wide calls forward to the wrapped model, so give each composition its own wrapped model rather than sharing
- * one.
+ * which abandons a stop-interrupted replay outright. The blocking composition never notices, because its durable
+ * model parks subscriptions before the catch-up model sees them, a gate the delegating path here does not run
+ * through. Cancelling or shutting down aborts in-flight replays. Waiting on a subscription that was cancelled before
+ * its handover completes successfully, matching the blocking {@code CancelledSubscription} contract that there is
+ * nothing left to start. Model-wide calls forward to the wrapped model, so give each composition its own wrapped
+ * model rather than sharing one.
  */
 @NullMarked
 final class NamedCatchupSupport {
@@ -104,9 +104,9 @@ final class NamedCatchupSupport {
     }
 
     /**
-     * Subscribe with a catch-up phase: replay from {@code startPosition} through {@code reader}, applying the caller's
-     * {@code action} to each replayed event without retry, then hand the live half to the wrapped model's named
-     * {@code subscribe(..)} resuming from a token captured before the replay, deduped against the replayed ids.
+     * Subscribes with a catch-up phase. It replays from {@code startPosition} through {@code reader}, applies the
+     * caller's {@code action} to each replayed event without retry, then hands the live half to the wrapped model's
+     * named {@code subscribe(..)} resuming from a token captured before the replay, deduped against the replayed ids.
      */
     Subscription subscribeWithCatchup(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
                                       CatchupReader reader, long windowSize, int handoverCacheSize, long startPosition,
@@ -166,9 +166,9 @@ final class NamedCatchupSupport {
     }
 
     /**
-     * Subscribe with no catch-up phase: pure delegation to the wrapped model's named {@code subscribe(..)}, filtered
-     * in-process by {@code livePredicate} so a backend that does not honor the filter server-side still only delivers
-     * matching events.
+     * Subscribes with no catch-up phase. It is pure delegation to the wrapped model's named {@code subscribe(..)},
+     * filtered in-process by {@code livePredicate} so a backend that does not honor the filter server-side still
+     * only delivers matching events.
      */
     Subscription subscribeStraightToLive(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
                                          StartAt startAt, Function<CloudEvent, Mono<Void>> action) {

--- a/tck/common/src/main/java/org/occurrent/tck/ConcurrentRendezvous.java
+++ b/tck/common/src/main/java/org/occurrent/tck/ConcurrentRendezvous.java
@@ -43,10 +43,10 @@ import static java.util.Objects.requireNonNull;
  * here is returned as a value, in the order the tasks were submitted, so a suite can count winners and losers
  * instead of inspecting shared state that the race itself corrupts.
  * <p>
- * Every wait here is bounded, and {@linkplain #collide every task is joined before this method returns or throws},
- * so a hung task cannot leave a sibling still running in the background after the assertion that was supposed to
- * observe it has already happened. That ordering is precisely what was fixed in
- * {@code MongoEventStoreDcbConcurrencyTest} shortly before this class was written; the same bug is easy to
+ * Every wait here has a timeout, and {@linkplain #collide every task is joined before this method returns or
+ * throws}, so a hung task cannot leave a sibling still running in the background after the assertion that was
+ * supposed to observe it has already happened. That ordering is precisely what was fixed in
+ * {@code MongoEventStoreDcbConcurrencyTest} shortly before this class was written. The same bug is easy to
  * reintroduce by returning as soon as one task's result is known.
  */
 @NullMarked
@@ -54,7 +54,7 @@ public final class ConcurrentRendezvous {
 
     /**
      * How long a task may wait at the barrier for its siblings. Generous relative to submitting a handful of tasks to
-     * a thread pool, so a wedged task is reported by this specific bounded wait rather than by a test's
+     * a thread pool, so a wedged task is reported by this wait's own timeout rather than by a test's
      * {@code @Timeout} killing the whole run without saying why.
      */
     public static final Duration DEFAULT_BARRIER_TIMEOUT = Duration.ofSeconds(10);
@@ -134,7 +134,7 @@ public final class ConcurrentRendezvous {
     }
 
     /**
-     * What one task did: either the value it returned, or the throwable it raised. Exactly one of {@link #value()} or
+     * What one task did, either the value it returned or the throwable it raised. Exactly one of {@link #value()} or
      * {@link #failure()} is non-null, which is why both are exposed as accessors rather than as a class a caller
      * would need to instanceof against.
      */

--- a/tck/common/src/main/java/org/occurrent/tck/ConformanceEvents.java
+++ b/tck/common/src/main/java/org/occurrent/tck/ConformanceEvents.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  * CloudEvents for the conformance suites to write and read back.
  * <p>
  * These are deliberately self-contained. The TCK is published, so it cannot depend on the unpublished
- * {@code test-support} module, and it does not pull in a JSON library just to build a payload: the data is a small
+ * {@code test-support} module, and it does not pull in a JSON library just to build a payload. The data is a small
  * hand-written JSON object. Nothing here is MongoDB-specific or Occurrent-specific beyond the CloudEvents
  * specification itself.
  * <p>
@@ -141,7 +141,7 @@ public final class ConformanceEvents {
 
     /**
      * An event carrying the supplied JSON body, for a suite that needs a payload shape the other factories do not
-     * build: a nested object, a number, an array, or a body whose root is not an object at all.
+     * build, such as a nested object, a number, an array, or a body whose root is not an object at all.
      *
      * @param json the body verbatim, so a caller can write the exact shape it means to test
      */

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/CapabilityGuardConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/CapabilityGuardConformance.java
@@ -54,8 +54,8 @@ import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.typesOf
  * <p>
  * A capability is a construction-time argument, and a store implements every interface either way, so there is always
  * an object to call and nothing on it announces that the call will not work. The contract is that such a call refuses
- * with an {@link UnsupportedOperationException} naming the missing capability. Refusing matters more than it looks:
- * quietly answering "no events" to a DCB read on a store that never enabled DCB is indistinguishable from an empty
+ * with an {@link UnsupportedOperationException} naming the missing capability. Refusing matters more than it looks.
+ * Quietly answering "no events" to a DCB read on a store that never enabled DCB is indistinguishable from an empty
  * store, so a decider would append against a boundary it never actually checked.
  * <p>
  * The suite needs two extra stores, one per direction, which the fixture builds through
@@ -191,9 +191,10 @@ public abstract class CapabilityGuardConformance extends EventStoreConformance {
     /**
      * Asserts that a call refuses because {@code capability} is not enabled.
      * <p>
-     * The type is pinned and the message is only required to name the capability. The stores shipping with Occurrent
-     * word it as "DCB capability is not enabled for this MongoEventStore", which carries the implementing class and so
-     * cannot be cross-store law, the same line {@code DuplicateCloudEventException.getDetails()} sits on. A subclass of
+     * This check requires an exact exception type, but only requires the message to name the capability. The stores
+     * shipping with Occurrent word it as "DCB capability is not enabled for this MongoEventStore", which carries the
+     * implementing class and so cannot be cross-store law, the same line
+     * {@code DuplicateCloudEventException.getDetails()} sits on. A subclass of
      * {@link UnsupportedOperationException} passes, since choosing a more specific type is not a contract violation.
      */
     private static void assertRefuses(EventStoreCapability capability, ThrowingCallable call) {

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbAppendConditionModel.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbAppendConditionModel.java
@@ -24,7 +24,7 @@ import org.occurrent.eventstore.api.dcb.DcbCriteria;
 /**
  * How a store decides whether a token-qualified {@link DcbAppendCondition} was violated.
  * <p>
- * Both models are sound in the sense that matters: neither lets a real conflict through as a successful append. They
+ * Both models are sound in the sense that matters. Neither lets a real conflict through as a successful append. They
  * differ in what else they do, and the difference is observable, so a fixture declares which one its store implements
  * and {@code DcbEventStoreConformance} asserts the outcome that model owes rather than skipping the question.
  * <p>
@@ -65,8 +65,8 @@ public enum DcbAppendConditionModel {
      * <ul>
      *     <li>An event whose type the criteria excludes <strong>does</strong> conflict when it carries a tag the
      *     criteria requires, because the marker the token was derived from is keyed on the tag and knows nothing about
-     *     types. A false conflict, which self-heals: the application service re-reads the still-excluded boundary and
-     *     retries.</li>
+     *     types. It is a false conflict, and it self-heals, because the application service re-reads the
+     *     still-excluded boundary and retries.</li>
      *     <li>{@link DcbAppendCondition#wholeStoreLock(DcbConsistencyToken)} does <strong>not</strong> detect a
      *     tag-scoped append committed after the read, because a whole-store lock is keyed on a marker that only
      *     another whole-store append touches. This is the limitation

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbConcurrencyConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbConcurrencyConformance.java
@@ -41,14 +41,14 @@ import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.tag;
 import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.taggedEventWithId;
 
 /**
- * What a DCB append condition is actually for: two writers deciding against the same consistency boundary at the same
- * time, where letting both through corrupts the invariant each of them checked.
+ * What a DCB append condition is actually for. Two writers decide against the same consistency boundary at the same
+ * time, and letting both through corrupts the invariant each of them checked.
  * <p>
  * Write skew is the case worth having tests for. Two writers read boundaries that are not obviously the same, decide
  * independently, and each appends an event the other's boundary would have matched. Both writers are individually
- * correct and the result is wrong, so a store has to reject one of them, and the interesting part is that the two
- * boundaries are described differently: one by type and one by tag, or two overlapping type sets. This suite drives
- * each of those into a real race rather than reasoning about it.
+ * correct and the result is wrong, so a store has to reject one of them. The interesting part is that the two
+ * boundaries are described differently, one by type and one by tag, or as two overlapping type sets. This suite
+ * drives each of those into a real race rather than reasoning about it.
  * <p>
  * Nothing here is fixture-declared, {@link EventStoreFixture#appendConditionModel()} included. Both models exist to
  * be sound, and soundness is exactly what safety under a race means, so a store failing anything below has a real
@@ -69,7 +69,7 @@ public abstract class DcbConcurrencyConformance extends EventStoreConformance {
     private static final String RESERVED = "SeatReserved";
     private static final String RELEASED = "SeatReleased";
 
-    /** Repetitions per test method. A single race proves little; this is how many independent races each test runs. */
+    /** Repetitions per test method. A single race proves little, so this is how many independent races each test runs. */
     private static final int ITERATIONS = 5;
 
     @Override

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbConformanceEvents.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbConformanceEvents.java
@@ -61,7 +61,7 @@ public final class DcbConformanceEvents {
      * An event with an explicit id and the supplied DCB tags, which the duplicate-detection and delete-by-id
      * assertions need so they can hand the same id back.
      * <p>
-     * Named apart from {@link #taggedEvent(String, String...)} rather than overloading it: with a trailing varargs of
+     * Named apart from {@link #taggedEvent(String, String...)} rather than overloading it. With a trailing varargs of
      * the same type, {@code taggedEvent("NameDefined", "name:1")} would match both and the compiler would say so at
      * every call site.
      */

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbEventStoreConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbEventStoreConformance.java
@@ -52,7 +52,7 @@ import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.typesOf
 import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.untaggedDcbEvent;
 
 /**
- * The Dynamic Consistency Boundary contract: which events a criteria selects, what the read options do to the
+ * The Dynamic Consistency Boundary contract covers which events a criteria selects, what the read options do to the
  * selection, and when an append condition conflicts.
  * <p>
  * Occurrent's stores answer a token-qualified append condition in two genuinely different ways, so the fixture
@@ -70,14 +70,14 @@ import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.untagge
  *     positions before its events commit can report a head ahead of what a reader can see, which is exactly why
  *     {@link DcbEventStream#consistencyToken()} exists.</li>
  *     <li><strong>Position contiguity across appends, or any literal position value.</strong> A block is contiguous
- *     within one append and nothing more: a rejected append can reserve and abandon a block, leaving a permanent gap
+ *     within one append and nothing more. A rejected append can reserve and abandon a block, leaving a permanent gap
  *     (ADR 84). Every bound read here is derived from a position handed back by an append, never written as a
  *     literal.</li>
  *     <li><strong>Which storage stream a DCB event landed in.</strong> Placement is a storage choice a store derives
- *     from tags, and {@link org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator} says so: it is not part of the DCB
+ *     from tags, and {@link org.occurrent.eventstore.api.dcb.DcbStreamIdGenerator} says so. It is not part of the DCB
  *     contract, and a caller reasons in tags rather than stream ids.</li>
  *     <li><strong>How {@code exists} and {@code count} are implemented.</strong> Both document a full read as their
- *     default and invite an implementation to do better, so asserting call counts or efficiency would pin the default
+ *     default and invite an implementation to do better, so asserting call counts or efficiency would test the default
  *     rather than the contract.</li>
  * </ul>
  */

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbStreamInteropConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/DcbStreamInteropConformance.java
@@ -44,7 +44,7 @@ import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.taggedE
 import static org.occurrent.tck.eventstore.blocking.DcbConformanceEvents.typesOf;
 
 /**
- * What a store owes when it has both capabilities at once: DCB reads see DCB events and nothing else, while the
+ * What a store owes when it has both capabilities at once. DCB reads see DCB events and nothing else, while the
  * general query API sees everything, because both modes share one CloudEvent store.
  * <p>
  * This is separate from {@link DcbEventStoreConformance} rather than folded into it because these assertions need

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreConformance.java
@@ -50,7 +50,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Not extending a suite is how an implementation declines a capability. That is deliberately a visible, greppable
  * absence rather than a runtime skip, because a suite that skips silently is worse than no suite at all. For the same
- * reason nothing in this TCK calls {@code Assumptions}: where behaviour legitimately differs, the fixture declares
+ * reason nothing in this TCK calls {@code Assumptions}. Where behaviour legitimately differs, the fixture declares
  * which way it goes and the suite asserts the documented outcome for that answer, so both branches are checked by
  * somebody.
  */

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreFixture.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreFixture.java
@@ -33,19 +33,19 @@ import java.util.Set;
  * What an event store implementation hands the conformance suites.
  * <p>
  * A fixture is created fresh for every test method, and the store it hands back <strong>must contain no events</strong>.
- * How that is achieved is the implementation's business: dropping a collection, truncating a table, or simply
- * constructing a new in-memory instance. A suite never cleans up on an implementation's behalf, because what needs
- * cleaning is exactly the part a contract cannot describe.
+ * How that is achieved is up to the implementation, whether that means dropping a collection, truncating a table, or
+ * simply constructing a new in-memory instance. A suite never cleans up on an implementation's behalf, because what
+ * needs cleaning is exactly the part a contract cannot describe.
  * <p>
  * The accessors are separate rather than one object the suites downcast, so a suite asks for precisely the capability
  * interface it exercises and an implementation says out loud which of them it can answer. Most implementations return
  * the same object from every accessor, which makes a fixture roughly one line per method.
  * <p>
- * {@link #capabilities()} is the load-bearing method. Occurrent's capabilities are a construction-time argument to a
- * store's config and nothing on {@link EventStore} reports them back, so the suites cannot discover what a store
- * supports and have to be told. Declaring a capability is a promise the suites will hold the implementation to,
- * including the negative: a store that does not declare {@link EventStoreCapability#DCB} is expected to reject DCB
- * calls rather than quietly accept them.
+ * Every other accessor here depends on {@link #capabilities()}. Occurrent's capabilities are a construction-time
+ * argument to a store's config and nothing on {@link EventStore} reports them back, so the suites cannot discover
+ * what a store supports and have to be told. Declaring a capability is a promise the suites will hold the
+ * implementation to, including the negative. A store that does not declare {@link EventStoreCapability#DCB} is
+ * expected to reject DCB calls rather than quietly accept them.
  */
 @NullMarked
 public interface EventStoreFixture {
@@ -64,7 +64,7 @@ public interface EventStoreFixture {
      * four stores shipping with Occurrent do.
      * <p>
      * This is a variation the contract already documents on {@link org.occurrent.eventstore.api.SortBy#natural}, not
-     * something the TCK discovered: the in-memory store treats natural order as an insertion-order tiebreaker for the
+     * something the TCK discovered. The in-memory store treats natural order as an insertion-order tiebreaker for the
      * preceding fields, while the MongoDB stores reject the compound sort with an {@link IllegalArgumentException}
      * because MongoDB cannot express a natural sort combined with other keys.
      * <p>
@@ -82,11 +82,11 @@ public interface EventStoreFixture {
      * <p>
      * This describes what the datastore actually promises, not an aspiration. {@link org.occurrent.eventstore.api.SortBy#natural}
      * documents natural order as "typically the insertion order, but it could also be undefined for certain
-     * datastores", so a fixture answering {@code false} is not failing anything: it is saying its store falls on the
+     * datastores", so a fixture answering {@code false} is not failing anything. It is saying its store falls on the
      * "could be undefined" side, which is true of every MongoDB store shipping with Occurrent, since {@code $natural}
      * on a non-capped collection is not a documented insertion-order guarantee.
      * <p>
-     * Declaring {@code true} is a stronger promise than the default and is asserted accordingly: the query suite
+     * Declaring {@code true} is a stronger promise than the default and is asserted accordingly. The query suite
      * checks insertion order itself, in both ascending and descending direction, rather than only checking that every
      * event comes back once.
      */
@@ -97,10 +97,10 @@ public interface EventStoreFixture {
     /**
      * Whether this store can filter on a field inside a CloudEvent's {@code data} payload with {@link
      * org.occurrent.filter.Filter#data}. Defaults to {@code true}, which is what every MongoDB store shipping with
-     * Occurrent does: it parses the payload into BSON on write specifically so a later {@code Filter.data(..)} can
+     * Occurrent does. It parses the payload into BSON on write specifically so a later {@code Filter.data(..)} can
      * reach inside it.
      * <p>
-     * A fixture answering {@code false} is documenting a real limitation, not a bug: the in-memory store keeps a
+     * A fixture answering {@code false} is documenting a real limitation, not a bug. The in-memory store keeps a
      * payload as opaque bytes and has nothing to reach into, so it must reject {@code Filter.data(..)} rather than
      * silently ignore it or scan every payload without an index.
      */
@@ -113,7 +113,7 @@ public interface EventStoreFixture {
      * {@link ChronoUnit#NANOS}, which is what the in-memory store and MongoDB's {@code RFC_3339_STRING} both manage.
      * <p>
      * <strong>A store must refuse a time it cannot represent, not round it off.</strong> That is the contract, not an
-     * implementation detail: an event is the record of something that happened, and a silently truncated timestamp
+     * implementation detail. An event is the record of something that happened, and a silently truncated timestamp
      * cannot be detected afterwards by anything. MongoDB's {@code DATE} representation stores a millisecond epoch value
      * and throws rather than lose the rest, which is the behaviour to copy.
      * <p>
@@ -129,7 +129,7 @@ public interface EventStoreFixture {
      * Defaults to {@code true}.
      * <p>
      * A store answering {@code false} must refuse a time that is not already in UTC, for the same reason as
-     * {@link #timePrecision()}: quietly rewriting {@code +02:00} to {@code Z} preserves the instant and loses the
+     * {@link #timePrecision()}. Quietly rewriting {@code +02:00} to {@code Z} preserves the instant and loses the
      * offset, and nothing downstream can tell that it happened. MongoDB's {@code DATE} representation cannot hold an
      * offset, so it rejects one.
      */
@@ -153,7 +153,8 @@ public interface EventStoreFixture {
     }
 
     /**
-     * The operations capability: deleting streams and single events, deleting by filter, and updating an event.
+     * The operations capability, covering deleting streams and single events, deleting by filter, and updating an
+     * event.
      */
     default EventStoreOperations operations() {
         throw notOverridden("operations", EventStoreCapability.STREAM);
@@ -178,10 +179,10 @@ public interface EventStoreFixture {
      * {@link EventStoreCapability#DCB} is declared, with no default, because there is no answer that is right often
      * enough to inherit and getting it wrong makes the suite assert the opposite of what the store does.
      * <p>
-     * This is a declaration rather than a question put to the store because there is nothing to ask: the model is a
-     * property of how the write path is built, and no method on {@link DcbEventStore} reports it. That is the same
-     * line {@code timePrecision()} sits on, and the opposite side of it from {@code PositionOrderedReader.writesPosition()},
-     * which the suites ask rather than being told.
+     * This is a declaration rather than a question put to the store because there is nothing to ask. The model is a
+     * property of how the write path is built, and no method on {@link DcbEventStore} reports it. {@code timePrecision()}
+     * is answered the same way, by declaration, which is the opposite of {@code PositionOrderedReader.writesPosition()},
+     * which the suites do ask the store directly.
      */
     default DcbAppendConditionModel appendConditionModel() {
         throw notOverridden("appendConditionModel", EventStoreCapability.DCB);
@@ -201,7 +202,7 @@ public interface EventStoreFixture {
      * Defaults to empty, meaning this implementation cannot build a store with position off.
      * <p>
      * Supplying one opts the implementation into the position-disabled conformance assertions. The returned store
-     * must be STREAM-only: {@link EventStoreCapability#DCB} always writes a position, and the stores reject building
+     * must be STREAM-only. {@link EventStoreCapability#DCB} always writes a position, and the stores reject building
      * one with DCB and position disabled together.
      */
     default Optional<StoreWithoutPosition> storeWithoutPosition() {

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreOperationsConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreOperationsConformance.java
@@ -40,8 +40,9 @@ import static org.occurrent.tck.ConformanceEvents.event;
 import static org.occurrent.tck.ConformanceEvents.idsOf;
 
 /**
- * The {@link org.occurrent.eventstore.api.blocking.EventStoreOperations} contract: deleting a whole stream, deleting a
- * single event by id and source, deleting everything a {@link Filter} matches, and updating one event in place.
+ * The {@link org.occurrent.eventstore.api.blocking.EventStoreOperations} contract covers deleting a whole stream,
+ * deleting a single event by id and source, deleting everything a {@link Filter} matches, and updating one event in
+ * place.
  * <p>
  * Extend it from a test class per store, as described on {@link EventStoreConformance}:
  * <pre>{@code
@@ -51,9 +52,9 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * }
  * }</pre>
  * <p>
- * These are the operations an event-sourced system is not supposed to need, which is exactly why they need pinning: a
- * store that silently does nothing on {@code deleteEvent}, or that leaves a stream version pointing past the events it
- * still holds, breaks callers in ways an append-only test never reaches.
+ * These are the operations an event-sourced system is not supposed to need, which is exactly why they need their own
+ * tests. A store that silently does nothing on {@code deleteEvent}, or that leaves a stream version pointing past the
+ * events it still holds, breaks callers in ways an append-only test never reaches.
  */
 @NullMarked
 @DisplayNameGeneration(ReplaceUnderscores.class)

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreQueriesConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/EventStoreQueriesConformance.java
@@ -60,7 +60,7 @@ import static org.occurrent.tck.ConformanceEvents.eventAt;
 import static org.occurrent.tck.ConformanceEvents.idsOf;
 
 /**
- * The {@link org.occurrent.eventstore.api.blocking.EventStoreQueries} contract: reading across streams with a
+ * The {@link org.occurrent.eventstore.api.blocking.EventStoreQueries} contract covers reading across streams with a
  * {@link Filter}, a {@link SortBy}, and paging, plus {@code count} and {@code exists}.
  * <p>
  * Extend it from a test class per store, as described on {@link EventStoreConformance}:
@@ -73,10 +73,10 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * <p>
  * Most of what is here filters and sorts on CloudEvent attributes the specification defines, so a store that keeps
  * events in a shape this TCK knows nothing about still has to answer. Three places are documented to differ, each
- * declared by the fixture and asserted both ways rather than skipped: composing a natural sort step with a field
- * sort ({@link EventStoreFixture#composesNaturalSortWithFieldSorts()}), whether natural order is insertion order
- * ({@link EventStoreFixture#naturalOrderIsInsertionOrder()}), and whether the store can filter on a field inside the
- * {@code data} payload ({@link EventStoreFixture#supportsDataFilter()}).
+ * declared by the fixture and asserted both ways rather than skipped. They are composing a natural sort step with a
+ * field sort ({@link EventStoreFixture#composesNaturalSortWithFieldSorts()}), whether natural order is insertion
+ * order ({@link EventStoreFixture#naturalOrderIsInsertionOrder()}), and whether the store can filter on a field
+ * inside the {@code data} payload ({@link EventStoreFixture#supportsDataFilter()}).
  */
 @NullMarked
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -288,7 +288,7 @@ public abstract class EventStoreQueriesConformance extends EventStoreConformance
 
         /**
          * Runs the assertions when the store declares it can read a payload, and otherwise asserts that it refuses.
-         * Returning early after asserting the refusal is not a skip: the store answered for itself either way.
+         * Returning early after asserting the refusal is not a skip. The store answered for itself either way.
          */
         private boolean declinesDataFilters(Filter probe) {
             // Call this after writing, never before. A query over an empty store never reaches the filter, so a store

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StoreWithoutPosition.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StoreWithoutPosition.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * An event store built with its global position turned off, presented as both of the interfaces the position-disabled
- * suite needs: it writes events through the {@link EventStore} and then asks the {@link PositionOrderedReader} what
+ * suite needs. It writes events through the {@link EventStore} and then asks the {@link PositionOrderedReader} what
  * the store reports and what it refuses.
  * <p>
  * Both views are handed over explicitly because {@link EventStore} does not extend {@link PositionOrderedReader}. An

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamConcurrencyConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamConcurrencyConformance.java
@@ -38,13 +38,13 @@ import static org.occurrent.tck.ConformanceEvents.event;
 import static org.occurrent.tck.ConformanceEvents.idsOf;
 
 /**
- * Two threads (or more) writing to the same stream at the same time: what a conditional write does when exactly one
- * of them can win, and what an unconditional write does when none of them can lose.
+ * Two or more threads write to the same stream at the same time. This checks what a conditional write does when
+ * exactly one of them can win, and what an unconditional write does when none of them can lose.
  * <p>
- * This is the replacement for issue 467: five tests existed for this already, in {@code MongoEventStoreTest}'s
+ * This replaces issue 467. Five tests existed for this already, in {@code MongoEventStoreTest}'s
  * {@code ParallelWritesToEventStoreReturns}, but every one of them was {@code @EnabledOnOs(MAC)} while every CI run
  * is Linux, so none of them had run anywhere in a long time. They also decided their outcome by having both racing
- * threads write into a single shared {@code AtomicReference}, which is itself a race: whichever thread wrote to the
+ * threads write into a single shared {@code AtomicReference}, which is itself a race. Whichever thread wrote to the
  * reference last is what the assertion saw, independent of which write actually reached the store first. This suite
  * uses {@link ConcurrentRendezvous} instead, which returns each thread's own outcome as a value, so counting winners
  * and losers does not depend on the order two threads happen to finish in.
@@ -60,7 +60,7 @@ public abstract class StreamConcurrencyConformance extends EventStoreConformance
 
     private static final String DEFINED = "NameDefined";
 
-    /** Repetitions per test method. A single race proves little; this is how many independent races each test runs. */
+    /** Repetitions per test method. A single race proves little, so each test runs this many independent races. */
     private static final int ITERATIONS = 5;
 
     @Override

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamEventStoreConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamEventStoreConformance.java
@@ -58,8 +58,8 @@ import static org.occurrent.tck.ConformanceEvents.event;
 import static org.occurrent.tck.ConformanceEvents.idsOf;
 
 /**
- * The stream half of the event-store contract: reading and writing a stream, paging a read, stream existence,
- * {@link WriteResult}, duplicate detection, reading through a {@link StreamReadFilter}, and the whole
+ * The stream half of the event-store contract. It covers reading and writing a stream, paging a read, stream
+ * existence, {@link WriteResult}, duplicate detection, reading through a {@link StreamReadFilter}, and the whole
  * {@link WriteCondition} family with its exact failure messages.
  * <p>
  * An implementation runs this by extending it and supplying a fixture:
@@ -76,7 +76,7 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * <ul>
  *     <li><strong>The cause and message of a {@link DuplicateCloudEventException}.</strong> The MongoDB stores wrap a
  *     driver exception and append its raw text to {@code getDetails()}, which lands in the message, while the
- *     in-memory store detects the duplicate itself and has neither. So the suite pins the exception type,
+ *     in-memory store detects the duplicate itself and has neither. So the suite asserts the exception type,
  *     {@code getId()}, {@code getSource()} and that nothing was written, which is what a caller can act on, and
  *     leaves {@code getDetails()} to each store.</li>
  *     <li><strong>Read skew.</strong> Whether a concurrent writer can be observed mid-write is an isolation property

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamPositionConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamPositionConformance.java
@@ -36,12 +36,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.occurrent.tck.ConformanceEvents.event;
 
 /**
- * The global sequence position contract, stated in ADR 84: a position is positive, unique, and strictly increasing,
+ * The global sequence position contract, stated in ADR 84. A position is positive, unique, and strictly increasing,
  * and is comparable across separate appends without being contiguous. A rejected write reserves and abandons a
  * position block, so gaps between two writes are expected, not a defect.
  * <p>
  * {@code DcbAppendResult} additionally documents that the very first position a store ever hands out is 1, but this
- * suite does not assert that: a fixture cannot guarantee its store's underlying position counter has never been used
+ * suite does not assert that. A fixture cannot guarantee its store's underlying position counter has never been used
  * before this test, only that the store contains no events. Nothing here asserts a literal position value or
  * contiguity. Every bound this suite reads a range with is derived from a position it read back off a written event,
  * never from a literal such as 1 or 2.

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamPositionDisabledConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamPositionDisabledConformance.java
@@ -38,11 +38,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.occurrent.tck.ConformanceEvents.event;
 
 /**
- * The documented behaviour of a store built with its global position turned off: {@link EventStoreFixture#storeWithoutPosition()}.
+ * The documented behaviour of a store built with its global position turned off, as returned by
+ * {@link EventStoreFixture#storeWithoutPosition()}.
  * <p>
  * Not every implementation can build one. {@link EventStoreFixture#storeWithoutPosition()} defaults to
  * {@link java.util.Optional#empty()} for exactly that reason, and this suite treats an empty answer as a test failure
- * rather than something to skip past: see {@link #storeWithoutPosition()} below. The TCK bans {@code Assumptions}
+ * rather than something to skip past. See {@link #storeWithoutPosition()} below. The TCK bans {@code Assumptions}
  * everywhere else for the same reason, and an {@code Optional} accessor is not an exemption from it.
  */
 @NullMarked
@@ -108,7 +109,7 @@ public abstract class StreamPositionDisabledConformance extends EventStoreConfor
      * <p>
      * {@link EventStoreFixture#storeWithoutPosition()} answers {@link java.util.Optional#empty()} when an
      * implementation cannot build one, which is a legitimate answer for a fixture to give. It is not, however, a
-     * legitimate reason for this suite to pass or to skip: every test above needs the store to make its assertion,
+     * legitimate reason for this suite to pass or to skip. Every test above needs the store to make its assertion,
      * so an empty answer fails loudly here, naming the fixture that owes an override, exactly as
      * {@link EventStoreFixture}'s own {@code notOverridden(..)} fails loudly for a capability declared but not wired
      * up. A store that declines this behaviour is expected to say so by never reaching this failure in the first

--- a/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/BlockingEventStoreOverReactive.java
+++ b/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/BlockingEventStoreOverReactive.java
@@ -52,8 +52,8 @@ import static java.util.Objects.requireNonNull;
  * Presents a reactive event store as a blocking one, so the blocking conformance suites can be run against it
  * unchanged instead of being written a second time in terms of {@code Mono} and {@code Flux}.
  * <p>
- * This is a test bridge and nothing more. It is not a general-purpose adapter and must not be used in production:
- * every method blocks the calling thread, which is exactly what a reactive store exists to avoid.
+ * This is a test bridge and nothing more. It is not a general-purpose adapter and must not be used in production.
+ * Every method blocks the calling thread, which is exactly what a reactive store exists to avoid.
  * <p>
  * A bridge cannot see everything. Whether a failure arrives as {@code Mono.error} rather than being thrown from the
  * assembly call, whether a store does any work before something subscribes, and what cancellation does are all

--- a/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/ReactiveEventStoreConformance.java
+++ b/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/ReactiveEventStoreConformance.java
@@ -57,10 +57,10 @@ import static org.occurrent.tck.ConformanceEvents.event;
  * <p>
  * Everything about what a store reads and writes is asserted once, by the blocking suites running over
  * {@link BlockingEventStoreOverReactive}, rather than described a second time in terms of {@code Mono} and {@code Flux}.
- * What that cannot reach is the shape of the publishers themselves: whether the work waits for a subscriber, whether a
+ * What that cannot reach is the shape of the publishers themselves. Whether the work waits for a subscriber, whether a
  * failure travels through the publisher or is thrown while assembling it, whether a {@code Mono} documented to always
- * emit ever completes empty, and what cancelling a read does. A store can get every one of those wrong and still pass
- * every blocking suite.
+ * emit ever completes empty, and what cancelling a read does, all fall outside it. A store can get every one of those
+ * wrong and still pass every blocking suite.
  * <p>
  * Why each of them matters to somebody using the store:
  * <ul>
@@ -72,7 +72,7 @@ import static org.occurrent.tck.ConformanceEvents.event;
  *       operator supplies. {@code count()} silently reads zero rather than failing.</li>
  * </ul>
  * <p>
- * Every wait here is bounded. The event-store CI shards have no rerun backstop, so a store that never completes has to
+ * Every wait here has a timeout. The event-store CI shards have no rerun backstop, so a store that never completes has to
  * fail the test rather than hang the build.
  * <p>
  * STREAM only, and with no capability declaration. Every reactive store shipping with Occurrent supports STREAM, and

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/Arrivals.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/Arrivals.java
@@ -32,9 +32,10 @@ import static java.util.Objects.requireNonNull;
  * Waiting on things that arrive, for the two recording handlers in this package.
  * <p>
  * {@link RecordedEvents} records delivered events and {@link RecordedLockChanges} records lock changes, and they wait
- * the same way: block on a queue until enough has arrived or a deadline passes, then take whatever else is already
- * there so an implementation delivering more than it should is caught by the caller's assertion rather than leaving
- * its extra items in the queue unnoticed. Package-private, so neither class grows a base type an implementor would see.
+ * the same way. Both block on a queue until enough has arrived or a deadline passes, then take whatever else is
+ * already there so an implementation delivering more than it should is caught by the caller's assertion rather than
+ * leaving its extra items in the queue unnoticed. Package-private, so neither class grows a base type an implementor
+ * would see.
  */
 @NullMarked
 final class Arrivals {
@@ -44,7 +45,7 @@ final class Arrivals {
 
     /**
      * Waits until {@code count} things have arrived, or the timeout expires, and returns everything that arrived. A
-     * short return is not an error: the caller asserts on the list, so "expected 3, got 1" is a comparison of two
+     * short return is not an error. The caller asserts on the list, so "expected 3, got 1" is a comparison of two
      * lists rather than a bare timeout.
      *
      * @param what what one item is, for the two messages this can produce
@@ -75,11 +76,11 @@ final class Arrivals {
 
     /**
      * Waits until everything that has arrived satisfies {@code condition}, or the timeout expires, and returns
-     * everything that arrived. For an assertion about arrival ORDER a plain count is the wrong thing to wait on: a
-     * model with a slow delivery seam (a catch-up replay handing over to a live feed, say) reaches the count while a
-     * later-ordered item is still in flight, and the assertion reads a list that was still growing. Waiting on the
-     * condition the caller is about to assert removes that race without changing what is asserted: a model that never
-     * satisfies it still comes back at the deadline, and the caller's assertion then fails on the full list.
+     * everything that arrived. For an assertion about arrival ORDER a plain count is the wrong thing to wait on. A
+     * model that hands a slow catch-up replay over to a live feed can reach the count while a later-ordered item is
+     * still in flight, and the assertion would then read a list that was still growing. Waiting on the condition the
+     * caller is about to assert removes that race without changing what is asserted. A model that never satisfies it
+     * still comes back at the deadline, and the caller's assertion then fails on the full list.
      */
     static <T> List<T> awaitUntil(BlockingQueue<T> arrived, Predicate<List<T>> condition, Duration timeout, String what) {
         requireNonNull(condition, "condition cannot be null");

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointAwareSubscriptionModelConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointAwareSubscriptionModelConformance.java
@@ -45,8 +45,8 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * <p>
  * A model that cannot report a position declines this suite by not extending it. There is no declaration, because
  * {@link CheckpointAwareSubscriptionModel} is itself the declaration, and the position is asked rather than declared for
- * the reason {@code PositionOrderedReader.writesPosition()} set on the event-store side: a declaration can go stale
- * while a runtime answer cannot.
+ * the same reason {@code PositionOrderedReader.writesPosition()} does on the event-store side. A declaration can go
+ * stale while a runtime answer cannot.
  * <p>
  * <strong>What this suite deliberately does not assert.</strong> {@code globalCheckpoint()} documents null as
  * "an unresolvable problem", and the honest consequence is that such a model cannot sit behind catch-up at all.

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageConformance.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * The contract every {@link CheckpointStorage} owes: a checkpoint saved for a subscription id can be read back, is
+ * The contract every {@link CheckpointStorage} owes. A checkpoint saved for a subscription id can be read back, is
  * gone once deleted, and reports its own existence honestly in between.
  * <p>
  * An implementation extends this and supplies a {@link CheckpointStorageFixture}:
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * }</pre>
  * <p>
  * Not extending this suite is how an implementation declines to be conformance tested. That is a visible, greppable
- * absence rather than a runtime skip, and nothing here calls {@code Assumptions}: where storages legitimately differ,
+ * absence rather than a runtime skip, and nothing here calls {@code Assumptions}. Where storages legitimately differ,
  * the fixture declares which way it goes and the suite asserts the documented outcome for that answer, so both branches
  * are checked by somebody.
  * <p>

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageFixture.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageFixture.java
@@ -26,9 +26,9 @@ import java.util.List;
  * What a {@link CheckpointStorage} implementation hands the conformance suite.
  * <p>
  * A fixture is created fresh for every test method, and the storage it hands back <strong>must hold no checkpoints</strong>.
- * How that is achieved is the implementation's business: dropping a collection, flushing a database, or constructing a
- * new instance. The suite never cleans up on an implementation's behalf, because what needs cleaning is exactly the part
- * a contract cannot describe.
+ * How that is achieved is the implementation's business, whether dropping a collection, flushing a database, or
+ * constructing a new instance. The suite never cleans up on an implementation's behalf, because what needs cleaning
+ * is exactly the part a contract cannot describe.
  * <p>
  * There is one thing the suite has to be told rather than ask, and it is {@link #preservesCheckpointType(Checkpoint)}.
  * Every storage round-trips the value, but they disagree about whether the {@link Checkpoint} that comes back is the

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CompetingConsumerStrategyConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CompetingConsumerStrategyConformance.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * The contract every {@link CompetingConsumerStrategy} owes: at most one subscriber consumes a subscription at a time,
+ * The contract every {@link CompetingConsumerStrategy} owes. At most one subscriber consumes a subscription at a time,
  * and the lock always finds its way to somebody who wants it.
  * <p>
  * Occurrent consumes this contract two ways, and the suite covers both. {@code CompetingConsumerSubscriptionModel}
@@ -48,15 +48,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * serves only the first of those passes nothing here.
  * <p>
  * <strong>What the suite does not have an opinion about is how a strategy coordinates.</strong> Occurrent's two
- * implementations use a lease in MongoDB, and none of that appears below: no test knows a lease exists, waits out one,
+ * implementations use a lease in MongoDB, and none of that appears below. No test knows a lease exists, waits out one,
  * or asserts when one expires. What is asserted instead is the property a lease is one way of providing, that a holder
  * which stops coordinating loses the lock to a rival rather than blocking the subscription forever. The lease's own
- * timing is a property of the implementation, and Occurrent pins it where it belongs, in deterministic tests against
+ * timing is a property of the implementation, and Occurrent covers it separately, in deterministic tests against
  * the MongoDB support class with a clock the test moves itself.
  * <p>
- * Every wait here is for something that must arrive, bounded by {@link CompetingConsumerStrategyFixture#timeToConverge()}.
- * There is no wait for a quiet period: it would pass just as well against a strategy that coordinates with nobody, and
- * any constant short enough to keep the suite quick is short enough to flake on a loaded machine.
+ * Every wait here is for something that must arrive, capped by {@link CompetingConsumerStrategyFixture#timeToConverge()}.
+ * There is no wait for a quiet period, because it would pass just as well against a strategy that coordinates with
+ * nobody, and any constant short enough to keep the suite quick is short enough to flake on a loaded machine.
  */
 @NullMarked
 @DisplayNameGeneration(ReplaceUnderscores.class)

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CompetingConsumerStrategyFixture.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CompetingConsumerStrategyFixture.java
@@ -27,7 +27,7 @@ import java.time.Duration;
  * A fixture is created fresh for every test method, and the storage behind it <strong>must hold no locks</strong>. How
  * that is achieved is the implementation's business, and the suite never cleans up on an implementation's behalf.
  * <p>
- * Two things the suite cannot get from the interface, and both are here for the same reason: contention between
+ * Two things the suite cannot get from the interface, and both are here for the same reason. Contention between
  * competing consumers is external. A strategy coordinates with rivals it never holds a reference to, through storage
  * the interface does not mention, on a schedule the interface does not report.
  */
@@ -43,12 +43,12 @@ public interface CompetingConsumerStrategyFixture {
      * Another strategy contending over the same storage as {@link #competingConsumerStrategy()}, holding no locks of its
      * own.
      * <p>
-     * This is a factory rather than a second accessor because a single call is not enough: the suite needs a rival for
+     * This is a factory rather than a second accessor because a single call is not enough. The suite needs a rival for
      * the strategy under test, and some of what it asserts needs a third instance that outlives a rival it deliberately
      * shuts down. Every call must hand back a <em>new</em> strategy contending over the same storage.
      * <p>
      * Constructing several strategies over one storage is therefore an explicit constraint on an implementor rather
-     * than an accident of how Occurrent's own strategies happen to be built: nothing on {@code CompetingConsumerStrategy}
+     * than an accident of how Occurrent's own strategies happen to be built. Nothing on {@code CompetingConsumerStrategy}
      * lets one instance reach another, so a contract about who holds a lock cannot be asserted from one reference.
      * <p>
      * The suite shuts down every strategy it obtains here, so the fixture does not have to track them.
@@ -67,7 +67,7 @@ public interface CompetingConsumerStrategyFixture {
      * <p>
      * <strong>This is a bound, not a delay.</strong> The suite waits for the condition to hold and stops as soon as it
      * does, so a generous bound costs a passing run nothing and is only paid in full by a test that was going to fail
-     * anyway. Declare it comfortably above the implementation's worst case rather than tightly: a bound too small turns
+     * anyway. Declare it comfortably above the implementation's worst case rather than tightly. A bound too small turns
      * a loaded machine into a red build, while a bound too large slows down only failures. Occurrent's MongoDB
      * strategies are lease based, so their worst case is one lease plus one refresh period, and their fixtures declare
      * several times that.

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/InProcessDeliveryConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/InProcessDeliveryConformance.java
@@ -39,7 +39,7 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * its own.
  * <p>
  * Extend it only if your model calls the handler on the thread that published the event. A model that delivers
- * asynchronously declines by not extending it, and there is deliberately no fixture flag for this: ADR 94 records why a
+ * asynchronously declines by not extending it, and there is deliberately no fixture flag for this. ADR 94 records why a
  * flag would be a switch for turning off the only test of the property. Nothing guards the suite either, so a model that
  * does deliver asynchronously fails the first assertion rather than being turned away, which is what keeps the suite open
  * to an implementation from outside this repository.

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/IntrospectableSubscriptionModelConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/IntrospectableSubscriptionModelConformance.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * any other suite. There is no declaration for it, because {@link IntrospectableSubscriptionModel} is itself the
  * declaration.
  * <p>
- * Worth having rather than assumed: both of Occurrent's MongoDB subscription models implement {@code subscriptionIds()}
+ * Worth having rather than assumed. Both of Occurrent's MongoDB subscription models implement {@code subscriptionIds()}
  * and neither had a test for it before this suite.
  */
 @NullMarked

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RecordedEvents.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RecordedEvents.java
@@ -51,7 +51,7 @@ public final class RecordedEvents implements Consumer<CloudEvent> {
 
     /**
      * Waits until {@code count} events have arrived, or the timeout expires, and returns everything that arrived. A
-     * short return is not an error here: the caller asserts on the list, so "expected 3, got 1" is a comparison of two
+     * short return is not an error here. The caller asserts on the list, so "expected 3, got 1" is a comparison of two
      * lists rather than a bare timeout. Anything else already there comes back too, so an over-delivering model is
      * caught by the caller's assertion.
      */
@@ -61,9 +61,10 @@ public final class RecordedEvents implements Consumer<CloudEvent> {
 
     /**
      * Waits until what has arrived satisfies {@code condition}, or the timeout expires, and returns everything that
-     * arrived. Use this over {@link #awaitAtLeast(int, Duration)} when the assertion is about arrival ORDER: a model
-     * with a slow delivery seam can satisfy a count while a later-ordered event is still in flight, so the wait must
-     * be for the very thing the assertion needs. A short return is not an error here either: the caller asserts on
+     * arrived. Use this over {@link #awaitAtLeast(int, Duration)} when the assertion is about arrival order. A model
+     * that hands delivery off between two mechanisms, such as a replay handing over to a live feed, can satisfy a
+     * count while a later-ordered event is still crossing that handover, so the wait must be for the very thing the
+     * assertion needs. A short return is not an error here either. The caller asserts on
      * the list, so a model that never satisfies the condition fails that assertion on the full list.
      */
     public List<CloudEvent> awaitUntil(Predicate<List<CloudEvent>> condition, Duration timeout) {

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RecordedLockChanges.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RecordedLockChanges.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
  * thing it asserts on.
  * <p>
  * It waits by blocking on a queue rather than by polling, the same shape {@link RecordedEvents} uses for delivered
- * events and for the same reason: a lock change is pushed to a listener, so a wait can wake on arrival instead of
+ * events and for the same reason. A lock change is pushed to a listener, so a wait can wake on arrival instead of
  * paying a poll interval. Where the suite has no listener to wait on it polls {@code hasLock} instead, because that is
  * the whole of what a strategy without a listener reports.
  * <p>
@@ -81,7 +81,7 @@ public final class RecordedLockChanges implements CompetingConsumerListener {
 
     /**
      * Waits until {@code count} changes have arrived, or the timeout expires, and returns everything that arrived. A
-     * short return is not an error here: the caller asserts on the list, so "expected a grant, got nothing" is a
+     * short return is not an error here. The caller asserts on the list, so "expected a grant, got nothing" is a
      * comparison of two lists rather than a bare timeout. Anything else already there comes back too, so a strategy
      * reporting the same change twice is caught by the caller's assertion.
      */

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RestartConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RestartConformance.java
@@ -34,28 +34,28 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
 import static org.occurrent.tck.subscription.blocking.SubscriptionModelConformance.DELIVERY_TIMEOUT;
 
 /**
- * What a model owes a subscription that outlives the model itself: an event published while nothing was running is
- * either still delivered afterwards, or it is gone, and which of the two is a promise the model makes rather than
- * something a caller finds out the hard way.
+ * What a model owes a subscription that outlives the model itself. An event published while nothing was running is
+ * either still delivered afterwards, or it is gone, and which of the two happens is a promise the model makes rather
+ * than something a caller finds out the hard way.
  * <p>
  * This is the half of the contract {@link SubscriptionModelConformance} deliberately leaves alone, because it needs
  * state that survives the model. A model whose events arrive by being handed to it has none, and no way to be handed
- * one while it is down, so it declines this suite by not extending it. That absence is visible and greppable, which is
- * the mechanism ADR 77 rule (d) already relies on, and it is the right one here: the alternative, a declaration on the
- * base fixture, would have a branch that asserts nothing at all for those models, and a declaration that is free on one
- * branch is a switch for turning off the only test of a property.
+ * one while it is down, so it declines this suite by not extending it. That absence is visible and searchable, which
+ * is the mechanism ADR 77 rule (d) already relies on, and it is the right one here. The alternative, a declaration on
+ * the base fixture, would have a branch that asserts nothing at all for those models, and a declaration that is free
+ * on one branch is a switch for turning off the only test of a property.
  * <p>
  * A model that <em>can</em> answer still gets to say which way it goes, through
  * {@link RestartableSubscriptionModelFixture#resumesAfterARestart()}, because two models with identical durable state
- * underneath them genuinely differ: a change-stream model reads from wherever the server is now, and the same model
+ * underneath them genuinely differ. A change-stream model reads from wherever the server is now, and the same model
  * wrapped in one that keeps a checkpoint reads from where the checkpoint says. Both branches are asserted.
  * <p>
  * <strong>Delivery here is at-least-once, not exactly-once.</strong> A model resuming from the last position it stored
  * rather than from just after it hands that event over a second time, and nothing in Occurrent promises otherwise, so
  * these assertions are about what must arrive and never about what must not repeat.
  * <p>
- * The 60 second class timeout is the same number the other suites use, and the margin here is thinner than it looks:
- * the longest test chains three {@code DELIVERY_TIMEOUT} waits at 10 seconds each, and between them it tears a model
+ * The 60 second class timeout is the same number the other suites use, and the margin here is thinner than it looks.
+ * The longest test chains three {@code DELIVERY_TIMEOUT} waits at 10 seconds each, and between them it tears a model
  * down and builds another one, which against a real store means closing a change stream and opening a fresh one. That
  * leaves about 30 seconds for two rebuilds. Raise this before raising {@code DELIVERY_TIMEOUT}, since a wait that
  * outlives the class timeout reports a {@code TimeoutException} instead of naming the event that never arrived.

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RestartableSubscriptionModelFixture.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/RestartableSubscriptionModelFixture.java
@@ -25,8 +25,8 @@ import java.util.List;
  * What a model hands {@link RestartConformance}, on top of everything {@link SubscriptionModelFixture} already asks
  * for.
  * <p>
- * Only a fixture that can do both halves of a restart supplies this: build the model a second time over whatever it
- * left behind, and feed events in while no model is running. A model whose events arrive by being handed to it has
+ * Only a fixture that can do both halves of a restart supplies this. It must build the model a second time over
+ * whatever it left behind, and feed events in while no model is running. A model whose events arrive by being handed to it has
  * neither, since there is nowhere for an event to wait, which is why declining is done by not extending the suite
  * rather than by answering a declaration.
  */
@@ -37,8 +37,8 @@ public interface RestartableSubscriptionModelFixture extends SubscriptionModelFi
      * Shuts the current model down and builds a fresh one over the same durable state, the way restarting the
      * application would.
      * <p>
-     * Rebuild rather than restart in place: {@code SubscriptionModelLifeCycle.shutdown()} is documented as not
-     * reversible, and starting the same instance again would prove nothing about state outliving a process.
+     * This rebuilds rather than restarts in place, because {@code SubscriptionModelLifeCycle.shutdown()} is documented
+     * as not reversible, and starting the same instance again would prove nothing about state outliving a process.
      * <p>
      * After this call {@link #subscriptionModel()} must answer with the new model, so {@link #close()} shuts down the
      * one that is actually running, and {@link #publish(List)} must feed the new model too.

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelConformance.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.occurrent.tck.ConformanceEvents.idsOf;
 
 /**
- * The contract every {@link SubscriptionModel} owes: an event published while a subscription is running reaches its
+ * The contract every {@link SubscriptionModel} owes. An event published while a subscription is running reaches its
  * handler, a filter decides which events do, and the life cycle does what it says.
  * <p>
  * An implementation extends this and supplies a {@link SubscriptionModelFixture}:
@@ -58,14 +58,14 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  * }
  * }</pre>
  * <p>
- * Not extending this suite is how an implementation declines to be conformance tested. That is a visible, greppable
- * absence rather than a runtime skip, and nothing here calls {@code Assumptions}: where models legitimately differ, the
+ * Not extending this suite is how an implementation declines to be conformance tested. That is a visible, searchable
+ * absence rather than a runtime skip, and nothing here calls {@code Assumptions}. Where models legitimately differ, the
  * fixture declares which way it goes and the suite asserts the documented outcome for that answer, so both branches are
  * checked by somebody.
  * <p>
- * <strong>How this suite waits.</strong> Every wait is for something that must arrive, bounded, through
- * {@link RecordedEvents}. For "this event must not arrive" it publishes a marker afterwards and waits for the marker,
- * then asserts the whole recorded list. That is not a stylistic choice: a wait for a period in which nothing happens
+ * <strong>How this suite waits.</strong> Every wait is for something that must arrive within {@link #DELIVERY_TIMEOUT},
+ * through {@link RecordedEvents}. For "this event must not arrive" it publishes a marker afterwards and waits for the marker,
+ * then asserts the whole recorded list. That is not a stylistic choice. A wait for a period in which nothing happens
  * passes just as well against a subscription that was never listening, and any constant short enough to keep a test
  * quick is short enough to flake on a loaded CI runner. The marker rests on one property every model has, that a
  * subscription receives events in publish order, so a marker published after the forbidden event cannot arrive first.
@@ -80,8 +80,8 @@ import static org.occurrent.tck.ConformanceEvents.idsOf;
  *     transaction, so a lower position can commit after a higher one. Arrival order is the promise, not position order.</li>
  *     <li><strong>That {@code start()} is idempotent.</strong> One model refuses a second {@code start()} and the rest
  *     accept it, and nothing says which is right.</li>
- *     <li><strong>At-least-once delivery, and resuming after a restart.</strong> Neither is a promise of this contract:
- *     both need durable state that survives the model, which only some models have. {@link RestartConformance} covers
+ *     <li><strong>At-least-once delivery, and resuming after a restart.</strong> Neither is a promise of this contract.
+ *     Both need durable state that survives the model, which only some models have. {@link RestartConformance} covers
  *     them, and a model that cannot be rebuilt over the state it left behind declines it by not extending it.</li>
  * </ul>
  */
@@ -114,7 +114,7 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
     /**
      * How long a wait for an event that must arrive is given.
      * <p>
-     * Ten seconds, and the number is arithmetic rather than taste: the longest test here chains four of these waits, so
+     * Ten seconds, and the number is arithmetic rather than taste. The longest test here chains four of these waits, so
      * anything above 15 would let a slow model blow the class-level {@code @Timeout} mid-wait and report a
      * {@code TimeoutException} instead of an assertion naming what never arrived. It is still generous against the rest
      * of this repository, where the same wait shape is usually spelled 2 to 5 seconds. Raise the {@code @Timeout} before
@@ -411,8 +411,8 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
                 CloudEvent marker = ConformanceEvents.event("3", "MarkerEvent");
                 publish(marker);
                 // The wait is for the order the assertion is about, not a count: a model resuming through a replay
-                // handed over to a live feed reaches a count of 2 while the marker is still crossing that seam, and a
-                // count-wait would then assert on a list that was still growing.
+                // handed over to a live feed reaches a count of 2 while the marker is still crossing that handover,
+                // and a count-wait would then assert on a list that was still growing.
                 List<CloudEvent> received = recorded.awaitUntil(events -> {
                     List<String> ids = idsOf(events);
                     int held = ids.indexOf(whilePaused.getId());

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelFixture.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelFixture.java
@@ -38,7 +38,7 @@ import java.util.Set;
  *     a subscription is open.</strong> Dropping either kills a live change stream, so a fixture that cleans up that way
  *     leaves the next test watching a stream that will never deliver. Delete documents instead.</li>
  *     <li><strong>Never let the suite publish the same event id twice.</strong> The suites never do, and a fixture must
- *     not make one up either: a store-backed model refuses a duplicate id through a unique index while an in-process
+ *     not make one up either. A store-backed model refuses a duplicate id through a unique index while an in-process
  *     model delivers it twice.</li>
  * </ul>
  */
@@ -53,8 +53,8 @@ public interface SubscriptionModelFixture {
     /**
      * Hands the events to whatever feeds this model, in order.
      * <p>
-     * What that is differs completely between implementations, which is exactly why the suite is not allowed to know:
-     * a store-backed model needs a write its change stream observes, and an in-process model is handed the events
+     * What that is differs completely between implementations, which is exactly why the suite is not allowed to know.
+     * A store-backed model needs a write its change stream observes, and an in-process model is handed the events
      * directly. The suite only ever asks for them to arrive.
      * <p>
      * <strong>This is allowed to throw.</strong> On a model that propagates a handler exception rather than retrying,
@@ -82,7 +82,7 @@ public interface SubscriptionModelFixture {
      * Whether a handler that throws is called again, or the exception reaches whoever published the event.
      * <p>
      * Both answers cost something to give. A retrying model owes a second call to the handler, and a propagating model
-     * owes the exception out of {@link #publish(List)}. Occurrent's models split on this: the three that deliver
+     * owes the exception out of {@link #publish(List)}. Occurrent's models split on this. The three that deliver
      * asynchronously wrap the handler in a {@code RetryStrategy}, and the two that deliver on the publishing thread
      * let the exception through.
      * <p>
@@ -94,7 +94,7 @@ public interface SubscriptionModelFixture {
     /**
      * Whether the model accepts more than one subscription at a time.
      * <p>
-     * Answering {@code false} is a real design position rather than a limitation: a sink driven by an external broker
+     * Answering {@code false} is a real design position rather than a limitation. A sink driven by an external broker
      * delivers one message under one acknowledgement, so a second consumer on it would mean one failing consumer
      * holding up the rest. A model answering {@code false} owes a refusal of the second {@code subscribe}, and one
      * answering {@code true} owes two subscriptions that receive independently.
@@ -115,7 +115,7 @@ public interface SubscriptionModelFixture {
      * <p>
      * Accepting a variant is not the same as acting on it. A model that dispatches events as they arrive has no
      * position to start from and its own javadoc says it ignores the one it is given, which is still an accepted
-     * variant here: what the suite holds it to is that the subscription works, not that the position moved anything.
+     * variant here. What the suite holds it to is that the subscription works, not that the position moved anything.
      * A model that cannot honour a position and refuses it instead owes the refusal, which is what
      * {@code CatchupThenPushSubscriptionModel} does with every variant but
      * {@link StartAtVariant#SUBSCRIPTION_MODEL_DEFAULT}, since it replays a whole history and has nothing to apply a
@@ -135,14 +135,14 @@ public interface SubscriptionModelFixture {
      * from {@code globalCheckpoint()}, which is the position a catch-up handover would use. A model that ignores the
      * start position may answer with anything, and {@code GlobalCheckpoint.of(0)} is the obvious nothing.
      * <p>
-     * Asked of the fixture rather than of the model because {@code SubscriptionModel} has no member that reports one:
-     * only the checkpoint-aware models do, and this suite runs against the rest as well.
+     * Asked of the fixture rather than of the model because {@code SubscriptionModel} has no member that reports one.
+     * Only the checkpoint-aware models do, and this suite runs against the rest as well.
      */
     Checkpoint aCheckpointToStartFrom();
 
     /**
-     * The answer for a model that reports a position but is allowed to answer null, which most of them are: hand back
-     * what it reported, or the global position zero when it reported nothing.
+     * For a model that reports a position but is allowed to answer null, which most of them are, hand back what it
+     * reported, or the global position zero when it reported nothing.
      * <p>
      * A convenience rather than a default on {@link #aCheckpointToStartFrom()}, which stays abstract on purpose. A
      * default would let a model that really does read a position inherit "position zero" by forgetting to override,
@@ -159,7 +159,7 @@ public interface SubscriptionModelFixture {
      * <p>
      * Both answers are asserted. Answering {@code false}, which every change-stream and in-process model does, owes a
      * new subscription that does <em>not</em> receive what was published before it existed. Answering {@code true} owes
-     * exactly the opposite, and it is a real contract rather than an accident of implementation: a model whose whole
+     * exactly the opposite, and it is a real contract rather than an accident of implementation. A model whose whole
      * job is to bring a read model up to date replays first and goes live after, which is why it also refuses a
      * caller-supplied start position in {@link #acceptedStartAtVariants()}.
      * <p>

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelSuite.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelSuite.java
@@ -25,8 +25,8 @@ import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The fixture lifecycle every subscription-model suite shares: created before each test, closed after each test even
- * when the test failed, and reachable only from inside a test.
+ * Every subscription-model suite shares this fixture lifecycle. A fixture is created before each test and closed
+ * after each test, even when the test failed, and it is reachable only from inside a test.
  * <p>
  * Package-private, so it adds nothing to what an implementation sees. It extends nothing and is extended only by the
  * three suites in this package, which is the same shape {@code EventStoreConformance} gives the event-store leaf.

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/BlockingSubscriptionOverReactive.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/BlockingSubscriptionOverReactive.java
@@ -35,22 +35,20 @@ import java.util.function.Consumer;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Presents a reactive subscription model as a blocking one, so the blocking conformance suites can be run against it
- * unchanged instead of being written a second time in terms of {@code Mono} and {@code Flux}.
+ * Presents a reactive subscription model as a blocking one, so the blocking conformance suites can run against it
+ * unchanged instead of being rewritten a second time in terms of {@code Mono} and {@code Flux}.
  * <p>
- * This is a test bridge and nothing more. It is not a general-purpose adapter and must not be used in production:
- * every wait blocks the calling thread, which is exactly what a reactive model exists to avoid.
+ * This is a test bridge only. It is not a general-purpose adapter and must not be used in production. Every wait
+ * blocks the calling thread, which is exactly what a reactive model exists to avoid.
  * <p>
- * The translation is small because reactor {@code SubscriptionModelLifeCycle} already returns plain values, a
- * deliberate choice its own javadoc records. What actually differs is the action type,
- * {@code Function<CloudEvent, Mono<Void>>} against {@code Consumer<CloudEvent>}, and the two waits: this bridge wraps
- * the consumer in {@code Mono.fromRunnable(..)} so the handler runs when the model subscribes to the returned
- * {@code Mono}, and blocks on {@code waitUntilStarted(Duration)}.
+ * The bridge wraps each {@code Consumer<CloudEvent>} action in {@code Mono.fromRunnable(..)}, so the handler runs
+ * when the model subscribes to the returned {@code Mono}. It blocks on {@code waitUntilStarted(Duration)} to turn
+ * the reactive wait into a blocking one.
  * <p>
- * A bridge cannot see everything. Whether the model subscribes to the action's {@code Mono} rather than merely
- * assembling it, whether {@code waitUntilStarted()} answers, and what disposing a wait does are invisible once a
- * result has been blocked on. Those are the reactive contract, not the behavioural one, and they belong to
- * {@link ReactiveSubscriptionModelConformance} rather than here.
+ * A bridge cannot see everything. Whether the model actually subscribes to the action's {@code Mono} rather than
+ * just assembling it, whether {@code waitUntilStarted()} answers, and what disposing a wait does are invisible
+ * once a result has been blocked on. Those parts of the contract are tested separately, by
+ * {@link ReactiveSubscriptionModelConformance}.
  */
 @NullMarked
 public class BlockingSubscriptionOverReactive implements SubscriptionModel, IntrospectableSubscriptionModel {
@@ -66,8 +64,8 @@ public class BlockingSubscriptionOverReactive implements SubscriptionModel, Intr
     /**
      * Bound on blocking for {@code globalCheckpoint()}. The blocking method the bridge implements has no timeout
      * parameter, so the bound has to live here, and an unbounded {@code block()} would hang a suite instead of
-     * failing it. Twenty seconds copies the reactive-only suite's budget: the answer is a single command against the
-     * store, so a model that has not answered by then is not going to.
+     * failing it. Twenty seconds matches the reactive-only suite's budget. The answer is a single command against
+     * the store, so a model that has not answered by then is not going to.
      */
     private static final Duration CHECKPOINT_TIMEOUT = Duration.ofSeconds(20);
 
@@ -101,13 +99,13 @@ public class BlockingSubscriptionOverReactive implements SubscriptionModel, Intr
     /**
      * Bridges a model that can also report where the event feed is, so
      * {@code CheckpointAwareSubscriptionModelConformance} can run against it. This is a separate factory rather than
-     * behaviour of the plain bridge on purpose: that suite treats implementing the blocking
+     * behaviour of the plain bridge on purpose. That suite treats implementing the blocking
      * {@link CheckpointAwareSubscriptionModel} as the declaration itself, so a bridge that implemented it
      * unconditionally would drag every bridged model through a suite only checkpoint-aware ones can answer.
      * <p>
      * A reactor model that completes {@code globalCheckpoint()} empty is mapped to the blocking {@code null}, which
      * the blocking interface documents as "an unresolvable problem" and the suite asserts on both branches. That
-     * empty completion is a real answer in the wild, not a hypothetical: see issue #517.
+     * empty completion is a real answer in the wild, not a hypothetical. See issue #517.
      */
     public static <T extends org.occurrent.subscription.api.reactor.SubscriptionModel
             & org.occurrent.subscription.api.reactor.IntrospectableSubscriptionModel

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
@@ -45,10 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Everything about what a model delivers, pauses, resumes and reports is asserted once, by the blocking suites running
  * over {@link BlockingSubscriptionOverReactive}, rather than described a second time in terms of {@code Mono}. What
- * that cannot reach is the two publishers the reactor API actually has: the {@code Mono<Void>} an action returns,
- * which the <em>model</em> is the subscriber of, and {@link Subscription#waitUntilStarted()}. A model can get both
- * wrong and still pass every bridged suite, because the bridge's own action does its work as a side effect of
- * assembly-time capture and the bridge always blocks.
+ * that cannot reach is the reactor API's two publishers, the {@code Mono<Void>} an action returns, which the
+ * <em>model</em> subscribes to, and {@link Subscription#waitUntilStarted()}. A model can get both wrong and still
+ * pass every bridged suite, because the bridge's own action does its work as a side effect of assembly-time capture
+ * and the bridge always blocks.
  * <p>
  * Why each of them matters to somebody using the model:
  * <ul>
@@ -59,13 +59,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       fixture declares as retry-or-propagate. A model that lets it detonate somewhere unrelated, or that stops
  *       itself, turns one failed delivery into an outage.</li>
  *   <li>{@link Subscription#waitUntilStarted()} is promised to answer, and callers gate application startup on it. One
- *       that never completes hangs the caller; one that consumes its answer on first use answers the second caller
- *       never.</li>
+ *       that never completes hangs the caller. One that consumes its answer on first use never answers a second
+ *       caller.</li>
  *   <li>Disposing a wait is a caller giving up on waiting, not on the subscription. A model that tears anything down
  *       on that disposal punishes an ordinary timeout pattern.</li>
  * </ul>
  * <p>
- * Every wait here is bounded, and no test installs an action that fails forever: a retrying model would retry it for
+ * Every wait here has a timeout, and no test installs an action that fails forever. A retrying model would retry it for
  * the rest of the timeout, so failures are always fail-once.
  */
 @NullMarked

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
@@ -47,8 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * over {@link BlockingSubscriptionOverReactive}, rather than described a second time in terms of {@code Mono}. What
  * that cannot reach is the reactor API's two publishers, the {@code Mono<Void>} an action returns, which the
  * <em>model</em> subscribes to, and {@link Subscription#waitUntilStarted()}. A model can get both wrong and still
- * pass every bridged suite, because the bridge's own action does its work as a side effect of assembly-time capture
- * and the bridge always blocks.
+ * pass every bridged suite, because the bridge's own action has already run by the time it hands back a {@code Mono},
+ * whether or not anything subscribes to it, and the bridge blocks either way.
  * <p>
  * Why each of them matters to somebody using the model:
  * <ul>

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelFixture.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelFixture.java
@@ -49,7 +49,7 @@ public interface ReactiveSubscriptionModelFixture {
      * <strong>This is allowed to throw.</strong> On a model that propagates a failed action rather than retrying it,
      * delivery happens inside this call, so an action whose {@code Mono} errors comes back out of here. The suite
      * accepts either, because which of the two a model does is the blocking fixture's declaration and is asserted
-     * there; here only the model's survival is asserted.
+     * there. Here only the model's survival is asserted.
      *
      * @param events The events to feed in, in order. Never empty, and no id is ever repeated within a test.
      */

--- a/test-support/src/main/java/org/occurrent/testsupport/mongodb/MongoTestDatabase.java
+++ b/test-support/src/main/java/org/occurrent/testsupport/mongodb/MongoTestDatabase.java
@@ -29,11 +29,11 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * The database a container owns, as a {@link MongoDatabase}, for the test-side APIs that ask for one rather than for a
- * connection string. {@code OccurrentMongoFlush} is the reason this exists: it takes a database on purpose, because a
+ * connection string. {@code OccurrentMongoFlush} is the reason this exists. It takes a database on purpose, because a
  * connection string is what let a test name a collection where it meant to name a database.
  * <p>
  * One {@link MongoClient} is kept per server for the lifetime of the JVM, and every test class asking for the same
- * server shares it. That is deliberate rather than incidental: a client per call would mean one per test method across
+ * server shares it. That is deliberate rather than incidental. A client per call would mean one per test method across
  * some ninety test classes, and the extension this replaces opened and closed one on every single {@code beforeEach}.
  * A shared client is safe here because the databases are not shared, since
  * {@link ReplicaSetReadyMongoDBContainer} gives each container object its own.

--- a/testing/junit-jupiter-blocking/src/main/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtension.java
+++ b/testing/junit-jupiter-blocking/src/main/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtension.java
@@ -130,7 +130,7 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
      * earlier test left it and receives events that test wrote.
      * <p>
      * Clearing the events alone does not achieve this. A stored checkpoint is what decides where a resumed subscription
-     * starts, so it has to go too, and it is not necessarily stored next to the events: a MongoDB event store keeping
+     * starts, so it has to go too, and it is not necessarily stored next to the events. A MongoDB event store keeping
      * its checkpoints in Redis is an ordinary setup.
      *
      * @param checkpointStorage the storage holding the checkpoints, must not be {@code null}

--- a/testing/junit-jupiter-reactor/src/main/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtension.java
+++ b/testing/junit-jupiter-reactor/src/main/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtension.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * The reactive counterpart of the blocking {@code OccurrentSubscriptionsExtension}: stops every subscription model
+ * The reactive counterpart of the blocking {@code OccurrentSubscriptionsExtension}. It stops every subscription model
  * before and after each test, so a test only runs the subscriptions it names with {@link #start(String)}. A test that
  * writes events then cannot race a subscription it never asked for.
  * <p>
@@ -145,7 +145,7 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
      * earlier test left it and receives events that test wrote.
      * <p>
      * Clearing the events alone does not achieve this. A stored checkpoint is what decides where a resumed subscription
-     * starts, so it has to go too, and it is not necessarily stored next to the events: a MongoDB event store keeping
+     * starts, so it has to go too, and it is not necessarily stored next to the events. A MongoDB event store keeping
      * its checkpoints in Redis is an ordinary setup.
      *
      * @param checkpointStorage the storage holding the checkpoints, must not be {@code null}

--- a/testing/mongodb/src/main/java/org/occurrent/testing/mongodb/OccurrentMongoFlush.java
+++ b/testing/mongodb/src/main/java/org/occurrent/testing/mongodb/OccurrentMongoFlush.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * Empties a MongoDB database between tests by deleting documents, leaving the collections and their indexes in place.
  * <p>
  * Compose it with {@code OccurrentSubscriptionsExtension} from {@code occurrent-testing-junit-jupiter-blocking}, which runs it
- * after stopping every subscription and before resuming any, so nothing has to pin extension order:
+ * after stopping every subscription and before resuming any, so you do not have to control extension order:
  * <pre>{@code
  * @RegisterExtension
  * OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel)
@@ -55,8 +55,8 @@ import java.util.Set;
  * the worse of the two failures, because the other one at least fails a test.
  *
  * <h2>What it covers</h2>
- * {@link #everyCollectionIn(MongoDatabase)} names no collections, which is the point: Occurrent creates more of them
- * than an application tends to remember. Alongside the events there is a stream position collection, a DCB checkpoint
+ * {@link #everyCollectionIn(MongoDatabase)} names no collections. That is the point, because Occurrent creates more
+ * of them than an application tends to remember. Alongside the events there is a stream position collection, a DCB checkpoint
  * collection, the subscription checkpoint collection, and a competing consumer lock collection, and a hand written list
  * silently stops covering one the day a feature is switched on. Views and {@code system.*} collections are skipped.
  */
@@ -162,7 +162,7 @@ public final class OccurrentMongoFlush implements Runnable, BeforeEachCallback {
     }
 
     /**
-     * Empties the database before each test. Deliberately not an {@code AfterEachCallback}: the next test's
+     * Empties the database before each test. This is deliberately not an {@code AfterEachCallback}. The next test's
      * {@code beforeEach} empties it anyway, so doing it twice costs time for nothing, and what a failing test left
      * behind is what you want to look at.
      */

--- a/testing/spring-boot/src/main/java/org/occurrent/testing/springboot/OccurrentReactorTestingConfiguration.java
+++ b/testing/spring-boot/src/main/java/org/occurrent/testing/springboot/OccurrentReactorTestingConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Scope;
 import java.util.List;
 
 /**
- * The reactive counterpart of {@link OccurrentTestingConfiguration}: exposes a reactive
+ * The reactive counterpart of {@link OccurrentTestingConfiguration}. It exposes a reactive
  * {@link OccurrentSubscriptionsExtension} over every reactive {@link SubscriptionModelLifeCycle} bean in the
  * application context.
  * <p>
@@ -42,7 +42,7 @@ public class OccurrentReactorTestingConfiguration {
     /**
      * The extension that stops every reactive subscription model before and after each test.
      * <p>
-     * It is a prototype bean for the same reason the blocking one is: the extension accumulates the subscription ids a
+     * It is a prototype bean for the same reason the blocking one is. The extension accumulates the subscription ids a
      * test told it about, and a test class registering it with {@code @RegisterExtension} should not inherit the ids
      * another test class named.
      *

--- a/testing/spring-boot/src/main/java/org/occurrent/testing/springboot/OccurrentTestingConfiguration.java
+++ b/testing/spring-boot/src/main/java/org/occurrent/testing/springboot/OccurrentTestingConfiguration.java
@@ -31,8 +31,9 @@ import java.util.List;
  * the application context, so a test can autowire the extension instead of constructing it from the subscription
  * models it first has to inject itself.
  * <p>
- * Every such bean, not just one: a context can hold more than one life-cycle bearing model, for example a durable
- * model and a {@code SynchronousSubscriptionModel}, and deny-by-default means none of them run until a test asks.
+ * It wires every such bean, not just one, because a context can hold more than one life-cycle bearing model, for
+ * example a durable model and a {@code SynchronousSubscriptionModel}, and deny-by-default means none of them run
+ * until a test asks.
  *
  * @see EnableOccurrentTesting
  */


### PR DESCRIPTION
## Summary

I swept the javadoc/kdoc in every `src/main` Java/Kotlin file created since the `occurrent-0.31.0` tag (84 files, found by checking what existed at the tag directly rather than `git log --diff-filter=A`, which misses renamed files), plus the one new user-facing doc, `doc/migration/upgrading-to-0.32.0.md`.

60 of the 84 source files needed edits; 24 were already clear. The dominant issue by far was colon-as-reveal mid-sentence construction ("X does this: it does Y"), showing up in nearly every file with multi-sentence javadoc, sometimes 3-5 times in one class comment. Secondary fixes: stray semicolons in prose, and a handful of jargon terms (`seam`, `pins`/`pinning`, `load-bearing`, unexplained `bounded`).

Out of scope, deliberately:
- The 24 new ADRs under `doc/architecture/decisions/`, maintainer decision records, not end-user documentation.
- Test files, since the ask was public documentation and `src/test` isn't public API surface.

## Verification

- `mvn -q -DskipTests compile` passes clean across the whole repo.
- Grepped every in-scope file myself for dashes, semicolons, colon-reveals, and banned jargon after the sweep to confirm nothing was missed or self-reported inaccurately.
- Diff is proportionate to the claim: 61 files changed, 294 insertions, 287 deletions, comment-only.

## Test plan

- [x] `mvn -q -DskipTests compile` (already run, clean)
- [ ] Spot-check a few of the touched conformance-test-kit javadoc blocks read naturally in an IDE