### PR TITLE
Fix reactor bridge silently dropping blocking-view replay behavior

### DIFF
--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/CoalescingMaterializedView.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/CoalescingMaterializedView.java
@@ -64,7 +64,7 @@ final class CoalescingMaterializedView<S extends @Nullable Object, E, ID> implem
     // Every access happens on the thread driving the catch-up replay: BlockingHandover.catchUp folds one payload at a
     // time on the calling thread, so this class does no synchronization of its own.
     private boolean replaying = false;
-    private final Map<ID, List<Buffered<E>>> buffered = new LinkedHashMap<>();
+    private Map<ID, List<Buffered<E>>> buffered = new LinkedHashMap<>();
     private int bufferedCount = 0;
 
     CoalescingMaterializedView(View<S, E> view, ViewStateRepository<S, ID> repository, RetryStrategy retryStrategy,
@@ -120,8 +120,8 @@ final class CoalescingMaterializedView<S extends @Nullable Object, E, ID> implem
         if (buffered.isEmpty()) {
             return;
         }
-        Map<ID, List<Buffered<E>>> batch = new LinkedHashMap<>(buffered);
-        buffered.clear();
+        Map<ID, List<Buffered<E>>> batch = buffered;
+        buffered = new LinkedHashMap<>();
         bufferedCount = 0;
 
         if (retryStrategy instanceof RetryStrategy.DontRetry) {

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/Projections.java
@@ -90,6 +90,13 @@ public final class Projections {
      * A strategy that retries everything also retries a fold that fails for a deterministic reason, which keeps the
      * failure away from the subscription model's error listener and from your broker's redelivery.
      * <p>
+     * {@code retryStrategy} also reaches this view's catch-up replay flush. Passing anything other than
+     * {@link RetryStrategy#none()} makes a flush re-read and re-write one key at a time instead of
+     * {@link ViewStateRepository#findAllById(java.util.Collection)} and {@link ViewStateRepository#saveAll(java.util.Map)}
+     * in one call each, because a repository that overrides those for a real bulk round trip reports no per-key outcome
+     * to retry against. See {@link #materializedView(Projection, ViewStateRepository, RetryStrategy, MaterializedViewOptions)}
+     * for the batching itself.
+     * <p>
      * Hand the result to whichever sink you drive through its {@link MaterializedView} overload:
      * {@code CatchupProjectionFeed.create(id, view, replayFilter, ..)},
      * {@code DomainEventFeed.register(id, view, replayFilter)}, or

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdate.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ReplayAwareMaterializedView;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.function.BiFunction;
+
+/**
+ * The reactive update {@link Projections#reactiveUpdateWithMetadata(MaterializedView)} and its single-instance twin
+ * build. Calls the blocking {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}.
+ * Implements {@link ReactiveReplayAwareMaterializedView} and forwards every lifecycle call to
+ * {@code materializedView} when it implements the blocking {@link ReplayAwareMaterializedView} capability, so a
+ * batching view built with the blocking view DSL (for example {@code Projections.materializedView(..)}) keeps
+ * batching instead of silently falling back to a write-through per event.
+ */
+@NullMarked
+final class BlockingMaterializedViewUpdate<E> implements BiFunction<EventMetadata, E, Mono<Void>>, ReactiveReplayAwareMaterializedView {
+
+    private final MaterializedView<E> materializedView;
+
+    BlockingMaterializedViewUpdate(MaterializedView<E> materializedView) {
+        this.materializedView = materializedView;
+    }
+
+    @Override
+    public Mono<Void> apply(EventMetadata metadata, E event) {
+        return Mono.<Void>fromRunnable(() -> materializedView.update(metadata, event)).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    public void replayStarted() {
+        if (materializedView instanceof ReplayAwareMaterializedView replayAware) {
+            replayAware.replayStarted();
+        }
+    }
+
+    @Override
+    public Mono<Void> replayCompleted() {
+        if (materializedView instanceof ReplayAwareMaterializedView replayAware) {
+            return Mono.<Void>fromRunnable(replayAware::replayCompleted).subscribeOn(Schedulers.boundedElastic());
+        }
+        return Mono.empty();
+    }
+
+    @Override
+    public void replayAbandoned() {
+        if (materializedView instanceof ReplayAwareMaterializedView replayAware) {
+            replayAware.replayAbandoned();
+        }
+    }
+}

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdate.java
@@ -26,11 +26,11 @@ import reactor.core.scheduler.Schedulers;
 import java.util.function.BiFunction;
 
 /**
- * The reactive update {@link Projections#reactiveUpdateWithMetadata(MaterializedView)} and its single-instance twin
- * build. Calls the blocking {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}.
- * Implements {@link ReactiveReplayAwareMaterializedView} and forwards every lifecycle call to
- * {@code materializedView} when it implements the blocking {@link ReplayAwareMaterializedView} capability, so a
- * batching view built with the blocking view DSL (for example {@code Projections.materializedView(..)}) keeps
+ * Built by {@link Projections#reactiveUpdateWithMetadata(MaterializedView)} and its single-instance twin. Calls the
+ * blocking {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}. Implements
+ * {@link ReactiveReplayAwareMaterializedView} and forwards every lifecycle call to {@code materializedView} when it
+ * implements the blocking {@link ReplayAwareMaterializedView} capability, so a batching view built with the blocking
+ * view DSL (for example {@code org.occurrent.dsl.projection.blocking.Projections.materializedView(..)}) keeps
  * batching instead of silently falling back to a write-through per event.
  */
 @NullMarked

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeed.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CatchupProjectionFeed.java
@@ -251,14 +251,14 @@ public final class CatchupProjectionFeed<E> {
 
             @Override
             public void replayStarted() {
-                if (fold instanceof ReplayAwareMaterializedView replayAware) {
+                if (fold instanceof ReactiveReplayAwareMaterializedView replayAware) {
                     replayAware.replayStarted();
                 }
             }
 
             @Override
             public Mono<Void> replayCompleted() {
-                if (fold instanceof ReplayAwareMaterializedView replayAware) {
+                if (fold instanceof ReactiveReplayAwareMaterializedView replayAware) {
                     return replayAware.replayCompleted();
                 }
                 return Mono.empty();
@@ -266,7 +266,7 @@ public final class CatchupProjectionFeed<E> {
 
             @Override
             public void replayAbandoned() {
-                if (fold instanceof ReplayAwareMaterializedView replayAware) {
+                if (fold instanceof ReactiveReplayAwareMaterializedView replayAware) {
                     replayAware.replayAbandoned();
                 }
             }

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CoalescingMaterializedUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/CoalescingMaterializedUpdate.java
@@ -47,12 +47,12 @@ import java.util.function.BiFunction;
  * {@link Schedulers#boundedElastic()}. {@link #apply(EventMetadata, Object)} and {@link #replayCompleted()} hop there
  * explicitly because they do real work (a repository round trip); {@link #replayStarted()} and
  * {@link #replayAbandoned()} do not, since the engine only ever calls them from inside that same pipeline and never
- * awaits them (see {@link ReplayAwareMaterializedView}). {@code lock} still guards the mutable state throughout,
+ * awaits them (see {@link ReactiveReplayAwareMaterializedView}). {@code lock} still guards the mutable state throughout,
  * because a plain field write on one worker thread is not guaranteed visible to whichever worker thread runs the next
  * call, even though the calls themselves never run concurrently.
  */
 @NullMarked
-final class CoalescingMaterializedUpdate<S extends @Nullable Object, E, ID> implements BiFunction<EventMetadata, E, Mono<Void>>, ReplayAwareMaterializedView {
+final class CoalescingMaterializedUpdate<S extends @Nullable Object, E, ID> implements BiFunction<EventMetadata, E, Mono<Void>>, ReactiveReplayAwareMaterializedView {
 
     private final View<S, E> view;
     private final ViewStateRepository<S, ID> repository;
@@ -61,7 +61,7 @@ final class CoalescingMaterializedUpdate<S extends @Nullable Object, E, ID> impl
 
     private final Object lock = new Object();
     private boolean replaying = false;
-    private final Map<ID, List<Buffered<E>>> buffered = new LinkedHashMap<>();
+    private Map<ID, List<Buffered<E>>> buffered = new LinkedHashMap<>();
     private int bufferedCount = 0;
 
     CoalescingMaterializedUpdate(View<S, E> view, ViewStateRepository<S, ID> repository, int batchSize,
@@ -137,8 +137,8 @@ final class CoalescingMaterializedUpdate<S extends @Nullable Object, E, ID> impl
 
     // Must be called holding lock.
     private Map<ID, List<Buffered<E>>> drainLocked() {
-        Map<ID, List<Buffered<E>>> batch = new LinkedHashMap<>(buffered);
-        buffered.clear();
+        Map<ID, List<Buffered<E>>> batch = buffered;
+        buffered = new LinkedHashMap<>();
         bufferedCount = 0;
         return batch;
     }

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
@@ -167,10 +167,10 @@ public final class Projections {
 
     /**
      * The metadata-aware form of {@link #reactiveUpdate(MaterializedView)}: calls the blocking
-     * {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}. When
-     * {@code materializedView} implements the blocking view DSL's {@code ReplayAwareMaterializedView} capability, the
-     * returned update also implements {@link ReactiveReplayAwareMaterializedView} and forwards
-     * {@code replayStarted}/{@code replayCompleted}/{@code replayAbandoned} to it, so a replay driven through a
+     * {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}. The returned update
+     * always implements {@link ReactiveReplayAwareMaterializedView}, and forwards
+     * {@code replayStarted}/{@code replayCompleted}/{@code replayAbandoned} to {@code materializedView} whenever it
+     * implements the blocking view DSL's {@code ReplayAwareMaterializedView} capability, so a replay driven through a
      * {@code CatchupProjectionFeed} still reaches a batching or position-recording view wrapped through this bridge.
      */
     public static <E> BiFunction<EventMetadata, E, Mono<Void>> reactiveUpdateWithMetadata(MaterializedView<E> materializedView) {

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
@@ -155,7 +155,10 @@ public final class Projections {
     /**
      * A reactive {@code (E) -> Mono<Void>} update that calls the blocking {@code materializedView.update(event)} on
      * {@link Schedulers#boundedElastic()}. Use this to drive a blocking {@link MaterializedView} (for example the one the
-     * view DSL's {@code materialized(...)} builds, with its own retry/locking policy) from a reactive pipeline.
+     * view DSL's {@code materialized(...)} builds, with its own retry/locking policy) from a reactive pipeline. When
+     * {@code materializedView} implements the blocking view DSL's replay-aware capability, the returned update forwards
+     * the replay lifecycle to it too, so a batching view keeps batching instead of writing through per event. See
+     * {@link #reactiveUpdateWithMetadata(MaterializedView)}.
      */
     public static <E> Function<E, Mono<Void>> reactiveUpdate(MaterializedView<E> materializedView) {
         BiFunction<EventMetadata, E, Mono<Void>> update = reactiveUpdateWithMetadata(materializedView);
@@ -164,11 +167,15 @@ public final class Projections {
 
     /**
      * The metadata-aware form of {@link #reactiveUpdate(MaterializedView)}: calls the blocking
-     * {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}.
+     * {@code materializedView.update(metadata, event)} on {@link Schedulers#boundedElastic()}. When
+     * {@code materializedView} implements the blocking view DSL's {@code ReplayAwareMaterializedView} capability, the
+     * returned update also implements {@link ReactiveReplayAwareMaterializedView} and forwards
+     * {@code replayStarted}/{@code replayCompleted}/{@code replayAbandoned} to it, so a replay driven through a
+     * {@code CatchupProjectionFeed} still reaches a batching or position-recording view wrapped through this bridge.
      */
     public static <E> BiFunction<EventMetadata, E, Mono<Void>> reactiveUpdateWithMetadata(MaterializedView<E> materializedView) {
         requireNonNull(materializedView, "materializedView cannot be null");
-        return (metadata, event) -> Mono.<Void>fromRunnable(() -> materializedView.update(metadata, event)).subscribeOn(Schedulers.boundedElastic());
+        return new BlockingMaterializedViewUpdate<>(materializedView);
     }
 
     /**
@@ -272,7 +279,7 @@ public final class Projections {
      * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md">ADR 111</a>).
      * Works with any {@code (EventMetadata, E) -> Mono<Void>} update, including
      * {@link #reactiveUpdateWithMetadata(Projection, ViewStateRepository)}'s coalescing catch-up batching through
-     * {@link ReplayAwareMaterializedView}: the returned update forwards the lifecycle calls to {@code update} and only
+     * {@link ReactiveReplayAwareMaterializedView}: the returned update forwards the lifecycle calls to {@code update} and only
      * records the position once the delegate's own write for that replay is durable.
      * <p>
      * An event whose {@link EventMetadata#getPosition()} is {@code null} makes the returned {@link Mono} error with an

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveReplayAwareMaterializedView.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveReplayAwareMaterializedView.java
@@ -37,7 +37,7 @@ import reactor.core.publisher.Mono;
  * A {@link Mono} that errors here fails the whole catch-up, exactly as a failed write inside the per-event fold does
  * today.
  */
-public interface ReplayAwareMaterializedView {
+public interface ReactiveReplayAwareMaterializedView {
 
     /** A catch-up replay is about to start delivering events to this view. */
     void replayStarted();

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdate.java
@@ -31,7 +31,7 @@ import java.util.function.BiFunction;
  * Applies the wrapped update and then advances {@code store}, so the recorded position is written only after the
  * state it describes.
  * <p>
- * Implements {@link ReplayAwareMaterializedView} and forwards every lifecycle call to the delegate when it implements
+ * Implements {@link ReactiveReplayAwareMaterializedView} and forwards every lifecycle call to the delegate when it implements
  * the capability too. During a replay the delegate may be buffering (a coalescing update), so the position seen so
  * far is kept in memory and only written in {@link #replayCompleted()}, after the delegate's own {@link Mono}
  * completes. {@link #replayAbandoned()} discards it instead, since the next replay recomputes everything anyway.
@@ -39,7 +39,7 @@ import java.util.function.BiFunction;
  * though its calls never run concurrently.
  */
 @NullMarked
-final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, Mono<Void>>, ReplayAwareMaterializedView {
+final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, Mono<Void>>, ReactiveReplayAwareMaterializedView {
 
     private final BiFunction<EventMetadata, E, Mono<Void>> delegate;
     private final AppliedPositionStore store;
@@ -81,7 +81,7 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
 
     @Override
     public void replayStarted() {
-        if (delegate instanceof ReplayAwareMaterializedView replayAware) {
+        if (delegate instanceof ReactiveReplayAwareMaterializedView replayAware) {
             replayAware.replayStarted();
         }
         synchronized (lock) {
@@ -92,7 +92,7 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
 
     @Override
     public Mono<Void> replayCompleted() {
-        Mono<Void> delegateCompletion = delegate instanceof ReplayAwareMaterializedView replayAware ? replayAware.replayCompleted() : Mono.empty();
+        Mono<Void> delegateCompletion = delegate instanceof ReactiveReplayAwareMaterializedView replayAware ? replayAware.replayCompleted() : Mono.empty();
         return delegateCompletion.then(Mono.<Void>fromRunnable(() -> {
             long highest;
             synchronized (lock) {
@@ -107,7 +107,7 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
 
     @Override
     public void replayAbandoned() {
-        if (delegate instanceof ReplayAwareMaterializedView replayAware) {
+        if (delegate instanceof ReactiveReplayAwareMaterializedView replayAware) {
             replayAware.replayAbandoned();
         }
         synchronized (lock) {

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdateTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdateTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.reactor;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ReplayAwareMaterializedView;
+import org.occurrent.eventstore.api.PositionRange;
+import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
+import org.occurrent.filter.Filter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link Projections#reactiveUpdateWithMetadata(MaterializedView)} bridges a blocking {@link MaterializedView} onto a
+ * reactive pipeline. Driven for real through {@link CatchupProjectionFeed}, so the assertions exercise the same
+ * {@code instanceof} probe a production catch-up replay does, not a hand-called shortcut.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class BlockingMaterializedViewUpdateTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:test");
+
+    @Test
+    void a_catch_up_replay_forwards_its_lifecycle_to_a_replay_aware_blocking_view_wrapped_through_the_bridge() {
+        FakeReplayAwareView view = new FakeReplayAwareView();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "counter", Projections.reactiveUpdateWithMetadata(view), Filter.all(), reader("1", "2"), countedConverter(), Counted::eventId, null);
+
+        feed.catchUp().block();
+
+        assertThat(view.calls).containsExactly("replayStarted", "update:1:replaying", "update:2:replaying", "replayCompleted");
+    }
+
+    @Test
+    void a_blocking_view_with_no_replay_awareness_is_driven_write_through_with_no_lifecycle_calls() {
+        FakeView view = new FakeView();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "counter", Projections.reactiveUpdateWithMetadata(view), Filter.all(), reader("1", "2"), countedConverter(), Counted::eventId, null);
+
+        feed.catchUp().block();
+
+        assertThat(view.calls).containsExactly("update:1", "update:2");
+    }
+
+    private static final class FakeReplayAwareView implements MaterializedView<Counted>, ReplayAwareMaterializedView {
+        private final List<String> calls = new CopyOnWriteArrayList<>();
+        private boolean replaying = false;
+
+        @Override
+        public void update(Counted event) {
+            update(EventMetadata.empty(), event);
+        }
+
+        @Override
+        public void update(EventMetadata metadata, Counted event) {
+            calls.add("update:" + event.eventId() + (replaying ? ":replaying" : ":live"));
+        }
+
+        @Override
+        public void replayStarted() {
+            calls.add("replayStarted");
+            replaying = true;
+        }
+
+        @Override
+        public void replayCompleted() {
+            replaying = false;
+            calls.add("replayCompleted");
+        }
+
+        @Override
+        public void replayAbandoned() {
+            replaying = false;
+            calls.add("replayAbandoned");
+        }
+    }
+
+    private static final class FakeView implements MaterializedView<Counted> {
+        private final List<String> calls = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void update(Counted event) {
+            update(EventMetadata.empty(), event);
+        }
+
+        @Override
+        public void update(EventMetadata metadata, Counted event) {
+            calls.add("update:" + event.eventId());
+        }
+    }
+
+    private PositionOrderedReader reader(String... eventIds) {
+        return new PositionOrderedReader() {
+            @Override
+            public Flux<CloudEvent> readInPositionOrder(Filter filter, PositionRange range) {
+                return Flux.fromIterable(List.of(eventIds)).map(BlockingMaterializedViewUpdateTest::cloudEvent);
+            }
+
+            @Override
+            public Mono<Long> currentPosition() {
+                return Mono.just((long) eventIds.length);
+            }
+
+            @Override
+            public boolean writesPosition() {
+                return true;
+            }
+        };
+    }
+
+    private static CloudEvent cloudEvent(String id) {
+        return CloudEventBuilder.v1().withId(id).withSource(SOURCE).withType("Counted").build();
+    }
+
+    private static CloudEventConverter<Counted> countedConverter() {
+        return new CloudEventConverter<>() {
+            @Override
+            public CloudEvent toCloudEvent(Counted domainEvent) {
+                return cloudEvent(domainEvent.eventId());
+            }
+
+            @Override
+            public Counted toDomainEvent(CloudEvent cloudEvent) {
+                return new Counted(cloudEvent.getId());
+            }
+
+            @Override
+            public String getCloudEventType(Class<? extends Counted> type) {
+                return "Counted";
+            }
+        };
+    }
+
+    record Counted(String eventId) {
+    }
+}

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdateTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdateTest.java
@@ -67,7 +67,7 @@ class RecordingReactiveUpdateTest {
         BiFunction<EventMetadata, String, Mono<Void>> delegate = recordingDelegate(calls);
         AppliedPositionStore storage = recordingStorage(calls);
         BiFunction<EventMetadata, String, Mono<Void>> recording = Projections.recordingAppliedPosition(delegate, storage, "orders");
-        ReplayAwareMaterializedView replayAware = (ReplayAwareMaterializedView) recording;
+        ReactiveReplayAwareMaterializedView replayAware = (ReactiveReplayAwareMaterializedView) recording;
 
         replayAware.replayStarted();
         recording.apply(metadataWithPosition(10), "event-1").block();
@@ -86,7 +86,7 @@ class RecordingReactiveUpdateTest {
         BiFunction<EventMetadata, String, Mono<Void>> delegate = recordingDelegate(calls);
         AppliedPositionStore storage = recordingStorage(calls);
         BiFunction<EventMetadata, String, Mono<Void>> recording = Projections.recordingAppliedPosition(delegate, storage, "orders");
-        ReplayAwareMaterializedView replayAware = (ReplayAwareMaterializedView) recording;
+        ReactiveReplayAwareMaterializedView replayAware = (ReactiveReplayAwareMaterializedView) recording;
 
         replayAware.replayStarted();
         recording.apply(metadataWithPosition(10), "event-1").block();
@@ -102,7 +102,7 @@ class RecordingReactiveUpdateTest {
         DelegateWithReplayAwareness delegate = new DelegateWithReplayAwareness(calls);
         AppliedPositionStore storage = recordingStorage(calls);
         BiFunction<EventMetadata, String, Mono<Void>> recording = Projections.recordingAppliedPosition(delegate, storage, "orders");
-        ReplayAwareMaterializedView replayAware = (ReplayAwareMaterializedView) recording;
+        ReactiveReplayAwareMaterializedView replayAware = (ReactiveReplayAwareMaterializedView) recording;
 
         replayAware.replayStarted();
         recording.apply(metadataWithPosition(10), "event-1").block();
@@ -131,7 +131,7 @@ class RecordingReactiveUpdateTest {
         return (metadata, event) -> Mono.fromRunnable(() -> calls.add("delegate:" + event));
     }
 
-    private static final class DelegateWithReplayAwareness implements BiFunction<EventMetadata, String, Mono<Void>>, ReplayAwareMaterializedView {
+    private static final class DelegateWithReplayAwareness implements BiFunction<EventMetadata, String, Mono<Void>>, ReactiveReplayAwareMaterializedView {
         private final List<String> calls;
 
         DelegateWithReplayAwareness(List<String> calls) {

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ViewStateRepository.java
@@ -54,7 +54,7 @@ public interface ViewStateRepository<S extends @Nullable Object, ID> {
      * settled for {@code CommandDispatcher.dispatchAll}: a seam an implementation may exploit, not a guarantee the
      * framework provides. The default loops {@link #findById(Object)} one id at a time, so behaviour is unchanged for
      * every existing repository, including one built from two lambdas through {@link #create(Function, BiConsumer)}.
-     * An id absent from {@code ids} is not present as a key of the returned map, the same as an empty
+     * An id with no stored state is simply absent from the returned map, the same as an empty
      * {@link #findById(Object)} result. An implementation backed by a store that supports an {@code _id in (..)} query
      * can override this to answer with one round trip instead of {@code ids.size()}.
      *

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/internal/MongoBulkViewStateOperations.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/internal/MongoBulkViewStateOperations.java
@@ -55,7 +55,7 @@ public final class MongoBulkViewStateOperations {
     /**
      * Reads every id in {@code ids} with a single {@code _id in (..)} query, in the same shape the looping
      * {@code ViewStateRepository.findAllById} default produces: a {@link LinkedHashMap} in {@code ids} iteration
-     * order, an id absent from the result store simply missing from the returned map.
+     * order, with an id that has no stored state simply absent from the returned map.
      */
     @SuppressWarnings("unchecked")
     public static <ID, S> Map<ID, S> findAllById(MongoOperations mongoOperations, Class<S> stateType, Collection<ID> ids) {


### PR DESCRIPTION
I fixed a bug in `dsl/projection-dsl/reactor`'s `Projections.reactiveUpdateWithMetadata(MaterializedView)`. The bridge it built was a bare lambda, so the reactor catch-up feed's replay-marker check never found it, and a blocking view wrapped through it silently lost its batching or deferred position-write behavior during a catch-up replay, with no signal that anything was wrong. I added `BlockingMaterializedViewUpdate`, a small class that implements the reactor replay marker and forwards `replayStarted`/`replayCompleted`/`replayAbandoned` to the wrapped view.

A few smaller fixes from the same review pass are bundled in here too:

- I renamed the reactor-only replay marker from `ReplayAwareMaterializedView` to `ReactiveReplayAwareMaterializedView`. It shared a bare name with an unrelated type in the blocking view DSL, and the reactor type is still unreleased, so the rename was free.
- I added the missing `retryStrategy` caveat to the three-arg `materializedView` javadoc overload in the blocking `Projections`, matching what its four-arg sibling already said.
- I changed `CoalescingMaterializedView` and `CoalescingMaterializedUpdate`'s flush from copy-then-clear to drain-and-swap. Same behavior, one fewer full-map copy per batch.
- I fixed a garbled `ViewStateRepository`/`MongoBulkViewStateOperations` javadoc sentence about which ids are missing from `findAllById`'s result.
