### PR TITLE
Add missing benchmark coverage for two 0.33.0 performance claims

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,9 +29,10 @@
 
     <name>${mavenProjectName}</name>
     <description>
-        JMH benchmarks that reproduce the measurement setups cited in ADR 108 and PR #615, and a payload-filter
-        read benchmark for the go/no-go decision on #623. Dev-only: never installed as a reactor module unless the
-        "benchmarks" profile is active, and never published even if it is (see maven.deploy.skip below).
+        JMH benchmarks that reproduce the measurement setups cited in ADR 108 and PR #615, a payload-filter read
+        benchmark for the go/no-go decision on #623, and a coalescing-flush benchmark for the batch-size default in
+        #692. Dev-only: never installed as a reactor module unless the "benchmarks" profile is active, and never
+        published even if it is (see maven.deploy.skip below).
     </description>
 
     <properties>
@@ -55,6 +56,11 @@
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-projection-dsl-reactor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-projection-dsl-blocking</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFixtures.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFixtures.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.coalescing;
+
+/**
+ * Builds the two key-distribution shapes {@link CoalescingFlushBenchmark} replays through a coalescing view. One is
+ * a sparse batch where every event updates a different view instance, the other a dense batch where every event
+ * updates one of a small, fixed pool of instances. A flush reads and writes once per distinct key in the batch, so
+ * these two shapes bound how much a flush can save by combining several events onto the same key before touching
+ * the repository, regardless of how large the batch itself is.
+ * <p>
+ * Public, and so is {@link KeyDensity}: JMH's generated benchmark harness lives in a {@code jmh_generated}
+ * sub-package and references {@code CoalescingFixtures.KeyDensity} as a {@code @Param} field type, so both need to
+ * be reachable from outside this package even though {@link CoalescingFlushBenchmark} itself sits in the same
+ * package as this class. Everything else here stays package-private.
+ */
+public final class CoalescingFixtures {
+
+    private CoalescingFixtures() {
+    }
+
+    public enum KeyDensity {
+        /** Every event in the batch targets its own key, so a flush touches as many keys as it has events. */
+        SPARSE,
+        /** Every event in the batch targets one of {@link #DENSE_KEY_COUNT} keys, however large the batch is. */
+        DENSE
+    }
+
+    /** How many distinct keys a dense batch cycles through, whatever its size. */
+    static final int DENSE_KEY_COUNT = 10;
+
+    /** How many distinct keys a batch of {@code eventCount} events touches under {@code density}. */
+    static int keyPoolSize(KeyDensity density, int eventCount) {
+        return density == KeyDensity.DENSE ? Math.min(DENSE_KEY_COUNT, eventCount) : eventCount;
+    }
+
+    /** The view-instance key for the {@code index}-th event in a batch of {@code eventCount} events. */
+    static String keyFor(KeyDensity density, int eventCount, long index) {
+        return "key-" + (index % keyPoolSize(density, eventCount));
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFlushBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFlushBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.coalescing;
+
+import org.occurrent.dsl.projection.MaterializedViewOptions;
+import org.occurrent.dsl.projection.Projection;
+import org.occurrent.dsl.projection.blocking.Projections;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ReplayAwareMaterializedView;
+import org.occurrent.retry.RetryStrategy;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Measures a catch-up replay's flush cost against {@link MaterializedViewOptions#batchSize()}
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md">ADR 110</a>),
+ * the number {@code MaterializedViewOptions.DEFAULT_BATCH_SIZE} defaults to without a benchmark behind it
+ * (<a href="https://github.com/johanhaleby/occurrent/issues/692">#692</a>).
+ * <p>
+ * Each invocation drives {@code batchSize} events through the real, shipped
+ * {@link Projections#materializedView(Projection, org.occurrent.dsl.view.ViewStateRepository, RetryStrategy, MaterializedViewOptions)}
+ * during a replay, which buffers them and flushes exactly once, on the last event, since the buffer reaches
+ * {@code batchSize} at that point. {@link SimulatedLatencyRepository} stands in for the store. Every
+ * {@code findAllById}/{@code saveAll} call (a flush uses one of each) pays a fixed round-trip cost plus a small cost
+ * per key it touches, the same shape a real network round trip to a database has. A flush's total cost is therefore
+ * two round trips plus one per-key cost for every key the batch touched, whatever the batch size.
+ * <p>
+ * {@link CoalescingFixtures.KeyDensity#SPARSE} gives every event in the batch its own key, so a flush touches as
+ * many keys as it has events, the same read/write volume coalescing was never going to reduce. {@code DENSE} cycles
+ * every event through a fixed pool of {@link CoalescingFixtures#DENSE_KEY_COUNT} keys, so a flush touches at most
+ * that many keys no matter how large the batch is, the case where combining several events for the same key before
+ * touching the repository actually pays off. Comparing both across {@code batchSize} 1, 100 and 1000 is what shows
+ * whether a bigger batch keeps paying for itself or only helps up to a point.
+ * <p>
+ * {@code @Setup(Level.Invocation)} builds a fresh view, repository and projection for every invocation, so one
+ * invocation's buffered state can never leak into the next. That is more setup work per invocation than a typical
+ * JMH benchmark does, but the timed region is only {@link BatchState#driveOneFlush()}, so the setup itself is not
+ * measured.
+ * <p>
+ * Run with, for example:
+ * <pre>{@code
+ * java -jar benchmark/target/benchmarks.jar CoalescingFlushBenchmark -wi 3 -i 5 -f 1
+ * }</pre>
+ * No external service or container is required.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class CoalescingFlushBenchmark {
+
+    private static final long ROUND_TRIP_MICROS = 500;
+    private static final long PER_KEY_MICROS = 5;
+
+    @State(Scope.Thread)
+    public static class BatchState {
+
+        @Param({"1", "100", "1000"})
+        public int batchSize;
+
+        @Param({"SPARSE", "DENSE"})
+        public CoalescingFixtures.KeyDensity keyDensity;
+
+        private final LongAdder sink = new LongAdder();
+        private MaterializedView<Long> view;
+
+        @Setup(Level.Invocation)
+        public void setUp() {
+            SimulatedLatencyRepository repository = new SimulatedLatencyRepository(ROUND_TRIP_MICROS, PER_KEY_MICROS, sink);
+            Projection<Long, Long, String> projection = Projection.<Long, Long, String>builder(0L)
+                    .id(event -> CoalescingFixtures.keyFor(keyDensity, batchSize, event))
+                    .on(Long.class, (state, event) -> state + 1)
+                    .build();
+            MaterializedView<Long> materializedView =
+                    Projections.materializedView(projection, repository, RetryStrategy.none(), new MaterializedViewOptions(batchSize));
+            if (!(materializedView instanceof ReplayAwareMaterializedView replayAware)) {
+                throw new IllegalStateException(Projections.class.getSimpleName() + " no longer returns a "
+                        + ReplayAwareMaterializedView.class.getSimpleName() + ", so this benchmark can no longer start a replay to buffer through.");
+            }
+            replayAware.replayStarted();
+            view = materializedView;
+        }
+
+        void driveOneFlush() {
+            for (long i = 0; i < batchSize; i++) {
+                view.update(i);
+            }
+        }
+    }
+
+    @Benchmark
+    public void flushOneBatch(BatchState state) {
+        state.driveOneFlush();
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/coalescing/SimulatedLatencyRepository.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/coalescing/SimulatedLatencyRepository.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.benchmark.coalescing;
+
+import org.occurrent.benchmark.handover.BusySpin;
+import org.occurrent.dsl.view.ViewStateRepository;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A {@link ViewStateRepository} standing in for a real store, charging a fixed round-trip cost once per call plus a
+ * small per-key cost for each key that call touches. {@code findAllById} and {@code saveAll} are overridden the way
+ * a real bulk-capable repository would override them, so one call handles every key in a batch instead of paying the
+ * round trip once per key the way the unoverridden default (and {@code findById}/{@code save}) would. That is the
+ * whole reason {@link CoalescingFlushBenchmark} exists. A flush's cost depends on how many of these calls it makes,
+ * not how many events it buffered.
+ */
+final class SimulatedLatencyRepository implements ViewStateRepository<Long, String> {
+
+    private final Map<String, Long> store = new ConcurrentHashMap<>();
+    private final long roundTripMicros;
+    private final long perKeyMicros;
+    private final LongAdder sink;
+
+    SimulatedLatencyRepository(long roundTripMicros, long perKeyMicros, LongAdder sink) {
+        this.roundTripMicros = roundTripMicros;
+        this.perKeyMicros = perKeyMicros;
+        this.sink = sink;
+    }
+
+    @Override
+    public Optional<Long> findById(String id) {
+        BusySpin.spinMicros(roundTripMicros, sink);
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void save(String id, Long state) {
+        BusySpin.spinMicros(roundTripMicros, sink);
+        store.put(id, state);
+    }
+
+    @Override
+    public Map<String, Long> findAllById(Collection<String> ids) {
+        BusySpin.spinMicros(roundTripMicros, sink);
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (String id : ids) {
+            BusySpin.spinMicros(perKeyMicros, sink);
+            Long value = store.get(id);
+            if (value != null) {
+                result.put(id, value);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void saveAll(Map<String, Long> states) {
+        BusySpin.spinMicros(roundTripMicros, sink);
+        for (Map.Entry<String, Long> entry : states.entrySet()) {
+            BusySpin.spinMicros(perKeyMicros, sink);
+            store.put(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFilterReadBenchmark.java
+++ b/benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFilterReadBenchmark.java
@@ -30,6 +30,9 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -40,11 +43,15 @@ import java.util.concurrent.TimeUnit;
  * {@link org.occurrent.filtermatching.DataFieldReader#read(CloudEvent, String)} once per leaf,
  * {@code FilterMatcher.java:46-57} and {@code ConditionMatcher.java:180-191}).
  * <p>
- * Also benchmarks {@link org.occurrent.filtermatching.DataFieldReader#readAll(CloudEvent, java.util.Collection)},
- * the bulk-read entry point PR #626 added: its default implementation is the same per-leaf loop
- * {@code FilterMatcher} already does, so it is not expected to differ from the composed-filter numbers here.
- * {@code JacksonDataFieldReader} does not override it, so this measures the current, unmemoized baseline both
- * paths share, not a hypothetical faster implementation.
+ * {@code JacksonDataFieldReader} now overrides
+ * {@link org.occurrent.filtermatching.DataFieldReader#readAll(CloudEvent, java.util.Collection)} (added by PR #626)
+ * to resolve every path in one parse instead of one per path. That makes both {@link #matchesFilter} and
+ * {@link #readAllPaths} exercise the batched path. {@code FilterMatcher.matchesAndFilter} calls {@code readAll} for
+ * a composed filter with two or more data-field leaves, and {@link #readAllPaths} calls it directly. Neither one
+ * measures the old, unmemoized baseline any more, but {@link #readEachPathIndependently} does. It calls
+ * {@link org.occurrent.filtermatching.DataFieldReader#read(CloudEvent, String)} once per path, the same per-leaf
+ * loop {@code ConditionMatcher} ran before {@code readAll} existed, so comparing it against the other two methods is
+ * what shows whether the batched path is actually faster.
  * <p>
  * Follows the protocol #623 asks for: 1, 5 and 20 leaves, 1 KB and 256 KB payloads, the needle fields placed early
  * or late in the payload, against both a byte-backed event (streaming re-parse per leaf) and a Map-backed event
@@ -83,13 +90,31 @@ public class PayloadFilterReadBenchmark {
         private final JacksonDataFieldReader reader = new JacksonDataFieldReader();
 
         @Setup(Level.Trial)
-        public void setUp() {
+        public void setUp() throws NoSuchMethodException {
+            requireReadAllOverride();
             Map<String, Object> payload = PayloadFixtures.payload(leafCount, payloadSizeBytes, fieldPosition);
             event = backing == PayloadFixtures.Backing.MAP
                     ? PayloadFixtures.eventWithMap(payload)
                     : PayloadFixtures.eventWithBytes(payload);
             paths = PayloadFixtures.needlePaths(leafCount);
             filter = PayloadFixtures.matchAllFilter(paths, payload);
+        }
+
+        /**
+         * {@link #matchesFilter} and {@link #readAllPaths} are only distinct from {@link #readEachPathIndependently}
+         * as long as {@code JacksonDataFieldReader} overrides {@code readAll} with a real batched implementation. If
+         * that override is ever removed, {@code readAll} silently falls back to
+         * {@link org.occurrent.filtermatching.DataFieldReader}'s default, which calls {@code read} once per path,
+         * the exact loop {@link #readEachPathIndependently} already measures, and this benchmark would keep running
+         * without ever telling anyone it stopped comparing two different implementations.
+         */
+        private static void requireReadAllOverride() throws NoSuchMethodException {
+            Method readAll = JacksonDataFieldReader.class.getMethod("readAll", CloudEvent.class, Collection.class);
+            if (readAll.getDeclaringClass() != JacksonDataFieldReader.class) {
+                throw new IllegalStateException(JacksonDataFieldReader.class.getSimpleName() + " no longer overrides readAll(..), "
+                        + "so matchesFilter and readAllPaths would silently measure the same per-path loop as "
+                        + "readEachPathIndependently instead of the batched path this benchmark exists to compare it against.");
+            }
         }
     }
 
@@ -101,5 +126,20 @@ public class PayloadFilterReadBenchmark {
     @Benchmark
     public Map<String, Object> readAllPaths(ReadState state) {
         return state.reader.readAll(state.event, state.paths);
+    }
+
+    /**
+     * The pre-{@code readAll} baseline, resolving every path in {@code state.paths} with its own
+     * {@link org.occurrent.filtermatching.DataFieldReader#read(CloudEvent, String)} call, reparsing a byte-backed
+     * payload from the start each time. This is what {@link #matchesFilter} and {@link #readAllPaths} used to
+     * measure before {@code JacksonDataFieldReader} started overriding {@code readAll}.
+     */
+    @Benchmark
+    public Map<String, Object> readEachPathIndependently(ReadState state) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String path : state.paths) {
+            state.reader.read(state.event, path).ifPresent(value -> result.put(path, value));
+        }
+        return result;
     }
 }

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/MaterializedViewOptions.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/MaterializedViewOptions.java
@@ -33,8 +33,9 @@ package org.occurrent.dsl.projection;
 public record MaterializedViewOptions(int batchSize) {
 
     /**
-     * The starting default. To be confirmed against the benchmark harness in
-     * <a href="https://github.com/johanhaleby/occurrent/issues/624">#624</a> rather than guessed at twice.
+     * The starting default. To be confirmed against {@code CoalescingFlushBenchmark} in the {@code benchmark}
+     * module, added for <a href="https://github.com/johanhaleby/occurrent/issues/692">#692</a>, rather than guessed
+     * at twice.
      */
     public static final int DEFAULT_BATCH_SIZE = 1000;
 


### PR DESCRIPTION
I added the missing benchmark harnesses for two performance claims in the 0.33.0 range that had no measurement behind them. I did not tune anything. `MaterializedViewOptions.batchSize`'s default stays 1000.

**`PayloadFilterReadBenchmark`** claimed to measure the unmemoized baseline, but `JacksonDataFieldReader` now overrides `readAll`, so both existing methods (`matchesFilter`, `readAllPaths`) exercise the batched path. I added `readEachPathIndependently`, which calls `read` once per path, the true pre-`readAll` baseline. I also added a reflection check in `@Setup` that fails the benchmark loudly if `JacksonDataFieldReader` ever stops overriding `readAll`, and fixed the class javadoc, which still described the old, no-longer-true behavior.

**Coalescing flush cost** had no harness at all. `MaterializedViewOptions.batchSize` defaults to 1000 with a javadoc note pointing at a benchmark harness in #624, which is closed and never had one. I added `CoalescingFlushBenchmark` (new `org.occurrent.benchmark.coalescing` package), which drives a batch of events through the real `Projections.materializedView(..)` during a replay and measures the resulting flush, at batch sizes 1, 100 and 1000, against a sparse workload (every event its own key) and a dense one (a fixed pool of 10 keys). `SimulatedLatencyRepository` stands in for the store, charging a fixed round-trip cost per `findAllById`/`saveAll` call plus a small per-key cost, so the numbers show what batching round trips actually buys. I repointed `MaterializedViewOptions`' javadoc at the new harness and at #692.

## Files

- `benchmark/src/main/java/org/occurrent/benchmark/payloadfilter/PayloadFilterReadBenchmark.java`: baseline arm, fail-fast fixture check, javadoc fix
- `benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFlushBenchmark.java`: new
- `benchmark/src/main/java/org/occurrent/benchmark/coalescing/CoalescingFixtures.java`: new
- `benchmark/src/main/java/org/occurrent/benchmark/coalescing/SimulatedLatencyRepository.java`: new
- `benchmark/pom.xml`: added the `occurrent-projection-dsl-blocking` dependency the new benchmark needs, updated the module description
- `dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/MaterializedViewOptions.java`: repointed the `DEFAULT_BATCH_SIZE` javadoc

## Verification

- `mvn -pl benchmark -am -Pbenchmarks test-compile` (the benchmark module only joins the reactor build under the `benchmarks` profile)
- `mvn -pl dsl/projection-dsl/common -am test-compile`
- Smoke run, `java -jar benchmark/target/benchmarks.jar PayloadFilterReadBenchmark -wi 1 -i 1 -f 1`: all three methods ran and produced numbers, `readAllPaths` and `readEachPathIndependently` diverge at leafCount 5 (0.674 vs 0.960 us/op), the difference this benchmark exists to show
- Smoke run, `java -jar benchmark/target/benchmarks.jar CoalescingFlushBenchmark -wi 1 -i 1 -f 1`: `DENSE` stays flat across batch sizes (~1012-1141 us/op) while `SPARSE` scales with batch size (~1016, ~2023, ~11238 us/op at 1, 100, 1000), matching what coalescing is supposed to buy

Fixes #692
