### PR TITLE
Fix reactive applied-position waits blocking past their deadline during a Mongo outage

### DIFF
--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStore.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStore.java
@@ -44,17 +44,18 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * read-modify-write race.
  * <p>
  * Two different mechanisms pace two different things here, and they do not overlap. The {@link Retry} retries a read
- * or a write that failed, so a transient store error neither fails the projection's delivery on the fold path nor
- * ends a caller's wait on the read path. The {@link Backoff} decides how long
- * {@link #waitUntilApplied(String, long, Duration)} sleeps between polls that succeeded and simply found the
- * projection still behind. {@link Retry} rather than the blocking {@code RetryStrategy} because this is the reactive
- * stack, matching how the reactive starter retries elsewhere.
+ * or a write that failed, so a transient store error neither fails the projection's delivery on the fold path nor a
+ * plain {@link #appliedPosition(String)} call. {@link #waitUntilApplied(String, long, Duration)} is the one
+ * exception. Its own reads retry on the same {@link Retry}, but bounded to the wait's deadline, so a sustained store
+ * outage still surfaces as a timeout rather than an unbounded block. The {@link Backoff} decides how long a wait
+ * sleeps between polls that succeeded and simply found the projection still behind. {@link Retry} rather than the
+ * blocking {@code RetryStrategy} because this is the reactive stack, matching how the reactive starter retries
+ * elsewhere.
  * <p>
  * {@link #defaultRetry()} gives up after a fixed number of attempts rather than retrying forever, a deliberate
- * divergence from the blocking store's default. This store has no {@code waitUntilApplied} override with a
- * wait-local deadline to fall back on, so bounding the retry itself is what keeps a sustained outage from blocking
- * {@link #appliedPosition(String)} and {@link #advance(String, long)} indefinitely. The two stores do not behave
- * the same way under a sustained outage, and an application that needs parity should supply its own {@link Retry}.
+ * divergence from the blocking store's default, which keeps {@link #appliedPosition(String)} and
+ * {@link #advance(String, long)} from blocking a direct caller indefinitely under a sustained outage. An application
+ * that needs parity with the blocking store's unbounded retry should supply its own {@link Retry}.
  */
 @NullMarked
 class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPositionStore {
@@ -92,6 +93,35 @@ class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPo
         Document document = mongoOperations.findOne(query(where(ID).is(projectionId)), Document.class, collection)
                 .retryWhen(retry)
                 .block();
+        return toPosition(document);
+    }
+
+    /**
+     * A read for {@link #waitUntilApplied(String, long, Duration, Backoff)} whose retries stop once {@code deadlineNanos}
+     * ({@link System#nanoTime()} scale) passes, rather than continuing on {@link #retry}'s own schedule. Blocking on
+     * the retried {@link Document} read with the remaining duration as the block timeout is what bounds the retries
+     * themselves, not just the wait loop around them. A store that is still failing once the deadline arrives answers
+     * empty instead of throwing, so the wait's own deadline check is what ends the wait.
+     */
+    private OptionalLong readOnceBoundedBy(String projectionId, long deadlineNanos) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+            return OptionalLong.empty();
+        }
+        try {
+            Document document = mongoOperations.findOne(query(where(ID).is(projectionId)), Document.class, collection)
+                    .retryWhen(retry)
+                    .block(Duration.ofNanos(remainingNanos));
+            return toPosition(document);
+        } catch (RuntimeException e) {
+            if (System.nanoTime() >= deadlineNanos) {
+                return OptionalLong.empty();
+            }
+            throw e;
+        }
+    }
+
+    private static OptionalLong toPosition(Document document) {
         if (document == null) {
             return OptionalLong.empty();
         }
@@ -113,6 +143,52 @@ class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPo
     @Override
     public boolean waitUntilApplied(String projectionId, long position, Duration timeout) {
         return waitUntilApplied(projectionId, position, timeout, pollBackoff);
+    }
+
+    /**
+     * Overrides {@link AppliedProjectionPositionStore}'s default loop so each poll's read retries against {@link #retry}
+     * bounded to this wait's own deadline, rather than continuing to block past it. Without this, a sustained store
+     * outage keeps a single read retrying (and blocking) past the wait's deadline and the wait throws instead of
+     * reaching the deadline check that is supposed to end it. The loop shape (read, check, sleep, grow the backoff)
+     * otherwise matches the interface default and the blocking store's own override. Only the read is store-specific.
+     */
+    @Override
+    public boolean waitUntilApplied(String projectionId, long position, Duration timeout, Backoff backoff) {
+        requireNonNull(projectionId, "projectionId cannot be null");
+        requireNonNull(timeout, "timeout cannot be null");
+        requireNonNull(backoff, "backoff cannot be null");
+        if (position <= 0) {
+            throw new IllegalArgumentException("position must be positive but was " + position);
+        }
+        if (backoff instanceof Backoff.None) {
+            throw new IllegalArgumentException("backoff cannot be Backoff.none(), a wait polls the store and needs a delay between polls. Use Backoff.fixed(..) or Backoff.exponential(..).");
+        }
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        long intervalNanos = switch (backoff) {
+            case Backoff.Fixed fixed -> Duration.ofMillis(fixed.millis).toNanos();
+            case Backoff.Exponential exponential -> exponential.initial.toNanos();
+            case Backoff.None ignored -> throw new IllegalStateException("unreachable, rejected above");
+        };
+        while (true) {
+            OptionalLong applied = readOnceBoundedBy(projectionId, deadlineNanos);
+            if (applied.isPresent() && applied.getAsLong() >= position) {
+                return true;
+            }
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                return false;
+            }
+            long sleepNanos = Math.min(intervalNanos, remainingNanos);
+            try {
+                Thread.sleep(sleepNanos / 1_000_000, (int) (sleepNanos % 1_000_000));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            if (backoff instanceof Backoff.Exponential exponential) {
+                intervalNanos = Math.min((long) (intervalNanos * exponential.multiplier), exponential.max.toNanos());
+            }
+        }
     }
 
     private static Retry defaultRetry() {

--- a/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStore.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/main/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStore.java
@@ -46,11 +46,12 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * Two different mechanisms pace two different things here, and they do not overlap. The {@link Retry} retries a read
  * or a write that failed, so a transient store error neither fails the projection's delivery on the fold path nor a
  * plain {@link #appliedPosition(String)} call. {@link #waitUntilApplied(String, long, Duration)} is the one
- * exception. Its own reads retry on the same {@link Retry}, but bounded to the wait's deadline, so a sustained store
- * outage still surfaces as a timeout rather than an unbounded block. The {@link Backoff} decides how long a wait
- * sleeps between polls that succeeded and simply found the projection still behind. {@link Retry} rather than the
- * blocking {@code RetryStrategy} because this is the reactive stack, matching how the reactive starter retries
- * elsewhere.
+ * exception. Its own reads retry on the same {@link Retry}, but bounded to the wait's deadline, and a read that is
+ * still failing once the deadline arrives, or once {@link #retry} itself gives up, answers empty rather than
+ * throwing, so a sustained store outage always surfaces as a timeout, never as an exception. The {@link Backoff}
+ * decides how long a wait sleeps between polls that succeeded and simply found the projection still behind.
+ * {@link Retry} rather than the blocking {@code RetryStrategy} because this is the reactive stack, matching how the
+ * reactive starter retries elsewhere.
  * <p>
  * {@link #defaultRetry()} gives up after a fixed number of attempts rather than retrying forever, a deliberate
  * divergence from the blocking store's default, which keeps {@link #appliedPosition(String)} and
@@ -70,11 +71,12 @@ class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPo
 
     /**
      * Retries a failing read or write with backoff from 100 ms up to 2 seconds, giving up after 5 retries (6
-     * attempts total) and surfacing the last failure. The blocking store does not give up this way.
-     * {@code MongoAppliedProjectionPositionStore} retries the same backoff forever, since it keeps {@code advance(..)} durable
-     * under an outage and bounds only {@code waitUntilApplied(..)}'s own reads to the wait's deadline instead. This
-     * store has no such wait-local bound, so its default retries a fixed number of times rather than forever, and
-     * polls a wait at {@link AppliedProjectionPositionStore#DEFAULT_POLL_BACKOFF}.
+     * attempts total) and surfacing the last failure. The blocking store does not give up this way, it retries the
+     * same backoff forever, since it keeps {@code advance(..)} durable under an outage. This store's default gives
+     * up so a direct call to {@link #appliedPosition(String)} or {@link #advance(String, long)} does not block a
+     * caller indefinitely. {@link #waitUntilApplied(String, long, Duration)} never inherits that exhaustion though,
+     * its own reads answer empty rather than surfacing the failure, so a wait against this default still resolves
+     * by its own deadline. Polls a wait at {@link AppliedProjectionPositionStore#DEFAULT_POLL_BACKOFF}.
      */
     ReactiveMongoAppliedProjectionPositionStore(ReactiveMongoOperations mongoOperations, String collection) {
         this(mongoOperations, collection, defaultRetry(), DEFAULT_POLL_BACKOFF);
@@ -97,11 +99,13 @@ class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPo
     }
 
     /**
-     * A read for {@link #waitUntilApplied(String, long, Duration, Backoff)} whose retries stop once {@code deadlineNanos}
-     * ({@link System#nanoTime()} scale) passes, rather than continuing on {@link #retry}'s own schedule. Blocking on
-     * the retried {@link Document} read with the remaining duration as the block timeout is what bounds the retries
-     * themselves, not just the wait loop around them. A store that is still failing once the deadline arrives answers
-     * empty instead of throwing, so the wait's own deadline check is what ends the wait.
+     * A read for {@link #waitUntilApplied(String, long, Duration, Backoff)} whose retries stop once
+     * {@code deadlineNanos} ({@link System#nanoTime()} scale) passes, rather than continuing on {@link #retry}'s own
+     * schedule. Blocking on the retried {@link Document} read with the remaining duration as the block timeout is
+     * what bounds the retries themselves, not just the wait loop around them. {@link #retry}'s default is finite, so
+     * a sustained outage can also exhaust the retry itself well before the deadline. Either way the read answers
+     * empty rather than throwing, since a wait polls for "not caught up yet" and leaves ending the wait to its own
+     * deadline check, never to the read's failure.
      */
     private OptionalLong readOnceBoundedBy(String projectionId, long deadlineNanos) {
         long remainingNanos = deadlineNanos - System.nanoTime();
@@ -113,11 +117,8 @@ class ReactiveMongoAppliedProjectionPositionStore implements AppliedProjectionPo
                     .retryWhen(retry)
                     .block(Duration.ofNanos(remainingNanos));
             return toPosition(document);
-        } catch (RuntimeException e) {
-            if (System.nanoTime() >= deadlineNanos) {
-                return OptionalLong.empty();
-            }
-            throw e;
+        } catch (RuntimeException ignored) {
+            return OptionalLong.empty();
         }
     }
 

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.reactor;
+
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.dsl.projection.AppliedProjectionPositionStore;
+import org.occurrent.retry.Backoff;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ReactiveMongoAppliedProjectionPositionStore#waitUntilApplied(String, long, Duration)} promises to return
+ * {@code false} once {@code timeout} elapses. Left unbounded, a single read's {@link Retry} sequence can run well
+ * past a short wait's own deadline before it gives up and throws, which is exactly the failure this test forces: a
+ * {@link Retry} whose backoff schedule outlives the wait's timeout, so the wait must cut the read off at its own
+ * deadline rather than let the retry run to its own exhaustion. No Testcontainers needed, a mocked
+ * {@link ReactiveMongoOperations} whose read always errors is enough to force the sustained-outage path.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Timeout(10)
+class ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest {
+
+    @Test
+    void returns_false_within_its_timeout_against_a_store_whose_reads_keep_failing() {
+        ReactiveMongoOperations mongoOperations = mock(ReactiveMongoOperations.class);
+        AtomicInteger attempts = new AtomicInteger();
+        // retryWhen resubscribes to this same Mono rather than calling findOne(..) again, so attempts are counted by
+        // subscription, not by the mock's own invocation count.
+        when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
+                .thenReturn(Mono.<Document>error(new RuntimeException("store outage")).doOnSubscribe(s -> attempts.incrementAndGet()));
+        // Retries alone would not exhaust for the better part of a second, well past the 200 ms wait below, so the
+        // wait's own deadline is what has to cut the read off rather than the retry's own exhaustion.
+        Retry slowRetry = Retry.backoff(5, Duration.ofMillis(50))
+                .maxBackoff(Duration.ofMillis(500))
+                .onRetryExhaustedThrow((spec, signal) -> signal.failure());
+        AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", slowRetry, Backoff.fixed(20));
+        Duration timeout = Duration.ofMillis(200);
+
+        Instant start = Instant.now();
+        boolean caughtUp = storage.waitUntilApplied("orders", 1, timeout);
+        Duration elapsed = Duration.between(start, Instant.now());
+
+        assertThat(caughtUp).isFalse();
+        // The deadline is only checked between retry attempts, so the last in-flight attempt can overrun it by up
+        // to one retry interval. This slack stays well short of whole extra retry cycles.
+        assertThat(elapsed).isLessThan(timeout.plusSeconds(2));
+        assertThat(attempts.get()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void propagates_exception_when_finite_retry_attempts_exhausted() {
+        ReactiveMongoOperations mongoOperations = mock(ReactiveMongoOperations.class);
+        RuntimeException storeFailure = new RuntimeException("persistent store error");
+        when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
+                .thenReturn(Mono.error(storeFailure));
+        Retry finiteRetry = Retry.fixedDelay(2, Duration.ofMillis(10))
+                .onRetryExhaustedThrow((spec, signal) -> signal.failure());
+        AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", finiteRetry, Backoff.fixed(100));
+        Duration generousTimeout = Duration.ofSeconds(10);
+
+        assertThatThrownBy(() ->
+                storage.waitUntilApplied("orders", 1, generousTimeout)
+        ).isEqualTo(storeFailure);
+    }
+}

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
@@ -59,10 +59,12 @@ class ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest {
         // subscription, not by the mock's own invocation count.
         when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
                 .thenReturn(Mono.<Document>error(new RuntimeException("store outage")).doOnSubscribe(s -> attempts.incrementAndGet()));
-        // This retry's own schedule would not exhaust for the better part of a second, well past the 200 ms wait
-        // below, so the wait's own deadline is what has to cut the read off rather than the retry's own exhaustion.
-        Retry slowRetry = Retry.backoff(5, Duration.ofMillis(50))
-                .maxBackoff(Duration.ofMillis(500))
+        // Zero jitter makes the schedule exact: 30+60+120+240+480 = 930 ms to exhaust, well past the 200 ms wait
+        // below, so the 500 ms assertion margin only fails if the wait's own deadline cuts the read off rather than
+        // the retry running to its own exhaustion. The second attempt still lands at 30 ms, well inside the wait.
+        Retry slowRetry = Retry.backoff(5, Duration.ofMillis(30))
+                .maxBackoff(Duration.ofSeconds(2))
+                .jitter(0)
                 .onRetryExhaustedThrow((spec, signal) -> signal.failure());
         AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", slowRetry, Backoff.fixed(20));
         Duration timeout = Duration.ofMillis(200);

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,26 +41,26 @@ import static org.mockito.Mockito.when;
 
 /**
  * {@link ReactiveMongoAppliedProjectionPositionStore#waitUntilApplied(String, long, Duration)} promises to return
- * {@code false} once {@code timeout} elapses. Left unbounded, a single read's {@link Retry} sequence can run well
- * past a short wait's own deadline before it gives up and throws, which is exactly the failure this test forces: a
- * {@link Retry} whose backoff schedule outlives the wait's timeout, so the wait must cut the read off at its own
- * deadline rather than let the retry run to its own exhaustion. No Testcontainers needed, a mocked
- * {@link ReactiveMongoOperations} whose read always errors is enough to force the sustained-outage path.
+ * {@code false} once {@code timeout} elapses and never to throw, the same contract every
+ * {@link AppliedProjectionPositionStore#waitUntilApplied(String, long, Duration, Backoff)} implementation makes. A
+ * failing read can miss that contract two different ways: its {@link Retry} sequence can still be running when the
+ * wait's own deadline arrives, or it can exhaust on its own well before that deadline. Both are forced here with a
+ * mocked {@link ReactiveMongoOperations} whose read always errors, no Testcontainers needed.
  */
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Timeout(10)
 class ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest {
 
     @Test
-    void returns_false_within_its_timeout_against_a_store_whose_reads_keep_failing() {
+    void returns_false_when_the_deadline_arrives_while_a_read_is_still_retrying() {
         ReactiveMongoOperations mongoOperations = mock(ReactiveMongoOperations.class);
         AtomicInteger attempts = new AtomicInteger();
         // retryWhen resubscribes to this same Mono rather than calling findOne(..) again, so attempts are counted by
         // subscription, not by the mock's own invocation count.
         when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
                 .thenReturn(Mono.<Document>error(new RuntimeException("store outage")).doOnSubscribe(s -> attempts.incrementAndGet()));
-        // Retries alone would not exhaust for the better part of a second, well past the 200 ms wait below, so the
-        // wait's own deadline is what has to cut the read off rather than the retry's own exhaustion.
+        // This retry's own schedule would not exhaust for the better part of a second, well past the 200 ms wait
+        // below, so the wait's own deadline is what has to cut the read off rather than the retry's own exhaustion.
         Retry slowRetry = Retry.backoff(5, Duration.ofMillis(50))
                 .maxBackoff(Duration.ofMillis(500))
                 .onRetryExhaustedThrow((spec, signal) -> signal.failure());
@@ -73,25 +72,45 @@ class ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest {
         Duration elapsed = Duration.between(start, Instant.now());
 
         assertThat(caughtUp).isFalse();
-        // The deadline is only checked between retry attempts, so the last in-flight attempt can overrun it by up
-        // to one retry interval. This slack stays well short of whole extra retry cycles.
-        assertThat(elapsed).isLessThan(timeout.plusSeconds(2));
+        // Bounded by the deadline itself, not by however long the retry's own backoff would otherwise run.
+        assertThat(elapsed).isLessThan(timeout.plusMillis(500));
         assertThat(attempts.get()).isGreaterThanOrEqualTo(2);
     }
 
     @Test
-    void propagates_exception_when_finite_retry_attempts_exhausted() {
+    void keeps_polling_until_its_own_deadline_when_a_finite_retry_exhausts_well_before_it() {
         ReactiveMongoOperations mongoOperations = mock(ReactiveMongoOperations.class);
-        RuntimeException storeFailure = new RuntimeException("persistent store error");
         when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
-                .thenReturn(Mono.error(storeFailure));
-        Retry finiteRetry = Retry.fixedDelay(2, Duration.ofMillis(10))
+                .thenReturn(Mono.error(new RuntimeException("persistent store error")));
+        // Exhausts in roughly 20 ms, far short of the 300 ms wait below, so a poll's own retry exhaustion must not
+        // end the wait early, only the wait's own deadline may.
+        Retry fastExhaustingRetry = Retry.fixedDelay(2, Duration.ofMillis(10))
                 .onRetryExhaustedThrow((spec, signal) -> signal.failure());
-        AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", finiteRetry, Backoff.fixed(100));
-        Duration generousTimeout = Duration.ofSeconds(10);
+        AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", fastExhaustingRetry, Backoff.fixed(20));
+        Duration timeout = Duration.ofMillis(300);
 
-        assertThatThrownBy(() ->
-                storage.waitUntilApplied("orders", 1, generousTimeout)
-        ).isEqualTo(storeFailure);
+        Instant start = Instant.now();
+        boolean caughtUp = storage.waitUntilApplied("orders", 1, timeout);
+        Duration elapsed = Duration.between(start, Instant.now());
+
+        assertThat(caughtUp).isFalse();
+        assertThat(elapsed).isGreaterThanOrEqualTo(timeout.minusMillis(50));
+        assertThat(elapsed).isLessThan(timeout.plusMillis(500));
+    }
+
+    @Test
+    void returns_true_when_a_read_recovers_within_the_deadline() {
+        ReactiveMongoOperations mongoOperations = mock(ReactiveMongoOperations.class);
+        Document applied = new Document("_id", "orders").append("position", 42L);
+        when(mongoOperations.findOne(any(Query.class), eq(Document.class), anyString()))
+                .thenReturn(Mono.error(new RuntimeException("transient store error")))
+                .thenReturn(Mono.just(applied));
+        Retry retry = Retry.fixedDelay(3, Duration.ofMillis(10))
+                .onRetryExhaustedThrow((spec, signal) -> signal.failure());
+        AppliedProjectionPositionStore storage = new ReactiveMongoAppliedProjectionPositionStore(mongoOperations, "appliedPositions", retry, Backoff.fixed(20));
+
+        boolean caughtUp = storage.waitUntilApplied("orders", 1, Duration.ofSeconds(5));
+
+        assertThat(caughtUp).isTrue();
     }
 }


### PR DESCRIPTION
I bounded the reactive Mongo applied-position store's `waitUntilApplied` reads to the wait's own deadline, the same way `MongoAppliedProjectionPositionStore` already does on the blocking side, and made the wait never throw regardless of when a read fails.

Without this, a poll's Mongo read retried on the store's own schedule (five attempts, backoff up to two seconds) regardless of how much time the wait itself had left. A short wait against a failing store could block for the whole retry sequence and then throw the exhausted-store exception, instead of returning `false` within its own timeout. Under a sustained outage, that turns a storage incident into threads piling up on these waits.

I added a `readOnceBoundedBy` override that blocks each retried read for only the wait's remaining duration and treats any read failure, whether the deadline has passed or the retry simply exhausted first, as "not caught up yet". The wait's own loop keeps polling until its deadline either way. This matches `AppliedProjectionPositionStore`'s documented contract that a wait returns `false` on timeout and never throws.

I added `ReactiveMongoAppliedProjectionPositionStoreWaitUntilAppliedTimeoutTest`, covering both ways a read can fail (a slow retry still running when the deadline hits, and a fast retry that exhausts well before it) plus a case where a transient failure recovers within the deadline.
