### PR TITLE
Land the two review fixes PR #641's merge missed

### DIFF
--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CoalescingMaterializedUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CoalescingMaterializedUpdate.java
@@ -19,6 +19,7 @@ package org.occurrent.dsl.projection.reactor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.view.View;
 import org.occurrent.dsl.view.ViewStateRepository;
 import reactor.core.publisher.Mono;

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
@@ -61,7 +61,7 @@ public interface ViewStateRepository<S extends @Nullable Object, ID> {
      * @param ids The ids to read state for.
      * @return The state found for each id, absent ids omitted.
      */
-    default Map<@NonNull ID, @NonNull S> findAllById(Collection<@NonNull ID> ids) {
+    default Map<@NonNull ID, @NonNull S> findAllById(@NonNull Collection<@NonNull ID> ids) {
         Map<ID, S> result = new LinkedHashMap<>();
         for (ID id : ids) {
             findById(id).ifPresent(state -> result.put(id, state));
@@ -93,7 +93,7 @@ public interface ViewStateRepository<S extends @Nullable Object, ID> {
      *
      * @param states The state to save, keyed by id.
      */
-    default void saveAll(Map<@NonNull ID, @NonNull S> states) {
+    default void saveAll(@NonNull Map<@NonNull ID, @NonNull S> states) {
         states.forEach(this::save);
     }
 


### PR DESCRIPTION
PR #641 (#638) had a couple of Copilot review fixes I'd pushed, but they lost a race with the merge and didn't make it into main. This re-applies both on top of current main.

`CoalescingMaterializedUpdate`'s javadoc now imports `Projection` for its `{@link}` target, and `ViewStateRepository.findAllById`'s `ids` parameter and `saveAll`'s `states` parameter are `@NonNull`, matching `findById`/`save`.
