### PR TITLE
Add CheckpointWriteCondition and thread it through CheckpointStorage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,10 @@
 * **A composed `AND` filter with several `data` payload leaves no longer reparses a byte-backed event's payload once per leaf.** Every leaf is now read in one pass, roughly 18 times faster for a 20-leaf filter over a 256 KB payload. An already-decoded, Map-backed event, the production MongoDB path, is unaffected. Resolves [#623](https://github.com/johanhaleby/occurrent/issues/623).
 * **A dotted path through an array of objects on a byte-backed event no longer picks up a same-named field nested inside a later sibling.** A filter on such a path could match the wrong events. Pre-existing, found and fixed as part of the filter work above.
 
+#### Breaking changes
+
+* **A checkpoint write now states its condition, so this changes behaviour that every `CheckpointStorage` implementation ships.** The existing two-argument `save` is unchanged, still an unconditional write. `save(subscriptionId, checkpoint, CheckpointWriteCondition)` also accepts `notOlderThan(long)`, refused once a newer version is already stored, and `ifAbsent()`, accepted only when nothing is stored yet. `writeVersion(subscriptionId)` reads back the version a condition is judged against. A refused write throws `CheckpointWriteConditionNotFulfilledException` on the blocking stack and signals it as a `Mono.error` on the reactive one. Occurrent's own Mongo and Redis storages accept only the unconditional form for now and refuse the other two with `UnsupportedOperationException`, both in-memory storages evaluate every condition for real. This is the foundation for the fencing token in [ADR 116](doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md), and nothing writes a conditional checkpoint yet, so behaviour is otherwise unchanged. If you implement `CheckpointStorage` yourself, see [Upgrading to 0.33.0](doc/migration/upgrading-to-0.33.0.md). Part of [#665](https://github.com/johanhaleby/occurrent/issues/665).
+
 ### 0.32.0 (2026-08-08)
 
 #### Highlights

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -1,0 +1,81 @@
+# Upgrading to Occurrent 0.33.0
+
+`CheckpointStorage` and its reactor twin gain a conditional write. This is a real break, and every implementation of
+either interface, in this repository and outside it, now has two more members to answer. No calling code changes,
+because the two-argument `save` you already call stays exactly as it was, as a default that delegates to the new
+one. There is no recipe, because filling in a method body is not a rename a recipe could apply.
+[ADR 116](../architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md) has the
+reasoning.
+
+## 1. What changed
+
+`CheckpointStorage.save` gained a third parameter, `CheckpointWriteCondition condition`, stating what must be true
+of the stored version before the write is allowed:
+
+```java
+Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition);
+
+default Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    return save(subscriptionId, checkpoint, CheckpointWriteCondition.any());
+}
+
+OptionalLong writeVersion(String subscriptionId);
+```
+
+The reactor twin gets the same two members, `Mono<Checkpoint> save(String, Checkpoint, CheckpointWriteCondition)`
+and `Mono<Long> writeVersion(String)`, with an empty `Mono` meaning no version is stored. A refusal on that stack
+signals `Mono.error`, it never throws from assembly.
+
+`CheckpointWriteCondition` is sealed with three cases. `any()` is what the two-argument `save` has always meant. The
+write always succeeds and the stored version, if there is one, is carried forward untouched. `notOlderThan(long)`
+succeeds when nothing is stored yet, or when the stored version is not greater than the one offered, and otherwise
+throws `CheckpointWriteConditionNotFulfilledException`. `ifAbsent()` succeeds only when no checkpoint is stored yet
+for that subscription id, whatever version it would carry, and refuses the same way otherwise.
+
+## 2. If you implement `CheckpointStorage` yourself, this one does not compile
+
+Add the `save` overload and `writeVersion`. A store that only ever wrote unconditionally can keep doing exactly
+that and refuse the rest:
+
+```java
+@Override
+public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
+    if (!(condition instanceof CheckpointWriteCondition.Any)) {
+        throw new UnsupportedOperationException("This storage cannot evaluate " + condition + ", only any() is supported.");
+    }
+    return save(subscriptionId, checkpoint); // your existing unconditional write
+}
+
+@Override
+public OptionalLong writeVersion(String subscriptionId) {
+    return OptionalLong.empty();
+}
+```
+
+That is not a stopgap you are expected to replace before compiling. It is the correct, permanent answer for a store
+that genuinely cannot evaluate a condition. `UnsupportedOperationException` is the same refusal an event store gives
+for a capability it was not built with, and Occurrent's own Mongo and Redis checkpoint storages answer this way
+today, until a later release teaches them the real comparison.
+
+If your store can evaluate a condition for real, the two rules that matter are the same two the TCK asserts on every
+storage that declares it supports them. `any()` must leave whatever version is stored untouched, carrying it
+forward, rather than clearing it or overwriting it with something inferred from the write. And `notOlderThan(v)`
+must accept when nothing is stored, since that is a checkpoint written before this condition existed, and every
+checkpoint saved by an earlier release has to stay readable.
+
+## 3. One release between the lease change and the fence
+
+Competing consumers ships the fencing token and the checkpoint write condition together in 0.33.0. During a rolling
+upgrade, a node still running 0.32.0 releases its lease the old way. It deletes the lock document rather than
+unsetting it, so the token restarts at zero instead of continuing to climb. A 0.33.0 node that then acquires the
+lease reads that fresh zero and offers it as `notOlderThan(0)`, which a checkpoint already stamped with a higher
+version refuses. The node's write is refused, its event is not acknowledged, its lease is judged idle at the next
+refresh and released, and the next node to acquire it lands in the same position. That repeats, once per unit of the
+version the checkpoint remembers, and each cycle costs one lease period and one re-run of whatever your handler did
+before the refusal.
+
+It ends on its own once every node in the deployment runs 0.33.0, because from then on every release keeps
+incrementing the token rather than resetting it. If you need it to end sooner, on a subscription that is stuck
+cycling, `CheckpointStorage.delete(subscriptionId)` clears the checkpoint and its stored version together, and the
+subscription resumes as a fresh one. That costs a replay. Everything since the subscription's global checkpoint is
+redelivered, which is within the at-least-once contract this library has always kept, not a new kind of loss.

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/BackgroundCatchupFailureTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/BackgroundCatchupFailureTest.java
@@ -33,6 +33,7 @@ import org.occurrent.springboot.common.PushCatchupStatus;
 import org.occurrent.springboot.common.PushCatchupStatusImpl;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.push.reactor.PushSubscriptionModel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -107,8 +108,13 @@ class BackgroundCatchupFailureTest {
                 }
 
                 @Override
-                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                     return Mono.just(checkpoint);
+                }
+
+                @Override
+                public Mono<Long> writeVersion(String subscriptionId) {
+                    return Mono.empty();
                 }
 
                 @Override

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationConfigurationTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationConfigurationTest.java
@@ -32,6 +32,7 @@ import org.occurrent.filter.Filter;
 import org.occurrent.springboot.common.PushCatchupStatus;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.push.reactor.PushSubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -169,8 +170,13 @@ class OccurrentReactiveAnnotationConfigurationTest {
                 }
 
                 @Override
-                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                     return Mono.just(checkpoint);
+                }
+
+                @Override
+                public Mono<Long> writeVersion(String subscriptionId) {
+                    return Mono.empty();
                 }
 
                 @Override

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ProjectionPushStartupModeTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ProjectionPushStartupModeTest.java
@@ -32,6 +32,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.push.reactor.PushSubscriptionModel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -148,8 +149,13 @@ class ProjectionPushStartupModeTest {
                 }
 
                 @Override
-                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                     return Mono.just(checkpoint);
+                }
+
+                @Override
+                public Mono<Long> writeVersion(String subscriptionId) {
+                    return Mono.empty();
                 }
 
                 @Override

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveAnnotationFailFastTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveAnnotationFailFastTest.java
@@ -34,6 +34,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.api.reactor.Subscribable;
 import org.occurrent.subscription.push.reactor.PushSubscriptionModel;
@@ -400,8 +401,13 @@ class ReactiveAnnotationFailFastTest {
                 }
 
                 @Override
-                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                     return Mono.just(checkpoint);
+                }
+
+                @Override
+                public Mono<Long> writeVersion(String subscriptionId) {
+                    return Mono.empty();
                 }
 
                 @Override

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveProjectionPushCatchupTunablesTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ReactiveProjectionPushCatchupTunablesTest.java
@@ -31,6 +31,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.push.reactor.PushSubscriptionModel;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -120,8 +121,13 @@ class ReactiveProjectionPushCatchupTunablesTest {
                 }
 
                 @Override
-                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+                public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                     return Mono.just(checkpoint);
+                }
+
+                @Override
+                public Mono<Long> writeVersion(String subscriptionId) {
+                    return Mono.empty();
                 }
 
                 @Override

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/CheckpointStorage.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/CheckpointStorage.java
@@ -20,7 +20,11 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.StartAt;
+
+import java.util.OptionalLong;
 
 /**
  * A {@code CheckpointStorage} provides means to read and write the checkpoint to storage.
@@ -51,11 +55,52 @@ public interface CheckpointStorage {
     @Nullable
     Checkpoint read(@NonNull String subscriptionId);
 
-    /*
-     * Save the checkpoint for the supplied subscriptionId to storage and then return it for easier chaining.
+    /**
+     * Save the checkpoint for the supplied subscriptionId to storage, unconditionally, and then return it for
+     * easier chaining. This is the same as calling {@link #save(String, Checkpoint, CheckpointWriteCondition)} with
+     * {@link CheckpointWriteCondition#any()}, so it always succeeds and leaves the stored version untouched.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint to save
+     * @param checkpoint     The checkpoint to save
+     * @return The checkpoint that was saved, for chaining
      */
     @NullMarked
-    Checkpoint save(String subscriptionId, Checkpoint checkpoint);
+    default Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+        return save(subscriptionId, checkpoint, CheckpointWriteCondition.any());
+    }
+
+    /**
+     * Save the checkpoint for the supplied subscriptionId to storage if {@code condition} is fulfilled, and then
+     * return it for easier chaining.
+     * <p>
+     * A store that can evaluate only {@link CheckpointWriteCondition#any()} refuses every other condition with
+     * {@link UnsupportedOperationException}, the same answer an event store gives for a capability it was not built
+     * with. Check the implementation's own documentation for whether it evaluates conditions.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint to save
+     * @param checkpoint     The checkpoint to save
+     * @param condition      What must be true of the stored version for the write to be allowed
+     * @return The checkpoint that was saved, for chaining
+     * @throws CheckpointWriteConditionNotFulfilledException if {@code condition} was not fulfilled
+     * @throws UnsupportedOperationException                 if this storage cannot evaluate {@code condition}
+     */
+    @NullMarked
+    Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition);
+
+    /**
+     * Read the version currently stored for the supplied subscriptionId, the one a {@link CheckpointWriteCondition}
+     * is evaluated against.
+     * <p>
+     * This is not needed to evaluate a condition, since {@link #save(String, Checkpoint, CheckpointWriteCondition)}
+     * does that itself. It exists so a caller can find out which version is stored and why a write keeps being
+     * refused, without reading the underlying database by hand.
+     *
+     * @param subscriptionId The id of the subscription whose stored version to find
+     * @return The version stored, or empty if none is stored, including for a storage that cannot evaluate
+     * conditions and therefore never records one
+     */
+    @NullMarked
+    OptionalLong writeVersion(String subscriptionId);
 
     /**
      * Delete the {@link Checkpoint} for the supplied {@code subscriptionId}.

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.GlobalCheckpointSource;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionAlreadyRunningException;
@@ -733,9 +734,14 @@ class ManualStartSubscriptionModelTest {
         }
 
         @Override
-        public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+        public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
             checkpoints.put(subscriptionId, checkpoint);
             return checkpoint;
+        }
+
+        @Override
+        public OptionalLong writeVersion(String subscriptionId) {
+            return OptionalLong.empty();
         }
 
         @Override

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/CheckpointStorage.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/CheckpointStorage.java
@@ -18,6 +18,8 @@ package org.occurrent.subscription.api.reactor;
 
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.StartAt;
 import reactor.core.publisher.Mono;
 
@@ -48,10 +50,50 @@ public interface CheckpointStorage {
      */
     Mono<Checkpoint> read(String subscriptionId);
 
-    /*
-     * Save the checkpoint for the supplied subscriptionId to storage and then return it for easier chaining.
+    /**
+     * Save the checkpoint for the supplied subscriptionId to storage, unconditionally, and then return it for
+     * easier chaining. This is the same as calling {@link #save(String, Checkpoint, CheckpointWriteCondition)} with
+     * {@link CheckpointWriteCondition#any()}, so it always succeeds and leaves the stored version untouched.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint to save
+     * @param checkpoint     The checkpoint to save
+     * @return A Mono with the checkpoint that was saved, for chaining
      */
-    Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint);
+    default Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+        return save(subscriptionId, checkpoint, CheckpointWriteCondition.any());
+    }
+
+    /**
+     * Save the checkpoint for the supplied subscriptionId to storage if {@code condition} is fulfilled, and then
+     * return it for easier chaining.
+     * <p>
+     * A store that can evaluate only {@link CheckpointWriteCondition#any()} refuses every other condition with a
+     * {@link Mono#error(Throwable)} carrying {@link UnsupportedOperationException}, the same answer an event store
+     * gives for a capability it was not built with, signalled rather than thrown so nothing escapes assembly. Check
+     * the implementation's own documentation for whether it evaluates conditions.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint to save
+     * @param checkpoint     The checkpoint to save
+     * @param condition      What must be true of the stored version for the write to be allowed
+     * @return A Mono with the checkpoint that was saved, for chaining, or a Mono signalling
+     * {@link CheckpointWriteConditionNotFulfilledException} if {@code condition} was not fulfilled, or
+     * {@link UnsupportedOperationException} if this storage cannot evaluate {@code condition}
+     */
+    Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition);
+
+    /**
+     * Read the version currently stored for the supplied subscriptionId, the one a {@link CheckpointWriteCondition}
+     * is evaluated against.
+     * <p>
+     * This is not needed to evaluate a condition, since {@link #save(String, Checkpoint, CheckpointWriteCondition)}
+     * does that itself. It exists so a caller can find out which version is stored and why a write keeps being
+     * refused, without reading the underlying database by hand.
+     *
+     * @param subscriptionId The id of the subscription whose stored version to find
+     * @return A Mono with the version stored, or an empty Mono if none is stored, including for a storage that
+     * cannot evaluate conditions and therefore never records one
+     */
+    Mono<Long> writeVersion(String subscriptionId);
 
 
     /**

--- a/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteCondition.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteCondition.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+/**
+ * What must be true of a checkpoint's stored version before {@code CheckpointStorage.save} is allowed to write it.
+ * <p>
+ * A checkpoint write states its condition the same way an event store write does, except the version here comes
+ * from the caller rather than from the store, and the store never learns where it comes from. That is what lets a
+ * competing-consumer subscription refuse a write made from a lease it has already lost, without a fencing token
+ * ever appearing in the vocabulary of a checkpoint store.
+ * <p>
+ * This is sealed with exactly the three cases below. A store that cannot evaluate anything but {@link #any()}
+ * refuses the others with {@link UnsupportedOperationException}, which is the same answer an event store gives for
+ * a capability it was not built with.
+ */
+public sealed interface CheckpointWriteCondition {
+
+    /**
+     * The version stored does not matter. The write always succeeds and leaves the stored version exactly as it
+     * was, carrying it forward rather than clearing it.
+     *
+     * @return A {@link CheckpointWriteCondition} with the behavior described above.
+     */
+    static CheckpointWriteCondition any() {
+        return new Any();
+    }
+
+    /**
+     * The write succeeds when nothing is stored, or when the stored version is not greater than {@code writeVersion}.
+     * On success the stored version becomes {@code writeVersion}. Otherwise the write is refused with a
+     * {@link CheckpointWriteConditionNotFulfilledException}.
+     * <p>
+     * Nothing stored is accepted rather than refused, because it means a checkpoint written before this condition
+     * existed, and every checkpoint written by an earlier release of Occurrent has to stay readable.
+     *
+     * @param writeVersion The version this write represents, assigned by the caller.
+     * @return A {@link CheckpointWriteCondition} with the behavior described above.
+     */
+    static CheckpointWriteCondition notOlderThan(long writeVersion) {
+        return new NotOlderThan(writeVersion);
+    }
+
+    /**
+     * The write succeeds only when no checkpoint is stored yet for the subscription id, whatever version it would
+     * carry. Otherwise the write is refused with a {@link CheckpointWriteConditionNotFulfilledException}.
+     * <p>
+     * This exists for a caller that wants to write a subscription's very first checkpoint, and only the very first
+     * one, so it can fix the subscription's start position without racing another writer through {@link #any()}.
+     *
+     * @return A {@link CheckpointWriteCondition} with the behavior described above.
+     */
+    static CheckpointWriteCondition ifAbsent() {
+        return new IfAbsent();
+    }
+
+    /**
+     * See {@link #any()}.
+     */
+    record Any() implements CheckpointWriteCondition {
+    }
+
+    /**
+     * See {@link #notOlderThan(long)}.
+     *
+     * @param writeVersion The version this write represents.
+     */
+    record NotOlderThan(long writeVersion) implements CheckpointWriteCondition {
+    }
+
+    /**
+     * See {@link #ifAbsent()}.
+     */
+    record IfAbsent() implements CheckpointWriteCondition {
+    }
+}

--- a/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteConditionNotFulfilledException.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteConditionNotFulfilledException.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.StringJoiner;
+
+/**
+ * A {@code CheckpointStorage} refused a checkpoint write because its {@link CheckpointWriteCondition} was not met.
+ * <p>
+ * This means the node that attempted the write is not the one the stored version belongs to, most often because its
+ * lease moved to another node while it was still delivering. That is the state of another machine rather than a
+ * mistake in the calling code, so unlike {@code WriteConditionNotFulfilledException} on the event store side,
+ * passing a different argument does not fix it, and this does not join
+ * {@link SubscriptionRefusedException}'s sealed family. It extends {@link IllegalStateException} instead, and it
+ * must never be retried on the path that threw it, since retrying only repeats the write that was already refused.
+ */
+@NullMarked
+public class CheckpointWriteConditionNotFulfilledException extends IllegalStateException {
+
+    /**
+     * The id of the subscription whose checkpoint write was refused.
+     */
+    public final String subscriptionId;
+
+    /**
+     * The version stored at the time the condition was evaluated, or empty if the store had no version recorded
+     * for this subscription id.
+     */
+    public final OptionalLong storedVersion;
+
+    /**
+     * The condition that was not fulfilled.
+     */
+    public final CheckpointWriteCondition condition;
+
+    /**
+     * Creates an exception with the standard message describing the condition that was not fulfilled and the
+     * version the store actually had. This is the message every Occurrent checkpoint storage produces, so prefer
+     * this constructor over supplying your own message.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint write was refused
+     * @param storedVersion  The version stored when the condition was evaluated, or empty if none was stored
+     * @param condition      The condition that was not fulfilled
+     */
+    public CheckpointWriteConditionNotFulfilledException(String subscriptionId, OptionalLong storedVersion, CheckpointWriteCondition condition) {
+        this(subscriptionId, storedVersion, condition, String.format(
+                "%s was not fulfilled for subscription %s. Condition was %s but stored version was %s.",
+                CheckpointWriteCondition.class.getSimpleName(), subscriptionId, condition,
+                storedVersion.isPresent() ? String.valueOf(storedVersion.getAsLong()) : "not set"));
+    }
+
+    /**
+     * Creates an exception with a message of your own, for a store that has something to add beyond the id, the
+     * stored version and the condition.
+     *
+     * @param subscriptionId The id of the subscription whose checkpoint write was refused
+     * @param storedVersion  The version stored when the condition was evaluated, or empty if none was stored
+     * @param condition      The condition that was not fulfilled
+     * @param message        The message to report
+     */
+    public CheckpointWriteConditionNotFulfilledException(String subscriptionId, OptionalLong storedVersion, CheckpointWriteCondition condition, String message) {
+        super(message);
+        this.subscriptionId = subscriptionId;
+        this.storedVersion = storedVersion;
+        this.condition = condition;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CheckpointWriteConditionNotFulfilledException that)) return false;
+        return Objects.equals(subscriptionId, that.subscriptionId) && Objects.equals(storedVersion, that.storedVersion)
+                && Objects.equals(condition, that.condition) && Objects.equals(getMessage(), that.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subscriptionId, storedVersion, condition);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", CheckpointWriteConditionNotFulfilledException.class.getSimpleName() + "[", "]")
+                .add("subscriptionId='" + subscriptionId + "'")
+                .add("storedVersion=" + storedVersion)
+                .add("condition=" + condition)
+                .add("message=" + super.getMessage())
+                .toString();
+    }
+}

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemoryCheckpointStorage.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemoryCheckpointStorage.java
@@ -19,10 +19,14 @@ package org.occurrent.subscription.inmemory;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,11 +34,16 @@ import static java.util.Objects.requireNonNull;
  * A {@link CheckpointStorage} that keeps checkpoints in a {@link ConcurrentHashMap}. It has nothing to connect to
  * and nothing to clean up, which makes it a good fit for tests and for small applications that don't need the
  * checkpoint to survive a restart.
+ * <p>
+ * {@link CheckpointWriteCondition} is evaluated for real, not refused. The checkpoint and its version are two
+ * separate maps, since {@link CheckpointWriteCondition#any()} writes the former and leaves the latter untouched.
  */
 @NullMarked
 public class InMemoryCheckpointStorage implements CheckpointStorage {
 
     private final Map<String, Checkpoint> checkpoints = new ConcurrentHashMap<>();
+    private final Map<String, Long> versions = new ConcurrentHashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
 
     @Override
     @Nullable
@@ -44,17 +53,53 @@ public class InMemoryCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(checkpoint, Checkpoint.class.getSimpleName() + " cannot be null");
-        checkpoints.put(subscriptionId, checkpoint);
-        return checkpoint;
+        requireNonNull(condition, CheckpointWriteCondition.class.getSimpleName() + " cannot be null");
+        lock.lock();
+        try {
+            if (condition instanceof CheckpointWriteCondition.NotOlderThan notOlderThan) {
+                Long stored = versions.get(subscriptionId);
+                if (stored != null && stored > notOlderThan.writeVersion()) {
+                    throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, OptionalLong.of(stored), condition);
+                }
+                checkpoints.put(subscriptionId, checkpoint);
+                versions.put(subscriptionId, notOlderThan.writeVersion());
+            } else if (condition instanceof CheckpointWriteCondition.IfAbsent) {
+                if (checkpoints.containsKey(subscriptionId)) {
+                    Long stored = versions.get(subscriptionId);
+                    OptionalLong storedVersion = stored == null ? OptionalLong.empty() : OptionalLong.of(stored);
+                    throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, storedVersion, condition);
+                }
+                checkpoints.put(subscriptionId, checkpoint);
+            } else {
+                // CheckpointWriteCondition.Any: the stored version, if any, is carried forward untouched.
+                checkpoints.put(subscriptionId, checkpoint);
+            }
+            return checkpoint;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
+        requireNonNull(subscriptionId, "subscriptionId cannot be null");
+        Long stored = versions.get(subscriptionId);
+        return stored == null ? OptionalLong.empty() : OptionalLong.of(stored);
     }
 
     @Override
     public void delete(String subscriptionId) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
-        checkpoints.remove(subscriptionId);
+        lock.lock();
+        try {
+            checkpoints.remove(subscriptionId);
+            versions.remove(subscriptionId);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorage.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorage.java
@@ -18,11 +18,15 @@ package org.occurrent.subscription.inmemory.reactor;
 
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,11 +42,17 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Every returned {@code Mono} is cold, so nothing is read, stored, or deleted until it is subscribed to. Arguments are
  * still validated eagerly, so a {@code null} fails the calling code and not a subscriber far away.
+ * <p>
+ * {@link CheckpointWriteCondition} is evaluated for real, not refused. The checkpoint and its version are two
+ * separate maps, since {@link CheckpointWriteCondition#any()} writes the former and leaves the latter untouched. A
+ * refusal signals {@link Mono#error(Throwable)} rather than throwing from assembly.
  */
 @NullMarked
 public class InMemoryCheckpointStorage implements CheckpointStorage {
 
     private final Map<String, Checkpoint> checkpoints = new ConcurrentHashMap<>();
+    private final Map<String, Long> versions = new ConcurrentHashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
 
     @Override
     public Mono<Checkpoint> read(String subscriptionId) {
@@ -51,18 +61,55 @@ public class InMemoryCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+    public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(checkpoint, Checkpoint.class.getSimpleName() + " cannot be null");
+        requireNonNull(condition, CheckpointWriteCondition.class.getSimpleName() + " cannot be null");
         return Mono.fromSupplier(() -> {
-            checkpoints.put(subscriptionId, checkpoint);
-            return checkpoint;
+            lock.lock();
+            try {
+                if (condition instanceof CheckpointWriteCondition.NotOlderThan notOlderThan) {
+                    Long stored = versions.get(subscriptionId);
+                    if (stored != null && stored > notOlderThan.writeVersion()) {
+                        throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, OptionalLong.of(stored), condition);
+                    }
+                    checkpoints.put(subscriptionId, checkpoint);
+                    versions.put(subscriptionId, notOlderThan.writeVersion());
+                } else if (condition instanceof CheckpointWriteCondition.IfAbsent) {
+                    if (checkpoints.containsKey(subscriptionId)) {
+                        Long stored = versions.get(subscriptionId);
+                        OptionalLong storedVersion = stored == null ? OptionalLong.empty() : OptionalLong.of(stored);
+                        throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, storedVersion, condition);
+                    }
+                    checkpoints.put(subscriptionId, checkpoint);
+                } else {
+                    // CheckpointWriteCondition.Any: the stored version, if any, is carried forward untouched.
+                    checkpoints.put(subscriptionId, checkpoint);
+                }
+                return checkpoint;
+            } finally {
+                lock.unlock();
+            }
         });
+    }
+
+    @Override
+    public Mono<Long> writeVersion(String subscriptionId) {
+        requireNonNull(subscriptionId, "subscriptionId cannot be null");
+        return Mono.fromSupplier(() -> versions.get(subscriptionId));
     }
 
     @Override
     public Mono<Void> delete(String subscriptionId) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
-        return Mono.fromRunnable(() -> checkpoints.remove(subscriptionId));
+        return Mono.fromRunnable(() -> {
+            lock.lock();
+            try {
+                checkpoints.remove(subscriptionId);
+                versions.remove(subscriptionId);
+            } finally {
+                lock.unlock();
+            }
+        });
     }
 }

--- a/subscription/mongodb/native/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorage.java
+++ b/subscription/mongodb/native/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorage.java
@@ -27,11 +27,13 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.mongodb.MongoOperationTimeCheckpoint;
 import org.occurrent.subscription.mongodb.MongoResumeTokenCheckpoint;
 
 import java.time.Duration;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 import static com.mongodb.client.model.Filters.eq;
@@ -115,7 +117,13 @@ public class NativeMongoCheckpointStorage implements CheckpointStorage {
 
     @Override
     @NullMarked
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
+        // This storage does not evaluate a condition yet, so only the unconditional one is honoured.
+        if (!(condition instanceof CheckpointWriteCondition.Any)) {
+            throw new UnsupportedOperationException(
+                    NativeMongoCheckpointStorage.class.getSimpleName() + " cannot evaluate " + condition + " yet, only "
+                            + CheckpointWriteCondition.any() + " is supported.");
+        }
         Supplier<Checkpoint> save = () -> {
             if (checkpoint instanceof MongoResumeTokenCheckpoint) {
                 persistResumeTokenCheckpoint(subscriptionId, ((MongoResumeTokenCheckpoint) checkpoint).resumeToken);
@@ -130,6 +138,12 @@ public class NativeMongoCheckpointStorage implements CheckpointStorage {
         };
 
         return requireNonNull(executeWithRetry(save, __ -> !shutdown, retryStrategy).get());
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
+        // No version is recorded yet, since this storage does not evaluate a condition. See save(..).
+        return OptionalLong.empty();
     }
 
     @Override

--- a/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageConformanceTest.java
+++ b/subscription/mongodb/native/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoCheckpointStorageConformanceTest.java
@@ -108,6 +108,14 @@ class NativeMongoCheckpointStorageConformanceTest extends CheckpointStorageConfo
                     new MongoOperationTimeCheckpoint(new BsonTimestamp(1735689600, 1)));
         }
 
+        /**
+         * Interim: this storage does not evaluate a write condition yet, see {@link NativeMongoCheckpointStorage#save}.
+         */
+        @Override
+        public boolean evaluatesWriteConditions() {
+            return false;
+        }
+
         @Override
         public void close() {
             collection.drop();

--- a/subscription/mongodb/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
+++ b/subscription/mongodb/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorage.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.mongodb.MongoOperationTimeCheckpoint;
 import org.occurrent.subscription.mongodb.MongoResumeTokenCheckpoint;
@@ -32,6 +33,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Update;
 
 import java.time.Duration;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -95,7 +97,13 @@ public class SpringMongoCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
+        // This storage does not evaluate a condition yet, so only the unconditional one is honoured.
+        if (!(condition instanceof CheckpointWriteCondition.Any)) {
+            throw new UnsupportedOperationException(
+                    SpringMongoCheckpointStorage.class.getSimpleName() + " cannot evaluate " + condition + " yet, only "
+                            + CheckpointWriteCondition.any() + " is supported.");
+        }
         Supplier<Checkpoint> save = () -> {
             if (checkpoint instanceof MongoResumeTokenCheckpoint mongoResumeTokenCheckpoint) {
                 persistResumeTokenStreamPosition(subscriptionId, mongoResumeTokenCheckpoint.resumeToken);
@@ -110,6 +118,12 @@ public class SpringMongoCheckpointStorage implements CheckpointStorage {
         };
 
         return requireNonNull(executeWithRetry(save, __ -> !shutdown, retryStrategy).get());
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
+        // No version is recorded yet, since this storage does not evaluate a condition. See save(..).
+        return OptionalLong.empty();
     }
 
     @Override

--- a/subscription/mongodb/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorageConformanceTest.java
+++ b/subscription/mongodb/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorageConformanceTest.java
@@ -112,6 +112,14 @@ class SpringMongoCheckpointStorageConformanceTest extends CheckpointStorageConfo
                     new MongoOperationTimeCheckpoint(new BsonTimestamp(1735689600, 1)));
         }
 
+        /**
+         * Interim: this storage does not evaluate a write condition yet, see {@link SpringMongoCheckpointStorage#save}.
+         */
+        @Override
+        public boolean evaluatesWriteConditions() {
+            return false;
+        }
+
         @Override
         public void close() {
             mongoOperations.dropCollection(collection);

--- a/subscription/mongodb/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorageTest.java
+++ b/subscription/mongodb/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoCheckpointStorageTest.java
@@ -39,6 +39,7 @@ import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.DelegatingSubscriptionModel;
@@ -61,6 +62,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -277,9 +279,15 @@ public class SpringMongoCheckpointStorageTest {
 
             @Override
             @NullMarked
-            public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+            public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                 numberOfWritesToBlockingSubscriptionStorage.incrementAndGet();
                 return checkpoint;
+            }
+
+            @Override
+            @NullMarked
+            public OptionalLong writeVersion(String subscriptionId) {
+                return OptionalLong.empty();
             }
 
             @Override
@@ -328,9 +336,15 @@ public class SpringMongoCheckpointStorageTest {
 
             @Override
             @NullMarked
-            public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+            public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                 numberOfWritesToBlockingSubscriptionStorage.incrementAndGet();
                 return checkpoint;
+            }
+
+            @Override
+            @NullMarked
+            public OptionalLong writeVersion(String subscriptionId) {
+                return OptionalLong.empty();
             }
 
             @Override

--- a/subscription/mongodb/spring/reactor-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
+++ b/subscription/mongodb/spring/reactor-checkpoint-storage/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorage.java
@@ -22,6 +22,7 @@ import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.mongodb.MongoOperationTimeCheckpoint;
 import org.occurrent.subscription.mongodb.MongoResumeTokenCheckpoint;
@@ -79,7 +80,13 @@ public class ReactorCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Mono<Checkpoint> save(String subscriptionId, Checkpoint changeStreamPosition) {
+    public Mono<Checkpoint> save(String subscriptionId, Checkpoint changeStreamPosition, CheckpointWriteCondition condition) {
+        // This storage does not evaluate a condition yet, so only the unconditional one is honoured.
+        if (!(condition instanceof CheckpointWriteCondition.Any)) {
+            return Mono.error(new UnsupportedOperationException(
+                    ReactorCheckpointStorage.class.getSimpleName() + " cannot evaluate " + condition + " yet, only "
+                            + CheckpointWriteCondition.any() + " is supported."));
+        }
         Mono<?> result;
         if (changeStreamPosition instanceof MongoResumeTokenCheckpoint mongoResumeTokenCheckpoint) {
             result = persistResumeTokenStreamPosition(subscriptionId, mongoResumeTokenCheckpoint.resumeToken);
@@ -91,6 +98,12 @@ public class ReactorCheckpointStorage implements CheckpointStorage {
             result = persistDocumentStreamPosition(subscriptionId, document);
         }
         return result.thenReturn(changeStreamPosition);
+    }
+
+    @Override
+    public Mono<Long> writeVersion(String subscriptionId) {
+        // No version is recorded yet, since this storage does not evaluate a condition. See save(..).
+        return Mono.empty();
     }
 
     @Override

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -21,11 +21,13 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.springframework.data.redis.core.RedisOperations;
 
 import java.time.Duration;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -81,9 +83,16 @@ public class SpringRedisCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(checkpoint, Checkpoint.class.getSimpleName() + " cannot be null");
+        requireNonNull(condition, CheckpointWriteCondition.class.getSimpleName() + " cannot be null");
+        // This storage does not evaluate a condition yet, so only the unconditional one is honoured.
+        if (!(condition instanceof CheckpointWriteCondition.Any)) {
+            throw new UnsupportedOperationException(
+                    SpringRedisCheckpointStorage.class.getSimpleName() + " cannot evaluate " + condition + " yet, only "
+                            + CheckpointWriteCondition.any() + " is supported.");
+        }
 
         Supplier<Checkpoint> save = () -> {
             String changeStreamPositionAsString = checkpoint.asString();
@@ -92,6 +101,12 @@ public class SpringRedisCheckpointStorage implements CheckpointStorage {
         };
 
         return requireNonNull(executeWithRetry(save, __ -> !shutdown, retryStrategy).get());
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
+        // No version is recorded yet, since this storage does not evaluate a condition. See save(..).
+        return OptionalLong.empty();
     }
 
     @Override

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorageConformanceTest.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/test/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorageConformanceTest.java
@@ -112,5 +112,13 @@ class SpringRedisCheckpointStorageConformanceTest extends CheckpointStorageConfo
                     new MongoResumeTokenCheckpoint(new BsonDocument("_data", new BsonString("82ABCDEF"))),
                     new MongoOperationTimeCheckpoint(new BsonTimestamp(1735689600, 1)));
         }
+
+        /**
+         * Interim: this storage does not evaluate a write condition yet, see {@link SpringRedisCheckpointStorage#save}.
+         */
+        @Override
+        public boolean evaluatesWriteConditions() {
+            return false;
+        }
     }
 }

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelTest.java
@@ -35,6 +35,7 @@ import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorCheckpointStorage;
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel;
@@ -152,8 +153,13 @@ public class ReactorDurableSubscriptionModelTest {
             }
 
             @Override
-            public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+            public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                 return Mono.fromRunnable(numberOfWritesToSubscriptionStorage::incrementAndGet).thenReturn(checkpoint);
+            }
+
+            @Override
+            public Mono<Long> writeVersion(String subscriptionId) {
+                return Mono.empty();
             }
 
             @Override
@@ -192,8 +198,13 @@ public class ReactorDurableSubscriptionModelTest {
             }
 
             @Override
-            public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+            public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
                 return Mono.fromRunnable(numberOfWritesToSubscriptionStorage::incrementAndGet).thenReturn(checkpoint);
+            }
+
+            @Override
+            public Mono<Long> writeVersion(String subscriptionId) {
+                return Mono.empty();
             }
 
             @Override

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageConformance.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
@@ -29,10 +31,12 @@ import org.occurrent.tck.FailureNamesTheTestClass;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The contract every {@link CheckpointStorage} owes. A checkpoint saved for a subscription id can be read back, is
@@ -356,6 +360,120 @@ public abstract class CheckpointStorageConformance {
                     .as("a subscription that was cancelled and registered again must be able to store a position, so "
                             + "delete cannot leave a tombstone that refuses later saves")
                     .isEqualTo("again");
+        }
+    }
+
+    @Nested
+    @DisplayName("write conditions")
+    class WriteConditions {
+
+        @Test
+        void not_older_than_is_accepted_when_nothing_is_stored_yet() {
+            String id = subscriptionId();
+
+            if (!fixture().evaluatesWriteConditions()) {
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(0)))
+                        .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
+                        .isInstanceOf(UnsupportedOperationException.class);
+                return;
+            }
+
+            checkpointStorage().save(id, new StringBasedCheckpoint("first-ever"), CheckpointWriteCondition.notOlderThan(0));
+
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("nothing stored means a checkpoint written before this condition existed, so the write must "
+                            + "be accepted whatever version it offers")
+                    .isEqualTo("first-ever");
+            assertThat(checkpointStorage().writeVersion(id))
+                    .as("the offered version becomes the stored one")
+                    .isEqualTo(OptionalLong.of(0));
+        }
+
+        @Test
+        void not_older_than_accepts_a_version_not_below_the_one_stored_and_refuses_a_lower_one() {
+            String id = subscriptionId();
+
+            if (!fixture().evaluatesWriteConditions()) {
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(5)))
+                        .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
+                        .isInstanceOf(UnsupportedOperationException.class);
+                return;
+            }
+
+            checkpointStorage().save(id, new StringBasedCheckpoint("at-5"), CheckpointWriteCondition.notOlderThan(5));
+            checkpointStorage().save(id, new StringBasedCheckpoint("at-7"), CheckpointWriteCondition.notOlderThan(7));
+
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("a version not below the stored one is accepted and its checkpoint written")
+                    .isEqualTo("at-7");
+            assertThat(checkpointStorage().writeVersion(id))
+                    .as("the accepted version becomes the stored one")
+                    .isEqualTo(OptionalLong.of(7));
+
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(3)))
+                    .as("a version below the stored one is refused, which is what keeps a node whose lease moved on "
+                            + "from writing a checkpoint over a newer one")
+                    .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("a refused write must not change the stored checkpoint")
+                    .isEqualTo("at-7");
+            assertThat(checkpointStorage().writeVersion(id))
+                    .as("a refused write must not change the stored version")
+                    .isEqualTo(OptionalLong.of(7));
+        }
+
+        @Test
+        void if_absent_is_accepted_only_when_nothing_is_stored() {
+            String id = subscriptionId();
+
+            if (!fixture().evaluatesWriteConditions()) {
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.ifAbsent()))
+                        .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
+                        .isInstanceOf(UnsupportedOperationException.class);
+                return;
+            }
+
+            checkpointStorage().save(id, new StringBasedCheckpoint("pinned"), CheckpointWriteCondition.ifAbsent());
+
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("nothing was stored for this subscription id, so the pinning write must be accepted")
+                    .isEqualTo("pinned");
+
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("overwrite"), CheckpointWriteCondition.ifAbsent()))
+                    .as("a checkpoint already exists for this subscription id, so a second ifAbsent write must be refused")
+                    .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("a refused write must not change the stored checkpoint")
+                    .isEqualTo("pinned");
+        }
+
+        @Test
+        void any_leaves_the_stored_version_untouched_and_carries_it_forward() {
+            String id = subscriptionId();
+
+            if (!fixture().evaluatesWriteConditions()) {
+                // any() is the one condition every storage is required to support, whatever it declares.
+                checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any());
+                assertThat(requireNonNull(checkpointStorage().read(id)).asString()).isEqualTo("unconditional");
+                return;
+            }
+
+            checkpointStorage().save(id, new StringBasedCheckpoint("fenced"), CheckpointWriteCondition.notOlderThan(9));
+
+            checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any());
+
+            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                    .as("any() writes the checkpoint")
+                    .isEqualTo("unconditional");
+            assertThat(checkpointStorage().writeVersion(id))
+                    .as("any() must leave the stored version exactly as it was, carrying it forward rather than "
+                            + "clearing it, since an unconditional write from a hand-wired caller or a node mid-deploy "
+                            + "must not re-arm the fence at zero")
+                    .isEqualTo(OptionalLong.of(9));
+
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(4)))
+                    .as("the version any() carried forward must still be enforced by a later conditional write")
+                    .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
         }
     }
 }

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageFixture.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/CheckpointStorageFixture.java
@@ -64,6 +64,23 @@ public interface CheckpointStorageFixture {
     boolean preservesCheckpointType(Checkpoint checkpoint);
 
     /**
+     * Whether this storage evaluates a {@link org.occurrent.subscription.CheckpointWriteCondition} for real.
+     * <p>
+     * {@code true}, the default, means {@code notOlderThan} and {@code ifAbsent} are both accepted and refused as
+     * documented, and {@code any()} leaves a stored version untouched and carries it forward. {@code false} means
+     * this storage refuses every condition but {@link org.occurrent.subscription.CheckpointWriteCondition#any()}
+     * with {@link UnsupportedOperationException}, which is the interim answer some of Occurrent's own storages give
+     * until a sibling change teaches them the real comparison.
+     * <p>
+     * This is a declaration rather than a question put to the storage, the same reason
+     * {@link #preservesCheckpointType(Checkpoint)} is one: it is a property of what the storage was built to do, and
+     * nothing on {@code CheckpointStorage} reports it back.
+     */
+    default boolean evaluatesWriteConditions() {
+        return true;
+    }
+
+    /**
      * Checkpoint types of the implementation's own, round-tripped in addition to the two the suite always covers.
      * <p>
      * The suite covers {@code StringBasedCheckpoint} and {@code GlobalCheckpoint} for every storage, because both live

--- a/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/NoopCheckpointStorage.java
+++ b/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/NoopCheckpointStorage.java
@@ -17,7 +17,10 @@
 package org.occurrent.tck.subscription.blocking;
 
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
+
+import java.util.OptionalLong;
 
 /**
  * A checkpoint storage that honours none of the contract. Run a suite against it and every single test must fail.
@@ -42,7 +45,12 @@ class NoopCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
+        throw new UnsupportedOperationException("NoopCheckpointStorage implements nothing on purpose");
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
         throw new UnsupportedOperationException("NoopCheckpointStorage implements nothing on purpose");
     }
 

--- a/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingCheckpointStorage.java
+++ b/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingCheckpointStorage.java
@@ -18,22 +18,26 @@ package org.occurrent.tck.subscription.blocking;
 
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalLong;
 
 /**
  * A checkpoint storage that honours the whole contract, so that {@link SuiteNeverSkipsTest} can run the suite green and
  * reach every line of it.
  * <p>
  * This is a copy of what {@code occurrent-subscription-inmemory} publishes, and it has to be, because that module runs
- * this suite and Maven refuses a dependency in both directions between two modules. A copy of nine lines is the cheaper
- * of the two, and it is only ever used to check the suite against itself.
+ * this suite and Maven refuses a dependency in both directions between two modules. A copy is the cheaper of the two,
+ * and it is only ever used to check the suite against itself.
  */
 class WorkingCheckpointStorage implements CheckpointStorage {
 
     private final Map<String, Checkpoint> checkpoints = new HashMap<>();
+    private final Map<String, Long> versions = new HashMap<>();
 
     @Override
     public @Nullable Checkpoint read(String subscriptionId) {
@@ -41,14 +45,38 @@ class WorkingCheckpointStorage implements CheckpointStorage {
     }
 
     @Override
-    public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
-        checkpoints.put(subscriptionId, checkpoint);
+    public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
+        if (condition instanceof CheckpointWriteCondition.NotOlderThan notOlderThan) {
+            Long stored = versions.get(subscriptionId);
+            if (stored != null && stored > notOlderThan.writeVersion()) {
+                throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, OptionalLong.of(stored), condition);
+            }
+            checkpoints.put(subscriptionId, checkpoint);
+            versions.put(subscriptionId, notOlderThan.writeVersion());
+        } else if (condition instanceof CheckpointWriteCondition.IfAbsent) {
+            if (checkpoints.containsKey(subscriptionId)) {
+                Long stored = versions.get(subscriptionId);
+                OptionalLong storedVersion = stored == null ? OptionalLong.empty() : OptionalLong.of(stored);
+                throw new CheckpointWriteConditionNotFulfilledException(subscriptionId, storedVersion, condition);
+            }
+            checkpoints.put(subscriptionId, checkpoint);
+        } else {
+            // CheckpointWriteCondition.Any: the stored version, if any, is carried forward untouched.
+            checkpoints.put(subscriptionId, checkpoint);
+        }
         return checkpoint;
+    }
+
+    @Override
+    public OptionalLong writeVersion(String subscriptionId) {
+        Long stored = versions.get(subscriptionId);
+        return stored == null ? OptionalLong.empty() : OptionalLong.of(stored);
     }
 
     @Override
     public void delete(String subscriptionId) {
         checkpoints.remove(subscriptionId);
+        versions.remove(subscriptionId);
     }
 
     @Override

--- a/testing/junit-jupiter-blocking/src/test/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtensionTest.java
+++ b/testing/junit-jupiter-blocking/src/test/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtensionTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.Subscription;
 import org.occurrent.subscription.api.blocking.SubscriptionModelLifeCycle;
@@ -35,6 +36,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -508,7 +510,7 @@ class OccurrentSubscriptionsExtensionTest {
                 });
     }
 
-    // CheckpointStorage has four methods, so this cannot be a lambda. Only delete is exercised here, and the rest
+    // CheckpointStorage has five methods, so this cannot be a lambda. Only delete is exercised here, and the rest
     // throw rather than returning a default, so a future change that starts calling them says so.
     private record RecordingCheckpointStorage(List<String> deleted, String prefix) implements CheckpointStorage {
 
@@ -522,8 +524,13 @@ class OccurrentSubscriptionsExtensionTest {
         }
 
         @Override
-        public Checkpoint save(String subscriptionId, Checkpoint checkpoint) {
+        public Checkpoint save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
             throw new UnsupportedOperationException("save");
+        }
+
+        @Override
+        public OptionalLong writeVersion(String subscriptionId) {
+            throw new UnsupportedOperationException("writeVersion");
         }
 
         @Override

--- a/testing/junit-jupiter-reactor/src/test/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtensionTest.java
+++ b/testing/junit-jupiter-reactor/src/test/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtensionTest.java
@@ -21,6 +21,7 @@ import io.cloudevents.core.v1.CloudEventBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.api.reactor.Subscription;
 import org.occurrent.subscription.api.reactor.SubscriptionModelLifeCycle;
@@ -472,7 +473,7 @@ class OccurrentSubscriptionsExtensionTest {
                 });
     }
 
-    // CheckpointStorage has three methods, so this cannot be a lambda. Only delete is exercised here, and the rest
+    // CheckpointStorage has four methods, so this cannot be a lambda. Only delete is exercised here, and the rest
     // throw rather than returning a default, so a future change that starts calling them says so.
     private record RecordingCheckpointStorage(List<String> deleted, String prefix) implements CheckpointStorage {
 
@@ -486,8 +487,13 @@ class OccurrentSubscriptionsExtensionTest {
         }
 
         @Override
-        public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint) {
+        public Mono<Checkpoint> save(String subscriptionId, Checkpoint checkpoint, CheckpointWriteCondition condition) {
             throw new UnsupportedOperationException("save");
+        }
+
+        @Override
+        public Mono<Long> writeVersion(String subscriptionId) {
+            throw new UnsupportedOperationException("writeVersion");
         }
 
         @Override


### PR DESCRIPTION
I added the checkpoint write-condition foundation ADR 116 designs for the checkpoint fence (part of the ccfence epic).

`CheckpointWriteCondition` (sealed: `any()`, `notOlderThan(long)`, `ifAbsent()`) and `CheckpointWriteConditionNotFulfilledException` (extends `IllegalStateException`, not the ADR 106 argument-exception family) now live in `subscription/core`. Both `CheckpointStorage` interfaces (blocking and reactor) gain `save(id, checkpoint, condition)` as the abstract method plus `writeVersion(id)`, with the existing two-argument `save` staying as a default meaning `any()`, so no calling code changes.

`ifAbsent()` is a third case beyond what the ADR text itself lists (`any()`/`notOlderThan(v)`), maintainer-approved for this unit. It is accepted only when nothing is stored for a subscription id, refused otherwise, and it exists for a later fix that fixes a subscription's start position in place.

Every in-repo implementer now compiles and behaves honestly:

- Both in-memory storages (blocking and reactor) evaluate every condition for real. `any()` leaves the stored version untouched and carries it forward.
- `NativeMongoCheckpointStorage`, `SpringMongoCheckpointStorage`, `ReactorCheckpointStorage`, and `SpringRedisCheckpointStorage` interim-refuse anything but `any()` with `UnsupportedOperationException` (`Mono.error` on the reactor stack) and answer `writeVersion` empty. A sibling unit replaces this with the real comparison before the release.
- TCK: `CheckpointStorageFixture` gains `evaluatesWriteConditions()`, default `true` (ADR 107 sanctions a default fixture member in a minor). `CheckpointStorageConformance` gets a new `WriteConditions` nested class asserting real conditional behavior on the true branch and the documented refusal on the false branch. The Mongo and Redis conformance tests override the fixture to `false`. `NoopCheckpointStorage` throws from both new members, `WorkingCheckpointStorage` implements them correctly, so the anti-skip guards keep working.
- Every other test double (`ManualStartSubscriptionModelTest`, the two `OccurrentSubscriptionsExtensionTest`s, five reactor autoconfigure tests, `ReactorDurableSubscriptionModelTest`, `SpringMongoCheckpointStorageTest`) now implements the three-argument `save` and `writeVersion`.

I checked the ~7 `mock(CheckpointStorage.class)` sites in `framework/spring-boot-autoconfigure/blocking` tests. Nothing in this change calls `writeVersion` at runtime, so none of them needed stubbing, and the blocking autoconfigure test suite passes unstubbed.

I also added `doc/migration/upgrading-to-0.33.0.md` and a changelog entry under Breaking changes.

Refs #665

## Out of scope (sibling units)

`rewrite/`, real Mongo/Redis conditional writes, `CheckpointWriteVersionSource` and subscription-model changes, retry-predicate exclusions, starter wiring beyond compiling, `ManualStartSubscriptionModel.pinStartPosition`, ADR edits.
