### PR TITLE
Document the identical-value edge on ifAbsent checkpoint writes

### DIFF
--- a/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteCondition.java
+++ b/subscription/core/src/main/java/org/occurrent/subscription/CheckpointWriteCondition.java
@@ -61,6 +61,10 @@ public sealed interface CheckpointWriteCondition {
      * <p>
      * This exists for a caller that wants to write a subscription's very first checkpoint, and only the very first
      * one, so it can fix the subscription's start position without racing another writer through {@link #any()}.
+     * <p>
+     * One edge is deliberately tolerated. A save offering exactly the value that is already stored may be reported
+     * as success rather than refused, since some storages tell the two outcomes apart by comparing values. The
+     * stored checkpoint is identical either way.
      *
      * @return A {@link CheckpointWriteCondition} with the behavior described above.
      */


### PR DESCRIPTION
I added one paragraph to the `ifAbsent()` javadoc naming the tolerated edge from #681. A save offering exactly the value already stored may be reported as success rather than refused, since some storages tell the two outcomes apart by comparing values, and the stored checkpoint is identical either way.

The maintainer decided against mechanizing exact detection after checking the AGENTS.md principles. There is no correctness gap (no divergence exists when the values are equal), and the fix would bind every checkpoint-storage implementer to a TCK case for a caller shape nobody has. The `returnDocument(BEFORE)` fix stays recorded on the issue if a real caller ever needs it.

Fixes #681
