### PR TITLE
Recast a semicolon in the purchase saga comment

### DIFF
--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/docs/DocumentedFlowSagaTest.java
@@ -619,7 +619,7 @@ class DocumentedFlowSagaTest {
         return FlowSaga.<PurchaseEvent, PurchaseCommand>builder()
                 .startsOn(PurchaseStarted.class)
                 .correlateAll(PurchaseEvent::purchaseId)
-                // A single payment covering the total releases immediately; otherwise two installments, of any amount, do.
+                // A single payment covering the total releases immediately, otherwise two installments, of any amount, do.
                 .step("collecting-payment", step -> step
                         .on(PaymentReceived.class,
                                 (payment, received) -> payment.amount() >= received.initiating(PurchaseStarted.class).total(),

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/docs/DocumentedFlowSagaKotlinTest.kt
@@ -552,7 +552,7 @@ class DocumentedFlowSagaKotlinTest {
         private fun purchase(): Saga<PurchaseEvent, FlowState<PurchaseEvent>, PurchaseCommand> = saga {
             startsOn<PurchaseStarted>()
             correlateAll { it.purchaseId }
-            // A single payment covering the total releases immediately; otherwise two installments, of any amount, do.
+            // A single payment covering the total releases immediately, otherwise two installments, of any amount, do.
             step("collecting-payment") {
                 on<PaymentReceived>(
                     then = end,


### PR DESCRIPTION
I replaced a semicolon with a comma in the comment on the `purchase()` saga, in both the Java and Kotlin doc guard tests. The code-comment conventions do not use semicolons and this one slipped through in #713.

The comment is the only change, so nothing needs re-verifying beyond a compile.