### PR TITLE
MongoListenerLockService's javadoc promises a fencing token that doesn't exist

### DIFF
--- a/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
+++ b/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
@@ -16,7 +16,7 @@ Nothing reads it. `MongoLeaseCompetingConsumerStrategySupport.acquireLease` coll
 
 ## Decision
 
-**The javadoc is corrected to describe what a lease handover can actually redo today, instead of promising a fence that doesn't exist.** A subscriber's lease can expire while it still believes it holds the lock and is still acting on events. A checkpoint written after that point can move the checkpoint backward, so the new holder redelivers events already handled once. Delivery stays at least once, and the redelivered events are processed again.
+**The javadoc is corrected to describe what a lease handover can actually redo today, instead of promising a fence that doesn't exist.** A subscriber's lease can expire while it still believes it holds the lock and is still acting on events. A checkpoint written after that point can move the checkpoint backward, so the new holder redelivers events already handled once. Delivery stays at-least-once, and the redelivered events are processed again.
 
 **`ListenerLock`, `version()`, and the version-increment logic in `MongoListenerLockService`'s update pipeline stay exactly as they are.** They cost nothing to keep, since the field is already computed as part of the same atomic update that decides who holds the lease, and a real fence needs precisely this value. Removing them now would mean rebuilding the same pipeline logic from scratch when the fence is wired.
 

--- a/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
+++ b/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
@@ -1,0 +1,29 @@
+# 115. A lease fencing token is computed but not yet checked
+
+Date: 2026-08-09
+
+## Status
+
+Accepted. Fixes #660. Wiring the token into a real check is filed separately as #665.
+
+## Context
+
+`MongoListenerLockService.acquireOrRefreshFor`'s javadoc promised that actions requiring the lock use a fencing token, an increasing number a downstream write can check so that a write from a node that already lost the lease is rejected. The service computes that number. `version` increments whenever the lease changes hands and stays the same on a refresh, and it comes back as `ListenerLock.version()`.
+
+Nothing reads it. `MongoLeaseCompetingConsumerStrategySupport.acquireLease` collapses the returned `Optional<ListenerLock>` to `.isPresent()` and throws the lock itself away. No write anywhere in Occurrent compares against the version. A subscriber whose lease has moved to another node, the case the javadoc warned about, is not rejected by anything.
+
+[ADR 113](0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md) already named this gap and filed it separately rather than fixing it. This ADR is that follow-up.
+
+## Decision
+
+**The javadoc is corrected to describe what a lease handover can actually redo today, instead of promising a fence that doesn't exist.** A subscriber's lease can expire while it still believes it holds the lock and is still acting on events. A checkpoint written after that point can move the checkpoint backward, so the new holder redelivers events already handled once. Delivery stays at least once, and the redelivered events are processed again.
+
+**`ListenerLock`, `version()`, and the version-increment logic in `MongoListenerLockService`'s update pipeline stay exactly as they are.** They cost nothing to keep, since the field is already computed as part of the same atomic update that decides who holds the lease, and a real fence needs precisely this value. Removing them now would mean rebuilding the same pipeline logic from scratch when the fence is wired.
+
+**Wiring the token into an actual check is deferred to #665, not built here.** Making a checkpoint write reject a stale token touches two public interfaces. `CompetingConsumerStrategy` is boolean-shaped throughout (`registerCompetingConsumer` and `hasLock` both return `boolean`) and its own javadoc invites third-party implementations, so widening it is a breaking change for anyone who implemented it. `CheckpointStorage` is the thing that would need to compare the token before accepting a write, and it ships four implementations, `NativeMongoCheckpointStorage`, `SpringMongoCheckpointStorage`, `ReactorCheckpointStorage`, and `SpringRedisCheckpointStorage`, all of which would need the same check added. `CompetingConsumerSubscriptionModel` sits between the two and never sees individual event deliveries today, so getting the token from the strategy to the checkpoint write needs a path that doesn't exist yet. That is a design task of its own, not a documentation-sized change.
+
+## Consequences
+
+Until #665 lands, a node can still write a checkpoint after losing its lease. The worst it can do is move the checkpoint backward, so some events get redelivered and reprocessed. Nothing is lost and no checkpoint is left permanently wrong, which is why documenting the gap rather than leaving it silently wrong is enough for now.
+
+A reader of `MongoListenerLockService` finds a `version` field and a `ListenerLock.version()` accessor with no caller. That is intentional, not an oversight, and this ADR is the record for it.

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/ListenerLock.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/ListenerLock.java
@@ -32,8 +32,9 @@ class ListenerLock {
     }
 
     /**
-     * Increments on a genuine takeover and stays put on a refresh. Nothing reads this yet (ADR 115),
-     * so it does not currently reject a write from a subscriber whose lease has already moved on.
+     * The lock's version, the fencing token referred to elsewhere in this class. It increments on a
+     * genuine takeover and stays put on a refresh. Nothing reads this yet (ADR 115), so it does not
+     * currently reject a write from a subscriber whose lease has already moved on.
      */
     public long version() {
         return version;

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/ListenerLock.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/ListenerLock.java
@@ -31,6 +31,10 @@ class ListenerLock {
         this.version = version.longValue();
     }
 
+    /**
+     * Increments on a genuine takeover and stays put on a refresh. Nothing reads this yet (ADR 115),
+     * so it does not currently reject a write from a subscriber whose lease has already moved on.
+     */
     public long version() {
         return version;
     }

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
@@ -56,8 +56,10 @@ class MongoListenerLockService {
      *
      * <p>Only one subscriber ID will hold a lock for a given {@code subscriptionId} at any time.
      *
-     * <p>A subscriber lease may expire however so it is necessary to still use a kind of fencing
-     * token, like an increasing version number, when taking actions which require the lock.
+     * <p>A subscriber's lease can expire while it still believes it holds the lock and is still
+     * acting on events. A checkpoint written after that point can move the checkpoint backward, so
+     * the new holder redelivers events already handled once. Delivery stays at least once, and the
+     * redelivered events are processed again (see ADR 115).
      *
      * @param subscriptionId The subscriptionId to lock.
      * @return {@code Optional} with a {@link ListenerLock} if the lock is held by this subscriber,

--- a/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
+++ b/subscription/mongodb/common/blocking/competing-consumer-strategy/src/main/java/org/occurrent/subscription/mongodb/blocking/ccs/internal/MongoListenerLockService.java
@@ -58,7 +58,7 @@ class MongoListenerLockService {
      *
      * <p>A subscriber's lease can expire while it still believes it holds the lock and is still
      * acting on events. A checkpoint written after that point can move the checkpoint backward, so
-     * the new holder redelivers events already handled once. Delivery stays at least once, and the
+     * the new holder redelivers events already handled once. Delivery stays at-least-once, and the
      * redelivered events are processed again (see ADR 115).
      *
      * @param subscriptionId The subscriptionId to lock.


### PR DESCRIPTION
Fixes #660.

I changed `MongoListenerLockService.acquireOrRefreshFor`'s javadoc so it no longer promises a fencing token Occurrent doesn't have. It now states what a lease handover can actually redo. A checkpoint written after the lease has already moved to another node can move the checkpoint backward, so the new holder redelivers events already handled once. Delivery stays at least once, the redelivered events just get processed again. I added a short javadoc note to `ListenerLock.version()` too, since it had none, saying nothing reads it yet.

I did not touch `ListenerLock`, `version()`, or the version-increment logic in the update pipeline. They cost nothing to keep, and whichever unit wires the token into a real check needs this exact value.

I put the reasoning in a new ADR, `doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md`. Wiring the token into an actual check touches two public interfaces, `CompetingConsumerStrategy` (boolean-shaped throughout, and its own javadoc invites third-party implementations) and `CheckpointStorage` (four shipped implementations), plus a path through `CompetingConsumerSubscriptionModel` that doesn't exist today. That's a design task of its own, so I filed it separately as #665 rather than building it here.

No changelog entry, this is javadoc-only with no behavior change.

## Verification

`mvn test -am` on the three affected modules, all green:
- `subscription/mongodb/common/blocking/competing-consumer-strategy`
- `subscription/mongodb/native/blocking-competing-consumer-strategy`, `subscription/mongodb/spring/blocking-competing-consumer-strategy`
- `subscription/util/blocking/competing-consumer-subscription`

No new tests, since nothing about the code's behavior changed.
