### PR TITLE
Qualify saga CAS amplification javadoc; fix unreachable branch comment

### DIFF
--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaExecution.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaExecution.java
@@ -157,7 +157,7 @@ final class SagaExecution<E, S extends @Nullable Object, C> {
                         log.warn("Saga '{}' has lost its compare-and-set save {} times (of a maximum {}) to concurrent writers; each retry re-dispatches the input's commands. Sustained contention may exhaust the retries and raise SagaConcurrencyException.",
                                 sagaId, attempt.getAttemptNumber(), config.maxCasAttempts());
                     }
-                    // A lost compare-and-set, or an outcome with nothing to save: retry the whole body.
+                    // Lost compare-and-set: retry the whole body. Processed outcomes always carry an envelope.
                     throw new CasConflict();
                 });
     }

--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunnerConfig.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunnerConfig.java
@@ -26,8 +26,10 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * {@code maxCasAttempts} also bounds dispatch amplification: because commands are dispatched before the save and a lost
  * compare-and-set retries the whole step, a single input can re-dispatch its entire command list up to
- * {@code maxCasAttempts} times. Command receivers must be idempotent and tolerate that multiplicity, not merely
- * at-least-once delivery.
+ * {@code maxCasAttempts} times. However, a timer retry re-checks if the timer is still due against the reloaded envelope
+ * before dispatching, which fences out stale timers and limits realistic amplification to roughly the number of competing
+ * nodes, not the full {@code maxCasAttempts}. Command receivers must be idempotent and tolerate that multiplicity, not
+ * merely at-least-once delivery.
  *
  * @param timerPollInterval    how often to poll for due timers
  * @param timerBatchLimit      the maximum number of due instances fired per poll


### PR DESCRIPTION
Qualify saga CAS amplification javadoc; fix unreachable branch comment.

SagaRunnerConfig.java: Add qualifier that timer retry re-checks hasDueTimer against reloaded envelope before dispatching, which fences out stale timers and limits realistic amplification to roughly the node count, not the full maxCasAttempts bound.

SagaExecution.java: Fix comment to note that processed outcomes always carry an envelope, removing the unreachable branch description.

Fixes #625
