### PR TITLE
Add three StepCondition examples to the flow saga doc guard tests

### DIFF
--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
@@ -483,7 +483,8 @@ class DocumentedFlowSagaTest {
             // Then
             assertAll(
                     () -> assertThat(afterLow.state().completed()).isFalse(),
-                    () -> assertThat(afterHigh.state().completed()).isTrue()
+                    () -> assertThat(afterHigh.state().completed()).isTrue(),
+                    () -> assertThat(afterHigh.effects()).containsExactly(SagaEffect.issue(new RaiseAlarm(SENSOR_ID)))
             );
         }
     }
@@ -608,7 +609,7 @@ class DocumentedFlowSagaTest {
                 .startsOn(SensorArmed.class)
                 .correlateAll(SensorEvent::sensorId)
                 .step("monitoring", step -> step
-                        .on(StepCondition.event(ReadingTaken.class, 1, (ReadingTaken reading) -> reading.celsius() > 40),
+                        .on(StepCondition.event(ReadingTaken.class, (ReadingTaken reading) -> reading.celsius() > 40),
                                 Continuation.end(),
                                 received -> List.of(new RaiseAlarm(received.initiating(SensorArmed.class).sensorId()))))
                 .build();

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
@@ -101,6 +101,57 @@ class DocumentedFlowSagaTest {
     record Discard(String reviewId) implements ReviewCommand {
     }
 
+    sealed interface ShipmentEvent permits ShipmentStarted, ItemPacked, CourierAssigned, PickupScheduled {
+        String shipmentId();
+    }
+
+    record ShipmentStarted(String shipmentId) implements ShipmentEvent {
+    }
+
+    record ItemPacked(String shipmentId, String sku) implements ShipmentEvent {
+    }
+
+    record CourierAssigned(String shipmentId) implements ShipmentEvent {
+    }
+
+    record PickupScheduled(String shipmentId) implements ShipmentEvent {
+    }
+
+    record DispatchShipment(String shipmentId) {
+    }
+
+    sealed interface SensorEvent permits SensorArmed, ReadingTaken {
+        String sensorId();
+    }
+
+    record SensorArmed(String sensorId) implements SensorEvent {
+    }
+
+    record ReadingTaken(String sensorId, int celsius) implements SensorEvent {
+    }
+
+    record RaiseAlarm(String sensorId) {
+    }
+
+    sealed interface PurchaseEvent permits PurchaseStarted, PaymentReceived {
+        String purchaseId();
+    }
+
+    record PurchaseStarted(String purchaseId, int total) implements PurchaseEvent {
+    }
+
+    record PaymentReceived(String purchaseId, int amount) implements PurchaseEvent {
+    }
+
+    sealed interface PurchaseCommand permits ReleaseGoods, NotifyLayawayComplete {
+    }
+
+    record ReleaseGoods(String purchaseId) implements PurchaseCommand {
+    }
+
+    record NotifyLayawayComplete(String purchaseId) implements PurchaseCommand {
+    }
+
     @Nested
     @DisplayName("when a lobby waits for a player to join")
     class When_a_lobby_waits_for_a_player_to_join {
@@ -323,6 +374,184 @@ class DocumentedFlowSagaTest {
         }
     }
 
+    @Nested
+    @DisplayName("when a step needs two packed items plus either a courier or a pickup slot")
+    class When_a_step_needs_two_packed_items_plus_either_a_courier_or_a_pickup_slot {
+
+        private static final String SHIPMENT_ID = "shipment-1";
+
+        @Test
+        void two_packed_items_alone_do_not_fulfil_the_condition() {
+            // Given
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> started = start(shipment(), new ShipmentStarted(SHIPMENT_ID));
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> afterFirstItem =
+                    shipment().step(started.state(), SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-1")));
+
+            // When
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> afterSecondItem =
+                    shipment().step(afterFirstItem.state(), SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-2")));
+
+            // Then
+            assertThat(afterSecondItem.state().completed()).isFalse();
+        }
+
+        @Test
+        void two_packed_items_and_a_courier_assignment_dispatch_and_complete_the_saga() {
+            // Given
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> started = start(shipment(), new ShipmentStarted(SHIPMENT_ID));
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> afterItems = shipment().step(
+                    shipment().step(started.state(), SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-1"))).state(),
+                    SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-2")));
+
+            // When
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> step =
+                    shipment().step(afterItems.state(), SagaInput.event(new CourierAssigned(SHIPMENT_ID)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(step.state().completed()).isTrue(),
+                    () -> assertThat(step.effects()).containsExactly(SagaEffect.issue(new DispatchShipment(SHIPMENT_ID)))
+            );
+        }
+
+        @Test
+        void two_packed_items_and_a_pickup_slot_dispatch_and_complete_the_saga_too() {
+            // Given
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> started = start(shipment(), new ShipmentStarted(SHIPMENT_ID));
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> afterItems = shipment().step(
+                    shipment().step(started.state(), SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-1"))).state(),
+                    SagaInput.event(new ItemPacked(SHIPMENT_ID, "sku-2")));
+
+            // When
+            Saga.Step<FlowState<ShipmentEvent>, DispatchShipment> step =
+                    shipment().step(afterItems.state(), SagaInput.event(new PickupScheduled(SHIPMENT_ID)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(step.state().completed()).isTrue(),
+                    () -> assertThat(step.effects()).containsExactly(SagaEffect.issue(new DispatchShipment(SHIPMENT_ID)))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("when a step waits for a reading above a threshold")
+    class When_a_step_waits_for_a_reading_above_a_threshold {
+
+        private static final String SENSOR_ID = "sensor-1";
+
+        @Test
+        void a_reading_at_the_threshold_does_not_fulfil_the_condition() {
+            // Given
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> started = start(sensor(), new SensorArmed(SENSOR_ID));
+
+            // When
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> step =
+                    sensor().step(started.state(), SagaInput.event(new ReadingTaken(SENSOR_ID, 40)));
+
+            // Then
+            assertThat(step.state().completed()).isFalse();
+        }
+
+        @Test
+        void a_reading_above_the_threshold_raises_the_alarm_and_completes_the_saga() {
+            // Given
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> started = start(sensor(), new SensorArmed(SENSOR_ID));
+
+            // When
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> step =
+                    sensor().step(started.state(), SagaInput.event(new ReadingTaken(SENSOR_ID, 41)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(step.state().completed()).isTrue(),
+                    () -> assertThat(step.effects()).containsExactly(SagaEffect.issue(new RaiseAlarm(SENSOR_ID)))
+            );
+        }
+
+        @Test
+        void a_low_reading_followed_by_a_high_one_still_raises_the_alarm() {
+            // Given
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> started = start(sensor(), new SensorArmed(SENSOR_ID));
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> afterLow =
+                    sensor().step(started.state(), SagaInput.event(new ReadingTaken(SENSOR_ID, 10)));
+
+            // When
+            Saga.Step<FlowState<SensorEvent>, RaiseAlarm> afterHigh =
+                    sensor().step(afterLow.state(), SagaInput.event(new ReadingTaken(SENSOR_ID, 45)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(afterLow.state().completed()).isFalse(),
+                    () -> assertThat(afterHigh.state().completed()).isTrue()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("when a step mixes a classic branch with a window condition")
+    class When_a_step_mixes_a_classic_branch_with_a_window_condition {
+
+        private static final String PURCHASE_ID = "purchase-1";
+
+        @Test
+        void a_single_full_payment_releases_the_goods_through_the_classic_branch() {
+            // Given
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> started = start(purchase(), new PurchaseStarted(PURCHASE_ID, 80));
+
+            // When
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> step =
+                    purchase().step(started.state(), SagaInput.event(new PaymentReceived(PURCHASE_ID, 80)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(step.state().completed()).isTrue(),
+                    () -> assertThat(step.effects()).containsExactly(SagaEffect.issue(new ReleaseGoods(PURCHASE_ID)))
+            );
+        }
+
+        @Test
+        void two_partial_payments_release_the_goods_through_the_window_condition() {
+            // Given
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> started = start(purchase(), new PurchaseStarted(PURCHASE_ID, 80));
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> afterFirst =
+                    purchase().step(started.state(), SagaInput.event(new PaymentReceived(PURCHASE_ID, 30)));
+
+            // When
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> afterSecond =
+                    purchase().step(afterFirst.state(), SagaInput.event(new PaymentReceived(PURCHASE_ID, 30)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(afterFirst.state().completed()).isFalse(),
+                    () -> assertThat(afterSecond.state().completed()).isTrue(),
+                    () -> assertThat(afterSecond.effects()).containsExactly(
+                            SagaEffect.issue(new ReleaseGoods(PURCHASE_ID)),
+                            SagaEffect.issue(new NotifyLayawayComplete(PURCHASE_ID)))
+            );
+        }
+
+        @Test
+        void a_full_payment_arriving_second_satisfies_both_branches_but_the_declared_first_classic_branch_wins() {
+            // Given
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> started = start(purchase(), new PurchaseStarted(PURCHASE_ID, 80));
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> afterFirst =
+                    purchase().step(started.state(), SagaInput.event(new PaymentReceived(PURCHASE_ID, 30)));
+
+            // When
+            Saga.Step<FlowState<PurchaseEvent>, PurchaseCommand> afterSecond =
+                    purchase().step(afterFirst.state(), SagaInput.event(new PaymentReceived(PURCHASE_ID, 80)));
+
+            // Then
+            assertAll(
+                    () -> assertThat(afterSecond.state().completed()).isTrue(),
+                    () -> assertThat(afterSecond.effects())
+                            .as("the window condition is also satisfied here (two PaymentReceived events), but the classic branch is declared first")
+                            .containsExactly(SagaEffect.issue(new ReleaseGoods(PURCHASE_ID)))
+            );
+        }
+    }
+
     private static Saga<GameEvent, FlowState<GameEvent>, CloseGame> lobby() {
         return FlowSaga.<GameEvent, CloseGame>builder()
                 .startsOn(GameCreated.class)
@@ -358,6 +587,48 @@ class DocumentedFlowSagaTest {
                                 received -> received.all(Rejected.class).isEmpty()
                                         ? List.of(new Publish(received.initiating(ReviewStarted.class).reviewId()))
                                         : List.of(new Discard(received.initiating(ReviewStarted.class).reviewId()))))
+                .build();
+    }
+
+    private static Saga<ShipmentEvent, FlowState<ShipmentEvent>, DispatchShipment> shipment() {
+        return FlowSaga.<ShipmentEvent, DispatchShipment>builder()
+                .startsOn(ShipmentStarted.class)
+                .correlateAll(ShipmentEvent::shipmentId)
+                .step("packing", step -> step
+                        .on(StepCondition.allOf(
+                                        StepCondition.event(ItemPacked.class, 2),
+                                        StepCondition.anyOf(StepCondition.event(CourierAssigned.class), StepCondition.event(PickupScheduled.class))),
+                                Continuation.end(),
+                                received -> List.of(new DispatchShipment(received.initiating(ShipmentStarted.class).shipmentId()))))
+                .build();
+    }
+
+    private static Saga<SensorEvent, FlowState<SensorEvent>, RaiseAlarm> sensor() {
+        return FlowSaga.<SensorEvent, RaiseAlarm>builder()
+                .startsOn(SensorArmed.class)
+                .correlateAll(SensorEvent::sensorId)
+                .step("monitoring", step -> step
+                        .on(StepCondition.event(ReadingTaken.class, 1, (ReadingTaken reading) -> reading.celsius() > 40),
+                                Continuation.end(),
+                                received -> List.of(new RaiseAlarm(received.initiating(SensorArmed.class).sensorId()))))
+                .build();
+    }
+
+    private static Saga<PurchaseEvent, FlowState<PurchaseEvent>, PurchaseCommand> purchase() {
+        return FlowSaga.<PurchaseEvent, PurchaseCommand>builder()
+                .startsOn(PurchaseStarted.class)
+                .correlateAll(PurchaseEvent::purchaseId)
+                // A single payment covering the total releases immediately; otherwise two installments, of any amount, do.
+                .step("collecting-payment", step -> step
+                        .on(PaymentReceived.class,
+                                (payment, received) -> payment.amount() >= received.initiating(PurchaseStarted.class).total(),
+                                Continuation.end(),
+                                payment -> List.of(new ReleaseGoods(payment.purchaseId())))
+                        .on(StepCondition.event(PaymentReceived.class, 2),
+                                Continuation.end(),
+                                received -> List.of(
+                                        new ReleaseGoods(received.initiating(PurchaseStarted.class).purchaseId()),
+                                        new NotifyLayawayComplete(received.initiating(PurchaseStarted.class).purchaseId()))))
                 .build();
     }
 

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
@@ -348,7 +348,8 @@ class DocumentedFlowSagaKotlinTest {
             // Then
             assertAll(
                 { assertThat(afterLow.state.completed()).isFalse() },
-                { assertThat(afterHigh.state.completed()).isTrue() }
+                { assertThat(afterHigh.state.completed()).isTrue() },
+                { assertThat(afterHigh.effects).containsExactly(SagaEffect.issue(RaiseAlarm(SENSOR_ID))) }
             )
         }
     }

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
@@ -253,11 +253,175 @@ class DocumentedFlowSagaKotlinTest {
         }
     }
 
+    @Nested
+    @DisplayName("when a step needs two packed items plus either a courier or a pickup slot")
+    inner class WhenAStepNeedsTwoPackedItemsPlusEitherACourierOrAPickupSlot {
+
+        @Test
+        fun `two packed items alone do not fulfil the condition`() {
+            // Given
+            val started = start(shipment(), ShipmentStarted(SHIPMENT_ID))
+            val afterFirstItem = shipment().step(started.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-1")))
+
+            // When
+            val afterSecondItem = shipment().step(afterFirstItem.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-2")))
+
+            // Then
+            assertThat(afterSecondItem.state.completed()).isFalse()
+        }
+
+        @Test
+        fun `two packed items and a courier assignment dispatch and complete the saga`() {
+            // Given
+            val started = start(shipment(), ShipmentStarted(SHIPMENT_ID))
+            val afterFirstItem = shipment().step(started.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-1")))
+            val afterItems = shipment().step(afterFirstItem.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-2")))
+
+            // When
+            val step = shipment().step(afterItems.state, SagaInput.event(CourierAssigned(SHIPMENT_ID)))
+
+            // Then
+            assertAll(
+                { assertThat(step.state.completed()).isTrue() },
+                { assertThat(step.effects).containsExactly(SagaEffect.issue(DispatchShipment(SHIPMENT_ID))) }
+            )
+        }
+
+        @Test
+        fun `two packed items and a pickup slot dispatch and complete the saga too`() {
+            // Given
+            val started = start(shipment(), ShipmentStarted(SHIPMENT_ID))
+            val afterFirstItem = shipment().step(started.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-1")))
+            val afterItems = shipment().step(afterFirstItem.state, SagaInput.event(ItemPacked(SHIPMENT_ID, "sku-2")))
+
+            // When
+            val step = shipment().step(afterItems.state, SagaInput.event(PickupScheduled(SHIPMENT_ID)))
+
+            // Then
+            assertAll(
+                { assertThat(step.state.completed()).isTrue() },
+                { assertThat(step.effects).containsExactly(SagaEffect.issue(DispatchShipment(SHIPMENT_ID))) }
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("when a step waits for a reading above a threshold")
+    inner class WhenAStepWaitsForAReadingAboveAThreshold {
+
+        @Test
+        fun `a reading at the threshold does not fulfil the condition`() {
+            // Given
+            val started = start(sensor(), SensorArmed(SENSOR_ID))
+
+            // When
+            val step = sensor().step(started.state, SagaInput.event(ReadingTaken(SENSOR_ID, 40)))
+
+            // Then
+            assertThat(step.state.completed()).isFalse()
+        }
+
+        @Test
+        fun `a reading above the threshold raises the alarm and completes the saga`() {
+            // Given
+            val started = start(sensor(), SensorArmed(SENSOR_ID))
+
+            // When
+            val step = sensor().step(started.state, SagaInput.event(ReadingTaken(SENSOR_ID, 41)))
+
+            // Then
+            assertAll(
+                { assertThat(step.state.completed()).isTrue() },
+                { assertThat(step.effects).containsExactly(SagaEffect.issue(RaiseAlarm(SENSOR_ID))) }
+            )
+        }
+
+        @Test
+        fun `a low reading followed by a high one still raises the alarm`() {
+            // Given
+            val started = start(sensor(), SensorArmed(SENSOR_ID))
+            val afterLow = sensor().step(started.state, SagaInput.event(ReadingTaken(SENSOR_ID, 10)))
+
+            // When
+            val afterHigh = sensor().step(afterLow.state, SagaInput.event(ReadingTaken(SENSOR_ID, 45)))
+
+            // Then
+            assertAll(
+                { assertThat(afterLow.state.completed()).isFalse() },
+                { assertThat(afterHigh.state.completed()).isTrue() }
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("when a step mixes a classic branch with a window condition")
+    inner class WhenAStepMixesAClassicBranchWithAWindowCondition {
+
+        @Test
+        fun `a single full payment releases the goods through the classic branch`() {
+            // Given
+            val started = start(purchase(), PurchaseStarted(PURCHASE_ID, 80))
+
+            // When
+            val step = purchase().step(started.state, SagaInput.event(PaymentReceived(PURCHASE_ID, 80)))
+
+            // Then
+            assertAll(
+                { assertThat(step.state.completed()).isTrue() },
+                { assertThat(step.effects).containsExactly(SagaEffect.issue(ReleaseGoods(PURCHASE_ID))) }
+            )
+        }
+
+        @Test
+        fun `two partial payments release the goods through the window condition`() {
+            // Given
+            val started = start(purchase(), PurchaseStarted(PURCHASE_ID, 80))
+            val afterFirst = purchase().step(started.state, SagaInput.event(PaymentReceived(PURCHASE_ID, 30)))
+
+            // When
+            val afterSecond = purchase().step(afterFirst.state, SagaInput.event(PaymentReceived(PURCHASE_ID, 30)))
+
+            // Then
+            assertAll(
+                { assertThat(afterFirst.state.completed()).isFalse() },
+                { assertThat(afterSecond.state.completed()).isTrue() },
+                {
+                    assertThat(afterSecond.effects).containsExactly(
+                        SagaEffect.issue(ReleaseGoods(PURCHASE_ID)),
+                        SagaEffect.issue(NotifyLayawayComplete(PURCHASE_ID))
+                    )
+                }
+            )
+        }
+
+        @Test
+        fun `a full payment arriving second satisfies both branches but the declared first classic branch wins`() {
+            // Given
+            val started = start(purchase(), PurchaseStarted(PURCHASE_ID, 80))
+            val afterFirst = purchase().step(started.state, SagaInput.event(PaymentReceived(PURCHASE_ID, 30)))
+
+            // When
+            val afterSecond = purchase().step(afterFirst.state, SagaInput.event(PaymentReceived(PURCHASE_ID, 80)))
+
+            // Then
+            assertAll(
+                { assertThat(afterSecond.state.completed()).isTrue() },
+                {
+                    // The window condition is also satisfied here (two PaymentReceived events), but the classic branch is declared first.
+                    assertThat(afterSecond.effects).containsExactly(SagaEffect.issue(ReleaseGoods(PURCHASE_ID)))
+                }
+            )
+        }
+    }
+
     companion object {
 
         private const val GAME_ID = "game-1"
         private const val AUCTION_ID = "auction-1"
         private const val REVIEW_ID = "review-1"
+        private const val SHIPMENT_ID = "shipment-1"
+        private const val SENSOR_ID = "sensor-1"
+        private const val PURCHASE_ID = "purchase-1"
 
         /** Fixed so the absolute timeout never depends on the machine's clock or zone. */
         private val ENDS_AT: Instant = Instant.parse("2026-07-28T18:00:00Z")
@@ -292,6 +456,37 @@ class DocumentedFlowSagaKotlinTest {
         sealed interface ReviewCommand
         data class Publish(val reviewId: String) : ReviewCommand
         data class Discard(val reviewId: String) : ReviewCommand
+
+        sealed interface ShipmentEvent {
+            val shipmentId: String
+        }
+
+        data class ShipmentStarted(override val shipmentId: String) : ShipmentEvent
+        data class ItemPacked(override val shipmentId: String, val sku: String) : ShipmentEvent
+        data class CourierAssigned(override val shipmentId: String) : ShipmentEvent
+        data class PickupScheduled(override val shipmentId: String) : ShipmentEvent
+
+        data class DispatchShipment(val shipmentId: String)
+
+        sealed interface SensorEvent {
+            val sensorId: String
+        }
+
+        data class SensorArmed(override val sensorId: String) : SensorEvent
+        data class ReadingTaken(override val sensorId: String, val celsius: Int) : SensorEvent
+
+        data class RaiseAlarm(val sensorId: String)
+
+        sealed interface PurchaseEvent {
+            val purchaseId: String
+        }
+
+        data class PurchaseStarted(override val purchaseId: String, val total: Int) : PurchaseEvent
+        data class PaymentReceived(override val purchaseId: String, val amount: Int) : PurchaseEvent
+
+        sealed interface PurchaseCommand
+        data class ReleaseGoods(val purchaseId: String) : PurchaseCommand
+        data class NotifyLayawayComplete(val purchaseId: String) : PurchaseCommand
 
         private fun lobby(): Saga<GameEvent, FlowState<GameEvent>, CloseGame> = saga {
             startsOn<GameCreated>()
@@ -329,6 +524,44 @@ class DocumentedFlowSagaKotlinTest {
                     } else {
                         issue(Discard(received.initiating<ReviewStarted>().reviewId))
                     }
+                }
+            }
+        }
+
+        private fun shipment(): Saga<ShipmentEvent, FlowState<ShipmentEvent>, DispatchShipment> = saga {
+            startsOn<ShipmentStarted>()
+            correlateAll { it.shipmentId }
+            step("packing") {
+                on(allOf(event<ItemPacked>(2), anyOf(event<CourierAssigned>(), event<PickupScheduled>())), then = end) { received ->
+                    issue(DispatchShipment(received.initiating<ShipmentStarted>().shipmentId))
+                }
+            }
+        }
+
+        private fun sensor(): Saga<SensorEvent, FlowState<SensorEvent>, RaiseAlarm> = saga {
+            startsOn<SensorArmed>()
+            correlateAll { it.sensorId }
+            step("monitoring") {
+                on(event<ReadingTaken> { it.celsius > 40 }, then = end) { received ->
+                    issue(RaiseAlarm(received.initiating<SensorArmed>().sensorId))
+                }
+            }
+        }
+
+        private fun purchase(): Saga<PurchaseEvent, FlowState<PurchaseEvent>, PurchaseCommand> = saga {
+            startsOn<PurchaseStarted>()
+            correlateAll { it.purchaseId }
+            // A single payment covering the total releases immediately; otherwise two installments, of any amount, do.
+            step("collecting-payment") {
+                on<PaymentReceived>(
+                    then = end,
+                    onlyIf = { payment, received -> payment.amount >= received.initiating<PurchaseStarted>().total }
+                ) { payment ->
+                    issue(ReleaseGoods(payment.purchaseId))
+                }
+                on(event<PaymentReceived>(2), then = end) { received ->
+                    issue(ReleaseGoods(received.initiating<PurchaseStarted>().purchaseId))
+                    issue(NotifyLayawayComplete(received.initiating<PurchaseStarted>().purchaseId))
                 }
             }
         }


### PR DESCRIPTION
I added three more StepCondition examples to the flow saga doc-snippet guard tests. `shipment()` covers `allOf` with a nested `anyOf`, the ADR's own motivating shape. `sensor()` covers a predicate leaf. `purchase()` covers a step mixing a classic `on<T>` branch with a window condition, where declaration order breaks the tie when one event satisfies both.

Before this change the guard tests carried exactly one StepCondition example, an `anyOf` over a counted leaf, so the held documentation branch could only show that one and had to describe the rest in prose. A documented example has to come from a passing test, never be written free-hand into the docs, so this closes the gap for the docs unit that follows.

Each example lives in both `DocumentedFlowSagaTest.java` and `DocumentedFlowSagaKotlinTest.kt`, driven through `evolve`/`react` and asserted the same way as the existing lobby, auction, and review examples. No production code changed.

`mvn -Drevision=0.0.0-SNAPSHOT -pl dsl/saga-dsl/common -am test`: 300 tests, 0 failures.
