### PR TITLE
Bring six ADRs back in line with shipped code

### DIFF
--- a/doc/architecture/decisions/0094-the-subscription-tck-declares-three-differences-and-waits-deterministically.md
+++ b/doc/architecture/decisions/0094-the-subscription-tck-declares-three-differences-and-waits-deterministically.md
@@ -136,6 +136,14 @@ the one `EventStoreFixture.timePrecision()` sits on: declare what cannot be aske
   **The lesson to carry: a declaration must not park a bug, reaching for the word bug before measuring what the fix
   costs is the other way to get this wrong, and a measured cost is what a decision is made against rather than an
   argument about which comment sounded more deliberate.**
+
+  **Amended 2026-08-09 by [ADR 117](0117-a-resumed-competing-consumer-continues-from-the-checkpoint.md).** This
+  bullet describes what the wrapped Mongo model itself does on resume, reopening from the change-stream position
+  it had already read. That is still true of the wrapped model in isolation, but a `DurableSubscriptionModel`
+  sitting above it now re-reads the stored checkpoint and repositions the wrapped model there first, whenever one
+  is stored and the model underneath can be repositioned. A regained lease resumes from the checkpoint another
+  node may have advanced while this node held no lease, not always from the position this node's own delegate
+  last read.
 - **Which `StartAt` variants a model accepts.** A sealed set of four, asserted as delivery for the accepted ones and
   refusal for the rest. This is phase 8's declared restriction mechanism, and it is where the per-wrapper deliberate
   refusals get asserted rather than rediscovered.

--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -115,6 +115,11 @@ No `static Optional<ReplayAwareMaterializedView> of(Object)` helper, unlike `Rep
 `IntrospectableSubscriptionModel`. Those exist to unwrap `DelegatingSubscriptionModel`. There is no delegating
 materialized view, so the helper would be ceremony around a bare `instanceof`.
 
+> **Amended on 2026-08-09 by [ADR 111](0111-a-projection-records-the-position-it-has-applied.md).** A
+> delegating materialized view now exists, the position recorder built there, and it wraps a view rather
+> than replacing it. It answers the `instanceof` probe itself and stays the outermost view, so it does not
+> bring the helper above back. A caller that wraps in the other order gets an unbatched replay.
+
 **3. The boundary is driven by whoever owns the replay, and every path that does not own one degrades to today's
 behaviour.** Internally, `BlockingHandover.Source` gains defaulted `replayStarted()`, `replayCompleted()` and
 `replayAbandoned()` methods, and `ReactiveHandover.Source` gains the same with `Mono<Void> replayCompleted()` so the
@@ -225,3 +230,7 @@ what makes `findAllById` useful at all.
 - The redundant per-event `subscribeOn(boundedElastic)` on the reactor fold bridge is worth removing while the replay
   path is open, since the handover pipeline already runs there. It is a separate change from batching and should be
   measured, not assumed.
+
+  > **Amended on 2026-08-08.** Measured in `ReactorProjectionHandoffBenchmark` (archrev B6, #639): the wrapping
+  > carries real load rather than being redundant, and it stays. The bullet above asked the right question, and
+  > removing it was the wrong answer.

--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -115,10 +115,12 @@ No `static Optional<ReplayAwareMaterializedView> of(Object)` helper, unlike `Rep
 `IntrospectableSubscriptionModel`. Those exist to unwrap `DelegatingSubscriptionModel`. There is no delegating
 materialized view, so the helper would be ceremony around a bare `instanceof`.
 
-> **Amended on 2026-08-09 by [ADR 111](0111-a-projection-records-the-position-it-has-applied.md).** A
+> **Amended on 2026-08-08 by [ADR 111](0111-a-projection-records-the-position-it-has-applied.md).** A
 > delegating materialized view now exists, the position recorder built there, and it wraps a view rather
 > than replacing it. It answers the `instanceof` probe itself and stays the outermost view, so it does not
-> bring the helper above back. A caller that wraps in the other order gets an unbatched replay.
+> bring the helper above back. Only this order is buildable through the public factories.
+> `Projections.materializedView` builds the coalescing view directly from a `View`, not from an existing
+> `MaterializedView`, so there is no public path to wrap it around the recorder instead.
 
 **3. The boundary is driven by whoever owns the replay, and every path that does not own one degrades to today's
 behaviour.** Internally, `BlockingHandover.Source` gains defaulted `replayStarted()`, `replayCompleted()` and
@@ -231,6 +233,6 @@ what makes `findAllById` useful at all.
   path is open, since the handover pipeline already runs there. It is a separate change from batching and should be
   measured, not assumed.
 
-  > **Amended on 2026-08-08.** Measured in `ReactorProjectionHandoffBenchmark` (archrev B6, #639): the wrapping
-  > carries real load rather than being redundant, and it stays. The bullet above asked the right question, and
-  > removing it was the wrong answer.
+  > **Measured 2026-08-08 in `ReactorProjectionHandoffBenchmark` (archrev B6, #639).** The wrapping carries real
+  > load rather than being redundant, and it stays. The bullet above asked the right question, and removing it
+  > was the wrong answer.

--- a/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md
+++ b/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md
@@ -121,6 +121,11 @@ so the default implementation polls. Polling is what makes the answer correct fo
 the projection, which is the common deployment. An implementation backed by a store that can push a change is free to
 override the method.
 
+**No reactive `Mono`-returning `waitUntilApplied` exists on the reactor stack, deliberately.**
+`AppliedPositionStore` is blocking-shaped on both stacks, and `ReactiveMongoAppliedPositionStore` implements that
+same interface directly. A reactor caller that waits blocks the calling thread, the same bridge the rest of that
+stack already makes in the other direction.
+
 **The polls back off rather than running at a fixed rate, and the pace is `org.occurrent.retry.Backoff`.** A fixed
 25 ms interval is wrong in the direction that matters, because the polls that keep coming are exactly the ones a
 lagging projection cannot afford. The load a waiting caller puts on the store is anti-correlated with the health of

--- a/doc/architecture/decisions/0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md
+++ b/doc/architecture/decisions/0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md
@@ -121,3 +121,8 @@ computes a version for each lease and its own javadoc says a caller needs it as 
 until its next refresh. And whether a lease has expired is judged against the asking node's own clock
 while `expiresAt` was written from the holder's, so a node whose clock runs fast can take a healthy lease.
 Both are filed separately.
+
+> **Superseded in part by [ADR 116](0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md).**
+> `ListenerLock.version()` now has a caller. `MongoLeaseCompetingConsumerStrategySupport.acquireLease` reads
+> it to record the version behind each granted lease, which a checkpoint write is compared against. The
+> clock-skew weakness is unaffected and stays filed separately.

--- a/doc/architecture/decisions/0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md
+++ b/doc/architecture/decisions/0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md
@@ -90,6 +90,11 @@ registering at the same time still wait for each other, which is the cost the lo
 avoid, and release and the refresh thread never go through it anyway. Taking it off is a change to two
 public classes in other modules, so it stays for now and comes out on its own.
 
+> **Amended. The `synchronized` came out.** Neither `NativeMongoLeaseCompetingConsumerStrategy` nor
+> `SpringMongoLeaseCompetingConsumerStrategy` declares `registerCompetingConsumer` or
+> `unregisterCompetingConsumer` `synchronized` any longer. Registering or unregistering a consumer no
+> longer waits behind every other consumer's call on the same strategy instance.
+
 Two threads can still deliver their callbacks in the other order, in the window between one of them
 releasing the lock and making its call. The model tolerates it, since `onConsumeGranted` looks the
 consumer up, does not find it and returns, and a paused consumer hands the lease back per ADR 112.

--- a/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
+++ b/doc/architecture/decisions/0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md
@@ -4,7 +4,9 @@ Date: 2026-08-09
 
 ## Status
 
-Accepted. Fixes #660. Wiring the token into a real check is filed separately as #665.
+Accepted. Fixes #660. Wiring the token into a real check is filed separately as #665. Superseded in part
+by [ADR 116](0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md), which wires the token
+into `CheckpointWriteCondition` and gives `ListenerLock.version()` its caller.
 
 ## Context
 
@@ -26,4 +28,14 @@ Nothing reads it. `MongoLeaseCompetingConsumerStrategySupport.acquireLease` coll
 
 Until #665 lands, a node can still write a checkpoint after losing its lease. The worst it can do is move the checkpoint backward, so some events get redelivered and reprocessed. Nothing is lost and no checkpoint is left permanently wrong, which is why documenting the gap rather than leaving it silently wrong is enough for now.
 
+**Amended by ADR 116: #665 landed.** A checkpoint write now carries the version through
+`CheckpointWriteCondition`, and a write from a lease that has moved on is refused rather than merely
+producing a backward-moving checkpoint. The paragraph above describes the gap as it stood before that
+fix, not the current behavior.
+
 A reader of `MongoListenerLockService` finds a `version` field and a `ListenerLock.version()` accessor with no caller. That is intentional, not an oversight, and this ADR is the record for it.
+
+**Amended by ADR 116: `ListenerLock.version()` now has a caller.**
+`MongoLeaseCompetingConsumerStrategySupport.acquireLease` reads it to record the version behind each
+granted lease, which is what a checkpoint write is compared against. The accessor was deliberately built
+ahead of its caller, and this is the record of when it got one.

--- a/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
+++ b/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
@@ -206,10 +206,20 @@ version is assigned outside the store and the rule is not older than what is sto
 would hand checkpoint stores conditions like `lt(5)` that mean nothing to them. Same idea, stated for
 this store, which is worth more than a shared class name.
 
-`CheckpointWriteCondition` is sealed and has exactly the two cases anything needs today. A third case
-would be a considered change to a contract every store implements, which is the right weight for it, and
-an open predicate would put a condition interpreter written in Lua into the Redis storage for cases
-nobody has asked for.
+`CheckpointWriteCondition` is sealed and has exactly the three cases anything needs today, `any()`,
+`notOlderThan(v)` and `ifAbsent()`. A fourth case would be a considered change to a contract every store
+implements, which is the right weight for it, and an open predicate would put a condition interpreter
+written in Lua into the Redis storage for cases nobody has asked for.
+
+**`ifAbsent()` is the case this section originally left out.** `notOlderThan(v)` accepts a write when
+nothing is stored yet, so it cannot tell a subscription's first checkpoint apart from a later one.
+Pinning a subscription's very first checkpoint, what `ManualStartSubscriptionModel.stoppedByDefault`
+does, needs exactly that distinction. Two nodes racing to start the same subscription both see nothing
+stored, and under `notOlderThan` both writes could succeed, with whichever writes second silently
+winning and losing the events between the two positions (#669). `ifAbsent()` succeeds only while nothing
+is stored, so the first of two racing writes wins and the second is refused instead of silently
+overwritten. That need surfaced after this section was written, which is why the starter section further
+down already assumes `ifAbsent()` exists.
 
 ### A subscription model stamps its own checkpoint writes
 
@@ -229,8 +239,10 @@ becomes `notOlderThan` the version they get, or `any()` when they get none. A mo
 writes `any()`, which is one code path rather than two.
 
 **A model does not learn what a lease is.** It learns that it has a source of write versions and that
-it stamps its writes with one. The words lease, fencing token and competing consumer appear nowhere in
-it, and a model with no source behaves exactly as it does today.
+it stamps its writes with one. No competing-consumer type is imported or depended on by a model that
+writes checkpoints. `DurableSubscriptionModel`'s own javadoc does name `CompetingConsumerSubscriptionModel`
+and a lease handover, but only in prose describing what a caller above it may be doing, never as a type
+its code references. A model with no source behaves exactly as it does today.
 
 **Neither interface names the other, and the two are joined by a method reference at the wiring site.**
 
@@ -367,12 +379,20 @@ through redelivery, and it is filed separately.
 ### Storage mechanics
 
 **Both Mongo storages.** One round trip. `findOneAndUpdate`, filter on `_id` alone, upsert,
-`returnDocument AFTER`, and an update pipeline whose `$cond` writes the new document only when the
-stored version is missing or not greater than the one being written, and yields `$$ROOT` otherwise. The caller
-tells the outcomes apart by comparing the token on the returned document to the one it offered, which is
-how ADR 114 made `acquireOrRefreshFor` tell its own two outcomes apart, including its reason for
-matching on `_id` alone against the unique index rather than leaning on a duplicate-key error. What gets
-written is `$mergeObjects` of the new document and the stored version, in that order, so no stale
+`returnDocument AFTER`, and an update pipeline whose `$cond` decides whether to write the new document.
+`notOlderThan(v)` gates on the stored version, missing or not greater than `v`, and stamps `v` into the
+returned document when it fires. `ifAbsent()` gates on whether a checkpoint is stored at all, not on a
+version, so a successful write carries the previous version forward unchanged instead of stamping a new
+one. Either condition failing yields `$$ROOT`, the document untouched.
+
+For `notOlderThan`, the caller tells the outcomes apart by comparing the version on the returned document
+to the one it offered, which is how ADR 114 made `acquireOrRefreshFor` tell its own two outcomes apart,
+including its reason for matching on `_id` alone against the unique index rather than leaning on a
+duplicate-key error. `ifAbsent` has no version to compare, since a successful write leaves the previous
+one in place, so the caller instead compares the checkpoint value on the returned document to the one it
+offered.
+
+What gets written is `$mergeObjects` of the new document and the stored version, in that order, so no stale
 `resumeToken` survives beside a new `operationTime` and the legacy `subscriptionPosition` field still
 disappears on first write.
 
@@ -402,6 +422,14 @@ The cost of two keys is Redis Cluster, where a script over two differently-named
 crossing slots, and the two names cannot be brought into one slot without renaming the existing
 checkpoint key. That failure is immediate and reaches only a cluster user who turned the fence on, while
 an unfenced cluster user is untouched.
+
+**The same-value edge is storage-dependent.** Mongo's `ifAbsent` gates on presence, not value, so a
+second write offering the exact same checkpoint value as the one already stored is indistinguishable from
+a first write and is reported as success rather than refused, though nothing is stored twice
+(`CheckpointWriteCondition.ifAbsent()` documents the edge). Redis is strict. The Lua script checks
+`EXISTS` on the checkpoint key, so a second write to an existing key is refused whatever value it offers.
+The one shipped caller, `ManualStartSubscriptionModel.pinStartPosition`, swallows the refusal either way
+and is unaffected by which family it runs against.
 
 The blocking in-memory storage implements the capability too, which is a few lines and gives the new
 conformance suite something to run without a container.
@@ -458,9 +486,10 @@ prevent. A refusal on that stack signals `Mono.error` rather than throwing.
 
 ### This breaks implementations, and that is the right price
 
-Everything on the competing consumer side is additive. A default method on `CompetingConsumerStrategy`,
-a new source interface, a new exception, a new Redis key, and an internal method that stops deleting a
-document all leave every call site as it was.
+Everything on the competing consumer side is additive. A default method on `CompetingConsumerStrategy`, a
+new source interface, the Spring Boot starter's `CompetingConsumerCheckpointWriteVersionSource` that
+adapts a strategy bean into that interface, a new exception, a new Redis key, and an internal method that
+stops deleting a document all leave every call site as it was.
 
 The checkpoint store is a real break, and deliberately. No calling code changes, since the
 two-argument `save` remains as a default, but every implementation of `CheckpointStorage` and of its

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ReplayAwareMaterializedView.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ReplayAwareMaterializedView.java
@@ -26,7 +26,10 @@ package org.occurrent.dsl.view;
  * before this capability existed. Whoever drives a replay (a catch-up handover, for example) probes for it with an
  * {@code instanceof} check at the point of need, the same idiom {@code SagaInstances} uses for
  * {@code SagaStateStoreQueries}. There is deliberately no {@code static Optional<ReplayAwareMaterializedView> of(Object)}
- * helper: that shape exists elsewhere to unwrap a delegating view, and there is no delegating {@link MaterializedView}.
+ * helper. That shape exists elsewhere to unwrap a delegating view. The one delegating {@link MaterializedView} this
+ * library builds, the position recorder from
+ * <a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md">ADR 111</a>,
+ * answers the {@code instanceof} probe itself and stays the outermost view, so it needs no unwrapping helper either.
  * <p>
  * {@link #replayCompleted()} runs before the replay's driver records the catch-up as complete, so an implementation
  * that buffers must have written every buffered update by the time this method returns. A write that fails here fails


### PR DESCRIPTION
I amended six ADRs (94, 110, 111, 113, 115, 116) that had drifted from the checkpoint-fence work in ADR 116 and the resume-from-checkpoint fix in ADR 117, and fixed a stale javadoc paragraph in `ReplayAwareMaterializedView`. Each amendment is a banner recording what changed. The original decisions stand.

ADR 116's decision sketch predated `CheckpointWriteCondition`'s third case, `ifAbsent()`, and its storage-mechanics paragraph only described `notOlderThan`'s token comparison, missing that `ifAbsent` compares values instead. I also recorded the same-value edge as a storage-dependent trade-off and named `CompetingConsumerCheckpointWriteVersionSource` in the additive-surface list. ADR 115's Consequences claimed a gap ADR 116 already closed, so I added a superseded-in-part status line and two banners. ADR 110 claimed no delegating `MaterializedView` exists, which ADR 111's `RecordingMaterializedView` falsified, and I closed its open question on the reactor `subscribeOn` wrapper with the archrev B6 measurement. It stays. ADR 113's deferred `synchronized` removal already happened. ADR 94 was missing the amendment banner ADR 117 says it carries. ADR 111 now states that no reactive `waitUntilApplied` exists on the reactor stack, deliberately, since `ReactiveMongoAppliedPositionStore` implements the blocking interface directly.

Verified with `mvn -pl dsl/view-dsl -am test-compile`, and each falsified sentence no longer matches by grep.

I also added the amendment banner ADR 113 was missing for the same `ListenerLock.version()` claim ADR 115 amends. That fixes #696. A second look also turned up two wrong claims in ADR 110, a delegating-view banner dated wrong and a wrap-order sentence that isn't actually buildable through the public factories (`CoalescingMaterializedView` only takes a `View`, never a `MaterializedView`). Both are corrected now.

Fixes #696
