### PR TITLE
Read a stored saga timer name out of a document the Mongo store did not write

### DIFF
--- a/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/StoredTimerNameTest.java
+++ b/dsl/saga-dsl/blocking/src/test/java/org/occurrent/dsl/saga/blocking/StoredTimerNameTest.java
@@ -148,7 +148,6 @@ class StoredTimerNameTest {
                 .correlate(GameCreated.class, GameCreated::gameId)
                 .startsOn(GameCreated.class)
                 .evolve(GameCreated.class, (state, event) -> "waiting")
-                .react(GameCreated.class, (state, event) -> List.of(SagaEffect.startTimeout(timerName, Duration.ofMinutes(30))))
                 .evolveOnTimeout(timerName, (state, timeout) -> "cancelled")
                 .reactOnTimeout(timerName, (state, timeout) -> List.of(SagaEffect.issue(new CancelGame(timeout.sagaId()))))
                 .build();

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/internal/TimerConsumptionSupportTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/internal/TimerConsumptionSupportTest.java
@@ -116,7 +116,7 @@ class TimerConsumptionSupportTest {
 
         Outcome<String, Cmd> fired = SagaExecutionSupport.process(saga, "s1", stored, SagaInput.timeout("s1", TimerName.parse(storedTimerName)), EventMeta.NONE, NOW.plusSeconds(1));
 
-        assertThat(fired.commands()).as("the stored name still matches the registration it was armed under").containsExactly(new Ping("s1"));
+        assertThat(fired.commands()).containsExactly(new Ping("s1"));
         assertThat(fired.envelope().timers()).as("the fired timer must be consumed so it does not re-fire every poll").isEmpty();
     }
 }

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SpringMongoSagaStateStoreMongoTest.java
@@ -133,6 +133,35 @@ class SpringMongoSagaStateStoreMongoTest {
     }
 
     @Test
+    void reads_a_timer_name_back_out_of_a_document_it_did_not_write() {
+        // The other half of the same promise, and the one an upgrade actually depends on. Inserting the document by hand
+        // is what makes this a saga that was already waiting when the upgrade happened, rather than one this store wrote
+        // a moment ago and can agree with itself about.
+        mongoOperations.insert(new Document("_id", "already-waiting")
+                .append("status", SagaStatus.ACTIVE.name())
+                .append("version", 1L)
+                .append("state", new Document("value", 1))
+                .append("timers", List.of(new Document("name", "payment").append("firesAtEpochMilli", 1_000L),
+                        new Document("name", "step:awaiting-players").append("firesAtEpochMilli", 2_000L),
+                        new Document("name", "a:b").append("firesAtEpochMilli", 3_000L)))
+                // The earliest of the three, copied to a top-level field, which is the only one the poll matches on.
+                .append("nextTimerFiresAt", 1_000L)
+                .append("streamWatermarks", new Document())
+                .append("createdAt", 1_000L)
+                .append("updatedAt", 1_000L), collection);
+
+        Optional<SagaEnvelope<Counter>> found = store.find("already-waiting");
+        List<SagaEnvelope<Counter>> due = store.findWithDueTimers(Instant.ofEpochMilli(4_000), 10);
+
+        assertAll(
+                () -> assertThat(found).hasValueSatisfying(e -> assertThat(e.timers()).extracting(TimerEntry::name)
+                        .containsExactlyInAnyOrder("payment", "step:awaiting-players", "a:b")),
+                () -> assertThat(due).singleElement().satisfies(e -> assertThat(e.timers()).extracting(TimerEntry::name)
+                        .containsExactlyInAnyOrder("payment", "step:awaiting-players", "a:b"))
+        );
+    }
+
+    @Test
     void updates_only_when_the_expected_version_matches() {
         store.compareAndSave("s3", active("s3", new Counter(1), 1, List.of(), 0), 0);
 


### PR DESCRIPTION
I added the read direction of the stored timer name to the Mongo store test. The existing test writes a saga and reads it back, which agrees with whatever the store just wrote, so it says nothing about a document written by 0.32.0. This one inserts that document by hand, with `payment`, `step:awaiting-players` and `a:b` in its timer array, then checks that `find` and `findWithDueTimers` both come back with all three names intact.

This is the commit the worker pushed two minutes after I merged [#723](https://github.com/johanhaleby/occurrent/pull/723), so it missed that merge through my timing rather than anything about the change.

Also drops an assertion message that claimed more than its check could fail on, and a start reaction the stored timer tests never reach.
