### PR TITLE
Stop the 0.32.0 time rewrite script from breaking equality filters

### DIFF
--- a/common/mongodb/specialfilterhandling/src/test/java/org/occurrent/mongodb/specialfilterhandling/internal/SpecialFilterHandlingTest.java
+++ b/common/mongodb/specialfilterhandling/src/test/java/org/occurrent/mongodb/specialfilterhandling/internal/SpecialFilterHandlingTest.java
@@ -18,6 +18,7 @@ package org.occurrent.mongodb.specialfilterhandling.internal;
 
 import org.junit.jupiter.api.Test;
 import org.occurrent.condition.Condition;
+import org.occurrent.condition.Condition.InOperandCondition;
 import org.occurrent.condition.Condition.MultiOperandCondition;
 import org.occurrent.condition.Condition.SingleOperandCondition;
 import org.occurrent.filter.Filter;
@@ -26,6 +27,7 @@ import org.occurrent.filter.Filter.SingleConditionFilter;
 import java.sql.Date;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.occurrent.mongodb.specialfilterhandling.internal.SpecialFilterHandling.resolveSpecialCases;
@@ -60,6 +62,31 @@ class SpecialFilterHandlingTest {
     void in_expands_every_operand_to_canonical_and_legacy_shape() {
         Condition<?> resolved = resolveRfc3339(Condition.in(INSTANT, OTHER_INSTANT));
         assertThat(resolved).isEqualTo(Condition.in(CANONICAL, LEGACY, OTHER_CANONICAL, OTHER_LEGACY));
+    }
+
+    // Simulates the doc/migration/upgrading-to-0.32.0.md "optional rewrite" script: $dateFromString parses the
+    // stored string into a BSON date (millisecond precision), and $dateToString with %L formats it back with
+    // exactly three fractional digits, regardless of how many fractional digits the original string carried.
+    @Test
+    void a_three_digit_rewritten_value_matches_neither_shape_the_shim_generates_for_a_microsecond_instant() {
+        // An event written pre-upgrade with microsecond precision, in the legacy variable-width shape. Legacy and
+        // canonical genuinely differ here (".123456" versus ".123456000"), unlike a nanosecond-precision instant,
+        // where both shapes happen to print identically.
+        OffsetDateTime microsecondInstant = OffsetDateTime.of(2024, 1, 1, 10, 0, 30, 123_456_000, ZoneOffset.UTC);
+        String storedBeforeRewrite = microsecondInstant.toString();
+        assertThat(storedBeforeRewrite).isEqualTo("2024-01-01T10:00:30.123456Z");
+        String storedAfterRewrite = storedBeforeRewrite.substring(0, 23) + "Z";
+        assertThat(storedAfterRewrite).isEqualTo("2024-01-01T10:00:30.123Z");
+
+        Condition<?> resolved = resolveRfc3339(Condition.eq(microsecondInstant));
+        @SuppressWarnings("unchecked")
+        List<String> matchedShapes = (List<String>) ((InOperandCondition<?>) resolved).operand();
+
+        // Before the rewrite, the shim's legacy branch matches the event exactly as stored.
+        assertThat(matchedShapes).contains(storedBeforeRewrite);
+        // After the rewrite, the event's new stored value matches neither the canonical nor the legacy shape the
+        // shim generates for this instant, so the rewrite turns a match into a miss.
+        assertThat(matchedShapes).doesNotContain(storedAfterRewrite);
     }
 
     @Test

--- a/doc/migration/upgrading-to-0.32.0.md
+++ b/doc/migration/upgrading-to-0.32.0.md
@@ -157,15 +157,25 @@ aggregation pipeline update. Replace `events` with your collection name, and tak
 
 ```js
 db.events.updateMany(
-  { time: { $type: "string" } },
+  {
+    $and: [
+      { time: { $type: "string" } },
+      { time: { $not: /\.\d{4,}/ } }
+    ]
+  },
   [
     {
       $set: {
         time: {
-          $dateToString: {
-            date: { $dateFromString: { dateString: "$time" } },
-            format: "%Y-%m-%dT%H:%M:%S.%LZ"
-          }
+          $concat: [
+            {
+              $dateToString: {
+                date: { $dateFromString: { dateString: "$time" } },
+                format: "%Y-%m-%dT%H:%M:%S.%L"
+              }
+            },
+            "000000Z"
+          ]
         }
       }
     }
@@ -173,17 +183,22 @@ db.events.updateMany(
 )
 ```
 
-Two caveats worth reading before you run it.
+The match stage skips a value whose fractional part already has more than three digits. `$dateFromString` parses
+into a BSON date, which only holds milliseconds, so touching a value that already carries more precision than that
+would throw the extra digits away. That protects two kinds of document from the same mistake. One is an event whose
+original timestamp genuinely had sub-millisecond precision. The other is an event 0.32.0 already wrote in the
+canonical nine-digit shape, which this script must not touch a second time either.
 
-`$dateFromString` parses into a BSON date, which holds milliseconds, so this loses any precision finer than a
-millisecond that was in the stored string. If your events carry microseconds or nanoseconds and you need them, do the
-rewrite in application code instead, reading each `time` with `OffsetDateTime.parse` and writing it back formatted with
-nine fractional digits.
+For an event the script does rewrite, it pads the three digits `$dateToString` produces out to nine with zeroes, so
+the result has the canonical fixed width and sorts correctly against the values 0.32.0 writes for new events. Those
+zeroes are filler, not real digits, so a rewritten value equals the canonical shape a filter checks only when the
+original event had no sub-millisecond precision to lose in the first place.
 
-`%L` emits three fractional digits, not nine, so the rewritten values are canonical in shape but not identical to what
-0.32.0 writes for new events. Comparisons still behave, because all rewritten values share one shape and sort against
-each other correctly, but an exact filter built from a nanosecond instant will not match a rewritten value. Use the
-application-code route if you need exact matching against these older events.
+An event the script skips keeps the shape it already had. An equality filter still matches it exactly as it did
+before you ran anything, through the legacy shape described above, because its stored value never changed. What
+stays open for it is the range-query gap. If you want that fixed too, rewrite it in application code instead, reading
+it with `OffsetDateTime.parse` and writing it back with nine real fractional digits, since only that route can supply
+digits `$dateFromString` would otherwise discard.
 
 ### Time range queries and UTC offsets
 


### PR DESCRIPTION
Fixes #650

I changed the "Optional: rewrite the stored values" section in `doc/migration/upgrading-to-0.32.0.md`. The script there used `$dateToString` with `%L`, which only emits three fractional digits, then called the result canonical in shape against a definition of canonical earlier on the same page that requires nine.

## Analysis

The real question was not just the digit-count mismatch. It was whether a three-digit rewritten value still matches through the two-form equality shim `SpecialFilterHandling.resolveSpecialCases` added in #631 (`eq` becomes an `in` over a canonical and a legacy shape). I added `a_three_digit_rewritten_value_matches_neither_shape_the_shim_generates_for_a_microsecond_instant` to `SpecialFilterHandlingTest` to check this concretely against the real shim, not from memory.

For an event with real microsecond precision (`OffsetDateTime.of(2024, 1, 1, 10, 0, 30, 123_456_000, UTC)`), stored pre-upgrade as `2024-01-01T10:00:30.123456Z`:

- Before running the old script, an `eq` filter for that instant matches it, through the shim's legacy branch.
- After the old script's `%L` rewrite, the stored value becomes `2024-01-01T10:00:30.123Z`, which equals neither the canonical shape nor the legacy shape the shim generates for that instant.

So the script did not just mislabel its output. For any event with genuine sub-millisecond precision, running it turned a working `eq`/`in`/`ne` match into a permanent miss. I mutation-tested the check by removing the shim's legacy branch in `SpecialFilterHandling.bothRepresentationsOf` and confirmed the new test fails on its own, not only via the other tests that also cover that branch, then restored the file.

## Fix

The script now does two things differently:

- It zero-pads `$dateToString`'s three digits out to nine, so its output is genuinely canonical and sorts correctly against values 0.32.0 writes for new events, closing the range-query gap the section describes for the events it touches.
- It skips any value whose fractional part already has more than three digits, in the `$match` stage. That covers both a legacy event with real sub-millisecond precision and an event 0.32.0 already wrote in canonical shape. The old, unfiltered script would have corrupted either one the same way if run against a mixed collection.

An event the script skips keeps matching exactly as it did before, through the legacy shape. Its range-query gap stays open, same as before, and the guide still points to the application-code route (`OffsetDateTime.parse`, nine real digits) for anyone who wants that closed too.

## Verification

```
mvn -pl common/mongodb/specialfilterhandling -am test -Dtest=SpecialFilterHandlingTest -Dsurefire.failIfNoSpecifiedTests=false
```

11 tests, 0 failures.

## Docs site

`pages/docs/docs.md` in `occurrent-org/occurrent-org.github.io` was reworded by PR 50 to stop calling the three-digit output canonical, scoped to the "comparisons still behave" claim to rewritten values only. That page still carries the old, unfixed three-digit script, so it now describes an older version of the rewrite than the one shipped here. It needs a follow-up to adopt the padded, filtered script and the corrected prose from this PR.
