### PR TITLE
Fix waitUntilApplied blocking past its timeout under a sustained Mongo outage

### DIFF
--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/AppliedPositionStore.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/AppliedPositionStore.java
@@ -81,8 +81,10 @@ public interface AppliedPositionStore {
 
     /**
      * Blocks until {@code projectionId} has applied a position at or beyond {@code position}, or {@code timeout}
-     * elapses. Returns {@code true} once caught up, {@code false} on timeout, and never throws for a timeout, the
-     * same shape {@code Subscription.waitUntilStarted(Duration)} uses for a blocking wait elsewhere in this library.
+     * elapses. Returns {@code true} once caught up, {@code false} on timeout or if the waiting thread is
+     * interrupted, and never throws for either, the same shape {@code Subscription.waitUntilStarted(Duration)} uses
+     * for a blocking wait elsewhere in this library. An interrupt restores the thread's interrupt flag before
+     * returning, so a caller that needs to tell the two apart can check {@link Thread#isInterrupted()} itself.
      * <p>
      * This is a plain read-and-sleep loop, since the position lives in a store this method cannot subscribe to for a
      * push notification. An implementation backed by a store that can push a change is free to override this method.

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdate.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdate.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.dsl.projection.AppliedPositionStore;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.function.BiFunction;
 
@@ -37,6 +38,12 @@ import java.util.function.BiFunction;
  * completes. {@link #replayAbandoned()} discards it instead, since the next replay recomputes everything anyway.
  * {@code lock} guards the mutable state because the reactor catch-up handover can hop between worker threads even
  * though its calls never run concurrently.
+ * <p>
+ * {@link AppliedPositionStore} is a blocking-shaped interface, so both store advances below hop to
+ * {@link Schedulers#boundedElastic()} first. The delegate this class wraps is caller-supplied
+ * ({@code Projections.recordingAppliedPosition(..)} accepts any {@code BiFunction}), and nothing guarantees it
+ * completes off a non-blocking thread the way the framework's own coalescing update does. A delegate that finishes
+ * on a Reactor Netty event loop would otherwise make a blocking store's advance throw.
  */
 @NullMarked
 final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, Mono<Void>>, ReactiveReplayAwareMaterializedView {
@@ -63,10 +70,10 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
                     "Either the event store has position writing turned off, or the event arrived on a path that carries no metadata " +
                     "(a live domain-event feed the application did not pass metadata into, or the metadata-less query/replay path).").formatted(projectionId)));
         }
-        return delegate.apply(metadata, event).doOnSuccess(ignored -> recordApplied(position));
+        return delegate.apply(metadata, event).then(Mono.defer(() -> recordApplied(position)));
     }
 
-    private void recordApplied(long position) {
+    private Mono<Void> recordApplied(long position) {
         boolean stillReplaying;
         synchronized (lock) {
             stillReplaying = replaying;
@@ -74,9 +81,10 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
                 highestPositionSeenDuringReplay = position;
             }
         }
-        if (!stillReplaying) {
-            store.advance(projectionId, position);
+        if (stillReplaying) {
+            return Mono.empty();
         }
+        return Mono.<Void>fromRunnable(() -> store.advance(projectionId, position)).subscribeOn(Schedulers.boundedElastic());
     }
 
     @Override
@@ -93,15 +101,16 @@ final class RecordingReactiveUpdate<E> implements BiFunction<EventMetadata, E, M
     @Override
     public Mono<Void> replayCompleted() {
         Mono<Void> delegateCompletion = delegate instanceof ReactiveReplayAwareMaterializedView replayAware ? replayAware.replayCompleted() : Mono.empty();
-        return delegateCompletion.then(Mono.<Void>fromRunnable(() -> {
+        return delegateCompletion.then(Mono.defer(() -> {
             long highest;
             synchronized (lock) {
                 highest = highestPositionSeenDuringReplay;
                 replaying = false;
             }
-            if (highest > 0) {
-                store.advance(projectionId, highest);
+            if (highest == 0) {
+                return Mono.empty();
             }
+            return Mono.<Void>fromRunnable(() -> store.advance(projectionId, highest)).subscribeOn(Schedulers.boundedElastic());
         }));
     }
 

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdateTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/RecordingReactiveUpdateTest.java
@@ -22,14 +22,18 @@ import org.junit.jupiter.api.Test;
 import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.dsl.projection.AppliedPositionStore;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -121,6 +125,39 @@ class RecordingReactiveUpdateTest {
         recording.apply(metadataWithPosition(10), "event-2").block();
 
         assertThat(storage.appliedPosition("orders")).hasValue(50L);
+    }
+
+    @Test
+    void advance_is_hopped_off_a_thread_reactor_forbids_blocking_on_even_when_the_delegate_completes_on_one() {
+        AtomicReference<String> threadThatCalledAdvance = new AtomicReference<>();
+        AppliedPositionStore inMemory = AppliedPositionStore.inMemory();
+        AppliedPositionStore storage = new AppliedPositionStore() {
+            @Override
+            public OptionalLong appliedPosition(String projectionId) {
+                return inMemory.appliedPosition(projectionId);
+            }
+
+            @Override
+            public void advance(String projectionId, long position) {
+                threadThatCalledAdvance.set(Thread.currentThread().getName());
+                // A genuinely async wait (an already-available value never actually parks the thread, so it would
+                // pass the check by accident). Reactor throws IllegalStateException here if called from a thread it
+                // has marked non-blocking, the same shape a real blocking AppliedPositionStore's own .block() call
+                // on a reactive Mongo read would fail with.
+                Mono.just(1).delayElement(Duration.ofMillis(1)).block();
+                inMemory.advance(projectionId, position);
+            }
+        };
+        // Completes on Schedulers.parallel(), which Reactor marks non-blocking, standing in for a delegate that
+        // finishes on a Reactor Netty event loop instead of the boundedElastic thread the framework's own
+        // coalescing update hops to.
+        BiFunction<EventMetadata, String, Mono<Void>> delegate = (metadata, event) -> Mono.<Void>empty().publishOn(Schedulers.parallel());
+        BiFunction<EventMetadata, String, Mono<Void>> recording = Projections.recordingAppliedPosition(delegate, storage, "orders");
+
+        assertThatCode(() -> recording.apply(metadataWithPosition(42), "event-1").block()).doesNotThrowAnyException();
+
+        assertThat(threadThatCalledAdvance.get()).startsWith("boundedElastic");
+        assertThat(storage.appliedPosition("orders")).hasValue(42L);
     }
 
     private static EventMetadata metadataWithPosition(long position) {

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedPositionStore.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedPositionStore.java
@@ -49,6 +49,12 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * {@link #waitUntilApplied(String, long, Duration)} sleeps between polls that succeeded and simply found the
  * projection still behind. {@link Retry} rather than the blocking {@code RetryStrategy} because this is the reactive
  * stack, matching how the reactive starter retries elsewhere.
+ * <p>
+ * {@link #defaultRetry()} gives up after a fixed number of attempts rather than retrying forever, a deliberate
+ * divergence from the blocking store's default. This store has no {@code waitUntilApplied} override with a
+ * wait-local deadline to fall back on, so bounding the retry itself is what keeps a sustained outage from blocking
+ * {@link #appliedPosition(String)} and {@link #advance(String, long)} indefinitely. The two stores do not behave
+ * the same way under a sustained outage, and an application that needs parity should supply its own {@link Retry}.
  */
 @NullMarked
 class ReactiveMongoAppliedPositionStore implements AppliedPositionStore {
@@ -62,8 +68,12 @@ class ReactiveMongoAppliedPositionStore implements AppliedPositionStore {
     private final Backoff pollBackoff;
 
     /**
-     * Retries a failing read or write with exponential backoff from 100 ms up to 2 seconds, mirroring the blocking
-     * store's default, and polls a wait at {@link AppliedPositionStore#DEFAULT_POLL_BACKOFF}.
+     * Retries a failing read or write with backoff from 100 ms up to 2 seconds, giving up after 5 retries (6
+     * attempts total) and surfacing the last failure. The blocking store does not give up this way.
+     * {@code MongoAppliedPositionStore} retries the same backoff forever, since it keeps {@code advance(..)} durable
+     * under an outage and bounds only {@code waitUntilApplied(..)}'s own reads to the wait's deadline instead. This
+     * store has no such wait-local bound, so its default retries a fixed number of times rather than forever, and
+     * polls a wait at {@link AppliedPositionStore#DEFAULT_POLL_BACKOFF}.
      */
     ReactiveMongoAppliedPositionStore(ReactiveMongoOperations mongoOperations, String collection) {
         this(mongoOperations, collection, defaultRetry(), DEFAULT_POLL_BACKOFF);

--- a/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/MongoAppliedPositionStore.java
+++ b/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/MongoAppliedPositionStore.java
@@ -27,6 +27,7 @@ import org.springframework.data.mongodb.core.query.Update;
 
 import java.time.Duration;
 import java.util.OptionalLong;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -44,10 +45,11 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * concurrent advances for the same projection id, with no read-modify-write race.
  * <p>
  * Two different mechanisms pace two different things here, and they do not overlap. The {@link RetryStrategy} retries
- * a read or a write that failed, so a transient store error neither fails the projection's delivery on the fold path
- * nor ends a caller's wait on the read path. The {@link Backoff} decides how long
- * {@link #waitUntilApplied(String, long, Duration)} sleeps between polls that succeeded and simply found the
- * projection still behind.
+ * a read or a write that failed, so a transient store error neither fails {@link #advance(String, long)} nor a plain
+ * {@link #appliedPosition(String)} call. {@link #waitUntilApplied(String, long, Duration)} is the one exception. Its
+ * own reads retry on the same {@link RetryStrategy}, but bounded to the wait's deadline, so a sustained store outage
+ * still surfaces as a timeout rather than an unbounded block. The {@link Backoff} decides how long a wait sleeps
+ * between polls that succeeded and simply found the projection still behind.
  */
 @NullMarked
 class MongoAppliedPositionStore implements AppliedPositionStore {
@@ -80,15 +82,33 @@ class MongoAppliedPositionStore implements AppliedPositionStore {
     @Override
     public OptionalLong appliedPosition(String projectionId) {
         requireNonNull(projectionId, "projectionId cannot be null");
-        Supplier<OptionalLong> read = () -> {
-            Document document = mongoOperations.findOne(query(where(ID).is(projectionId)), Document.class, collection);
-            if (document == null) {
-                return OptionalLong.empty();
-            }
-            Number position = document.get(POSITION, Number.class);
-            return position == null ? OptionalLong.empty() : OptionalLong.of(position.longValue());
-        };
+        Supplier<OptionalLong> read = () -> readOnce(projectionId);
         return requireNonNull(executeWithRetry(read, __ -> !shutdown, retryStrategy).get());
+    }
+
+    private OptionalLong readOnce(String projectionId) {
+        Document document = mongoOperations.findOne(query(where(ID).is(projectionId)), Document.class, collection);
+        if (document == null) {
+            return OptionalLong.empty();
+        }
+        Number position = document.get(POSITION, Number.class);
+        return position == null ? OptionalLong.empty() : OptionalLong.of(position.longValue());
+    }
+
+    /**
+     * A read for {@link #waitUntilApplied(String, long, Duration, Backoff)} whose retries stop once {@code deadlineNanos}
+     * ({@link System#nanoTime()} scale) passes, rather than continuing on {@link #retryStrategy}'s own unbounded
+     * schedule. A store that is still failing once the deadline arrives answers empty instead of retrying past it,
+     * so the wait's own deadline check is what ends the wait.
+     */
+    private OptionalLong readOnceBoundedBy(String projectionId, long deadlineNanos) {
+        Supplier<OptionalLong> read = () -> readOnce(projectionId);
+        Predicate<Throwable> notShutdownAndBeforeDeadline = __ -> !shutdown && System.nanoTime() < deadlineNanos;
+        try {
+            return requireNonNull(executeWithRetry(read, notShutdownAndBeforeDeadline, retryStrategy).get());
+        } catch (RuntimeException e) {
+            return OptionalLong.empty();
+        }
     }
 
     @Override
@@ -104,6 +124,52 @@ class MongoAppliedPositionStore implements AppliedPositionStore {
     @Override
     public boolean waitUntilApplied(String projectionId, long position, Duration timeout) {
         return waitUntilApplied(projectionId, position, timeout, pollBackoff);
+    }
+
+    /**
+     * Overrides {@link AppliedPositionStore}'s default loop so each poll's read retries against {@link #retryStrategy}
+     * bounded to this wait's own deadline, rather than {@link #retryStrategy}'s unbounded schedule. Without this, a
+     * sustained store outage keeps a single read retrying forever and the wait never reaches the deadline check that
+     * is supposed to end it. The loop shape (read, check, sleep, grow the backoff) otherwise matches the interface
+     * default. Only the read is store-specific.
+     */
+    @Override
+    public boolean waitUntilApplied(String projectionId, long position, Duration timeout, Backoff backoff) {
+        requireNonNull(projectionId, "projectionId cannot be null");
+        requireNonNull(timeout, "timeout cannot be null");
+        requireNonNull(backoff, "backoff cannot be null");
+        if (position <= 0) {
+            throw new IllegalArgumentException("position must be positive but was " + position);
+        }
+        if (backoff instanceof Backoff.None) {
+            throw new IllegalArgumentException("backoff cannot be Backoff.none(), a wait polls the store and needs a delay between polls. Use Backoff.fixed(..) or Backoff.exponential(..).");
+        }
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        long intervalNanos = switch (backoff) {
+            case Backoff.Fixed fixed -> Duration.ofMillis(fixed.millis).toNanos();
+            case Backoff.Exponential exponential -> exponential.initial.toNanos();
+            case Backoff.None ignored -> throw new IllegalStateException("unreachable, rejected above");
+        };
+        while (true) {
+            OptionalLong applied = readOnceBoundedBy(projectionId, deadlineNanos);
+            if (applied.isPresent() && applied.getAsLong() >= position) {
+                return true;
+            }
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                return false;
+            }
+            long sleepNanos = Math.min(intervalNanos, remainingNanos);
+            try {
+                Thread.sleep(sleepNanos / 1_000_000, (int) (sleepNanos % 1_000_000));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            if (backoff instanceof Backoff.Exponential exponential) {
+                intervalNanos = Math.min((long) (intervalNanos * exponential.multiplier), exponential.max.toNanos());
+            }
+        }
     }
 
     @PreDestroy

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/MongoAppliedPositionStoreWaitUntilAppliedTimeoutTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/MongoAppliedPositionStoreWaitUntilAppliedTimeoutTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.dsl.projection.AppliedPositionStore;
+import org.occurrent.retry.Backoff;
+import org.occurrent.retry.RetryStrategy;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link MongoAppliedPositionStore#waitUntilApplied(String, long, Duration)} promises to return {@code false} once
+ * {@code timeout} elapses. The store's read is wrapped in a {@link RetryStrategy} that, left to its own default,
+ * retries forever, so a wait against a store that never stops failing must bound that retry to its own deadline
+ * itself rather than inherit the store's unbounded one. No Testcontainers needed, a mocked {@link MongoOperations}
+ * whose read always throws is enough to force the sustained-outage path.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Timeout(10)
+class MongoAppliedPositionStoreWaitUntilAppliedTimeoutTest {
+
+    @Test
+    void returns_false_within_its_timeout_against_a_store_whose_reads_keep_failing() {
+        MongoOperations mongoOperations = mock(MongoOperations.class);
+        when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
+                .thenThrow(new RuntimeException("store outage"));
+        RetryStrategy fastRetry = RetryStrategy.exponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(50), 2.0);
+        AppliedPositionStore storage = new MongoAppliedPositionStore(mongoOperations, "appliedPositions", fastRetry, Backoff.fixed(20));
+        Duration timeout = Duration.ofMillis(200);
+
+        Instant start = Instant.now();
+        boolean caughtUp = storage.waitUntilApplied("orders", 1, timeout);
+        Duration elapsed = Duration.between(start, Instant.now());
+
+        assertThat(caughtUp).isFalse();
+        // The deadline is only checked between retry attempts, so the last in-flight attempt can overrun it by up
+        // to one retry interval. This slack stays well short of whole extra retry cycles.
+        assertThat(elapsed).isLessThan(timeout.plusSeconds(2));
+        verify(mongoOperations, atLeast(2)).findOne(any(Query.class), eq(Document.class), anyString());
+    }
+}


### PR DESCRIPTION
`waitUntilApplied` promises to return `false` once its timeout elapses, but `MongoAppliedPositionStore`'s read went through a `RetryStrategy` that retries forever. Under a sustained store outage, one poll could block indefinitely and the wait never reached the deadline check meant to end it. I bounded the wait's own reads to a deadline-aware retry that gives up once the wait's timeout passes, while leaving `advance`'s retry unbounded so a durable write still survives an outage.

I also found two related issues while I was in this code:
- `RecordingReactiveUpdate` called `store.advance(..)` from whatever thread the wrapped delegate's `Mono` completed on. That's safe for the framework's own coalescing update, which hops to `boundedElastic`, but not for an arbitrary caller-supplied delegate (`Projections.recordingAppliedPosition` accepts any `BiFunction`) finishing on a Reactor Netty event loop, where a blocking store's `advance` would throw. I added the same defensive hop.
- `ReactiveMongoAppliedPositionStore`'s javadoc claimed its default retry mirrors the blocking store's. It does not. The reactive store gives up after 6 attempts, and the two stores deliberately diverge under a sustained outage. I corrected the javadoc.

I also documented that `AppliedPositionStore.waitUntilApplied` returns `false` on an interrupt too, not only on timeout, since the existing javadoc only covered the timeout case.

Verification (three modules, run sequentially, each `-am` built and installed from source first):
- `mvn -pl dsl/projection-dsl/reactor test`: 71 tests, 0 failures
- `mvn -pl framework/spring-boot-starter-mongodb test`: 182 tests, 0 failures
- `mvn -pl framework/spring-boot-starter-mongodb-reactive test`: 70 tests, 0 failures

I verified both new tests by temporarily reverting the fix each covers and confirming the test failed, then restoring from a pre-mutation copy.
