### PR TITLE
Disclose the CheckpointStorage upgrade recipe is Java only in the 0.33.0 guide

### DIFF
--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -3,9 +3,10 @@
 `CheckpointStorage` and its reactor twin gain a conditional write. This is a real break, and every implementation of
 either interface, in this repository and outside it, now has two more members to answer. No calling code changes,
 because the two-argument `save` you already call stays exactly as it was, as a default that delegates to the new
-one. `UpgradeToOccurrent_0_33` stubs the two new members for you on a class it finds missing them, delegating `any()`
-to your existing write and marking the rest with a review comment, so the module compiles again. Evaluating a
-condition for real is still yours, see section 2.
+one. `UpgradeToOccurrent_0_33` stubs the two new members for you on a Java class it finds missing them, delegating
+`any()` to your existing write and marking the rest with a review comment, so the module compiles again. The recipe
+is Java only, so a Kotlin implementer adds the same two members by hand, see section 2. Evaluating a condition for
+real is still yours either way.
 [ADR 116](../architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md) has the
 reasoning.
 
@@ -61,11 +62,13 @@ for that subscription id, whatever version it would carry, and refuses the same 
 
 ## 2. If you implement `CheckpointStorage` yourself, this one does not compile
 
-Run `UpgradeToOccurrent_0_33` first. On every implementation it finds missing them, it adds the `save` overload and
-`writeVersion`, each marked with a `TODO [Occurrent 0.33 upgrade]` comment, so the module compiles again without a
-manual pass. What it generates is exactly the snippet below. `save` delegates `any()` to your existing two-argument
-override and refuses anything stronger, and `writeVersion` answers empty. A store that only ever wrote
-unconditionally can leave that exactly as generated:
+If you implement in Java, run `UpgradeToOccurrent_0_33` first. On every Java implementation it finds missing them, it
+adds the `save` overload and `writeVersion`, each marked with a `TODO [Occurrent 0.33 upgrade]` comment, so the
+module compiles again without a manual pass. The recipe is Java only, the same limitation the saga timer rewrite in
+section 7 runs into, so a Kotlin implementer does the equivalent by hand, below. What the recipe generates for a Java
+class is exactly the snippet below. `save` delegates `any()` to your existing two-argument override and refuses
+anything stronger, and `writeVersion` answers empty. A store that only ever wrote unconditionally can leave that
+exactly as generated:
 
 ```java
 @Override
@@ -102,6 +105,41 @@ storage that declares it supports them. `any()` must leave whatever version is s
 forward, rather than clearing it or overwriting it with something inferred from the write. And `notOlderThan(v)`
 must accept when nothing is stored, since that is a checkpoint written before this condition existed, and every
 checkpoint saved by an earlier release has to stay readable.
+
+### By hand in Kotlin
+
+`UpgradeToOccurrent_0_33` does not touch a Kotlin file at all, the same limitation the saga timer rewrite in section 7
+runs into. A Kotlin implementer of the blocking `CheckpointStorage` adds the same two members the Java stub above
+adds, against the interface's real signatures:
+
+```kotlin
+override fun save(subscriptionId: String, checkpoint: Checkpoint, condition: CheckpointWriteCondition): Checkpoint {
+    if (condition !is CheckpointWriteCondition.Any) {
+        throw UnsupportedOperationException("This storage cannot evaluate $condition, only any() is supported.")
+    }
+    return save(subscriptionId, checkpoint) // your existing unconditional write
+}
+
+override fun writeVersion(subscriptionId: String): OptionalLong = OptionalLong.empty()
+```
+
+The reactor twin signals rather than throws, the same way the Java reactor stub does:
+
+```kotlin
+override fun save(subscriptionId: String, checkpoint: Checkpoint, condition: CheckpointWriteCondition): Mono<Checkpoint> {
+    if (condition !is CheckpointWriteCondition.Any) {
+        return Mono.error(UnsupportedOperationException("This storage cannot evaluate $condition, only any() is supported."))
+    }
+    return save(subscriptionId, checkpoint) // your existing unconditional write
+}
+
+override fun writeVersion(subscriptionId: String): Mono<Long> = Mono.empty()
+```
+
+Both are the same permanent answer as the Java stub, not a placeholder to replace before compiling: `any()`
+delegates to your existing two-argument `save`, anything stronger is refused, and `writeVersion` answers empty.
+Leave `evaluatesWriteConditions()` at its default `false` unless your store evaluates `notOlderThan` and `ifAbsent`
+for real, in which case write the same real evaluation the paragraph above asks of a Java store.
 
 ## 3. A 0.32.0 node during a rolling upgrade
 

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -4,7 +4,7 @@
 either interface, in this repository and outside it, now has two more members to answer. No calling code changes,
 because the two-argument `save` you already call stays exactly as it was, as a default that delegates to the new
 one. `UpgradeToOccurrent_0_33` stubs the two new members for you on a Java class it finds missing them, delegating
-`any()` to your existing write and marking the rest with a review comment, so the module compiles again. The recipe
+`any()` to your existing write and marking the rest with a review comment, so the module compiles again. That stub
 is Java only, so a Kotlin implementer adds the same two members by hand, see section 2. Evaluating a condition for
 real is still yours either way.
 [ADR 116](../architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md) has the
@@ -64,9 +64,9 @@ for that subscription id, whatever version it would carry, and refuses the same 
 
 If you implement in Java, run `UpgradeToOccurrent_0_33` first. On every Java implementation it finds missing them, it
 adds the `save` overload and `writeVersion`, each marked with a `TODO [Occurrent 0.33 upgrade]` comment, so the
-module compiles again without a manual pass. The recipe is Java only, the same limitation the saga timer rewrite in
-section 7 runs into, so a Kotlin implementer does the equivalent by hand, below. What the recipe generates for a Java
-class is exactly the snippet below. `save` delegates `any()` to your existing two-argument override and refuses
+module compiles again without a manual pass. This checkpoint-storage stub is Java only, the same limitation the saga
+timer rewrite in section 7 runs into, so a Kotlin implementer does the equivalent by hand, below. What it generates
+for a Java class is exactly the snippet below. `save` delegates `any()` to your existing two-argument override and refuses
 anything stronger, and `writeVersion` answers empty. A store that only ever wrote unconditionally can leave that
 exactly as generated:
 
@@ -108,9 +108,9 @@ checkpoint saved by an earlier release has to stay readable.
 
 ### By hand in Kotlin
 
-`UpgradeToOccurrent_0_33` does not touch a Kotlin file at all, the same limitation the saga timer rewrite in section 7
-runs into. A Kotlin implementer of the blocking `CheckpointStorage` adds the same two members the Java stub above
-adds, against the interface's real signatures:
+This checkpoint-storage stub does not touch a Kotlin file at all, the same limitation the saga timer rewrite in
+section 7 runs into. A Kotlin implementer of the blocking `CheckpointStorage` adds the same two members the Java
+stub above adds, against the interface's real signatures:
 
 ```kotlin
 override fun save(subscriptionId: String, checkpoint: Checkpoint, condition: CheckpointWriteCondition): Checkpoint {


### PR DESCRIPTION
The 0.33.0 upgrade guide told a Kotlin implementer that `UpgradeToOccurrent_0_33` adds the missing `CheckpointStorage` members for every implementation, in this repository and outside it. The recipe is Java only. It bails out on anything that is not a genuine Java compilation unit, and `CheckpointStorageConditionalWriteStubsKotlinTest` asserts a Kotlin implementer is left with both members missing. A Kotlin author running the recipe would see nothing happen and hit a compiler error with no guidance in section 2.

I disclosed the Java-only scope in the top summary and in section 2, and added the manual Kotlin path to section 2, a blocking and a reactor snippet adding the same two members the Java stub generates, written against the real `CheckpointStorage` interfaces' signatures.

Docs only, markdown-only diff, no code touched.

This PR waits for U4 (`cdx33b/u4-stepwindow-preprogress`) to merge first. Guide-touching PRs in this epic land in order U2, U4, U8, U7, and I'll rebase over U4 before this lands.
