### PR TITLE
Test that a saga timer stored by 0.32.0 still fires

### DIFF
--- a/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/StoredTimerNameTest.java
+++ b/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/StoredTimerNameTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.saga.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.command.CommandDispatcher;
+import org.occurrent.dsl.saga.Saga;
+import org.occurrent.dsl.saga.SagaEffect;
+import org.occurrent.dsl.saga.SagaEnvelope;
+import org.occurrent.dsl.saga.SagaEnvelope.TimerEntry;
+import org.occurrent.dsl.saga.SagaInput;
+import org.occurrent.dsl.saga.SagaStateStore;
+import org.occurrent.dsl.saga.SagaStatus;
+import org.occurrent.dsl.saga.TimerName;
+import org.occurrent.dsl.saga.flow.Continuation;
+import org.occurrent.dsl.saga.flow.FlowSaga;
+import org.occurrent.dsl.saga.flow.FlowState;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+/**
+ * A timer's name became a {@link TimerName} value while the stored form stayed the string it always was, so an instance
+ * with a pending timer keeps firing across the upgrade. Each test here seeds a store with a name exactly as it was
+ * written before that change and runs the real timer poll over it, so a change to how a stored name is read back or
+ * matched against a registration fails here.
+ */
+@DisplayName("A pending timer stored under its 0.32.0 name")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StoredTimerNameTest {
+
+    // The exact strings a pending timer was stored under before TimerName existed. Written out rather than produced by
+    // stepTimer(..) or TimerName.encode(), because a name built by today's code still matches today's code after a
+    // format change, and every stored timer would stop firing with these tests still green.
+    private static final String STORED_STEP_TIMER = "step:awaiting-players";
+    private static final String STORED_TIMER_WITHOUT_A_NAMESPACE = "payment";
+    private static final String STORED_TIMER_CONTAINING_A_COLON = "a:b";
+
+    // Epoch millis far enough in the past that the poll always finds the timer due, whatever the wall clock says.
+    private static final long LONG_OVERDUE = 1_000;
+
+    private final CloudEventConverter<LobbyEvent> converter =
+            new JacksonCloudEventConverter.Builder<LobbyEvent>(new ObjectMapper(), URI.create("urn:occurrent:stored-timer-name-test")).build();
+
+    @Test
+    void a_flow_saga_step_timeout_stored_as_step_awaiting_players_still_fires() {
+        Saga<LobbyEvent, FlowState<LobbyEvent>, LobbyCommand> saga = lobbySaga();
+        SagaStateStore<FlowState<LobbyEvent>> store = SagaStateStore.inMemory();
+        FlowState<LobbyEvent> awaitingPlayers = saga.evolve(saga.initialState(), SagaInput.event(new GameCreated("game-1")));
+        store.compareAndSave("game-1", storedWith(awaitingPlayers, "game-1", STORED_STEP_TIMER), 0);
+        List<LobbyCommand> dispatched = new ArrayList<>();
+
+        execution(saga, store, dispatched::add).pollTimers();
+
+        // Ending the step completes the instance and clears every pending timer, so completion is what says the timeout
+        // ran. Consuming a fired timer is checked on the two core DSL timers, which stay active after firing.
+        assertAll(
+                () -> assertThat(dispatched).as("the stored step timer still reaches the step's timeout reaction").containsExactly(new CancelGame("game-1")),
+                () -> assertThat(store.find("game-1")).hasValueSatisfying(e -> assertThat(e.isCompleted()).isTrue())
+        );
+    }
+
+    @Test
+    void a_core_dsl_timer_stored_without_a_namespace_fires_and_is_consumed() {
+        Saga<LobbyEvent, String, LobbyCommand> saga = coreSaga(STORED_TIMER_WITHOUT_A_NAMESPACE);
+        SagaStateStore<String> store = SagaStateStore.inMemory();
+        store.compareAndSave("game-2", storedWith("waiting", "game-2", STORED_TIMER_WITHOUT_A_NAMESPACE), 0);
+        List<LobbyCommand> dispatched = new ArrayList<>();
+
+        execution(saga, store, dispatched::add).pollTimers();
+
+        assertAll(
+                () -> assertThat(dispatched).containsExactly(new CancelGame("game-2")),
+                () -> assertThat(store.find("game-2")).hasValueSatisfying(e -> assertThat(e.timers()).isEmpty())
+        );
+    }
+
+    @Test
+    void a_core_dsl_timer_whose_stored_name_contains_a_colon_fires_and_is_consumed() {
+        // The subtle one. "a:b" is registered through the string-taking reactOnTimeout and read back out of the store as
+        // a plain string, and the two only meet because both go through TimerName.parse and land on the same value. A
+        // change that read one side differently would stop this timer firing with nothing thrown anywhere.
+        Saga<LobbyEvent, String, LobbyCommand> saga = coreSaga(STORED_TIMER_CONTAINING_A_COLON);
+        SagaStateStore<String> store = SagaStateStore.inMemory();
+        store.compareAndSave("game-3", storedWith("waiting", "game-3", STORED_TIMER_CONTAINING_A_COLON), 0);
+        List<LobbyCommand> dispatched = new ArrayList<>();
+
+        execution(saga, store, dispatched::add).pollTimers();
+
+        assertAll(
+                () -> assertThat(dispatched).containsExactly(new CancelGame("game-3")),
+                () -> assertThat(store.find("game-3")).hasValueSatisfying(e -> assertThat(e.timers()).isEmpty())
+        );
+    }
+
+    private <S> SagaExecution<LobbyEvent, S, LobbyCommand> execution(Saga<LobbyEvent, S, LobbyCommand> saga,
+                                                                     SagaStateStore<S> store,
+                                                                     CommandDispatcher<LobbyCommand> dispatcher) {
+        return new SagaExecution<>("stored-timer-name", saga, store, dispatcher, converter, SagaRunnerConfig.defaults());
+    }
+
+    private static <S> SagaEnvelope<S> storedWith(S state, String sagaId, String storedTimerName) {
+        return new SagaEnvelope<>(sagaId, state, SagaStatus.ACTIVE, 1, List.of(new TimerEntry(storedTimerName, LONG_OVERDUE)),
+                Map.of(), null, Instant.ofEpochMilli(1), Instant.ofEpochMilli(1), null, null);
+    }
+
+    private static Saga<LobbyEvent, FlowState<LobbyEvent>, LobbyCommand> lobbySaga() {
+        return FlowSaga.<LobbyEvent, LobbyCommand>builder()
+                .startsOn(GameCreated.class)
+                .correlate(GameCreated.class, GameCreated::gameId)
+                .correlate(PlayerJoined.class, PlayerJoined::gameId)
+                .step("awaiting-players", step -> step
+                        .on(PlayerJoined.class, Continuation.end())
+                        .timeout(Duration.ofMinutes(30), Continuation.end(),
+                                r -> List.of(new CancelGame(r.initiating(GameCreated.class).gameId()))))
+                .build();
+    }
+
+    private static Saga<LobbyEvent, String, LobbyCommand> coreSaga(String timerName) {
+        return Saga.<LobbyEvent, String, LobbyCommand>builder("waiting")
+                .correlate(GameCreated.class, GameCreated::gameId)
+                .startsOn(GameCreated.class)
+                .evolve(GameCreated.class, (state, event) -> "waiting")
+                .react(GameCreated.class, (state, event) -> List.of(SagaEffect.startTimeout(timerName, Duration.ofMinutes(30))))
+                .evolveOnTimeout(timerName, (state, timeout) -> "cancelled")
+                .reactOnTimeout(timerName, (state, timeout) -> List.of(SagaEffect.issue(new CancelGame(timeout.sagaId()))))
+                .build();
+    }
+
+    sealed interface LobbyEvent permits GameCreated, PlayerJoined {
+    }
+
+    record GameCreated(String gameId) implements LobbyEvent {
+    }
+
+    record PlayerJoined(String gameId) implements LobbyEvent {
+    }
+
+    sealed interface LobbyCommand permits CancelGame {
+    }
+
+    record CancelGame(String gameId) implements LobbyCommand {
+    }
+}

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/internal/TimerConsumptionSupportTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/internal/TimerConsumptionSupportTest.java
@@ -18,9 +18,14 @@ package org.occurrent.dsl.saga.internal;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.occurrent.dsl.saga.Saga;
 import org.occurrent.dsl.saga.SagaEffect;
+import org.occurrent.dsl.saga.SagaEnvelope;
+import org.occurrent.dsl.saga.SagaEnvelope.TimerEntry;
 import org.occurrent.dsl.saga.SagaInput;
+import org.occurrent.dsl.saga.SagaStatus;
 import org.occurrent.dsl.saga.SagaTimeout;
 import org.occurrent.dsl.saga.TimerName;
 import org.occurrent.dsl.saga.internal.SagaExecutionSupport.EventMeta;
@@ -29,6 +34,7 @@ import org.occurrent.dsl.saga.internal.SagaExecutionSupport.Outcome;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -89,5 +95,28 @@ class TimerConsumptionSupportTest {
 
         assertThat(fired.envelope().timers()).extracting("name").containsExactly("t");
         assertThat(fired.envelope().timers().getFirst().firesAtEpochMilli()).isEqualTo(NOW.plusSeconds(60).plus(Duration.ofMinutes(5)).toEpochMilli());
+    }
+
+    @ParameterizedTest(name = "stored as \"{0}\"")
+    @ValueSource(strings = {"payment", "step:awaiting-players", "a:b"})
+    @DisplayName("and one already in the store when the upgrade happened is removed under the name it was stored under")
+    void aTimerStoredBeforeTimerNameExistedIsConsumed(String storedTimerName) {
+        // Each of these is a name written into a store before TimerName existed, spelled out rather than encoded from a
+        // TimerName, so the key that removes the timer is checked against the stored string and not against itself. A key
+        // that disagrees leaves the timer pending and it fires again on every poll for as long as the instance lives.
+        Saga<Ev, String, Cmd> saga = Saga.<Ev, String, Cmd>builder("new")
+                .correlate(Started.class, Started::id)
+                .startsOn(Started.class)
+                .evolve(Started.class, (state, event) -> "active")
+                .evolveOnTimeout(storedTimerName, (state, timeout) -> "active")
+                .reactOnTimeout(storedTimerName, (state, timeout) -> List.of(SagaEffect.issue(new Ping(timeout.sagaId()))))
+                .build();
+        SagaEnvelope<String> stored = new SagaEnvelope<>("s1", "active", SagaStatus.ACTIVE, 1,
+                List.of(new TimerEntry(storedTimerName, NOW.toEpochMilli())), Map.of(), null, NOW, NOW, null, null);
+
+        Outcome<String, Cmd> fired = SagaExecutionSupport.process(saga, "s1", stored, SagaInput.timeout("s1", TimerName.parse(storedTimerName)), EventMeta.NONE, NOW.plusSeconds(1));
+
+        assertThat(fired.commands()).as("the stored name still matches the registration it was armed under").containsExactly(new Ping("s1"));
+        assertThat(fired.envelope().timers()).as("the fired timer must be consumed so it does not re-fire every poll").isEmpty();
     }
 }

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
@@ -115,6 +115,23 @@ class SpringMongoSagaStateStoreMongoTest {
     }
 
     @Test
+    void stores_a_timer_name_in_the_document_as_the_string_it_was_given() {
+        // The three shapes a pending timer's name can have, checked against the raw document rather than a read back
+        // through the store, which would agree with whatever the store had just written. Changing any of these strings
+        // means an instance that was already waiting on that timer stops firing after the upgrade.
+        List<TimerEntry> timers = List.of(new TimerEntry("payment", 1_000),
+                new TimerEntry("step:awaiting-players", 2_000),
+                new TimerEntry("a:b", 3_000));
+        store.compareAndSave("timer-names", active("timer-names", new Counter(1), 1, timers, 0), 0);
+
+        Document raw = mongoOperations.findById("timer-names", Document.class, collection);
+
+        assertThat(raw.getList("timers", Document.class))
+                .extracting(timer -> timer.getString("name"))
+                .containsExactly("payment", "step:awaiting-players", "a:b");
+    }
+
+    @Test
     void updates_only_when_the_expected_version_matches() {
         store.compareAndSave("s3", active("s3", new Counter(1), 1, List.of(), 0), 0);
 

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
@@ -122,13 +122,14 @@ class SpringMongoSagaStateStoreMongoTest {
         List<TimerEntry> timers = List.of(new TimerEntry("payment", 1_000),
                 new TimerEntry("step:awaiting-players", 2_000),
                 new TimerEntry("a:b", 3_000));
-        store.compareAndSave("timer-names", active("timer-names", new Counter(1), 1, timers, 0), 0);
+        assertThat(store.compareAndSave("timer-names", active("timer-names", new Counter(1), 1, timers, 0), 0)).isTrue();
 
         Document raw = mongoOperations.findById("timer-names", Document.class, collection);
 
+        assertThat(raw).isNotNull();
         assertThat(raw.getList("timers", Document.class))
                 .extracting(timer -> timer.getString("name"))
-                .containsExactly("payment", "step:awaiting-players", "a:b");
+                .containsExactlyInAnyOrder("payment", "step:awaiting-players", "a:b");
     }
 
     @Test


### PR DESCRIPTION
ADR 121 says nothing on disk changed when a saga timer's name became a `TimerName`, so an instance with a pending timer keeps firing across the upgrade. That was an argument you could check by reading the code, and now it is a test that fails when it stops being true.

I added `StoredTimerNameTest`, which seeds a store with the name as it was written before the change and runs the real timer poll over it, for a flow saga's `step:awaiting-players`, a plain `payment`, and `a:b`. The last one is the subtle one, where the colon survives only because the registration and the stored string both go through `TimerName.parse`. I also put the consumption case in `TimerConsumptionSupportTest`, since a fired timer that is not removed re-fires on every poll, and one assertion in `SpringMongoSagaStateStoreMongoTest` that the raw document still holds the same string.

Every literal is written out rather than derived from the production helper, because a name built by today's code would still match today's code after a format change. No changelog entry, since `AGENTS.md` folds a refinement to a still-unreleased feature into that feature's own entry and this is test-only.
