### PR TITLE
Type the findIn rewrite test callers as SubscriptionModelCapability, not Object

### DIFF
--- a/rewrite/src/test/java/org/occurrent/rewrite/MigrateOccurrentRenames_0_33Test.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/MigrateOccurrentRenames_0_33Test.java
@@ -360,12 +360,19 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
 
     @Test
     void aRealUpgradeRenamesReplayAwareSubscriptionsOfToFindIn() {
-        // ReplayAwareSubscriptionModel is supplied as a compiled dependency with the of(Object) shape it actually
-        // shipped with in 0.32.0, the way a user's classpath looks before the upgrade, rather than as a rewritten
-        // source. One user source using the old type and the old of(..) call, migrated to the new type and findIn
-        // in a single recipe run.
+        // ReplayAwareSubscriptionModel and its of(Object) are supplied as a compiled dependency, the way a user's
+        // classpath looks before the upgrade, rather than as a rewritten source. The caller's own parameter is typed
+        // as the real 0.33.0 SubscriptionModelCapability marker rather than Object, so the migrated example matches
+        // the narrowed findIn(SubscriptionModelCapability) it now calls, instead of only compiling by accident
+        // because the stub dependency's of(Object) still accepts anything.
         rewriteRun(
                 spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+                        """
+                        package org.occurrent.subscription.api.blocking;
+
+                        public interface SubscriptionModelCapability {
+                        }
+                        """,
                         """
                         package org.occurrent.subscription.api.blocking;
 
@@ -385,9 +392,10 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
                         package com.example;
 
                         import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptionModel;
+                        import org.occurrent.subscription.api.blocking.SubscriptionModelCapability;
 
                         class Foo {
-                            void bar(Object model) {
+                            void bar(SubscriptionModelCapability model) {
                                 ReplayAwareSubscriptionModel.of(model);
                             }
                         }
@@ -396,9 +404,10 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
                         package com.example;
 
                         import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
+                        import org.occurrent.subscription.api.blocking.SubscriptionModelCapability;
 
                         class Foo {
-                            void bar(Object model) {
+                            void bar(SubscriptionModelCapability model) {
                                 ReplayAwareSubscriptions.findIn(model);
                             }
                         }
@@ -409,9 +418,16 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
 
     @Test
     void aRealUpgradeRenamesIntrospectableSubscriptionsOfToFindIn() {
-        // Same shape as the ReplayAwareSubscriptions case above, for IntrospectableSubscriptionModel's of(Object).
+        // Same shape as the ReplayAwareSubscriptions case above, for IntrospectableSubscriptionModel's of(Object),
+        // with the caller's parameter typed as SubscriptionModelCapability for the same reason.
         rewriteRun(
                 spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+                        """
+                        package org.occurrent.subscription.api.blocking;
+
+                        public interface SubscriptionModelCapability {
+                        }
+                        """,
                         """
                         package org.occurrent.subscription.api.blocking;
 
@@ -432,9 +448,10 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
                         package com.example;
 
                         import org.occurrent.subscription.api.blocking.IntrospectableSubscriptionModel;
+                        import org.occurrent.subscription.api.blocking.SubscriptionModelCapability;
 
                         class Foo {
-                            void bar(Object model) {
+                            void bar(SubscriptionModelCapability model) {
                                 IntrospectableSubscriptionModel.of(model);
                             }
                         }
@@ -443,9 +460,10 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
                         package com.example;
 
                         import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
+                        import org.occurrent.subscription.api.blocking.SubscriptionModelCapability;
 
                         class Foo {
-                            void bar(Object model) {
+                            void bar(SubscriptionModelCapability model) {
                                 IntrospectableSubscriptions.findIn(model);
                             }
                         }

--- a/rewrite/src/test/java/org/occurrent/rewrite/MigrateOccurrentRenames_0_33Test.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/MigrateOccurrentRenames_0_33Test.java
@@ -361,10 +361,10 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
     @Test
     void aRealUpgradeRenamesReplayAwareSubscriptionsOfToFindIn() {
         // ReplayAwareSubscriptionModel and its of(Object) are supplied as a compiled dependency, the way a user's
-        // classpath looks before the upgrade, rather than as a rewritten source. The caller's own parameter is typed
-        // as the real 0.33.0 SubscriptionModelCapability marker rather than Object, so the migrated example matches
-        // the narrowed findIn(SubscriptionModelCapability) it now calls, instead of only compiling by accident
-        // because the stub dependency's of(Object) still accepts anything.
+        // classpath looks before the upgrade, rather than as a rewritten source. ReplayAwareSubscriptions, the
+        // rename target, is also supplied with its real narrowed findIn(SubscriptionModelCapability) signature,
+        // so the migrated "after" example is type-attributed against the actual post-upgrade contract rather than
+        // an unresolved type the parser cannot check.
         rewriteRun(
                 spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
                         """
@@ -383,6 +383,19 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
 
                             static Optional<ReplayAwareSubscriptionModel> of(Object subscriptionModel) {
                                 return subscriptionModel instanceof ReplayAwareSubscriptionModel r ? Optional.of(r) : Optional.empty();
+                            }
+                        }
+                        """,
+                        """
+                        package org.occurrent.subscription.api.blocking;
+
+                        import java.util.Optional;
+
+                        public interface ReplayAwareSubscriptions extends SubscriptionModelCapability {
+                            boolean isCatchingUp(String subscriptionId);
+
+                            static Optional<ReplayAwareSubscriptions> findIn(SubscriptionModelCapability subscriptionModel) {
+                                return subscriptionModel instanceof ReplayAwareSubscriptions r ? Optional.of(r) : Optional.empty();
                             }
                         }
                         """
@@ -418,8 +431,9 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
 
     @Test
     void aRealUpgradeRenamesIntrospectableSubscriptionsOfToFindIn() {
-        // Same shape as the ReplayAwareSubscriptions case above, for IntrospectableSubscriptionModel's of(Object),
-        // with the caller's parameter typed as SubscriptionModelCapability for the same reason.
+        // Same shape as the ReplayAwareSubscriptions case above, for IntrospectableSubscriptionModel's of(Object):
+        // IntrospectableSubscriptions, the rename target, is supplied too, with its real narrowed
+        // findIn(SubscriptionModelCapability) signature, so the "after" example is checked against it.
         rewriteRun(
                 spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
                         """
@@ -439,6 +453,20 @@ class MigrateOccurrentRenames_0_33Test implements RewriteTest {
 
                             static Optional<IntrospectableSubscriptionModel> of(Object subscriptionModel) {
                                 return subscriptionModel instanceof IntrospectableSubscriptionModel i ? Optional.of(i) : Optional.empty();
+                            }
+                        }
+                        """,
+                        """
+                        package org.occurrent.subscription.api.blocking;
+
+                        import java.util.Optional;
+                        import java.util.Set;
+
+                        public interface IntrospectableSubscriptions extends SubscriptionModelCapability {
+                            Set<String> subscriptionIds();
+
+                            static Optional<IntrospectableSubscriptions> findIn(SubscriptionModelCapability subscriptionModel) {
+                                return subscriptionModel instanceof IntrospectableSubscriptions i ? Optional.of(i) : Optional.empty();
                             }
                         }
                         """


### PR DESCRIPTION
I opened this as a follow-up because #708 (rv33/U12) merged before Copilot's review landed on it, and by the time the review came back with a real finding, main had already moved past that PR. This carries just the one fix commit, cherry-picked cleanly onto current main.

Copilot flagged that the two new `of`-to-`findIn` rewrite recipe tests I added in #708 typed the caller's parameter as `Object` in the migrated "after" example, while the real `findIn` now requires `SubscriptionModelCapability`. The example only compiled because the test's stub dependency still declares `findIn(Object)`, unchanged by the rename recipe, so it silently looked like a valid post-upgrade result without actually matching the real API's narrowed contract.

I added a stubbed `SubscriptionModelCapability` to both tests and typed the caller's parameter as it instead of `Object`, so the migrated example matches what a real caller looks like against the narrowed signature.

**Verification**: `mvn -pl rewrite test`, 73 tests, all pass.
