### PR TITLE
Fix status drift in ADR 0110 and ADR 0116

### DIFF
--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -53,9 +53,9 @@ the event rather than which phase it belongs to. `deliver` then reads it exactly
 because that is what picks the `MaterializedView` overload (`:193-204`). The replay/live distinction does exist
 elsewhere. `ReplayAwareSubscriptions.isCatchingUp`
 (`ReplayAwareSubscriptions.java:48`) answers it, reached through
-`static Optional<ReplayAwareSubscriptions> findIn(SubscriptionModelCapability)` (`:61-63`). But its only consumers are the Spring registrars
-and the saga timer check (`SagaAnnotationRegistrar.java:226-227`). Nothing in the projection DSL, in `MaterializedView`,
-or in `ViewStateRepository` consults it, and the DSL does not hold the subscription model to ask.
+`static Optional<ReplayAwareSubscriptions> findIn(SubscriptionModelCapability)` (`:61-63`). But its only consumers are
+the Spring registrars and the saga timer check (`SagaAnnotationRegistrar.java:226-227`). Nothing in the projection DSL,
+in `MaterializedView`, or in `ViewStateRepository` consults it, and the DSL does not hold the subscription model to ask.
 
 **The completion marker is ordered last on purpose.** `BlockingHandover.catchUp` drains the live buffer and only then
 calls `source.markCaughtUp()` (`:218-219`). The class javadoc (`:52-57`) says why. A blocking `accept` returns before its

--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -111,9 +111,10 @@ method every user of `MaterializedView` must implement, for the benefit of the f
 between the question and the update, and it makes the view ask where the runner already knows the answer and can simply
 say so.
 
-No `static Optional<ReplayAware> findIn(SubscriptionModelCapability)` helper, unlike `ReplayAwareSubscriptions` and
-`IntrospectableSubscriptions`. Those exist to unwrap `SubscriptionModelWrapper`. There is no delegating
-materialized view, so the helper would be ceremony around a bare `instanceof`.
+No static lookup helper for `ReplayAware`, unlike `ReplayAwareSubscriptions.findIn(SubscriptionModelCapability)`
+and `IntrospectableSubscriptions.findIn(SubscriptionModelCapability)`. Those exist to unwrap a
+`SubscriptionModelWrapper`. There is no delegating materialized view, so the helper would be ceremony around a
+bare `instanceof`.
 
 > **Amended on 2026-08-08 by [ADR 111](0111-a-projection-records-the-position-it-has-applied.md).** A
 > delegating materialized view now exists, the position recorder built there, and it wraps a view rather

--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -6,9 +6,9 @@ Date: 2026-08-08
 
 Accepted. Unit B1 of the post-0.31.0 architecture review remediation arc, which trails the 0.32.0 tag.
 
-This ADR decides a contract and nothing else. The implementation follows in its own unit, as
-[#622](https://github.com/johanhaleby/occurrent/issues/622) asks for. Nothing described under "Decision" exists in the
-code yet.
+This ADR decided a contract, and [#638](https://github.com/johanhaleby/occurrent/issues/638) has since implemented it.
+`ReplayAware`, the coalescing views, and `ViewStateRepository.findAllById`/`saveAll` all exist in the DSLs described
+under "Decision" below.
 
 ## Context
 
@@ -53,7 +53,7 @@ the event rather than which phase it belongs to. `deliver` then reads it exactly
 because that is what picks the `MaterializedView` overload (`:193-204`). The replay/live distinction does exist
 elsewhere. `ReplayAwareSubscriptions.isCatchingUp`
 (`ReplayAwareSubscriptions.java:48`) answers it, reached through
-`static Optional<ReplayAwareSubscriptions> of(Object)` (`:58-65`). But its only consumers are the Spring registrars
+`static Optional<ReplayAwareSubscriptions> findIn(SubscriptionModelCapability)` (`:61-63`). But its only consumers are the Spring registrars
 and the saga timer check (`SagaAnnotationRegistrar.java:226-227`). Nothing in the projection DSL, in `MaterializedView`,
 or in `ViewStateRepository` consults it, and the DSL does not hold the subscription model to ask.
 
@@ -111,7 +111,7 @@ method every user of `MaterializedView` must implement, for the benefit of the f
 between the question and the update, and it makes the view ask where the runner already knows the answer and can simply
 say so.
 
-No `static Optional<ReplayAware> of(Object)` helper, unlike `ReplayAwareSubscriptions` and
+No `static Optional<ReplayAware> findIn(SubscriptionModelCapability)` helper, unlike `ReplayAwareSubscriptions` and
 `IntrospectableSubscriptions`. Those exist to unwrap `SubscriptionModelWrapper`. There is no delegating
 materialized view, so the helper would be ceremony around a bare `instanceof`.
 

--- a/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
+++ b/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
@@ -4,7 +4,10 @@ Date: 2026-08-09
 
 ## Status
 
-Accepted. Designs the fix for #665, which stays open for the implementation.
+Accepted. Designs the fix for #665, and the fence shipped whole into 0.33.0, covering the strategy's
+token, the `CheckpointWriteCondition` break on `CheckpointStorage` and its reactor twin, the conditional
+Mongo and Redis writes, the four models' write-version stamping, and the Spring Boot starter's wiring at
+every site that builds a checkpoint-writing model.
 [ADR 115](0115-a-lease-fencing-token-is-computed-but-not-yet-checked.md) corrected the javadoc that
 promised this and deferred the design here. Builds on
 [ADR 113](0113-a-competing-consumers-status-and-its-lease-call-are-one-step.md) and


### PR DESCRIPTION
Finding 6 of the codex 0.32.0 design review flagged status drift in the architecture decision records. This closes the two ADRs assigned to this unit.

ADR 0110 still said "no implementation work has been done" and pointed at a `ReplayAwareSubscriptions.of(Object)` lookup that no longer exists. `#638` implemented the replay-batching contract in full, and the lookup is now `findIn(SubscriptionModelCapability)`. I verified both against the code:

```
$ git grep -n "interface ReplayAware " -- '*.java'
dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ReplayAware.java:38:public interface ReplayAware {

$ git grep -n "findIn" -- subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ReplayAwareSubscriptions.java
...:32:...reach it with {@link #findIn(SubscriptionModelCapability)}...
...:61:    static Optional<ReplayAwareSubscriptions> findIn(SubscriptionModelCapability subscriptionModel) {
```

ADR 0116 described the checkpoint lease fence as a design still waiting on an implementation. `#665` shipped it whole into unreleased 0.33.0, covering the strategy token, `CheckpointWriteCondition` on `CheckpointStorage` and its reactor twin, the conditional Mongo and Redis writes, write-version stamping in all four models, and the starter wiring. I confirmed each piece is in the tree:

```
$ git grep -l "CheckpointWriteCondition" -- '*.java' | wc -l
      31
$ git grep -l "fencingToken\|CompetingConsumerCheckpointWriteVersionSource" -- '*.java' framework/
framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/CompetingConsumerCheckpointWriteVersionSource.java
framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrar.java
framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAutoConfiguration.java
```

Both source issues, `#622`/`#638` and `#665`, are closed. Doc-only change, no code touched.
