### PR TITLE
Reconcile ADR drift left by the applied-position withdrawal

### DIFF
--- a/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
+++ b/doc/architecture/decisions/0110-a-replay-tells-the-view-where-it-begins-and-ends.md
@@ -123,6 +123,12 @@ bare `instanceof`.
 > `Projections.materializedView` builds the coalescing view directly from a `View`, not from an existing
 > `MaterializedView`, so there is no public path to wrap it around the recorder instead.
 
+> **Withdrawn on 2026-08-11 by [ADR 122](0122-an-applied-position-is-not-a-completed-prefix.md), before it
+> ever shipped.** The delegating position recorder the amendment above describes, `RecordingMaterializedView`,
+> is removed for 0.33.0 along with `AppliedProjectionPositionStore` and its recording wrappers. The "only this
+> order is buildable" claim above described a design that never released. `ReplayAware` and the `instanceof`
+> probe it names are unaffected. Nothing about them depended on the withdrawn recorder.
+
 **3. The boundary is driven by whoever owns the replay, and every path that does not own one degrades to today's
 behaviour.** Internally, `BlockingHandover.Source` gains defaulted `replayStarted()`, `replayCompleted()` and
 `replayAbandoned()` methods, and `ReactiveHandover.Source` gains the same with `Mono<Void> replayCompleted()` so the

--- a/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md
+++ b/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md
@@ -4,14 +4,16 @@ Date: 2026-08-08
 
 ## Status
 
-Accepted. Resolves [#361](https://github.com/johanhaleby/occurrent/issues/361). Additive across the projection DSL, the
-view DSL and the Spring Boot starters.
+Withdrawn on 2026-08-11 by [ADR 122](0122-an-applied-position-is-not-a-completed-prefix.md), before this feature
+ever shipped.
 
-> **Withdrawn on 2026-08-11 by [ADR 122](0122-an-applied-position-is-not-a-completed-prefix.md), before this
-> feature ever shipped.** `waitUntilApplied` read a monotonic maximum as a completed prefix, which needs
-> position-ordered delivery, and no delivery source Occurrent ships provides that. `AppliedProjectionPositionStore`,
-> its recording wrappers, both Mongo-backed stores, and `@Projection`'s `recordAppliedPosition` attribute are all
-> removed from 0.33.0. [#361](https://github.com/johanhaleby/occurrent/issues/361) reopens.
+Originally accepted, resolving [#361](https://github.com/johanhaleby/occurrent/issues/361), additive across the
+projection DSL, the view DSL and the Spring Boot starters.
+
+> `waitUntilApplied` read a monotonic maximum as a completed prefix, which needs position-ordered delivery, and no
+> delivery source Occurrent ships provides that. `AppliedProjectionPositionStore`, its recording wrappers, both
+> Mongo-backed stores, and `@Projection`'s `recordAppliedPosition` attribute are all removed from 0.33.0.
+> [#361](https://github.com/johanhaleby/occurrent/issues/361) reopens.
 
 ## Context
 

--- a/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
+++ b/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
@@ -498,7 +498,9 @@ counts as no version, which keeps a checkpoint write from a registrar-driven sub
 the strategy bean is still being built.
 
 A user who declares their own `CheckpointStorage` bean is unaffected, since that bean no longer carries
-the fence. A user who hand-wires their own models passes the source themselves, which is one argument
+the fence, unless fencing is enabled and the bean cannot evaluate write conditions, in which case the
+amendment below refuses it at startup rather than accepting a checkpoint the fence cannot actually
+protect. A user who hand-wires their own models passes the source themselves, which is one argument
 in two places.
 
 > **Amended for 0.33.0.** Several strategy beans with no `@Primary` no longer start the application. The
@@ -587,7 +589,8 @@ The migration guide documents the window.
 
 A user who wires their own subscription models gets the fence by passing the source and gets today's
 behaviour by leaving it out. A user on the Spring Boot starter gets it without doing anything, whatever
-their checkpoint storage bean is, because the fence no longer travels through that bean.
+their checkpoint storage bean is, because the fence no longer travels through that bean, unless that
+bean cannot evaluate write conditions, in which case startup refuses rather than running unfenced.
 
 A `CheckpointStorage` implementation outside this repository has to be updated, which the recipe does
 for the signature and the author does for the behaviour. A store that cannot write conditionally stays

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/Projections.java
@@ -170,7 +170,7 @@ public final class Projections {
      * always implements {@link ReactiveReplayAware}, and forwards
      * {@code replayStarted}/{@code replayCompleted}/{@code replayAbandoned} to {@code materializedView} whenever it
      * implements the blocking view DSL's {@code ReplayAware} capability, so a replay driven through a
-     * {@code CatchupProjectionFeed} still reaches a batching or position-recording view wrapped through this bridge.
+     * {@code CatchupProjectionFeed} still reaches a batching view wrapped through this bridge.
      */
     public static <E> BiFunction<EventMetadata, E, Mono<Void>> reactiveUpdateWithMetadata(MaterializedView<E> materializedView) {
         requireNonNull(materializedView, "materializedView cannot be null");


### PR DESCRIPTION
ADR 122 withdrew the applied-position feature before it shipped, and three surfaces still described it, or its neighboring fence, as real when they no longer are.

- ADR 110's amendment blockquote said the delegating position recorder existed and was buildable. I added a dated follow-up blockquote pointing at ADR 122, rather than rewriting the original, per the append-only convention this file already uses.
- ADR 111's Status line still read `Accepted` right above its own withdrawal notice, which two independent reviews flagged as self-contradictory. I flipped the Status line to `Withdrawn on 2026-08-11 by ADR 122` and moved the original acceptance text into the body as history.
- ADR 116 had two passages claiming every checkpoint storage bean is unaffected by the fence, which its own fenced-startup amendment already contradicts (a storage that cannot evaluate write conditions is refused at startup). I qualified both passages in place, matching the ADR 124 precedent for factual corrections inside an already-amended record.
- `Projections.java`'s javadoc still promised a replay reaches "a batching or position-recording view". The position-recording half described the withdrawn feature, so I dropped it.

No behavior change, docs plus one javadoc line. `mvn -pl dsl/projection-dsl/reactor -am compile` passes.