### PR TITLE
Cover the untested reactor checkpoint-storage write path (ADR 116)

### DIFF
--- a/subscription/inmemory/pom.xml
+++ b/subscription/inmemory/pom.xml
@@ -82,6 +82,12 @@
         </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-tck-subscription-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>occurrent-eventstore-inmemory</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorageConformanceTest.java
+++ b/subscription/inmemory/src/test/java/org/occurrent/subscription/inmemory/reactor/InMemoryCheckpointStorageConformanceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.inmemory.reactor;
+
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.api.reactor.CheckpointStorage;
+import org.occurrent.tck.subscription.reactor.CheckpointStorageConformance;
+import org.occurrent.tck.subscription.reactor.CheckpointStorageFixture;
+
+class InMemoryCheckpointStorageConformanceTest extends CheckpointStorageConformance {
+
+    @Override
+    protected CheckpointStorageFixture createFixture() {
+        return new InMemoryCheckpointStorageFixture();
+    }
+
+    /**
+     * A fresh instance per test is all the cleanup a map needs, so there is nothing to close.
+     */
+    private static class InMemoryCheckpointStorageFixture implements CheckpointStorageFixture {
+
+        private final InMemoryCheckpointStorage storage = new InMemoryCheckpointStorage();
+
+        @Override
+        public CheckpointStorage checkpointStorage() {
+            return storage;
+        }
+
+        /**
+         * The map holds the {@link Checkpoint} it was handed, so every type comes back as itself. This is the only
+         * storage that can promise that, since the others have to encode the checkpoint to store it.
+         */
+        @Override
+        public boolean preservesCheckpointType(Checkpoint checkpoint) {
+            return true;
+        }
+    }
+}

--- a/subscription/mongodb/spring/reactor-checkpoint-storage/pom.xml
+++ b/subscription/mongodb/spring/reactor-checkpoint-storage/pom.xml
@@ -60,6 +60,12 @@
         <!-- Test -->
         <dependency>
             <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-tck-subscription-reactor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
             <artifactId>occurrent-eventstore-mongodb-spring-reactor</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageConformanceTest.java
+++ b/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageConformanceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.subscription.mongodb.spring.reactor;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.StringBasedCheckpoint;
+import org.occurrent.subscription.api.reactor.CheckpointStorage;
+import org.occurrent.subscription.mongodb.MongoOperationTimeCheckpoint;
+import org.occurrent.subscription.mongodb.MongoResumeTokenCheckpoint;
+import org.occurrent.tck.subscription.reactor.CheckpointStorageConformance;
+import org.occurrent.tck.subscription.reactor.CheckpointStorageFixture;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The ADR 116 conditional-checkpoint-write glue, {@link ReactorCheckpointStorage#save(String, Checkpoint,
+ * org.occurrent.subscription.CheckpointWriteCondition)} and {@link ReactorCheckpointStorage#writeVersion(String)},
+ * had no assertion anywhere before this test. Everything else in this module exercises the unconditional path.
+ */
+@Testcontainers
+class ReactorCheckpointStorageConformanceTest extends CheckpointStorageConformance {
+
+    private static final String DATABASE = "reactorcheckpointconformance";
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    // One client and one template for the class, since standing a client up means server discovery. What has to be
+    // fresh per test is the collection, which the fixture takes care of.
+    private static MongoClient mongoClient;
+    private static ReactiveMongoOperations mongoOperations;
+
+    @BeforeAll
+    static void connect() {
+        mongoClient = MongoClients.create(mongoDBContainer.getReplicaSetUrl(DATABASE));
+        mongoOperations = new ReactiveMongoTemplate(mongoClient, DATABASE);
+    }
+
+    @AfterAll
+    static void disconnect() {
+        mongoClient.close();
+    }
+
+    @Override
+    protected CheckpointStorageFixture createFixture() {
+        return new ReactorCheckpointStorageFixture(mongoOperations);
+    }
+
+    private static class ReactorCheckpointStorageFixture implements CheckpointStorageFixture {
+
+        private final ReactiveMongoOperations mongoOperations;
+        private final String collection;
+        private final CheckpointStorage storage;
+
+        ReactorCheckpointStorageFixture(ReactiveMongoOperations mongoOperations) {
+            this.mongoOperations = mongoOperations;
+            // A collection of its own per test, rather than dropping a shared one, so the storage starts empty without
+            // depending on cleanup order and without disturbing anything else running against this container.
+            this.collection = "checkpoints-" + UUID.randomUUID();
+            this.storage = new ReactorCheckpointStorage(mongoOperations, collection);
+        }
+
+        @Override
+        public CheckpointStorage checkpointStorage() {
+            return storage;
+        }
+
+        /**
+         * Same encoding the blocking Spring and native adapters use, since all three build and read the document
+         * through the shared {@code MongoCommons}.
+         */
+        @Override
+        public boolean preservesCheckpointType(Checkpoint checkpoint) {
+            return checkpoint instanceof MongoResumeTokenCheckpoint
+                    || checkpoint instanceof MongoOperationTimeCheckpoint
+                    || checkpoint instanceof StringBasedCheckpoint;
+        }
+
+        /**
+         * The two checkpoints a MongoDB change stream actually hands this storage. A resume token is only ever read
+         * back through its {@code _data} field, which is why the token declared here carries that and nothing else.
+         */
+        @Override
+        public List<Checkpoint> additionalCheckpoints() {
+            return List.of(
+                    new MongoResumeTokenCheckpoint(new BsonDocument("_data", new BsonString("82ABCDEF"))),
+                    new MongoOperationTimeCheckpoint(new BsonTimestamp(1735689600, 1)));
+        }
+
+        @Override
+        public void close() {
+            mongoOperations.dropCollection(collection).block();
+        }
+    }
+}

--- a/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageResilienceTest.java
+++ b/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageResilienceTest.java
@@ -236,11 +236,13 @@ class ReactorCheckpointStorageResilienceTest {
             ReactorCheckpointStorage seedStorage = new ReactorCheckpointStorage(realMongoOperations, CHECKPOINT_COLLECTION);
             seedStorage.save(subscriptionId, new StringBasedCheckpoint("fenced"), CheckpointWriteCondition.notOlderThan(9)).block();
 
-            AtomicInteger attempts = new AtomicInteger();
+            // persistConditionalCheckpointDocument calls getCollection() once per findOneAndUpdate attempt, so
+            // counting subscriptions to getCollection() is counting write attempts.
+            AtomicInteger getCollectionSubscriptions = new AtomicInteger();
             ReactiveMongoOperations countingOperations = mock(ReactiveMongoOperations.class);
             when(countingOperations.getCollection(eq(CHECKPOINT_COLLECTION)))
                     .thenAnswer(invocation -> Mono.defer(() -> {
-                        attempts.incrementAndGet();
+                        getCollectionSubscriptions.incrementAndGet();
                         return realMongoOperations.getCollection(CHECKPOINT_COLLECTION);
                     }));
             ReactorCheckpointStorage storage = new ReactorCheckpointStorage(countingOperations, CHECKPOINT_COLLECTION);
@@ -250,10 +252,10 @@ class ReactorCheckpointStorageResilienceTest {
 
             // Then
             assertThat(thrown).isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
-            assertThat(attempts.get())
-                    .as("a refusal is not a transient failure, so it must reach the caller after exactly one "
-                            + "findOneAndUpdate, not after retryWhen mistook a deterministic refusal for one and "
-                            + "spent its budget repeating it")
+            assertThat(getCollectionSubscriptions.get())
+                    .as("a refusal is not a transient failure, so it must reach the caller after exactly one write "
+                            + "attempt, not after retryWhen mistook a deterministic refusal for one and spent its "
+                            + "budget repeating it")
                     .isEqualTo(1);
         }
     }

--- a/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageResilienceTest.java
+++ b/subscription/mongodb/spring/reactor-checkpoint-storage/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorCheckpointStorageResilienceTest.java
@@ -25,6 +25,8 @@ import org.bson.Document;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.CheckpointWriteCondition;
+import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
@@ -210,6 +212,49 @@ class ReactorCheckpointStorageResilienceTest {
             // Then
             assertThat(thrown).hasCauseInstanceOf(MongoSocketReadException.class);
             assertThat(attempts.upsert.get()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * See ADR 116, "A refused write throws, and it must never be retried": {@code save} places
+     * {@code assertCheckpointWriteSucceeded} outside {@code retryWhen}, in the {@code .map} that follows it, so a
+     * refusal is thrown from there rather than from inside the retried source. A refusal is a successful
+     * {@code findOneAndUpdate}, the pipeline chose {@code $$ROOT} over the new document, not a driver error, so
+     * {@code retryWhen} has no error signal to react to regardless of where the throw sits. What breaks if the throw
+     * moves back inside the retried source is that a synchronous throw there becomes an error signal
+     * {@code retryWhen} does see, and it would retry a write that is refused deterministically every single time,
+     * turning one refusal into up to six identical attempts before the same exception finally surfaces.
+     */
+    @Nested
+    @DisplayName("a refused conditional write")
+    class RefusedConditionalWrite {
+
+        @Test
+        void is_never_retried() {
+            // Given: a version already stored higher than the one about to be offered, so the write is refused.
+            String subscriptionId = UUID.randomUUID().toString();
+            ReactorCheckpointStorage seedStorage = new ReactorCheckpointStorage(realMongoOperations, CHECKPOINT_COLLECTION);
+            seedStorage.save(subscriptionId, new StringBasedCheckpoint("fenced"), CheckpointWriteCondition.notOlderThan(9)).block();
+
+            AtomicInteger attempts = new AtomicInteger();
+            ReactiveMongoOperations countingOperations = mock(ReactiveMongoOperations.class);
+            when(countingOperations.getCollection(eq(CHECKPOINT_COLLECTION)))
+                    .thenAnswer(invocation -> Mono.defer(() -> {
+                        attempts.incrementAndGet();
+                        return realMongoOperations.getCollection(CHECKPOINT_COLLECTION);
+                    }));
+            ReactorCheckpointStorage storage = new ReactorCheckpointStorage(countingOperations, CHECKPOINT_COLLECTION);
+
+            // When
+            Throwable thrown = catchThrowable(() -> storage.save(subscriptionId, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(4)).block());
+
+            // Then
+            assertThat(thrown).isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
+            assertThat(attempts.get())
+                    .as("a refusal is not a transient failure, so it must reach the caller after exactly one "
+                            + "findOneAndUpdate, not after retryWhen mistook a deterministic refusal for one and "
+                            + "spent its budget repeating it")
+                    .isEqualTo(1);
         }
     }
 }

--- a/tck/subscription-reactor/pom.xml
+++ b/tck/subscription-reactor/pom.xml
@@ -29,7 +29,9 @@
     <name>${mavenProjectName}</name>
 
     <dependencies>
-        <!-- The behavioral suites are the blocking ones, reached through the bridge in this module -->
+        <!-- The behavioral suites for a subscription model are the blocking ones, reached through the bridge in
+             this module. CheckpointStorageConformance is the exception: it lives here because the property it
+             checks, which signal a refused write produces, only exists on the Mono a blocking bridge would consume. -->
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-tck-subscription-blocking</artifactId>
@@ -39,6 +41,22 @@
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-subscription-api-reactor</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Deliberately compile scope, not test: CheckpointStorageConformance lives in src/main and its public
+             surface is JUnit annotations and AssertJ assertions, so a consumer cannot run it without these on its
+             compile path. Same reasoning as the blocking TCK's pom, see ADR 77. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jspecify</groupId>

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/CheckpointStorageConformance.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/CheckpointStorageConformance.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.occurrent.tck.subscription.blocking;
+package org.occurrent.tck.subscription.reactor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -26,12 +26,11 @@ import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.CheckpointWriteConditionNotFulfilledException;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StringBasedCheckpoint;
-import org.occurrent.subscription.api.blocking.CheckpointStorage;
+import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.tck.FailureNamesTheTestClass;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -39,40 +38,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * The contract every {@link CheckpointStorage} owes. A checkpoint saved for a subscription id can be read back, is
- * gone once deleted, and reports its own existence honestly in between.
+ * The contract every reactive {@link CheckpointStorage} owes, the reactive twin of
+ * {@code org.occurrent.tck.subscription.blocking.CheckpointStorageConformance}.
+ * <p>
+ * Every assertion here bridges through {@link reactor.core.publisher.Mono#block()}, the same way
+ * {@code ReactiveSubscriptionModelConformance} does elsewhere in this module, since what this suite is proving is the
+ * signal a caller eventually sees, not how the signal travels. That bridging is exactly why this suite exists
+ * separately from the blocking one rather than reusing it over some adapter. {@link WriteConditions} tests which
+ * signal a refused write produces, {@code Mono.error} versus a silent empty completion, and a bridge that turns both
+ * into "block threw" or "block returned null" would erase the very distinction being checked. See ADR 116.
  * <p>
  * An implementation extends this and supplies a {@link CheckpointStorageFixture}:
  * <pre>{@code
- * class PostgresqlCheckpointStorageTest extends CheckpointStorageConformance {
+ * class ReactorPostgresqlCheckpointStorageTest extends CheckpointStorageConformance {
  *     @Override
  *     protected CheckpointStorageFixture createFixture() {
- *         return new PostgresqlCheckpointStorageFixture();
+ *         return new ReactorPostgresqlCheckpointStorageFixture();
  *     }
  * }
  * }</pre>
  * <p>
  * Not extending this suite is how an implementation declines to be conformance tested. That is a visible, greppable
- * absence rather than a runtime skip, and nothing here calls {@code Assumptions}. Where storages legitimately differ,
- * the fixture declares which way it goes and the suite asserts the documented outcome for that answer, so both branches
- * are checked by somebody.
+ * absence rather than a runtime skip, and nothing here calls {@code Assumptions}.
  * <p>
  * What this suite deliberately does not assert:
  * <ul>
- *     <li><strong>What a stored checkpoint looks like.</strong> A document, a row, a string key, one collection or
- *     several, are all storage's business. The suite only ever reads back through {@code read}.</li>
- *     <li><strong>What happens on a null argument.</strong> The interface is JSpecify-annotated, so null is outside the
- *     contract rather than a case with a defined outcome, and demanding a particular exception would hold every
- *     implementation to this repository's own validation convention.</li>
- *     <li><strong>Concurrency.</strong> Whether two threads saving the same subscription id leave a coherent value is
- *     unspecified today, so the suite does not invent an answer.</li>
- *     <li><strong>Legacy field migration.</strong> Occurrent's MongoDB storages read an older field name and rewrite
- *     it, which the suite cannot describe without naming a field. That stays in their own tests.</li>
+ *     <li><strong>Existence.</strong> The reactive {@link CheckpointStorage} has no {@code exists} method, unlike its
+ *     blocking counterpart, so there is nothing here to mirror the blocking suite's existence nested class with.</li>
+ *     <li><strong>What a stored checkpoint looks like, what happens on a null argument, or concurrency.</strong> The
+ *     same reasons the blocking suite gives apply unchanged.</li>
+ *     <li><strong>Whether a refusal was retried.</strong> That is an implementation's own retry policy, not part of
+ *     the contract every storage owes, and it is asserted where a storage's own retry exists to get it wrong, such as
+ *     {@code ReactorCheckpointStorageResilienceTest}.</li>
  * </ul>
  */
 @NullMarked
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@DisplayName("the checkpoint storage contract")
+@DisplayName("the reactive checkpoint storage contract")
 @Timeout(60)
 @ExtendWith(FailureNamesTheTestClass.class)
 public abstract class CheckpointStorageConformance {
@@ -93,8 +95,6 @@ public abstract class CheckpointStorageConformance {
                 created.getClass().getName() + " returned null from checkpointStorage()");
         List<Checkpoint> additional = requireNonNull(created.additionalCheckpoints(),
                 created.getClass().getName() + " returned null from additionalCheckpoints()");
-        // Not contains(null): an immutable list from List.of(..) throws rather than answering false, and List.of() is
-        // exactly what the fixture returns by default.
         if (additional.stream().anyMatch(java.util.Objects::isNull)) {
             throw new IllegalStateException(created.getClass().getName()
                     + " returned a null checkpoint from additionalCheckpoints(). A checkpoint the suite cannot save is "
@@ -141,20 +141,26 @@ public abstract class CheckpointStorageConformance {
         return UUID.randomUUID().toString();
     }
 
+    /**
+     * The version currently stored, bridging {@code writeVersion}'s empty-Mono-means-absent signal to a nullable
+     * {@code Long} the way {@code read} already does for a checkpoint, rather than introducing a second convention.
+     */
+    private @Nullable Long storedVersion(String id) {
+        return checkpointStorage().writeVersion(id).block();
+    }
+
     @Nested
     @DisplayName("round tripping")
     class RoundTripping {
 
         @Test
         void reads_back_the_value_of_every_checkpoint_it_was_given() {
-            // asString() is the whole of what Checkpoint promises, so it is the one thing every storage owes for every
-            // checkpoint, whatever it does to the type on the way through.
             for (Checkpoint checkpoint : checkpointsToRoundTrip()) {
                 String id = subscriptionId();
 
-                checkpointStorage().save(id, checkpoint);
+                checkpointStorage().save(id, checkpoint).block();
 
-                Checkpoint read = checkpointStorage().read(id);
+                Checkpoint read = checkpointStorage().read(id).block();
                 assertThat(read)
                         .as("a saved checkpoint must be readable, for %s", checkpoint.getClass().getSimpleName())
                         .isNotNull();
@@ -168,9 +174,9 @@ public abstract class CheckpointStorageConformance {
         void keeps_the_checkpoint_type_only_where_the_fixture_declares_it() {
             for (Checkpoint checkpoint : checkpointsToRoundTrip()) {
                 String id = subscriptionId();
-                checkpointStorage().save(id, checkpoint);
+                checkpointStorage().save(id, checkpoint).block();
 
-                Checkpoint read = requireNonNull(checkpointStorage().read(id));
+                Checkpoint read = requireNonNull(checkpointStorage().read(id).block());
 
                 if (fixture().preservesCheckpointType(checkpoint)) {
                     assertThat(read)
@@ -178,9 +184,6 @@ public abstract class CheckpointStorageConformance {
                                     checkpoint.getClass().getSimpleName())
                             .isInstanceOf(checkpoint.getClass());
                 } else {
-                    // Not a weaker assertion, the same one in the other direction. Without this a fixture could answer
-                    // false for everything and never be asked to prove any of it, which is a flag hiding behaviour
-                    // rather than a declared difference. The value it still owes is pinned by the test above.
                     assertThat(read)
                             .as("this storage declares it does not rebuild %s, so it must not come back as one",
                                     checkpoint.getClass().getSimpleName())
@@ -191,7 +194,7 @@ public abstract class CheckpointStorageConformance {
 
         @Test
         void reads_nothing_for_a_subscription_it_has_never_seen() {
-            assertThat(checkpointStorage().read(subscriptionId()))
+            assertThat(checkpointStorage().read(subscriptionId()).block())
                     .as("an unknown subscription id has no checkpoint, which is how a subscription starting for the "
                             + "first time is told to ask the model for a global checkpoint instead")
                     .isNull();
@@ -200,11 +203,11 @@ public abstract class CheckpointStorageConformance {
         @Test
         void the_last_saved_checkpoint_is_the_one_that_is_read() {
             String id = subscriptionId();
-            checkpointStorage().save(id, new StringBasedCheckpoint("first"));
+            checkpointStorage().save(id, new StringBasedCheckpoint("first")).block();
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("second"));
+            checkpointStorage().save(id, new StringBasedCheckpoint("second")).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("saving again for the same subscription replaces the checkpoint rather than adding one, since "
                             + "a subscription has one position")
                     .isEqualTo("second");
@@ -214,11 +217,11 @@ public abstract class CheckpointStorageConformance {
         void a_checkpoint_of_one_type_can_be_overwritten_by_a_checkpoint_of_another() {
             for (Checkpoint checkpoint : checkpointsToRoundTrip()) {
                 String id = subscriptionId();
-                checkpointStorage().save(id, checkpoint);
+                checkpointStorage().save(id, checkpoint).block();
 
-                checkpointStorage().save(id, new StringBasedCheckpoint("replaced-a-" + checkpoint.getClass().getSimpleName()));
+                checkpointStorage().save(id, new StringBasedCheckpoint("replaced-a-" + checkpoint.getClass().getSimpleName())).block();
 
-                assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+                assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                         .as("saving over a %s must replace it rather than leave part of it behind. A storage that "
                                 + "encodes different checkpoint types into different fields has to clear the old field, "
                                 + "or a subscription resumes from the position it had two saves ago",
@@ -231,12 +234,8 @@ public abstract class CheckpointStorageConformance {
         void gives_back_the_checkpoint_it_saved_so_a_caller_can_chain() {
             Checkpoint checkpoint = new StringBasedCheckpoint("chained");
 
-            Checkpoint returned = checkpointStorage().save(subscriptionId(), checkpoint);
+            Checkpoint returned = requireNonNull(checkpointStorage().save(subscriptionId(), checkpoint).block());
 
-            // The same instance, not an equal one. A storage that hands back a StringBasedCheckpoint carrying the same
-            // value would pass an asString() check while quietly changing what the caller chains into: StartAt on the
-            // MongoDB path branches on the checkpoint's type first and only parses the string if it recognises neither
-            // of its own two types.
             assertThat(returned)
                     .as("save returns the checkpoint it was given, which is what lets a caller write "
                             + "StartAt.checkpoint(storage.save(id, checkpoint))")
@@ -248,53 +247,13 @@ public abstract class CheckpointStorageConformance {
             String first = subscriptionId();
             String second = subscriptionId();
 
-            checkpointStorage().save(first, new StringBasedCheckpoint("for-first"));
-            checkpointStorage().save(second, new StringBasedCheckpoint("for-second"));
+            checkpointStorage().save(first, new StringBasedCheckpoint("for-first")).block();
+            checkpointStorage().save(second, new StringBasedCheckpoint("for-second")).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(first)).asString()).isEqualTo("for-first");
-            assertThat(requireNonNull(checkpointStorage().read(second)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(first).block()).asString()).isEqualTo("for-first");
+            assertThat(requireNonNull(checkpointStorage().read(second).block()).asString())
                     .as("one subscription's checkpoint must not overwrite another's, since the subscription id is the key")
                     .isEqualTo("for-second");
-        }
-    }
-
-    @Nested
-    @DisplayName("existence")
-    class Existence {
-
-        @Test
-        void reports_no_checkpoint_before_one_is_saved() {
-            assertThat(checkpointStorage().exists(subscriptionId())).isFalse();
-        }
-
-        @Test
-        void reports_a_checkpoint_once_it_is_saved() {
-            String id = subscriptionId();
-
-            checkpointStorage().save(id, GlobalCheckpoint.of(7));
-
-            assertThat(checkpointStorage().exists(id))
-                    .as("exists is what ResumeStartPositions asks to decide whether a subscription is resuming or "
-                            + "starting fresh, so it must agree with read")
-                    .isTrue();
-        }
-
-        @Test
-        void agrees_with_read_for_every_checkpoint_type() {
-            for (Checkpoint checkpoint : checkpointsToRoundTrip()) {
-                String id = subscriptionId();
-                checkpointStorage().save(id, checkpoint);
-
-                // Both are asserted against true rather than against each other. Comparing the two answers alone would
-                // hold for a storage that saves nothing, since a missing checkpoint makes exists false and read null,
-                // and those agree.
-                assertThat(checkpointStorage().exists(id))
-                        .as("a saved %s must exist", checkpoint.getClass().getSimpleName())
-                        .isTrue();
-                assertThat(checkpointStorage().read(id))
-                        .as("exists and read must not disagree, for %s", checkpoint.getClass().getSimpleName())
-                        .isNotNull();
-            }
         }
     }
 
@@ -303,60 +262,59 @@ public abstract class CheckpointStorageConformance {
     class Deleting {
 
         @Test
-        void a_deleted_checkpoint_is_gone_from_both_read_and_exists() {
+        void a_deleted_checkpoint_is_gone_from_read() {
             String id = subscriptionId();
-            checkpointStorage().save(id, new StringBasedCheckpoint("doomed"));
+            checkpointStorage().save(id, new StringBasedCheckpoint("doomed")).block();
 
-            checkpointStorage().delete(id);
+            checkpointStorage().delete(id).block();
 
-            assertThat(checkpointStorage().read(id))
+            assertThat(checkpointStorage().read(id).block())
                     .as("a deleted checkpoint must not be readable, since cancelling a subscription discards its "
                             + "position and the next start has to be treated as a first one")
                     .isNull();
-            assertThat(checkpointStorage().exists(id)).isFalse();
         }
 
         @Test
         void deleting_a_subscription_it_has_never_seen_does_nothing() {
             String unknown = subscriptionId();
 
-            checkpointStorage().delete(unknown);
+            checkpointStorage().delete(unknown).block();
 
-            assertThat(checkpointStorage().exists(unknown)).isFalse();
+            assertThat(checkpointStorage().read(unknown).block()).isNull();
         }
 
         @Test
         void deleting_twice_does_nothing_the_second_time() {
             String id = subscriptionId();
-            checkpointStorage().save(id, new StringBasedCheckpoint("doomed"));
-            checkpointStorage().delete(id);
+            checkpointStorage().save(id, new StringBasedCheckpoint("doomed")).block();
+            checkpointStorage().delete(id).block();
 
-            checkpointStorage().delete(id);
+            checkpointStorage().delete(id).block();
 
-            assertThat(checkpointStorage().exists(id)).isFalse();
+            assertThat(checkpointStorage().read(id).block()).isNull();
         }
 
         @Test
         void deleting_one_subscription_leaves_another_alone() {
             String deleted = subscriptionId();
             String kept = subscriptionId();
-            checkpointStorage().save(deleted, new StringBasedCheckpoint("doomed"));
-            checkpointStorage().save(kept, new StringBasedCheckpoint("kept"));
+            checkpointStorage().save(deleted, new StringBasedCheckpoint("doomed")).block();
+            checkpointStorage().save(kept, new StringBasedCheckpoint("kept")).block();
 
-            checkpointStorage().delete(deleted);
+            checkpointStorage().delete(deleted).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(kept)).asString()).isEqualTo("kept");
+            assertThat(requireNonNull(checkpointStorage().read(kept).block()).asString()).isEqualTo("kept");
         }
 
         @Test
         void a_checkpoint_can_be_saved_again_after_being_deleted() {
             String id = subscriptionId();
-            checkpointStorage().save(id, new StringBasedCheckpoint("first"));
-            checkpointStorage().delete(id);
+            checkpointStorage().save(id, new StringBasedCheckpoint("first")).block();
+            checkpointStorage().delete(id).block();
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("again"));
+            checkpointStorage().save(id, new StringBasedCheckpoint("again")).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("a subscription that was cancelled and registered again must be able to store a position, so "
                             + "delete cannot leave a tombstone that refuses later saves")
                     .isEqualTo("again");
@@ -372,21 +330,21 @@ public abstract class CheckpointStorageConformance {
             String id = subscriptionId();
 
             if (!fixture().evaluatesWriteConditions()) {
-                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(0)))
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(0)).block())
                         .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
                         .isInstanceOf(UnsupportedOperationException.class);
                 return;
             }
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("first-ever"), CheckpointWriteCondition.notOlderThan(0));
+            checkpointStorage().save(id, new StringBasedCheckpoint("first-ever"), CheckpointWriteCondition.notOlderThan(0)).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("nothing stored means a checkpoint written before this condition existed, so the write must "
                             + "be accepted whatever version it offers")
                     .isEqualTo("first-ever");
-            assertThat(checkpointStorage().writeVersion(id))
+            assertThat(storedVersion(id))
                     .as("the offered version becomes the stored one")
-                    .isEqualTo(OptionalLong.of(0));
+                    .isEqualTo(0L);
         }
 
         @Test
@@ -394,32 +352,36 @@ public abstract class CheckpointStorageConformance {
             String id = subscriptionId();
 
             if (!fixture().evaluatesWriteConditions()) {
-                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(5)))
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.notOlderThan(5)).block())
                         .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
                         .isInstanceOf(UnsupportedOperationException.class);
                 return;
             }
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("at-5"), CheckpointWriteCondition.notOlderThan(5));
-            checkpointStorage().save(id, new StringBasedCheckpoint("at-7"), CheckpointWriteCondition.notOlderThan(7));
+            checkpointStorage().save(id, new StringBasedCheckpoint("at-5"), CheckpointWriteCondition.notOlderThan(5)).block();
+            checkpointStorage().save(id, new StringBasedCheckpoint("at-7"), CheckpointWriteCondition.notOlderThan(7)).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("a version not below the stored one is accepted and its checkpoint written")
                     .isEqualTo("at-7");
-            assertThat(checkpointStorage().writeVersion(id))
+            assertThat(storedVersion(id))
                     .as("the accepted version becomes the stored one")
-                    .isEqualTo(OptionalLong.of(7));
+                    .isEqualTo(7L);
 
-            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(3)))
+            // The refusal must reach the caller as an error signal, never as an empty completion. A .block() on a
+            // Mono that completed empty instead of erroring would return null here, and assertThatThrownBy would
+            // fail with "Expecting code to raise a throwable" rather than silently pass, which is exactly what turns
+            // a refused-write-degrades-to-nothing-happened regression into a failing test rather than a quiet one.
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(3)).block())
                     .as("a version below the stored one is refused, which is what keeps a node whose lease moved on "
                             + "from writing a checkpoint over a newer one")
                     .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("a refused write must not change the stored checkpoint")
                     .isEqualTo("at-7");
-            assertThat(checkpointStorage().writeVersion(id))
+            assertThat(storedVersion(id))
                     .as("a refused write must not change the stored version")
-                    .isEqualTo(OptionalLong.of(7));
+                    .isEqualTo(7L);
         }
 
         @Test
@@ -427,22 +389,22 @@ public abstract class CheckpointStorageConformance {
             String id = subscriptionId();
 
             if (!fixture().evaluatesWriteConditions()) {
-                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.ifAbsent()))
+                assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("v"), CheckpointWriteCondition.ifAbsent()).block())
                         .as("a storage that declares it does not evaluate write conditions refuses anything but any()")
                         .isInstanceOf(UnsupportedOperationException.class);
                 return;
             }
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("pinned"), CheckpointWriteCondition.ifAbsent());
+            checkpointStorage().save(id, new StringBasedCheckpoint("pinned"), CheckpointWriteCondition.ifAbsent()).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("nothing was stored for this subscription id, so the pinning write must be accepted")
                     .isEqualTo("pinned");
 
-            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("overwrite"), CheckpointWriteCondition.ifAbsent()))
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("overwrite"), CheckpointWriteCondition.ifAbsent()).block())
                     .as("a checkpoint already exists for this subscription id, so a second ifAbsent write must be refused")
                     .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("a refused write must not change the stored checkpoint")
                     .isEqualTo("pinned");
         }
@@ -453,25 +415,25 @@ public abstract class CheckpointStorageConformance {
 
             if (!fixture().evaluatesWriteConditions()) {
                 // any() is the one condition every storage is required to support, whatever it declares.
-                checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any());
-                assertThat(requireNonNull(checkpointStorage().read(id)).asString()).isEqualTo("unconditional");
+                checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any()).block();
+                assertThat(requireNonNull(checkpointStorage().read(id).block()).asString()).isEqualTo("unconditional");
                 return;
             }
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("fenced"), CheckpointWriteCondition.notOlderThan(9));
+            checkpointStorage().save(id, new StringBasedCheckpoint("fenced"), CheckpointWriteCondition.notOlderThan(9)).block();
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any());
+            checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any()).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("any() writes the checkpoint")
                     .isEqualTo("unconditional");
-            assertThat(checkpointStorage().writeVersion(id))
+            assertThat(storedVersion(id))
                     .as("any() must leave the stored version exactly as it was, carrying it forward rather than "
                             + "clearing it, since an unconditional write from a hand-wired caller or a node mid-deploy "
                             + "must not re-arm the fence at zero")
-                    .isEqualTo(OptionalLong.of(9));
+                    .isEqualTo(9L);
 
-            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(4)))
+            assertThatThrownBy(() -> checkpointStorage().save(id, new StringBasedCheckpoint("stale"), CheckpointWriteCondition.notOlderThan(4)).block())
                     .as("the version any() carried forward must still be enforced by a later conditional write")
                     .isInstanceOf(CheckpointWriteConditionNotFulfilledException.class);
         }
@@ -484,16 +446,16 @@ public abstract class CheckpointStorageConformance {
                 return;
             }
 
-            checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any());
+            checkpointStorage().save(id, new StringBasedCheckpoint("unconditional"), CheckpointWriteCondition.any()).block();
 
-            assertThat(requireNonNull(checkpointStorage().read(id)).asString())
+            assertThat(requireNonNull(checkpointStorage().read(id).block()).asString())
                     .as("any() writes the checkpoint even on a key nothing was ever stored for")
                     .isEqualTo("unconditional");
-            assertThat(checkpointStorage().writeVersion(id))
+            assertThat(storedVersion(id))
                     .as("an unconditional write on a subscription id with no stored version must not create one, or "
                             + "it arms the fence at version zero for a caller that never asked for a fence at all, "
                             + "refusing the very next notOlderThan(0) write it should have accepted")
-                    .isEqualTo(OptionalLong.empty());
+                    .isNull();
         }
     }
 }

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/CheckpointStorageFixture.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/CheckpointStorageFixture.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.tck.subscription.reactor;
+
+import org.jspecify.annotations.NullMarked;
+import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.api.reactor.CheckpointStorage;
+
+import java.util.List;
+
+/**
+ * What a reactive {@link CheckpointStorage} implementation hands the conformance suite.
+ * <p>
+ * This is the reactive twin of {@code org.occurrent.tck.subscription.blocking.CheckpointStorageFixture}, kept as a
+ * separate interface rather than a shared one because the storage it hands back is the reactive
+ * {@link CheckpointStorage}, whose {@code save}, {@code read}, {@code writeVersion} and {@code delete} all return a
+ * {@code Mono} instead of the blocking storage's plain values. A fixture is created fresh for every test method, and
+ * the storage it hands back <strong>must hold no checkpoints</strong>. How that is achieved is the implementation's
+ * business, whether dropping a collection, flushing a database, or constructing a new instance. The suite never
+ * cleans up on an implementation's behalf, because what needs cleaning is exactly the part a contract cannot
+ * describe.
+ */
+@NullMarked
+public interface CheckpointStorageFixture {
+
+    /**
+     * The storage under test, holding no checkpoints.
+     */
+    CheckpointStorage checkpointStorage();
+
+    /**
+     * Whether {@code read} gives back a checkpoint of the same type that {@code save} was given, for this checkpoint.
+     * <p>
+     * A storage that answers {@code false} still has to round-trip {@link Checkpoint#asString()} faithfully, which is
+     * the whole of what {@code Checkpoint} promises, and the suite asserts that either way. What differs is only
+     * whether the type survives. See the blocking fixture's version of this method for the full reasoning, which
+     * applies unchanged here.
+     *
+     * @param checkpoint the checkpoint the suite is about to save
+     */
+    boolean preservesCheckpointType(Checkpoint checkpoint);
+
+    /**
+     * Whether this storage evaluates a {@link org.occurrent.subscription.CheckpointWriteCondition} for real.
+     * <p>
+     * {@code true}, the default, means {@code notOlderThan} and {@code ifAbsent} are both accepted and refused as
+     * documented, and {@code any()} leaves a stored version untouched and carries it forward. {@code false} means
+     * this storage refuses every condition but {@link org.occurrent.subscription.CheckpointWriteCondition#any()}
+     * with {@link UnsupportedOperationException} signalled through {@link reactor.core.publisher.Mono#error(Throwable)},
+     * the interim answer some of Occurrent's own storages give until a sibling change teaches them the real
+     * comparison. This is a declaration rather than a question put to the storage, the same reason
+     * {@link #preservesCheckpointType(Checkpoint)} is one. It is a property of what the storage was built to do, and
+     * nothing on {@code CheckpointStorage} reports it back.
+     */
+    default boolean evaluatesWriteConditions() {
+        return true;
+    }
+
+    /**
+     * Checkpoint types of the implementation's own, round-tripped in addition to the two the suite always covers.
+     * <p>
+     * The suite covers {@code StringBasedCheckpoint} and {@code GlobalCheckpoint} for every storage, because both live
+     * in {@code occurrent-subscription-core} and {@link Checkpoint#asString()} is the whole contract, so every storage
+     * owes an answer for them. A storage that recognises checkpoint types of its own adds them here and the suite
+     * round-trips those too.
+     */
+    default List<Checkpoint> additionalCheckpoints() {
+        return List.of();
+    }
+
+    /**
+     * Releases whatever the fixture opened. Called after every test method, including a failing one.
+     */
+    default void close() {
+    }
+}


### PR DESCRIPTION
I added conformance coverage for the reactor checkpoint-storage write path, the one part of ADR 116's mechanism that had no assertion anywhere. `ReactorCheckpointStorage` had zero tests exercising `notOlderThan`, `ifAbsent`, or `writeVersion`, so two specific regressions could have shipped silently. A refusal could degrade from `Mono.error` to an empty completion (the check sits in a `.map()` after `.retryWhen()`), and a refused write could get retried as if it were transient.

I added a reactive `CheckpointStorageConformance` suite in `tck/subscription-reactor`, mirroring the existing blocking suite, and wired it against both reactive `CheckpointStorage` implementations in the repo (MongoDB, in-memory). It specifically asserts a refusal reaches the caller as `Mono.error`, never a silent empty completion. I also added a targeted regression test proving a refused conditional write reaches the caller after exactly one `findOneAndUpdate`, not after `retryWhen` mistakes it for a transient failure and burns its retry budget on it.

Separately, I added one case to the blocking TCK's `CheckpointStorageConformance`. An unconditional write on a subscription id with no stored version must not create one, or it arms the fence at version zero for a caller that never asked for one. That case runs automatically against every existing blocking `CheckpointStorage` implementation.

No production code changed. I verified every new assertion by temporarily mutating the specific production behavior it checks and confirming the test failed, then restored from a backup copy rather than via git.
