### PR TITLE
Fix Kotlin's on(StepCondition) rejecting a narrower event type

### DIFF
--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -239,9 +239,12 @@ class StepScope<E : Any, C : Any> @PublishedApi internal constructor(@PublishedA
      *
      * A [StepCondition] first argument cannot bind to the reified `on<T>` overloads above, so there is no resolution
      * collision between a classic branch and a window-condition one.
+     *
+     * [condition] takes `StepCondition<out E>`, matching the Java side's `StepCondition<? extends E>`, so a leaf built
+     * over a narrower event type can be passed to a step declared over a broader one.
      */
     fun on(
-        condition: StepCondition<E>,
+        condition: StepCondition<out E>,
         then: Continuation,
         whenFulfilled: FlowReactions<C>.(ReceivedEvents<E>) -> FlowReactions<C> = { nothing }
     ) {

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/StepConditionKotlinVarianceTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/StepConditionKotlinVarianceTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.saga.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.occurrent.dsl.saga.SagaInput
+
+/**
+ * Kept out of SagaFlowExtensionsTest.kt because PR #742 is concurrently editing that file.
+ *
+ * Proves [StepScope.on]'s [StepCondition] parameter matches the Java side's `StepCondition<? extends E>` rather than
+ * the invariant `StepCondition<E>`: a leaf built once over a narrower event type binds, unmodified, to a step
+ * declared over a broader event hierarchy.
+ */
+class StepConditionKotlinVarianceTest {
+
+    sealed interface BaseEvent
+    data class Started(val id: String) : BaseEvent
+    data class Narrow(val id: String) : BaseEvent
+
+    sealed interface Cmd
+
+    /** Built over [Narrow] alone, and reused below in a step declared over the wider [BaseEvent]. */
+    private val narrowCondition: StepCondition<Narrow> = StepCondition.event(Narrow::class.java)
+
+    @Test
+    fun `a StepCondition built over a narrower type binds to a step declared over the broader hierarchy`() {
+        val saga = saga<BaseEvent, Cmd> {
+            startsOn<Started>()
+            correlateAll { "s1" }
+            step("wait") {
+                on(narrowCondition, then = end)
+            }
+        }
+
+        val started = saga.evolve(saga.initialState(), SagaInput.event(Started("s1")))
+        val fulfilled = saga.evolve(started, SagaInput.event(Narrow("s1")))
+
+        assertThat(saga.isTerminal(fulfilled)).isTrue()
+    }
+}


### PR DESCRIPTION
I changed the Kotlin `on(StepCondition, ...)` extension in `SagaFlowExtensions.kt` to accept `StepCondition<out E>` instead of the invariant `StepCondition<E>`. The Java side, `StepBuilder.on(StepCondition<? extends E>, ...)`, already accepts a subtype tree, and ADR 120 records that as intentional, so a Kotlin caller couldn't pass a reusable `StepCondition<NarrowEvent>` into a step declared over a broader `BaseEvent`, while a Java caller could.

The same file already uses `StepCondition<out E>` for its `allOf`/`anyOf` composition helpers, so the invariant parameter on `on` looks like an oversight rather than a decision. There's only one `StepCondition`-taking `on` overload in this file. The Java side has two (a two-arg and a three-arg form), both already correctly variant.

I added a new test file, `StepConditionKotlinVarianceTest.kt`, with a compile-time proof. It builds a `StepCondition` over a narrower type and passes it into a step declared over the broader hierarchy. I kept it out of `SagaFlowExtensionsTest.kt` because PR #742 is editing that file concurrently.

This is source-compatible. Adding `out` to an existing parameter never breaks an existing caller.

Verification: `mvn -pl dsl/saga-dsl/common -am test-compile` and `test` both pass. I confirmed the test is a real proof by reverting the `out` and checking the new file failed to compile with the expected type-mismatch error, then restored the fix from a saved copy.

I did not touch `changelog.md`. The existing "next version" entry describing step conditions is the same bullet PR #742 is actively rewording, so folding this in would collide with that edit.
