### PR TITLE
Prove the checkpoint fence rejects a stale node's write end to end

### DIFF
--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/CompetingConsumerFencingSagaEndToEndMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/CompetingConsumerFencingSagaEndToEndMongoTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.springboot.mongo.blocking.SagaAnnotationMongoTest.OrderPlaced;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoCheckpointStorage;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoLeaseCompetingConsumerStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
+import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Scenario 4 of the checkpoint fence's end-to-end proof (ADR 116, #665): the registrar-driven starter path. The
+ * fence is wired by hand everywhere else this epic tests it. The starter reaches it differently, through
+ * {@code SagaAnnotationRegistrar} (and {@code ProjectionAnnotationRegistrar}) pulling {@code CheckpointStorage} and
+ * {@code CompetingConsumerStrategy} out of the application context and building a
+ * {@code CatchupThenPushSubscriptionModel} itself, per subscription, at registration time. A wiring site missed
+ * there writes {@code any()} silently and nothing but a real subscription running through it would catch that, which
+ * is why hand-wired coverage elsewhere in this epic does not stand in for this test.
+ * <p>
+ * Reuses {@link SagaAnnotationMongoTest}'s application and domain. Its saga registers a real, competing-consumer
+ * gated event subscription named {@code order-fulfillment}, confirmed by that class's own
+ * {@code gates_the_timer_poller_with_a_lease_keyed_apart_from_the_event_subscription} test. Only one strategy bean
+ * is in the context (the starter's own {@code occurrentCompetingConsumerStrategy}), so
+ * {@code CompetingConsumerFencingWiringTest}'s "which bean wins" question does not apply here. This test is about
+ * whether the wiring that bean reaches actually produces a fenced write against a real MongoDB, not about bean
+ * resolution.
+ */
+@DisplayName("Checkpoint fence through the starter's saga registrar (ADR 116, #665)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(
+        classes = SagaAnnotationMongoTest.SagaApplication.class,
+        properties = {
+                "occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:saga-annotation-test",
+                "occurrent.saga.timer-poll-interval=150ms"
+        }
+)
+@Import(SagaAnnotationMongoTest.MongoDbContainerConfiguration.class)
+@Testcontainers
+@Timeout(60)
+class CompetingConsumerFencingSagaEndToEndMongoTest {
+
+    private static final String SUBSCRIPTION_ID = "order-fulfillment";
+    private static final String CHECKPOINT_COLLECTION = "subscriptions";
+    private static final String LOCKS_COLLECTION = "competing-consumer-locks";
+
+    @Autowired
+    private ApplicationService<SagaAnnotationMongoTest.OrderEvent> applicationService;
+    @Autowired
+    private MongoOperations mongoOperations;
+    @Autowired
+    private SpringMongoLeaseCompetingConsumerStrategy appStrategy;
+
+    @Test
+    void a_registrar_driven_checkpoint_write_is_stamped_with_a_real_token_and_refused_for_a_stale_holder() {
+        // Given
+        // The saga's registrar-driven subscription is live and has already checkpointed at least once, from an
+        // event this test publishes itself rather than trusting startup timing.
+        applicationService.execute("scenario4-seed", events -> List.of(new OrderPlaced("scenario4-seed")));
+        await("the registrar-driven subscription checkpoints the seed event").atMost(ofSeconds(30))
+                .untilAsserted(() -> assertThat(appStrategy.fencingToken(SUBSCRIPTION_ID)).isPresent());
+
+        OptionalLong appToken = appStrategy.fencingToken(SUBSCRIPTION_ID);
+        SpringMongoCheckpointStorage checkpointStorage = new SpringMongoCheckpointStorage(mongoOperations, CHECKPOINT_COLLECTION);
+        await("the checkpoint document itself is stamped with the app's real token, not left absent by a missed wiring site (any())").atMost(ofSeconds(30))
+                .untilAsserted(() -> assertThat(checkpointStorage.writeVersion(SUBSCRIPTION_ID)).isEqualTo(appToken));
+
+        // When
+        // A rival steals the subscription's lease, out of band, the same way the sibling tests in this epic do
+        // (direct write, ADR 114's database clock, no waiting on any scheduled refresh).
+        mongoOperations.getCollection(LOCKS_COLLECTION).updateOne(eq("_id", SUBSCRIPTION_ID), set("expiresAt", Instant.now().minusSeconds(2)));
+        SpringMongoLeaseCompetingConsumerStrategy rivalStrategy = new SpringMongoLeaseCompetingConsumerStrategy.Builder(mongoOperations).collectionName(LOCKS_COLLECTION).build();
+        try {
+            assertThat(rivalStrategy.registerCompetingConsumer(SUBSCRIPTION_ID, "rival-" + UUID.randomUUID())).isTrue();
+            OptionalLong rivalToken = rivalStrategy.fencingToken(SUBSCRIPTION_ID);
+            assertThat(rivalToken).isPresent();
+            assertThat(rivalToken.getAsLong()).as("a genuine takeover raises the fencing token").isGreaterThan(appToken.getAsLong());
+
+            // The rival's own write, standing in for another node's redelivery landing first. This test's own
+            // subject is the registrar wiring, not the race, and CheckpointFenceLeaseTransferTest already proves the
+            // race outcome through live delivery.
+            Checkpoint currentCheckpoint = requireNonNull(checkpointStorage.read(SUBSCRIPTION_ID));
+            checkpointStorage.save(SUBSCRIPTION_ID, currentCheckpoint, CheckpointWriteCondition.notOlderThan(rivalToken.getAsLong()));
+
+            // Then
+            // The app's own, still-live registrar-driven subscription attempts a write under its stale token when
+            // the next event arrives, and that write is refused. The stored version must stay at the rival's and
+            // never revert to the app's stale one, even once the app has had time to try.
+            applicationService.execute("scenario4-after-steal", events -> List.of(new OrderPlaced("scenario4-after-steal")));
+            await("the stored checkpoint never regresses to the app's stale token").during(ofSeconds(5)).atMost(ofSeconds(30))
+                    .untilAsserted(() -> assertThat(checkpointStorage.writeVersion(SUBSCRIPTION_ID)).isEqualTo(rivalToken));
+        } finally {
+            rivalStrategy.shutdown();
+        }
+    }
+}

--- a/subscription/util/blocking/competing-consumer-subscription/pom.xml
+++ b/subscription/util/blocking/competing-consumer-subscription/pom.xml
@@ -87,6 +87,33 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- The native stack, test-only: scenario 3 of the checkpoint-fence end-to-end proof (#665) reverts
+             NativeMongoSubscriptionModel's retry exclusion locally to prove the mutation, so it needs the native
+             models rather than the Spring ones every other test here uses. -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-mongodb-native-blocking</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-mongodb-native-blocking-competing-consumer-strategy</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-mongodb-native-blocking-checkpoint-storage</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-eventstore-mongodb-native</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CheckpointFenceIsolatesOtherSubscriptionsTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CheckpointFenceIsolatesOtherSubscriptionsTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.competingconsumers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.mongodb.nativedriver.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.nativedriver.MongoEventStore;
+import org.occurrent.filter.Filter;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StreamSubscriptionFilter;
+import org.occurrent.subscription.blocking.durable.DurableSubscriptionModel;
+import org.occurrent.subscription.internal.ExecutorShutdown;
+import org.occurrent.subscription.mongodb.nativedriver.blocking.HoldableNativeMongoCheckpointStorage;
+import org.occurrent.subscription.mongodb.nativedriver.blocking.NativeMongoCheckpointStorage;
+import org.occurrent.subscription.mongodb.nativedriver.blocking.NativeMongoLeaseCompetingConsumerStrategy;
+import org.occurrent.subscription.mongodb.nativedriver.blocking.NativeMongoSubscriptionModel;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.occurrent.functional.CheckedFunction.unchecked;
+import static org.occurrent.time.TimeConversion.toLocalDateTime;
+
+/**
+ * Scenario 3 of the checkpoint fence's end-to-end proof (ADR 116, #665): "the hard rule" from the ADR's
+ * Consequences section, checked against a live node rather than trusted. Two subscriptions share one
+ * {@link CompetingConsumerSubscriptionModel} and one {@link NativeMongoLeaseCompetingConsumerStrategy}, standing in
+ * for one node. One of them has its lease stolen and its checkpoint write refused. The other must keep delivering
+ * and its lease must keep refreshing, undisturbed, because a refusal thrown on a delivery thread must never reach
+ * the lease refresh thread that serves both.
+ * <p>
+ * This is the native stack, not the Spring one the sibling {@link CheckpointFenceLeaseTransferTest} uses, because
+ * this scenario's mutation proof reverts {@code NativeMongoSubscriptionModel}'s retry exclusion specifically.
+ */
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Timeout(180)
+class CheckpointFenceIsolatesOtherSubscriptionsTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CheckpointFenceIsolatesOtherSubscriptionsTest.class);
+    // Shorter than the sibling test's 30 seconds, unlike it, because this scenario's assertion needs healthySub's
+    // lease to actually cycle a few times inside the await budgets below. Not shorter than this, because node's own
+    // scheduled refresh (every LEASE_TIME/2, unsynchronized with anything this test does) has to stay comfortably
+    // behind the test's own steal-and-arm sequence, which runs in low tens of milliseconds. A shorter lease made
+    // that a real race, not a hoped-for one. Refresh sometimes noticed refusedSub's stolen lease and paused it
+    // before this test ever got to write the event the hold is armed for, which is a different, uninteresting
+    // failure to what this test is about. Generous await budgets on top (not tight ones, which is what flaked a
+    // low-lease-time Awaitility test elsewhere this week) absorb CI's own slowness rather than a tight timeout
+    // doing that job.
+    private static final Duration LEASE_TIME = Duration.ofSeconds(6);
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @RegisterExtension
+    OccurrentMongoFlush flushMongoDBExtension = OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer));
+
+    private MongoClient mongoClient;
+    private MongoDatabase database;
+    private MongoEventStore eventStore;
+    private ObjectMapper objectMapper;
+    private ExecutorService dispatcherNode;
+    private ExecutorService dispatcherRival;
+    private CompetingConsumerSubscriptionModel node;
+    private CompetingConsumerSubscriptionModel rival;
+    private String locksCollection;
+    private String checkpointCollectionName;
+
+    @BeforeEach
+    void create_mongo_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events");
+        mongoClient = MongoClients.create(connectionString);
+        database = mongoClient.getDatabase(requireNonNull(connectionString.getDatabase()));
+        TimeRepresentation timeRepresentation = TimeRepresentation.RFC_3339_STRING;
+        eventStore = new MongoEventStore(mongoClient, requireNonNull(connectionString.getDatabase()), requireNonNull(connectionString.getCollection()), new EventStoreConfig(timeRepresentation));
+        objectMapper = new ObjectMapper();
+        // Tolerant of exactly the refusal this test provokes on purpose: ADR 116 has it reach "an executor's
+        // uncaught handler" once logged, on refusedSub's dispatcher thread, and Awaitility otherwise catches any
+        // thread's uncaught exception and rethrows it into whichever await() is polling at the time, turning this
+        // test's own expected, provoked escape into a spurious failure (same reasoning and same fix as
+        // NativeMongoSubscriptionModelResilienceTest's CheckpointWriteRefusalTest).
+        dispatcherNode = Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setUncaughtExceptionHandler((t, throwable) -> {
+                if (!(throwable instanceof org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException)) {
+                    throw new AssertionError("Unexpected uncaught exception on subscription dispatcher thread " + t, throwable);
+                }
+            });
+            return thread;
+        });
+        dispatcherRival = Executors.newCachedThreadPool();
+        locksCollection = "competing-consumer-locks-" + UUID.randomUUID();
+        checkpointCollectionName = "checkpoints-" + UUID.randomUUID();
+    }
+
+    @AfterEach
+    void shutdown() {
+        if (node != null) {
+            node.shutdown();
+        }
+        if (rival != null) {
+            rival.shutdown();
+        }
+        ExecutorShutdown.shutdownSafely(dispatcherNode, 5, TimeUnit.SECONDS);
+        ExecutorShutdown.shutdownSafely(dispatcherRival, 5, TimeUnit.SECONDS);
+        mongoClient.close();
+    }
+
+    @Test
+    void a_refused_write_on_one_subscription_never_stops_lease_refresh_or_delivery_for_another_on_the_same_node() {
+        // Given
+        // One node running two subscriptions, refusedSub and healthySub, sharing one strategy and one checkpoint
+        // storage, the way two subscriptions on one process genuinely do.
+        String refusedSub = "refused-" + UUID.randomUUID();
+        String healthySub = "healthy-" + UUID.randomUUID();
+        String refusedStream = UUID.randomUUID().toString();
+        String healthyStream = UUID.randomUUID().toString();
+        String nodeSubscriberId = "node-subscriber";
+        CopyOnWriteArrayList<CloudEvent> refusedEvents = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<CloudEvent> healthyEvents = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<CloudEvent> rivalEvents = new CopyOnWriteArrayList<>();
+        // Counts invocations for the one event whose checkpoint write is refused, so this test also proves the
+        // mutation ADR 116 names outright. Excluding the refusal from retry is what keeps the node from re-running
+        // this action's side effects forever, which is scenario 3's mutation target
+        // (NativeMongoSubscriptionModel.RETRYABLE).
+        java.util.concurrent.atomic.AtomicInteger targetRefusedInvocations = new java.util.concurrent.atomic.AtomicInteger();
+
+        HoldableNativeMongoCheckpointStorage checkpointStorageNode = new HoldableNativeMongoCheckpointStorage(database.getCollection(checkpointCollectionName));
+        NativeMongoCheckpointStorage checkpointStorageRival = new NativeMongoCheckpointStorage(database, checkpointCollectionName);
+        NativeMongoLeaseCompetingConsumerStrategy strategyNode = new NativeMongoLeaseCompetingConsumerStrategy.Builder(database, locksCollection).leaseTime(LEASE_TIME).build();
+        NativeMongoLeaseCompetingConsumerStrategy strategyRival = new NativeMongoLeaseCompetingConsumerStrategy.Builder(database, locksCollection).leaseTime(LEASE_TIME).build();
+
+        DurableSubscriptionModel durableNode = new DurableSubscriptionModel(nativeModel(dispatcherNode), checkpointStorageNode, strategyNode::fencingToken);
+        DurableSubscriptionModel durableRival = new DurableSubscriptionModel(nativeModel(dispatcherRival), checkpointStorageRival, strategyRival::fencingToken);
+        node = new CompetingConsumerSubscriptionModel(durableNode, strategyNode);
+        rival = new CompetingConsumerSubscriptionModel(durableRival, strategyRival);
+
+        // Each filtered to its own stream. The native model applies no filter at all when none is given, so without
+        // this both subscriptions would see every event either one publishes.
+        node.subscribe(nodeSubscriberId, refusedSub, StreamSubscriptionFilter.filter(Filter.streamId(refusedStream)), org.occurrent.subscription.StartAt.subscriptionModelDefault(), event -> {
+            if (event.getId().equals("target-refused")) {
+                targetRefusedInvocations.incrementAndGet();
+            }
+            refusedEvents.add(event);
+        }).waitUntilStarted();
+        node.subscribe(nodeSubscriberId, healthySub, StreamSubscriptionFilter.filter(Filter.streamId(healthyStream)), org.occurrent.subscription.StartAt.subscriptionModelDefault(), healthyEvents::add).waitUntilStarted();
+
+        NameDefined seedRefused = new NameDefined("seed-refused", LocalDateTime.of(2026, 1, 1, 0, 0), "name", "seed");
+        NameDefined seedHealthy = new NameDefined("seed-healthy", LocalDateTime.of(2026, 1, 1, 0, 0), "name", "seed");
+        eventStore.write(refusedStream, serialize(seedRefused));
+        eventStore.write(healthyStream, serialize(seedHealthy));
+        await("both subscriptions deliver their seed event, so their tracked change-stream position concretizes before the failure scenario runs").atMost(10, SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(refusedEvents).hasSize(1);
+                    assertThat(healthyEvents).hasSize(1);
+                });
+        // The action running is not the same as the checkpoint save completing: DurableSubscriptionModel calls the
+        // action first and only then saves, on the same thread but not atomically with the assertion above. Waiting
+        // for the save too, not only the action, is what keeps the hold armed below from catching the seed event's
+        // own (still in-flight) write instead of the target event's.
+        await("the seed checkpoint save itself has completed, not only the action that precedes it").atMost(10, SECONDS)
+                .untilAsserted(() -> assertThat(checkpointStorageNode.writeVersion(refusedSub)).isPresent());
+
+        // When
+        // RefusedSub's lease is stolen by a rival, the same way CheckpointFenceLeaseTransferTest steals one, while
+        // healthySub is never contested by anybody.
+        expireLeaseFor(refusedSub);
+        rival.subscribe("rival-subscriber", refusedSub, StreamSubscriptionFilter.filter(Filter.streamId(refusedStream)), org.occurrent.subscription.StartAt.subscriptionModelDefault(), rivalEvents::add).waitUntilStarted();
+
+        // A new event on refusedSub reaches both node (still unaware) and rival. Node's write is held so rival's
+        // write, offering the higher token, is guaranteed to land first.
+        checkpointStorageNode.armHold(refusedSub);
+        NameWasChanged targetRefused = new NameWasChanged("target-refused", LocalDateTime.of(2026, 1, 1, 0, 0, 1), "name", "changed while node was stale");
+        eventStore.write(refusedStream, serialize(targetRefused));
+        checkpointStorageNode.awaitHeldWriteArrived();
+        await("rival redelivers/delivers the event under its own, higher token").atMost(10, SECONDS)
+                .untilAsserted(() -> assertThat(rivalEvents).extracting(CloudEvent::getId).contains(targetRefused.eventId()));
+        OptionalLong rivalToken = strategyRival.fencingToken(refusedSub);
+        assertThat(rivalToken).isPresent();
+        await("rival's write lands and is stamped with rival's token").atMost(10, SECONDS)
+                .untilAsserted(() -> assertThat(checkpointStorageRival.writeVersion(refusedSub)).isEqualTo(rivalToken));
+        // Node's held write is released. It is now guaranteed to be refused, since the stored version already
+        // exceeds the stale token node is still offering.
+        checkpointStorageNode.release();
+
+        // The mutation target. The refusal must never be retried, so the action that threw it runs exactly once.
+        // A reverted exclusion retries it forever instead, re-running this action's side effects every backoff
+        // interval, which during() catches even though a single poll could land between retries and miss it.
+        await("the refused action is invoked exactly once, never retried").atMost(15, SECONDS)
+                .untilAsserted(() -> assertThat(targetRefusedInvocations.get()).isEqualTo(1));
+        await("and stays exactly once well past what a retry backoff would allow").during(3, SECONDS).atMost(10, SECONDS)
+                .untilAsserted(() -> assertThat(targetRefusedInvocations.get()).isEqualTo(1));
+
+        // Then
+        // The hard rule. HealthySub is never affected. It keeps delivering, and a sniper that spends the same
+        // window trying to steal it must never succeed, which is the strongest available proof that its lease kept
+        // refreshing rather than merely that nobody happened to look at the wrong moment.
+        NameWasChanged healthyFollowUp = new NameWasChanged("healthy-follow-up", LocalDateTime.of(2026, 1, 1, 0, 0, 1), "name", "still healthy");
+        eventStore.write(healthyStream, serialize(healthyFollowUp));
+        await("healthySub keeps delivering, unaffected by refusedSub's refusal").atMost(15, SECONDS)
+                .untilAsserted(() -> assertThat(healthyEvents).extracting(CloudEvent::getId).contains(healthyFollowUp.eventId()));
+
+        NativeMongoLeaseCompetingConsumerStrategy sniperStrategy = new NativeMongoLeaseCompetingConsumerStrategy.Builder(database, locksCollection).leaseTime(LEASE_TIME).build();
+        try {
+            // Spans several lease periods (LEASE_TIME=6s, refreshed every 3s, window=15s is 4-5 cycles), generous
+            // atMost so CI slowness fails loud rather than flaking, during() so it re-checks continuously rather
+            // than trusting one truthy poll (pollDelay().atMost() would pass on the first sniper attempt regardless
+            // of what happens for the rest of the window).
+            await("healthySub's lease never expires long enough for a sniper to take it, across several lease periods")
+                    .atMost(30, SECONDS).during(15, SECONDS)
+                    .untilAsserted(() -> assertThat(sniperStrategy.registerCompetingConsumer(healthySub, "sniper")).isFalse());
+        } finally {
+            sniperStrategy.shutdown();
+        }
+
+        assertThat(node.isRunning(healthySub)).as("healthySub must still be the node's own, undisturbed").isTrue();
+
+        // The ADR's other requirement on the refused side is that the subscription stays known and pausable rather
+        // than forgotten, so the strategy's own refresh (which detects the loss independently of any of the above)
+        // can pause it within a couple of lease periods once it notices.
+        await("refusedSub becomes known-paused once the strategy's refresh notices the lease is gone").atMost(20, SECONDS)
+                .untilAsserted(() -> assertThat(node.isPaused(refusedSub)).isTrue());
+    }
+
+    /**
+     * Writes {@code expiresAt} on the subscription's lock document directly, so it looks expired to the database's
+     * own clock (ADR 114), without moving anything or waiting on anyone's scheduled refresh in this process. Same
+     * technique {@code MongoLeaseRaceTest} uses.
+     */
+    private void expireLeaseFor(String subscriptionId) {
+        database.getCollection(locksCollection).updateOne(eq("_id", subscriptionId), set("expiresAt", Instant.now().minusSeconds(2)));
+    }
+
+    private NativeMongoSubscriptionModel nativeModel(ExecutorService dispatcher) {
+        return new NativeMongoSubscriptionModel(database, requireNonNull(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events").getCollection()), TimeRepresentation.RFC_3339_STRING, dispatcher);
+    }
+
+    private List<CloudEvent> serialize(DomainEvent e) {
+        return List.of(CloudEventBuilder.v1()
+                .withId(e.eventId())
+                .withSource(URI.create("http://name"))
+                .withType(e.getClass().getName())
+                .withTime(toLocalDateTime(e.timestamp()).atOffset(UTC))
+                .withSubject(e.name())
+                .withDataContentType("application/json")
+                .withData(unchecked(objectMapper::writeValueAsBytes).apply(e))
+                .build());
+    }
+}

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CheckpointFenceLeaseTransferTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CheckpointFenceLeaseTransferTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.blocking.competingconsumers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.domain.DomainEvent;
+import org.occurrent.domain.NameDefined;
+import org.occurrent.domain.NameWasChanged;
+import org.occurrent.eventstore.api.blocking.EventStore;
+import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
+import org.occurrent.subscription.blocking.durable.DurableSubscriptionModel;
+import org.occurrent.subscription.mongodb.spring.blocking.HoldableSpringMongoCheckpointStorage;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoCheckpointStorage;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoLeaseCompetingConsumerStrategy;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
+import static org.occurrent.functional.CheckedFunction.unchecked;
+import static org.occurrent.time.TimeConversion.toLocalDateTime;
+
+/**
+ * The checkpoint fence (ADR 116, #665) proved end to end over a real MongoDB replica set, as one system. A real
+ * {@link SpringMongoLeaseCompetingConsumerStrategy} lease, a real fencing token, a real
+ * {@link CompetingConsumerSubscriptionModel} wiring {@code strategy::fencingToken} into a real
+ * {@link DurableSubscriptionModel}, and a real conditional write against a real
+ * {@link org.occurrent.subscription.api.blocking.CheckpointStorage}. Two "nodes" are two model-and-strategy stacks
+ * against one Mongo container in this one JVM, the pattern {@code CompetingConsumerSubscriptionModelTest} and
+ * {@code MongoLeaseRaceTest} both use.
+ * <p>
+ * Covers the first two scenarios of the epic's end-to-end proof. The first is an expired-lease takeover, where the
+ * old holder is still delivering and has to be refused rather than trusted to notice. The second is a graceful
+ * handover, where the old holder gives its lease up on purpose.
+ * <p>
+ * Scenario 3 lives in {@link CheckpointFenceIsolatesOtherSubscriptionsTest}, in its own class because it needs the
+ * native stack this module normally has no reason to depend on, and its mutation proof reverts
+ * {@code NativeMongoSubscriptionModel}'s retry exclusion. Scenario 4, the Spring Boot starter's registrar-driven
+ * wiring, lives in {@code framework/spring-boot-starter-mongodb} because it needs a Spring application context.
+ */
+@Testcontainers
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CheckpointFenceLeaseTransferTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CheckpointFenceLeaseTransferTest.class);
+    // Large enough that neither strategy's own scheduled refresh fires within a test's lifetime, so every state
+    // change here is caused by the direct Mongo writes and explicit calls below, not a background race with the
+    // refresh thread. That background behavior is scenario 3's subject, not this one's.
+    private static final Duration LEASE_TIME = Duration.ofSeconds(30);
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @RegisterExtension
+    OccurrentMongoFlush flushMongoDBExtension = OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer));
+
+    private EventStore eventStore;
+    private MongoTemplate mongoTemplate;
+    private ObjectMapper objectMapper;
+    private String streamId;
+    private String locksCollection;
+    private String checkpointCollection;
+
+    private CompetingConsumerSubscriptionModel nodeA;
+    private CompetingConsumerSubscriptionModel nodeB;
+    private SpringMongoLeaseCompetingConsumerStrategy strategyA;
+    private SpringMongoLeaseCompetingConsumerStrategy strategyB;
+
+    @BeforeEach
+    void create_mongo_event_store() {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events");
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        mongoTemplate = new MongoTemplate(mongoClient, requireNonNull(connectionString.getDatabase()));
+        MongoTransactionManager mongoTransactionManager = new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(mongoClient, requireNonNull(connectionString.getDatabase())));
+        TimeRepresentation timeRepresentation = TimeRepresentation.RFC_3339_STRING;
+        EventStoreConfig eventStoreConfig = new EventStoreConfig.Builder().eventStoreCollectionName(connectionString.getCollection()).transactionConfig(mongoTransactionManager).timeRepresentation(timeRepresentation).build();
+        eventStore = new SpringMongoEventStore(mongoTemplate, eventStoreConfig);
+        objectMapper = new ObjectMapper();
+        streamId = UUID.randomUUID().toString();
+        // Collections of their own per test, the same isolation CompetingConsumerSubscriptionModelFixture uses. A
+        // leftover lease or checkpoint from one test must never answer for another's subscription id.
+        locksCollection = "competing-consumer-locks-" + UUID.randomUUID();
+        checkpointCollection = "checkpoints-" + UUID.randomUUID();
+    }
+
+    @AfterEach
+    void shutdown() {
+        if (nodeA != null) {
+            nodeA.shutdown();
+        }
+        if (nodeB != null) {
+            nodeB.shutdown();
+        }
+    }
+
+    @Test
+    void expired_lease_takeover_refuses_the_stale_holders_write_and_the_new_holder_redelivers() {
+        // Given
+        // Node A wins the (uncontested) lease and delivers a seed event, so its tracked change-stream position
+        // concretizes on a real delivery before the failure scenario runs (a resume or restart before that point
+        // would resolve to "now" and skip straight past the event this test is about).
+        CopyOnWriteArrayList<CloudEvent> eventsA = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<CloudEvent> eventsB = new CopyOnWriteArrayList<>();
+        String subscriptionId = UUID.randomUUID().toString();
+
+        HoldableSpringMongoCheckpointStorage checkpointStorageA = new HoldableSpringMongoCheckpointStorage(mongoTemplate, checkpointCollection);
+        SpringMongoCheckpointStorage checkpointStorageB = new SpringMongoCheckpointStorage(mongoTemplate, checkpointCollection);
+        strategyA = new SpringMongoLeaseCompetingConsumerStrategy.Builder(mongoTemplate).leaseTime(LEASE_TIME).collectionName(locksCollection).build();
+        strategyB = new SpringMongoLeaseCompetingConsumerStrategy.Builder(mongoTemplate).leaseTime(LEASE_TIME).collectionName(locksCollection).build();
+        DurableSubscriptionModel durableA = new DurableSubscriptionModel(springModel(), checkpointStorageA, strategyA::fencingToken);
+        DurableSubscriptionModel durableB = new DurableSubscriptionModel(springModel(), checkpointStorageB, strategyB::fencingToken);
+        nodeA = new CompetingConsumerSubscriptionModel(durableA, strategyA);
+        nodeB = new CompetingConsumerSubscriptionModel(durableB, strategyB);
+
+        nodeA.subscribe(subscriptionId, eventsA::add).waitUntilStarted();
+
+        NameDefined seed = new NameDefined("seed", LocalDateTime.of(2026, 1, 1, 0, 0), "name", "seed value");
+        eventStore.write(streamId, serialize(seed));
+        await("node A delivers the seed event").atMost(5, SECONDS).untilAsserted(() -> assertThat(eventsA).hasSize(1));
+
+        OptionalLong tokenA = strategyA.fencingToken(subscriptionId);
+        assertThat(tokenA).as("the fence must actually be active for this proof to mean anything, since a missed wiring site answers empty and stamps any()").isPresent();
+
+        // When
+        // A's lease expires on the database clock (ADR 114), out of band, so A never notices from inside its own
+        // process. Node B then takes the lease over. Registering while it looks expired to Mongo wins it
+        // synchronously, without waiting on anyone's scheduled refresh.
+        expireLeaseFor(subscriptionId);
+        nodeB.subscribe(subscriptionId, eventsB::add).waitUntilStarted();
+
+        OptionalLong tokenB = strategyB.fencingToken(subscriptionId);
+        assertThat(tokenB).isPresent();
+        assertThat(tokenB.getAsLong()).as("a genuine takeover raises the fencing token").isGreaterThan(tokenA.getAsLong());
+
+        // A new event now reaches both A's change stream, open all along and still unaware, and B's, freshly opened
+        // from the seed checkpoint. A's checkpoint write for it is held so B's write is guaranteed to land first,
+        // modeling the race ADR 116 names explicitly rather than hoping for one interleaving over the other.
+        checkpointStorageA.armHold();
+        NameWasChanged staleEvent = new NameWasChanged("stale-write", LocalDateTime.of(2026, 1, 1, 0, 0, 1), "name", "changed while A was stale");
+        eventStore.write(streamId, serialize(staleEvent));
+
+        checkpointStorageA.awaitHeldWriteArrived();
+        await("node B redelivers/delivers the event under its own, higher token").atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(eventsB).extracting(CloudEvent::getId).contains(staleEvent.eventId()));
+        await("B's checkpoint write lands and is stamped with B's token").atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(checkpointStorageB.writeVersion(subscriptionId)).isEqualTo(tokenB));
+
+        // Then
+        // A's held write is released. It is now guaranteed to be refused, since the stored version already exceeds
+        // the stale token A is still offering.
+        checkpointStorageA.release();
+
+        // The stored checkpoint never moves backward. It stays at B's version well past the moment A's refused
+        // write lands. during(), not a single poll, since a redelivered-back regression would show up between polls.
+        await("the stored checkpoint never regresses to A's stale token").during(2, SECONDS).atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(checkpointStorageB.writeVersion(subscriptionId)).isEqualTo(tokenB));
+
+        // At-least-once holds. Every event that was published was processed by somebody, none lost. A's own
+        // delivery of the stale event (its handler runs before the checkpoint write that later gets refused, ADR
+        // 116's "the event is not acknowledged" is about the position, not the handler) plus B's redelivery both
+        // count.
+        assertThat(Stream.concat(eventsA.stream(), eventsB.stream()).map(CloudEvent::getId).distinct())
+                .as("at-least-once, nothing published is missing from what somebody delivered")
+                .contains(seed.eventId(), staleEvent.eventId());
+    }
+
+    @Test
+    void graceful_handover_increments_the_version_and_refuses_a_late_write_from_the_old_token() {
+        // Given
+        // Node A wins the (uncontested) lease and delivers a seed event.
+        CopyOnWriteArrayList<CloudEvent> eventsA = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<CloudEvent> eventsB = new CopyOnWriteArrayList<>();
+        String subscriptionId = UUID.randomUUID().toString();
+
+        SpringMongoCheckpointStorage checkpointStorageA = new SpringMongoCheckpointStorage(mongoTemplate, checkpointCollection);
+        SpringMongoCheckpointStorage checkpointStorageB = new SpringMongoCheckpointStorage(mongoTemplate, checkpointCollection);
+        strategyA = new SpringMongoLeaseCompetingConsumerStrategy.Builder(mongoTemplate).leaseTime(LEASE_TIME).collectionName(locksCollection).build();
+        strategyB = new SpringMongoLeaseCompetingConsumerStrategy.Builder(mongoTemplate).leaseTime(LEASE_TIME).collectionName(locksCollection).build();
+        DurableSubscriptionModel durableA = new DurableSubscriptionModel(springModel(), checkpointStorageA, strategyA::fencingToken);
+        DurableSubscriptionModel durableB = new DurableSubscriptionModel(springModel(), checkpointStorageB, strategyB::fencingToken);
+        nodeA = new CompetingConsumerSubscriptionModel(durableA, strategyA);
+        nodeB = new CompetingConsumerSubscriptionModel(durableB, strategyB);
+
+        nodeA.subscribe(subscriptionId, eventsA::add).waitUntilStarted();
+
+        NameDefined seed = new NameDefined("seed", LocalDateTime.of(2026, 1, 1, 0, 0), "name", "seed value");
+        eventStore.write(streamId, serialize(seed));
+        await("node A delivers the seed event").atMost(5, SECONDS).untilAsserted(() -> assertThat(eventsA).hasSize(1));
+
+        OptionalLong tokenA = strategyA.fencingToken(subscriptionId);
+        assertThat(tokenA).isPresent();
+        // The write A's own model made for the seed event, kept so this test can play it back late, standing in for
+        // a write A's process had already issued before pausing that only reaches MongoDB afterwards.
+        Checkpoint staleCheckpoint = requireNonNull(checkpointStorageA.read(subscriptionId));
+
+        // When
+        // Node A pauses (a user pause unregisters, see CompetingConsumerSubscriptionModel.pauseSubscription), which
+        // releases the lease through the unset-not-delete path PR 672 put in place rather than deleting the lock
+        // document.
+        nodeA.pauseSubscription(subscriptionId);
+
+        Document lockDocumentAfterPause = requireNonNull(mongoTemplate.getCollection(locksCollection).find(eq("_id", subscriptionId)).first());
+        assertThat(lockDocumentAfterPause.containsKey("subscriberId"))
+                .as("released, not deleted, so subscriberId is unset rather than the document being gone")
+                .isFalse();
+        assertThat(lockDocumentAfterPause.get("version"))
+                .as("the version survives the release, which is what keeps it a fencing token rather than a counter that resets")
+                .isNotNull();
+
+        // Node B acquires the now-free lease and its write is accepted.
+        nodeB.subscribe(subscriptionId, eventsB::add).waitUntilStarted();
+        OptionalLong tokenB = strategyB.fencingToken(subscriptionId);
+        assertThat(tokenB).isPresent();
+        assertThat(tokenB.getAsLong()).as("a genuine handover raises the fencing token").isGreaterThan(tokenA.getAsLong());
+
+        NameWasChanged afterHandover = new NameWasChanged("after-handover", LocalDateTime.of(2026, 1, 1, 0, 0, 1), "name", "changed after handover");
+        eventStore.write(streamId, serialize(afterHandover));
+        await("node B delivers the event under its own, accepted token").atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(eventsB).extracting(CloudEvent::getId).contains(afterHandover.eventId()));
+        await("B's write is accepted and stamped with B's token").atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(checkpointStorageB.writeVersion(subscriptionId)).isEqualTo(tokenB));
+
+        // Then
+        // A late write still carrying A's old token, arriving after B has already moved the stored version forward,
+        // is refused.
+        Throwable lateWrite = catchThrowable(() -> checkpointStorageA.save(subscriptionId, staleCheckpoint, CheckpointWriteCondition.notOlderThan(tokenA.getAsLong())));
+        assertThat(lateWrite).isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
+
+        assertThat(checkpointStorageB.writeVersion(subscriptionId))
+                .as("the refused late write must not have moved the stored checkpoint backward")
+                .isEqualTo(tokenB);
+    }
+
+    /**
+     * Writes {@code expiresAt} on the subscription's lock document directly, so it looks expired to the database's
+     * own clock, which ADR 114 makes production code judge it against, without moving anything or waiting on
+     * anyone's scheduled refresh in this process. Same technique {@code MongoLeaseRaceTest} uses.
+     */
+    private void expireLeaseFor(String subscriptionId) {
+        mongoTemplate.getCollection(locksCollection).updateOne(eq("_id", subscriptionId), set("expiresAt", Instant.now().minusSeconds(2)));
+    }
+
+    private SpringMongoSubscriptionModel springModel() {
+        return new SpringMongoSubscriptionModel(mongoTemplate, requireNonNull(new ConnectionString(mongoDBContainer.getReplicaSetUrl() + ".events").getCollection()), TimeRepresentation.RFC_3339_STRING);
+    }
+
+    private List<CloudEvent> serialize(DomainEvent e) {
+        return List.of(CloudEventBuilder.v1()
+                .withId(e.eventId())
+                .withSource(URI.create("http://name"))
+                .withType(e.getClass().getName())
+                .withTime(toLocalDateTime(e.timestamp()).atOffset(UTC))
+                .withSubject(e.name())
+                .withDataContentType("application/json")
+                .withData(unchecked(objectMapper::writeValueAsBytes).apply(e))
+                .build());
+    }
+}

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/HoldableNativeMongoCheckpointStorage.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/mongodb/nativedriver/blocking/HoldableNativeMongoCheckpointStorage.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.nativedriver.blocking;
+
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.subscription.CheckpointWriteCondition;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link NativeMongoCheckpointStorage} whose next conditional write for one specific subscription id can be held
+ * open until a test releases it, through the package-private {@code persistConditionalCheckpointDocument} hook the
+ * production class already exposes for exactly this kind of interception. See
+ * {@code org.occurrent.subscription.mongodb.spring.blocking.HoldableSpringMongoCheckpointStorage}, its Spring
+ * twin, for the full rationale. This one filters by subscription id because one {@code CompetingConsumerStrategy}
+ * node here serves two subscriptions through a single shared storage, and holding indiscriminately would also hold
+ * the healthy subscription's own, unrelated writes.
+ */
+@NullMarked
+public class HoldableNativeMongoCheckpointStorage extends NativeMongoCheckpointStorage {
+
+    private static final java.time.Duration HOLD_TIMEOUT = java.time.Duration.ofSeconds(10);
+
+    private final AtomicReference<@org.jspecify.annotations.Nullable String> armedForSubscriptionId = new AtomicReference<>();
+    private final AtomicBoolean triggered = new AtomicBoolean(false);
+    private final CountDownLatch arrived = new CountDownLatch(1);
+    private final CountDownLatch released = new CountDownLatch(1);
+
+    public HoldableNativeMongoCheckpointStorage(MongoCollection<Document> checkpointCollection) {
+        super(checkpointCollection);
+    }
+
+    /**
+     * The next conditional write this storage attempts for {@code subscriptionId} blocks inside
+     * {@code persistConditionalCheckpointDocument} until {@link #release()} is called. Every other subscription id's
+     * write passes straight through, unheld. Single-shot, arm again only after releasing.
+     */
+    public void armHold(String subscriptionId) {
+        if (!armedForSubscriptionId.compareAndSet(null, subscriptionId)) {
+            throw new IllegalStateException("Already armed, this storage holds only one write at a time");
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the held write has arrived at the hold point, so a test can be sure a rival's
+     * own write is free to land first.
+     */
+    public void awaitHeldWriteArrived() {
+        awaitUninterruptibly(arrived, "The held write never arrived");
+    }
+
+    /**
+     * Releases the write {@link #armHold(String)} is holding, letting it proceed against MongoDB.
+     */
+    public void release() {
+        released.countDown();
+    }
+
+    @Override
+    Document persistConditionalCheckpointDocument(String subscriptionId, Document newCheckpointDocument, CheckpointWriteCondition condition) {
+        if (subscriptionId.equals(armedForSubscriptionId.get()) && triggered.compareAndSet(false, true)) {
+            arrived.countDown();
+            awaitUninterruptibly(released, "Held write was never released");
+        }
+        return super.persistConditionalCheckpointDocument(subscriptionId, newCheckpointDocument, condition);
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch, String timeoutMessage) {
+        try {
+            if (!latch.await(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException(timeoutMessage + " within " + HOLD_TIMEOUT);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/HoldableSpringMongoCheckpointStorage.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/HoldableSpringMongoCheckpointStorage.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.spring.blocking;
+
+import org.bson.Document;
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.springframework.data.mongodb.core.MongoOperations;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link SpringMongoCheckpointStorage} whose next conditional write can be held open until a test releases it,
+ * through the package-private {@code persistConditionalCheckpointDocument} hook the production class already
+ * exposes for exactly this kind of interception (see its javadoc: "so a test can inject a transient failure into
+ * it"). Deliberately placed in {@code SpringMongoCheckpointStorage}'s own package, a split package that exists only
+ * in test sources, rather than proxying the Mongo driver the way {@code MongoLeaseRaceTest} does. The write this
+ * holds is one {@code findOneAndUpdate}, and holding at the method the production class already isolates for
+ * testing is simpler than intercepting the driver call beneath it.
+ * <p>
+ * A stale node's checkpoint write and the node that took its lease over both reach this same document, and which
+ * one lands first decides whether the stale write is accepted or refused (ADR 116 names this window explicitly).
+ * {@link #armHold()} lets a test hold the stale node's write open until the rival's own write has landed, so an
+ * end-to-end test can assert the fence's outcome on a real race instead of hoping for one interleaving over another.
+ */
+@NullMarked
+public class HoldableSpringMongoCheckpointStorage extends SpringMongoCheckpointStorage {
+
+    private static final java.time.Duration HOLD_TIMEOUT = java.time.Duration.ofSeconds(10);
+
+    private final AtomicBoolean armed = new AtomicBoolean(false);
+    private final CountDownLatch arrived = new CountDownLatch(1);
+    private final CountDownLatch released = new CountDownLatch(1);
+
+    public HoldableSpringMongoCheckpointStorage(MongoOperations mongoOperations, String checkpointCollection) {
+        super(mongoOperations, checkpointCollection);
+    }
+
+    /**
+     * The next conditional write this storage attempts blocks inside {@code persistConditionalCheckpointDocument}
+     * until {@link #release()} is called. Single-shot, arm again only after releasing.
+     */
+    public void armHold() {
+        if (!armed.compareAndSet(false, true)) {
+            throw new IllegalStateException("Already armed, this storage holds only one write at a time");
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the held write has arrived at the hold point, so a test can be sure a rival's
+     * own write is free to land first.
+     */
+    public void awaitHeldWriteArrived() {
+        awaitUninterruptibly(arrived, "The held write never arrived");
+    }
+
+    /**
+     * Releases the write {@link #armHold()} is holding, letting it proceed against MongoDB.
+     */
+    public void release() {
+        released.countDown();
+    }
+
+    @Override
+    @NullMarked
+    Document persistConditionalCheckpointDocument(String subscriptionId, Document newCheckpointDocument, CheckpointWriteCondition condition) {
+        if (armed.compareAndSet(true, false)) {
+            arrived.countDown();
+            awaitUninterruptibly(released, "Held write was never released");
+        }
+        return super.persistConditionalCheckpointDocument(subscriptionId, newCheckpointDocument, condition);
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch, String timeoutMessage) {
+        try {
+            if (!latch.await(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException(timeoutMessage + " within " + HOLD_TIMEOUT);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
I added four end-to-end tests proving the checkpoint fence (ADR 116) works as one system over a real MongoDB replica set, closing #665.

- `CheckpointFenceLeaseTransferTest` covers an expired-lease takeover (the old holder is still delivering and gets refused) and a graceful handover (the old holder releases on purpose, and its stale write is refused after the new holder advances the version).
- `CheckpointFenceIsolatesOtherSubscriptionsTest` proves the hard rule from the ADR's Consequences section. One subscription's refused write never stops another subscription's lease refresh or delivery on the same node. I mutation-tested this by reverting `NativeMongoSubscriptionModel`'s retry exclusion locally, confirmed the test goes red (invocation count grows past 1 instead of staying at 1), and restored the file from a backup copy.
- `CompetingConsumerFencingSagaEndToEndMongoTest` (in the Spring Boot starter module) proves the registrar-driven wiring, not just the hand-wired path. The saga's real subscription stamps a real fencing token, and a stale write against it is refused, over a real Spring context and MongoDB.

To make the races deterministic instead of hoping for one interleaving, I added `HoldableSpringMongoCheckpointStorage` and `HoldableNativeMongoCheckpointStorage` (test-only, in the storage classes' own package) that hold a specific subscription's checkpoint write open through the package-private hook each storage already exposes for testing. Same "interleave on purpose" approach `MongoLeaseRaceTest` uses for the lease itself.

I added the native subscription stack as a test dependency to `subscription/util/blocking/competing-consumer-subscription`'s pom, since scenario 3's mutation proof needs `NativeMongoSubscriptionModel` specifically.

No production code changes. No changelog entry, since nothing here changes behavior.
