### PR TITLE
Add a re-runnable benchmark harness for the numbers ADR 108 and #615 cite

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,49 @@
+# occurrent-benchmark
+
+JMH benchmarks that make two previously ad-hoc, uncommitted measurements re-runnable:
+
+- `BlockingHandoverThroughputBenchmark`: the throughput comparison behind
+  [ADR 108](../doc/architecture/decisions/0108-a-live-push-handler-runs-outside-the-handover-lock.md), the handover
+  lock change.
+- `PayloadFilterReadBenchmark`: the per-leaf payload read cost behind [PR #615](https://github.com/johanhaleby/occurrent/pull/615)
+  and the go/no-go question for [#623](https://github.com/johanhaleby/occurrent/issues/623) (memoizing payload-field
+  reads across filter condition leaves).
+
+Both benchmarks run entirely in-process. No Docker, no MongoDB, no other container is required.
+
+## Why this module is not part of a normal build
+
+This module is dev-only: it is never published, and it never even enters a plain `mvn install` or `mvn -Prelease
+install` reactor. It is registered under an opt-in `benchmarks` profile in the root `pom.xml` (unlike the
+`examples-module` profile, this one is not `activeByDefault`), and it additionally sets `maven.deploy.skip` in its
+own `pom.xml` as a second, independent guard in case `-Pbenchmarks` and `-Prelease` are ever combined.
+
+## Building
+
+```
+mvn -Pbenchmarks -pl benchmark -am test-compile
+```
+
+## Running
+
+Build the self-contained benchmarks jar, then run it directly with the JMH CLI:
+
+```
+mvn -Pbenchmarks -pl benchmark -am package -DskipTests
+java -jar benchmark/target/benchmarks.jar BlockingHandoverThroughputBenchmark -wi 3 -i 5 -f 1
+java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 3 -i 5 -f 1
+```
+
+`-wi 3 -i 5 -f 1` is the exact protocol ADR 108's table states. It is also a reasonable default for
+`PayloadFilterReadBenchmark`, though with 3 leaf counts x 2 payload sizes x 2 field positions x 2 backings x 2
+benchmark methods = 48 forked-parameter combinations, a full run takes several minutes.
+
+For a fast smoke run that only proves the harness executes end to end, shrink warmup/measurement:
+
+```
+java -jar benchmark/target/benchmarks.jar BlockingHandoverThroughputBenchmark -wi 1 -i 1 -f 1 -w 200ms -r 200ms
+java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 1 -i 1 -f 1 -w 200ms -r 200ms
+```
+
+Numbers from a smoke run are not meaningful for citing anywhere; only numbers from the full protocol above should be
+recorded against an ADR, a changelog entry, or an issue.

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Johan Haleby
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>occurrent</artifactId>
+        <groupId>org.occurrent</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>occurrent-benchmark</artifactId>
+    <packaging>jar</packaging>
+
+    <name>${mavenProjectName}</name>
+    <description>
+        JMH benchmarks that reproduce the measurement setups cited in ADR 108 and PR #615, and a payload-filter
+        read benchmark for the go/no-go decision on #623. Dev-only: never installed as a reactor module unless the
+        "benchmarks" profile is active, and never published even if it is (see maven.deploy.skip below).
+    </description>
+
+    <properties>
+        <!-- Belt and suspenders alongside the "benchmarks" profile being opt-in in the root pom: even a
+             "-Pbenchmarks -Prelease" build cannot deploy this module. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <jmh.version>1.37</jmh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-api-blocking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-common-inmemory-filter-matching-jackson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/benchmark/src/main/java/org/occurrent/benchmark/handover/BlockingHandoverThroughputBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/handover/BlockingHandoverThroughputBenchmark.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.handover;
+
+import org.occurrent.subscription.CatchupThenLiveOptions;
+import org.occurrent.subscription.api.blocking.internal.BlockingHandover;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
+
+/**
+ * Reproduces the measurement setup behind ADR 108 ("A live push handler runs outside the handover lock"): the real
+ * {@code BlockingHandover.accept(T)} live-delivery path, driven from 1, 2, 4 and 8 concurrent threads, at handler
+ * costs of 50 and 200 microseconds, compared against {@link FullyLockedHandover}, which reconstructs the pre-ADR-108
+ * shape (fold inside the lock) since that shape no longer exists in production code.
+ * <p>
+ * The ADR's own 1-microsecond row is intentionally not reproduced here: the ADR itself notes that at that size the
+ * benchmark measures lock/dedup overhead rather than the handler cost in question, with error bars the ADR describes
+ * as "±100-400%".
+ * <p>
+ * Run with, for example:
+ * <pre>{@code
+ * java -jar benchmark/target/benchmarks.jar BlockingHandoverThroughputBenchmark -wi 3 -i 5 -f 1
+ * }</pre>
+ * which is the exact {@code -wi 3 -i 5 -f 1} protocol ADR 108 states.
+ * <p>
+ * No external service or container is required; this benchmark only exercises in-process code.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class BlockingHandoverThroughputBenchmark {
+
+    private static final BlockingHandover.Source<Long> ALREADY_CAUGHT_UP = new BlockingHandover.Source<>() {
+        @Override
+        public boolean isAlreadyCaughtUp() {
+            return true;
+        }
+
+        @Override
+        public Stream<Long> replay() {
+            return Stream.empty();
+        }
+
+        @Override
+        public void markCaughtUp() {
+        }
+    };
+
+    /**
+     * The "proposed" column from ADR 108's table: the real, shipped {@code BlockingHandover}, where only the de-dup
+     * reservation runs under the lock and the fold runs outside it.
+     */
+    @State(Scope.Benchmark)
+    public static class ProposedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private BlockingHandover<Long> handover;
+        private final LongAdder sink = new LongAdder();
+        private final java.util.concurrent.atomic.AtomicLong idSequence = new java.util.concurrent.atomic.AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            handover = BlockingHandover.create(
+                    payload -> BusySpin.spinMicros(workMicros, sink),
+                    Object::toString,
+                    CatchupThenLiveOptions.defaults(),
+                    "benchmark");
+            handover.catchUp(ALREADY_CAUGHT_UP);
+        }
+
+        void acceptOnePayload() {
+            handover.accept(idSequence.getAndIncrement());
+        }
+    }
+
+    /**
+     * The "current (locked)" column from ADR 108's table: {@link FullyLockedHandover}, folding inside the lock.
+     */
+    @State(Scope.Benchmark)
+    public static class LockedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private FullyLockedHandover<Long> handover;
+        private final LongAdder sink = new LongAdder();
+        private final java.util.concurrent.atomic.AtomicLong idSequence = new java.util.concurrent.atomic.AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            handover = new FullyLockedHandover<>(payload -> BusySpin.spinMicros(workMicros, sink), Object::toString);
+        }
+
+        void acceptOnePayload() {
+            handover.accept(idSequence.getAndIncrement());
+        }
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void proposed_threads1(ProposedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void proposed_threads2(ProposedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void proposed_threads4(ProposedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void proposed_threads8(ProposedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void locked_threads1(LockedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void locked_threads2(LockedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void locked_threads4(LockedState state) {
+        state.acceptOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void locked_threads8(LockedState state) {
+        state.acceptOnePayload();
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/handover/BusySpin.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/handover/BusySpin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.handover;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Stands in for a real push handler's per-event work, the same role ADR 108's own benchmark used a busy spin for:
+ * "a busy-spin standing in for real per-event work". A fixed nanosecond deadline is used rather than a JMH
+ * {@code Blackhole} token count, since a token is only an approximate proxy for a fixed wall-clock duration, and the
+ * ADR's workloads are stated in microseconds (1, 50, 200).
+ */
+final class BusySpin {
+
+    private BusySpin() {
+    }
+
+    /**
+     * Spins until {@code micros} has elapsed, folding a counter into {@code sink} on every iteration so the loop is
+     * not eligible for dead-code elimination.
+     */
+    static void spinMicros(long micros, LongAdder sink) {
+        long deadlineNanos = System.nanoTime() + (micros * 1_000L);
+        long iterations = 0;
+        while (System.nanoTime() < deadlineNanos) {
+            iterations++;
+        }
+        sink.add(iterations);
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/handover/FullyLockedHandover.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/handover/FullyLockedHandover.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.handover;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Reconstructs the live-delivery shape {@code BlockingHandover} had before ADR 108: every payload handed to
+ * {@link #accept(Object)} is folded while holding the handover's own monitor, so concurrent callers queue behind
+ * whichever thread is currently inside the fold.
+ * <p>
+ * Production {@code BlockingHandover} no longer looks like this (the dedup bookkeeping is still reserved under the
+ * lock, but the fold itself now runs outside it, see
+ * {@code org.occurrent.subscription.api.blocking.internal.BlockingHandover}), so there is nothing left in the
+ * codebase to benchmark it against directly. This class exists only to give
+ * {@link org.occurrent.benchmark.handover.BlockingHandoverThroughputBenchmark} a "current (locked)" baseline that
+ * matches the one ADR 108 measured, restricted to what that measurement actually exercised: the live-accept path,
+ * with de-dup and the fold both under one lock. It intentionally does not reproduce the replay/buffer/catch-up
+ * machinery, which the ADR's benchmark did not touch either.
+ */
+final class FullyLockedHandover<T> {
+
+    private final Consumer<T> deliver;
+    private final Function<T, String> dedupId;
+    private final Object lock = new Object();
+    private final Set<String> deliveredIds = new HashSet<>();
+
+    FullyLockedHandover(Consumer<T> deliver, Function<T, String> dedupId) {
+        this.deliver = deliver;
+        this.dedupId = dedupId;
+    }
+
+    void accept(T payload) {
+        synchronized (lock) {
+            String key = dedupId.apply(payload);
+            if (deliveredIds.add(key)) {
+                // The fold runs here, still inside the monitor, which is exactly what ADR 108 changed.
+                deliver.accept(payload);
+            }
+        }
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFilterReadBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFilterReadBenchmark.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.payloadfilter;
+
+import io.cloudevents.CloudEvent;
+import org.occurrent.filter.Filter;
+import org.occurrent.filtermatching.jackson.JacksonDataFieldReader;
+import org.occurrent.inmemory.filtermatching.FilterMatcher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks the cost {@code #623} is about: a composed payload filter with several data-field leaves, each reading
+ * the payload independently with no memoization ({@code ConditionMatcher} calls
+ * {@link org.occurrent.filtermatching.DataFieldReader#read(CloudEvent, String)} once per leaf,
+ * {@code FilterMatcher.java:46-57} and {@code ConditionMatcher.java:180-191}).
+ * <p>
+ * Also benchmarks {@link org.occurrent.filtermatching.DataFieldReader#readAll(CloudEvent, java.util.Collection)},
+ * the bulk-read entry point PR #626 added: its default implementation is the same per-leaf loop
+ * {@code FilterMatcher} already does, so it is not expected to differ from the composed-filter numbers here.
+ * {@code JacksonDataFieldReader} does not override it, so this measures the current, unmemoized baseline both
+ * paths share, not a hypothetical faster implementation.
+ * <p>
+ * Follows the protocol #623 asks for: 1, 5 and 20 leaves, 1 KB and 256 KB payloads, the needle fields placed early
+ * or late in the payload, against both a byte-backed event (streaming re-parse per leaf) and a Map-backed event
+ * (already-decoded, as {@code DocumentCloudEventReader} hands it to the reader). Every condition is built to match,
+ * so {@code FilterMatcher}'s AND does not short-circuit and every leaf is actually read; a filter that fails fast on
+ * its first leaf costs one read regardless of leafCount, which is not the case this benchmark is measuring.
+ * <p>
+ * Run with, for example:
+ * <pre>{@code
+ * java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 3 -i 5 -f 1
+ * }</pre>
+ * No external service or container is required.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class PayloadFilterReadBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class ReadState {
+
+        @Param({"1", "5", "20"})
+        public int leafCount;
+
+        @Param({"1024", "262144"})
+        public int payloadSizeBytes;
+
+        @Param({"EARLY", "LATE"})
+        public PayloadFixtures.FieldPosition fieldPosition;
+
+        @Param({"BYTES", "MAP"})
+        public PayloadFixtures.Backing backing;
+
+        private CloudEvent event;
+        private Filter filter;
+        private List<String> paths;
+        private final JacksonDataFieldReader reader = new JacksonDataFieldReader();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            Map<String, Object> payload = PayloadFixtures.payload(leafCount, payloadSizeBytes, fieldPosition);
+            event = backing == PayloadFixtures.Backing.MAP
+                    ? PayloadFixtures.eventWithMap(payload)
+                    : PayloadFixtures.eventWithBytes(payload);
+            paths = PayloadFixtures.needlePaths(leafCount);
+            filter = PayloadFixtures.matchAllFilter(paths, payload);
+        }
+    }
+
+    @Benchmark
+    public boolean matchesFilter(ReadState state) {
+        return FilterMatcher.matchesFilter(state.event, state.filter, state.reader);
+    }
+
+    @Benchmark
+    public Map<String, Object> readAllPaths(ReadState state) {
+        return state.reader.readAll(state.event, state.paths);
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFixtures.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFixtures.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.payloadfilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.core.data.PojoCloudEventData;
+import org.occurrent.condition.Condition;
+import org.occurrent.filter.Filter;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Builds the payload/filter fixtures {@link PayloadFilterReadBenchmark} measures: a JSON object with N "needle"
+ * fields the filter reads and one filler field padding the payload to a target size, with the needles placed either
+ * right after the filler (late) or right before it (early), so a streaming, byte-backed read pays a different
+ * skip cost depending on where in the payload it has to look.
+ */
+// Public, and so are the two nested enums below: JMH's generated benchmark harness lives in a jmh_generated
+// sub-package and references PayloadFixtures.FieldPosition/Backing as @Param field types, so both the enums and
+// their enclosing class need to be reachable from outside this package even though PayloadFilterReadBenchmark
+// itself sits in the same package as this class. Everything else here stays package-private; only the two enums
+// are part of that accidental cross-package surface.
+public final class PayloadFixtures {
+
+    private PayloadFixtures() {
+    }
+
+    public enum FieldPosition {EARLY, LATE}
+
+    public enum Backing {BYTES, MAP}
+
+    static List<String> needlePaths(int leafCount) {
+        List<String> paths = new ArrayList<>(leafCount);
+        for (int i = 0; i < leafCount; i++) {
+            paths.add("needle" + i);
+        }
+        return paths;
+    }
+
+    /**
+     * A payload with {@code leafCount} needle fields and a filler field, ordered by {@code position}, sized so the
+     * resulting JSON document is approximately {@code targetSizeBytes}.
+     */
+    static Map<String, Object> payload(int leafCount, int targetSizeBytes, FieldPosition position) {
+        List<String> needles = needlePaths(leafCount);
+        Map<String, Object> needleFields = new LinkedHashMap<>();
+        for (String needle : needles) {
+            needleFields.put(needle, needle + "-value");
+        }
+        int needleFieldsOverheadEstimate = leafCount * 24;
+        int fillerLength = Math.max(0, targetSizeBytes - needleFieldsOverheadEstimate);
+        String filler = "x".repeat(fillerLength);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (position == FieldPosition.EARLY) {
+            result.putAll(needleFields);
+            result.put("filler", filler);
+        } else {
+            result.put("filler", filler);
+            result.putAll(needleFields);
+        }
+        return result;
+    }
+
+    /**
+     * A composed AND filter over every path in {@code paths}, each condition matching the value already in
+     * {@code payload}, so evaluating the filter reads every leaf rather than short-circuiting after the first: the
+     * worst case for repeated, unmemoized reads that #623 is about.
+     */
+    static Filter matchAllFilter(List<String> paths, Map<String, Object> payload) {
+        Filter filter = null;
+        for (String path : paths) {
+            Filter leaf = Filter.data(path, Condition.eq(payload.get(path)));
+            filter = filter == null ? leaf : filter.and(leaf);
+        }
+        return filter;
+    }
+
+    static CloudEvent eventWithBytes(Map<String, Object> payload) {
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("urn:occurrent:benchmark"))
+                .withType("BenchmarkPayload")
+                .withDataContentType("application/json")
+                .withData(toJsonBytes(payload))
+                .build();
+    }
+
+    /**
+     * Wraps the payload the way {@code DocumentCloudEventReader} wraps a Mongo-decoded document: already a
+     * {@code Map}, reachable through {@link PojoCloudEventData} without a byte round trip.
+     */
+    static CloudEvent eventWithMap(Map<String, Object> payload) {
+        PojoCloudEventData<Map<String, Object>> wrapped = PojoCloudEventData.wrap(payload, PayloadFixtures::toJsonBytes);
+        return CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create("urn:occurrent:benchmark"))
+                .withType("BenchmarkPayload")
+                .withDataContentType("application/json")
+                .withData(wrapped)
+                .build();
+    }
+
+    private static byte[] toJsonBytes(Map<String, Object> map) {
+        try {
+            return new ObjectMapper().writeValueAsBytes(map);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,19 @@
             </activation>
         </profile>
         <profile>
+            <!--
+              Opt-in only (no activeByDefault), unlike examples-module. A plain "mvn install" or "mvn -Prelease
+              install" never discovers this module at all, which is stronger than excluding it from
+              central-publishing-maven-plugin's excludeArtifacts list below: there is nothing to keep in sync, and
+              combining -Prelease with this profile by mistake still cannot publish it, since the module also sets
+              maven.deploy.skip (see benchmark/pom.xml). Build it explicitly with "-Pbenchmarks -pl benchmark -am".
+            -->
+            <id>benchmarks</id>
+            <modules>
+                <module>benchmark</module>
+            </modules>
+        </profile>
+        <profile>
             <id>skip-pom-modules-deployment</id>
             <activation>
                 <file>


### PR DESCRIPTION
I added a JMH module, `benchmark/`, that reproduces the two measurements ADR 108 and PR #615 cited without a committed harness behind them. It has two benchmarks.

`BlockingHandoverThroughputBenchmark` reproduces ADR 108's handover-lock comparison. It drives the real `BlockingHandover` against `FullyLockedHandover`, a small reconstruction of the pre-ADR-108 shape kept only for this comparison, since production code no longer has a locked variant to benchmark against directly.

`PayloadFilterReadBenchmark` reproduces #615's read-cost comparison and runs #623's benchmark-first protocol (1, 5 and 20 filter leaves, 1 KB and 256 KB payloads, needle fields placed early or late, byte-backed and Map-backed events). It also exercises `DataFieldReader.readAll`, the bulk-read method PR #626 added, alongside the existing per-leaf `read` path.

The module is dev-only. It never enters a plain `mvn install` or `mvn -Prelease install` reactor, since it is registered under an opt-in `benchmarks` profile in the root `pom.xml` rather than being active by default. It also sets `maven.deploy.skip`, so it cannot be published even if `-Pbenchmarks` and `-Prelease` are combined. `benchmark/README.md` has the build and run commands.

I ran both benchmarks with the full protocol and recorded the numbers as a comment on #624, including what they mean for #623's memoization go/no-go call. No Docker or MongoDB is needed to run either benchmark.

Fixes #624
