### PR TITLE
Benchmark the reactor projection DSL's boundedElastic hand-off

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -8,6 +8,9 @@ JMH benchmarks that make two previously ad-hoc, uncommitted measurements re-runn
 - `PayloadFilterReadBenchmark`: the per-leaf payload read cost behind [PR #615](https://github.com/johanhaleby/occurrent/pull/615)
   and the go/no-go question for [#623](https://github.com/johanhaleby/occurrent/issues/623) (memoizing payload-field
   reads across filter condition leaves).
+- `ReactorProjectionHandoffBenchmark`: the per-event `Mono.fromRunnable(..).subscribeOn(Schedulers.boundedElastic())`
+  hand-off cost the reactor projection DSL's fold pays at
+  [#639](https://github.com/johanhaleby/occurrent/issues/639), wrapped against unwrapped, for both wrapping sites.
 
 Both benchmarks run entirely in-process. No Docker, no MongoDB, no other container is required.
 
@@ -32,17 +35,21 @@ Build the self-contained benchmarks jar, then run it directly with the JMH CLI:
 mvn -Pbenchmarks -pl benchmark -am package -DskipTests
 java -jar benchmark/target/benchmarks.jar BlockingHandoverThroughputBenchmark -wi 3 -i 5 -f 1
 java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 3 -i 5 -f 1
+java -jar benchmark/target/benchmarks.jar ReactorProjectionHandoffBenchmark -wi 3 -i 5 -f 1
 ```
 
 `-wi 3 -i 5 -f 1` is the exact protocol ADR 108's table states. It is also a reasonable default for
 `PayloadFilterReadBenchmark`, though with 3 leaf counts x 2 payload sizes x 2 field positions x 2 backings x 2
 benchmark methods = 48 forked-parameter combinations, a full run takes several minutes.
+`ReactorProjectionHandoffBenchmark` has 2 wrapping sites x wrapped/unwrapped x 4 thread counts x 2 work sizes = 32
+forked-parameter combinations, so a full run also takes several tens of minutes.
 
 For a fast smoke run that only proves the harness executes end to end, shrink warmup/measurement:
 
 ```
 java -jar benchmark/target/benchmarks.jar BlockingHandoverThroughputBenchmark -wi 1 -i 1 -f 1 -w 200ms -r 200ms
 java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 1 -i 1 -f 1 -w 200ms -r 200ms
+java -jar benchmark/target/benchmarks.jar ReactorProjectionHandoffBenchmark -wi 1 -i 1 -f 1 -w 200ms -r 200ms
 ```
 
 Numbers from a smoke run are not meaningful for citing anywhere; only numbers from the full protocol above should be

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # occurrent-benchmark
 
-JMH benchmarks that make two previously ad-hoc, uncommitted measurements re-runnable:
+JMH benchmarks that make previously ad-hoc, uncommitted measurements re-runnable:
 
 - `BlockingHandoverThroughputBenchmark`: the throughput comparison behind
   [ADR 108](../doc/architecture/decisions/0108-a-live-push-handler-runs-outside-the-handover-lock.md), the handover
@@ -12,7 +12,7 @@ JMH benchmarks that make two previously ad-hoc, uncommitted measurements re-runn
   hand-off cost the reactor projection DSL's fold pays at
   [#639](https://github.com/johanhaleby/occurrent/issues/639), wrapped against unwrapped, for both wrapping sites.
 
-Both benchmarks run entirely in-process. No Docker, no MongoDB, no other container is required.
+All three benchmarks run entirely in-process. No Docker, no MongoDB, no other container is required.
 
 ## Why this module is not part of a normal build
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -53,6 +53,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-projection-dsl-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-core</artifactId>
         </dependency>

--- a/benchmark/src/main/java/org/occurrent/benchmark/handover/BusySpin.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/handover/BusySpin.java
@@ -19,12 +19,13 @@ package org.occurrent.benchmark.handover;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
- * Stands in for a real push handler's per-event work, the same role ADR 108's own benchmark used a busy spin for:
- * "a busy-spin standing in for real per-event work". A fixed nanosecond deadline is used rather than a JMH
+ * Stands in for a real push handler's or fold's per-event work, the same role ADR 108's own benchmark used a busy
+ * spin for: "a busy-spin standing in for real per-event work". A fixed nanosecond deadline is used rather than a JMH
  * {@code Blackhole} token count, since a token is only an approximate proxy for a fixed wall-clock duration, and the
- * ADR's workloads are stated in microseconds (1, 50, 200).
+ * ADR's workloads are stated in microseconds (1, 50, 200). Shared across the benchmark module's classes rather than
+ * reimplemented per benchmark, so every benchmark's simulated work stays the same shape.
  */
-final class BusySpin {
+public final class BusySpin {
 
     private BusySpin() {
     }
@@ -33,7 +34,7 @@ final class BusySpin {
      * Spins until {@code micros} has elapsed, folding a counter into {@code sink} on every iteration so the loop is
      * not eligible for dead-code elimination.
      */
-    static void spinMicros(long micros, LongAdder sink) {
+    public static void spinMicros(long micros, LongAdder sink) {
         long deadlineNanos = System.nanoTime() + (micros * 1_000L);
         long iterations = 0;
         while (System.nanoTime() < deadlineNanos) {

--- a/benchmark/src/main/java/org/occurrent/benchmark/reactorhandoff/ReactorProjectionHandoffBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/reactorhandoff/ReactorProjectionHandoffBenchmark.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.reactorhandoff;
+
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.dsl.projection.Projection;
+import org.occurrent.dsl.projection.reactor.Projections;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.View;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.BiFunction;
+
+/**
+ * Measures the per-event thread hand-off <a href="https://github.com/johanhaleby/occurrent/issues/639">#639</a> asks
+ * about: the reactor projection DSL folds every event through {@code Mono.fromRunnable(..).subscribeOn(Schedulers.boundedElastic())},
+ * both in {@code Projections.reactiveUpdateWithMetadata(MaterializedView)} ({@code Projections.java}) and in
+ * {@code CoalescingMaterializedUpdate.apply}, the write-through fold {@code Projections.reactiveUpdateWithMetadata(Projection, ViewStateRepository, ...)}
+ * builds on.
+ * <p>
+ * Each site is measured two ways: {@code wrapped} is the real, shipped fold, unmodified; {@code unwrapped} is the
+ * same fold run synchronously on the calling thread, the shape removing the {@code subscribeOn} hop would leave.
+ * The difference between the two columns is the hand-off's own cost, isolated from the fold's own work (a busy spin
+ * standing in for a repository round trip, the same role and the same 50/200 microsecond magnitudes ADR 108's own
+ * benchmark uses, see {@code BlockingHandoverThroughputBenchmark}), driven from 1, 2, 4 and 8 concurrent threads the
+ * same way.
+ * <p>
+ * This benchmark answers the performance half of #639 only. Whether the hand-off can be removed at all is a
+ * separate, correctness-first question answered on the issue: every path that reaches these folds is not guaranteed
+ * to already be running on {@code boundedElastic} (a live push-subscription delivery thread is not), so a wrapped
+ * fold reachable from such a path cannot drop the hop without moving blocking repository work onto whatever thread
+ * the source used to deliver the event.
+ * <p>
+ * Run with, for example:
+ * <pre>{@code
+ * java -jar benchmark/target/benchmarks.jar ReactorProjectionHandoffBenchmark -wi 3 -i 5 -f 1
+ * }</pre>
+ * the same {@code -wi 3 -i 5 -f 1} protocol ADR 108's table uses.
+ * <p>
+ * No external service or container is required; this benchmark only exercises in-process code.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ReactorProjectionHandoffBenchmark {
+
+    /**
+     * Stands in for a real fold's per-event work (a repository round trip), the same role and the same
+     * nanosecond-deadline shape ADR 108's own benchmark uses: a fixed wall-clock duration is closer to the ADR's
+     * stated 50/200 microsecond workloads than a JMH token count, and folding a counter into {@code sink} on every
+     * iteration keeps the loop from being eligible for dead-code elimination.
+     */
+    private static void spinMicros(long micros, LongAdder sink) {
+        long deadlineNanos = System.nanoTime() + (micros * 1_000L);
+        long iterations = 0;
+        while (System.nanoTime() < deadlineNanos) {
+            iterations++;
+        }
+        sink.add(iterations);
+    }
+
+    private static View<Long, Long> spinningView(long workMicros, LongAdder sink) {
+        return View.create(0L, (state, event) -> {
+            spinMicros(workMicros, sink);
+            return state + 1;
+        });
+    }
+
+    private static MaterializedView<Long> materializedView(long workMicros, LongAdder sink) {
+        ConcurrentHashMap<String, Long> store = new ConcurrentHashMap<>();
+        ViewStateRepository<Long, String> repository = ViewStateRepository.create(store::get, store::put);
+        return MaterializedView.create(event -> "singleton", spinningView(workMicros, sink), repository);
+    }
+
+    private static Projection<Long, Long, String> singletonProjection(long workMicros, LongAdder sink) {
+        return Projection.<Long, Long>singletonBuilder(0L)
+                .on(Long.class, (state, event) -> {
+                    spinMicros(workMicros, sink);
+                    return state + 1;
+                })
+                .build();
+    }
+
+    private static ViewStateRepository<Long, String> newRepository() {
+        ConcurrentHashMap<String, Long> store = new ConcurrentHashMap<>();
+        return ViewStateRepository.create(store::get, store::put);
+    }
+
+    // --- MaterializedView site: Projections.reactiveUpdateWithMetadata(MaterializedView) ---
+
+    /**
+     * The real, shipped {@link Projections#reactiveUpdateWithMetadata(MaterializedView)}: every fold wrapped in
+     * {@code Mono.fromRunnable(..).subscribeOn(Schedulers.boundedElastic())}.
+     */
+    @State(Scope.Benchmark)
+    public static class MaterializedViewWrappedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private BiFunction<EventMetadata, Long, Mono<Void>> fold;
+        private final LongAdder sink = new LongAdder();
+        private final AtomicLong idSequence = new AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            fold = Projections.reactiveUpdateWithMetadata(materializedView(workMicros, sink));
+        }
+
+        void applyOnePayload() {
+            fold.apply(EventMetadata.empty(), idSequence.getAndIncrement()).block();
+        }
+    }
+
+    /**
+     * The same fold as {@link MaterializedViewWrappedState}, called directly on the calling thread with no
+     * {@code Mono}/{@code subscribeOn} hop at all, the shape removing the wrapping would leave.
+     */
+    @State(Scope.Benchmark)
+    public static class MaterializedViewUnwrappedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private MaterializedView<Long> materializedView;
+        private final LongAdder sink = new LongAdder();
+        private final AtomicLong idSequence = new AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            materializedView = materializedView(workMicros, sink);
+        }
+
+        void applyOnePayload() {
+            materializedView.update(EventMetadata.empty(), idSequence.getAndIncrement());
+        }
+    }
+
+    // --- CoalescingMaterializedUpdate site: Projections.reactiveUpdateWithMetadata(Projection, ViewStateRepository, String) ---
+
+    /**
+     * The real, shipped write-through fold behind {@code Projections.reactiveUpdateWithMetadata(Projection,
+     * ViewStateRepository, String)}: {@code CoalescingMaterializedUpdate.apply}, wrapped in the same
+     * {@code Mono.fromRunnable(..).subscribeOn(Schedulers.boundedElastic())} shape. No replay is started, so every
+     * call takes the write-through branch (read, fold, save) rather than the batching one.
+     */
+    @State(Scope.Benchmark)
+    public static class CoalescingWrappedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private BiFunction<EventMetadata, Long, Mono<Void>> fold;
+        private final LongAdder sink = new LongAdder();
+        private final AtomicLong idSequence = new AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            fold = Projections.reactiveUpdateWithMetadata(singletonProjection(workMicros, sink), newRepository(), "singleton");
+        }
+
+        void applyOnePayload() {
+            fold.apply(EventMetadata.empty(), idSequence.getAndIncrement()).block();
+        }
+    }
+
+    /**
+     * The same read-fold-save sequence {@code CoalescingMaterializedUpdate.apply}'s write-through branch runs, called
+     * directly on the calling thread with no {@code Mono}/{@code subscribeOn} hop, the shape removing the wrapping
+     * would leave.
+     */
+    @State(Scope.Benchmark)
+    public static class CoalescingUnwrappedState {
+
+        @Param({"50", "200"})
+        public long workMicros;
+
+        private View<Long, Long> view;
+        private ViewStateRepository<Long, String> repository;
+        private final LongAdder sink = new LongAdder();
+        private final AtomicLong idSequence = new AtomicLong();
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            view = singletonProjection(workMicros, sink).view();
+            repository = newRepository();
+        }
+
+        void applyOnePayload() {
+            Long event = idSequence.getAndIncrement();
+            Long currentState = repository.findById("singleton").orElse(view.initialState());
+            repository.save("singleton", view.evolve(currentState, EventMetadata.empty(), event));
+        }
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void materializedView_wrapped_threads1(MaterializedViewWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void materializedView_wrapped_threads2(MaterializedViewWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void materializedView_wrapped_threads4(MaterializedViewWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void materializedView_wrapped_threads8(MaterializedViewWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void materializedView_unwrapped_threads1(MaterializedViewUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void materializedView_unwrapped_threads2(MaterializedViewUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void materializedView_unwrapped_threads4(MaterializedViewUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void materializedView_unwrapped_threads8(MaterializedViewUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void coalescing_wrapped_threads1(CoalescingWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void coalescing_wrapped_threads2(CoalescingWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void coalescing_wrapped_threads4(CoalescingWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void coalescing_wrapped_threads8(CoalescingWrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void coalescing_unwrapped_threads1(CoalescingUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(2)
+    public void coalescing_unwrapped_threads2(CoalescingUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void coalescing_unwrapped_threads4(CoalescingUnwrappedState state) {
+        state.applyOnePayload();
+    }
+
+    @Benchmark
+    @Threads(8)
+    public void coalescing_unwrapped_threads8(CoalescingUnwrappedState state) {
+        state.applyOnePayload();
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/reactorhandoff/ReactorProjectionHandoffBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/reactorhandoff/ReactorProjectionHandoffBenchmark.java
@@ -16,6 +16,7 @@
 
 package org.occurrent.benchmark.reactorhandoff;
 
+import org.occurrent.benchmark.handover.BusySpin;
 import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.projection.reactor.Projections;
@@ -72,24 +73,9 @@ import java.util.function.BiFunction;
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class ReactorProjectionHandoffBenchmark {
 
-    /**
-     * Stands in for a real fold's per-event work (a repository round trip), the same role and the same
-     * nanosecond-deadline shape ADR 108's own benchmark uses: a fixed wall-clock duration is closer to the ADR's
-     * stated 50/200 microsecond workloads than a JMH token count, and folding a counter into {@code sink} on every
-     * iteration keeps the loop from being eligible for dead-code elimination.
-     */
-    private static void spinMicros(long micros, LongAdder sink) {
-        long deadlineNanos = System.nanoTime() + (micros * 1_000L);
-        long iterations = 0;
-        while (System.nanoTime() < deadlineNanos) {
-            iterations++;
-        }
-        sink.add(iterations);
-    }
-
     private static View<Long, Long> spinningView(long workMicros, LongAdder sink) {
         return View.create(0L, (state, event) -> {
-            spinMicros(workMicros, sink);
+            BusySpin.spinMicros(workMicros, sink);
             return state + 1;
         });
     }
@@ -103,7 +89,7 @@ public class ReactorProjectionHandoffBenchmark {
     private static Projection<Long, Long, String> singletonProjection(long workMicros, LongAdder sink) {
         return Projection.<Long, Long>singletonBuilder(0L)
                 .on(Long.class, (state, event) -> {
-                    spinMicros(workMicros, sink);
+                    BusySpin.spinMicros(workMicros, sink);
                     return state + 1;
                 })
                 .build();
@@ -193,9 +179,12 @@ public class ReactorProjectionHandoffBenchmark {
     }
 
     /**
-     * The same read-fold-save sequence {@code CoalescingMaterializedUpdate.apply}'s write-through branch runs, called
-     * directly on the calling thread with no {@code Mono}/{@code subscribeOn} hop, the shape removing the wrapping
-     * would leave.
+     * The same per-event work {@code CoalescingMaterializedUpdate.apply}'s write-through branch runs
+     * ({@code resolveId}, the {@code synchronized(lock)} replaying check, then read-fold-save), called directly on
+     * the calling thread with no {@code Mono}/{@code subscribeOn} hop, the shape removing the wrapping would leave.
+     * Reproducing that bookkeeping here, rather than only the read-fold-save, keeps the wrapped/unwrapped delta
+     * isolating the hand-off cost: the lock is uncontended cheap work at 1 thread but real contention at 2, 4 and 8,
+     * and skipping it would have let the wrapped column absorb that contention cost too.
      */
     @State(Scope.Benchmark)
     public static class CoalescingUnwrappedState {
@@ -205,6 +194,8 @@ public class ReactorProjectionHandoffBenchmark {
 
         private View<Long, Long> view;
         private ViewStateRepository<Long, String> repository;
+        private BiFunction<EventMetadata, Long, String> resolveId;
+        private final Object lock = new Object();
         private final LongAdder sink = new LongAdder();
         private final AtomicLong idSequence = new AtomicLong();
 
@@ -212,12 +203,23 @@ public class ReactorProjectionHandoffBenchmark {
         public void setUp() {
             view = singletonProjection(workMicros, sink).view();
             repository = newRepository();
+            resolveId = (metadata, event) -> "singleton";
         }
 
         void applyOnePayload() {
             Long event = idSequence.getAndIncrement();
-            Long currentState = repository.findById("singleton").orElse(view.initialState());
-            repository.save("singleton", view.evolve(currentState, EventMetadata.empty(), event));
+            String id = resolveId.apply(EventMetadata.empty(), event);
+            if (id == null) {
+                return;
+            }
+            boolean writeThrough;
+            synchronized (lock) {
+                writeThrough = true;
+            }
+            if (writeThrough) {
+                Long currentState = repository.findById(id).orElse(view.initialState());
+                repository.save(id, view.evolve(currentState, EventMetadata.empty(), event));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #639

I added `ReactorProjectionHandoffBenchmark` to `benchmark/`, covering both `Mono.fromRunnable(..).subscribeOn(Schedulers.boundedElastic())` sites in the reactor projection DSL fold, `Projections.reactiveUpdateWithMetadata(MaterializedView)` and `CoalescingMaterializedUpdate.apply`. Each is measured wrapped, the real shipped code, against an unwrapped reconstruction of the same fold, at 1, 2, 4 and 8 threads and 50 and 200 microsecond simulated work.

I did not remove the wrapping. #639 asked to measure first, then either remove it if the cost is real or keep it with the numbers attached. The numbers say the cost is real, wrapped is slower in all 16 param combinations, worse with more concurrency. But a correctness check the issue also asked for rules out removing it anyway.

`ReactiveHandover.accept()` pushes a live payload into a `Sinks.Many` unicast sink whose subscriber is already running. I wrote a standalone reactor-core check and confirmed that once that subscriber has settled in, `tryEmitNext` runs the fold synchronously on whatever thread calls `accept()`, not on `boundedElastic`. The one-time `subscribeOn(boundedElastic)` in `ReactiveHandover.catchUp()` only covers the pipeline's own initial subscription.

In production that calling thread is the MongoDB reactive driver's own I/O thread. `ReactorMongoSubscriptionModel` has no scheduler hop anywhere in it. It calls `action.apply(cloudEvent)` directly on whatever thread the change stream `Flux` emits on. So a live event reaches the wrapped fold on the Mongo driver's I/O thread, and removing `subscribeOn(boundedElastic)` would move a blocking `ViewStateRepository` call onto that thread instead.

The full reasoning and the measured numbers are posted on #639.

## Verification

`mvn -Pbenchmarks -pl benchmark -am package -DskipTests` builds clean. `java -jar benchmark/target/benchmarks.jar ReactorProjectionHandoffBenchmark -wi 3 -i 5 -f 1` ran the full protocol, all 32 param combinations, results on #639. No production code changed, so no test suite reruns needed here.
