### PR TITLE
Fix Kotlin predicate identity mismatch in named step-condition leaves

### DIFF
--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -66,6 +66,19 @@ fun <E : Any, C : Any> saga(block: FlowSagaBuilder<E, C>.() -> Unit): Saga<E, Fl
  */
 fun stepTimer(stepName: String): TimerName = FlowSaga.stepTimer(stepName)
 
+/**
+ * Wraps a Kotlin function as a [Predicate] with equals/hashCode delegating to [delegate], since a bare SAM conversion
+ * allocates a fresh object on every call and two leaves built from the very same function value would then never be
+ * recognized as counting the same events (see [StepScope.event]). Parity only. Two separately-declared lambdas, even
+ * functionally identical ones, still compare unequal here, exactly as two separately-declared Java lambdas do.
+ */
+@PublishedApi
+internal class NamedPredicate<T>(private val delegate: (T) -> Boolean) : Predicate<T> {
+    override fun test(candidate: T): Boolean = delegate(candidate)
+    override fun equals(other: Any?): Boolean = other is NamedPredicate<*> && delegate == other.delegate
+    override fun hashCode(): Int = delegate.hashCode()
+}
+
 /** Receiver for the flow [saga] block. Delegates to the Java [FlowSaga.Builder]. */
 @SagaDsl
 class FlowSagaBuilder<E : Any, C : Any> @PublishedApi internal constructor() {
@@ -167,9 +180,13 @@ class StepScope<E : Any, C : Any> @PublishedApi internal constructor(@PublishedA
      * that predicate so a saga can keep the leaf's count in its state instead of counting the step's events again. Naming a
      * predicate is what makes `stepWindow` usable on the step. Change the name whenever the predicate's meaning changes,
      * since keeping the name while changing the test is the one thing this cannot detect.
+     *
+     * Wraps [predicate] in [NamedPredicate] rather than a bare SAM conversion, so two leaves built from the same Kotlin
+     * function value compare equal the way two leaves sharing a Java [Predicate] instance do. A fresh SAM object has
+     * identity equality and would never match another one, even one wrapping the exact same function.
      */
     inline fun <reified T : E> event(count: Int = 1, predicateId: String, noinline predicate: (T) -> Boolean): StepCondition<E> =
-        StepCondition.event<E, T>(T::class.java, count, predicateId, Predicate { candidate: T -> predicate(candidate) })
+        StepCondition.event<E, T>(T::class.java, count, predicateId, NamedPredicate(predicate))
 
     /** [allOf] over an existing [StepCondition] tree, fulfilled once every one of [first] plus [rest] is. */
     fun allOf(first: StepCondition<out E>, vararg rest: StepCondition<out E>): StepCondition<E> =

--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -69,15 +69,23 @@ fun stepTimer(stepName: String): TimerName = FlowSaga.stepTimer(stepName)
 /**
  * Wraps a Kotlin function as a [Predicate] with equals/hashCode delegating to [delegate], since a bare SAM conversion
  * allocates a fresh object on every call and two leaves built from the very same function value would then never be
- * recognized as counting the same events (see [StepScope.event]). Parity only. Two separately-declared lambdas, even
- * functionally identical ones, still compare unequal here, exactly as two separately-declared Java lambdas do.
+ * recognized as counting the same events, or as sharing an [allOf] child's requirement (see [StepScope.event]). Parity
+ * only. Two separately-declared lambdas, even functionally identical ones, still compare unequal here, exactly as two
+ * separately-declared Java lambdas do.
+ *
+ * Equality here is decided by [delegate]'s own equals. A bound method reference such as `thing::test` compares equal
+ * to another one whenever their receivers do, even if that receiver's equals happens to ignore a field the method
+ * itself reads.
  */
-@PublishedApi
-internal class NamedPredicate<T>(private val delegate: (T) -> Boolean) : Predicate<T> {
+private class FunctionPredicate<T>(private val delegate: (T) -> Boolean) : Predicate<T> {
     override fun test(candidate: T): Boolean = delegate(candidate)
-    override fun equals(other: Any?): Boolean = other is NamedPredicate<*> && delegate == other.delegate
+    override fun equals(other: Any?): Boolean = other is FunctionPredicate<*> && delegate == other.delegate
     override fun hashCode(): Int = delegate.hashCode()
 }
+
+/** Constructs [FunctionPredicate], kept out of the two inline [StepScope.event] bodies so the class itself can stay private. */
+@PublishedApi
+internal fun <T> wrapPredicate(predicate: (T) -> Boolean): Predicate<T> = FunctionPredicate(predicate)
 
 /** Receiver for the flow [saga] block. Delegates to the Java [FlowSaga.Builder]. */
 @SagaDsl
@@ -169,9 +177,13 @@ class StepScope<E : Any, C : Any> @PublishedApi internal constructor(@PublishedA
     /**
      * A leaf [StepCondition] matching [count] events of type [T], optionally also satisfying [predicate]. Combine leaves
      * with [allOf]/[anyOf] and hand the tree to [on].
+     *
+     * [predicate] goes through [wrapPredicate] rather than a bare SAM conversion, so [allOf] can tell two leaves built
+     * from the same Kotlin function value apart from two that happen to test the same thing independently, the same
+     * way it already can for two leaves sharing a Java [Predicate] instance.
      */
     inline fun <reified T : E> event(count: Int = 1, noinline predicate: ((T) -> Boolean)? = null): StepCondition<E> {
-        val javaPredicate: Predicate<T>? = predicate?.let { test -> Predicate { candidate: T -> test(candidate) } }
+        val javaPredicate: Predicate<T>? = predicate?.let { wrapPredicate(it) }
         return StepCondition.event<E, T>(T::class.java, count, javaPredicate)
     }
 
@@ -181,12 +193,12 @@ class StepScope<E : Any, C : Any> @PublishedApi internal constructor(@PublishedA
      * predicate is what makes `stepWindow` usable on the step. Change the name whenever the predicate's meaning changes,
      * since keeping the name while changing the test is the one thing this cannot detect.
      *
-     * Wraps [predicate] in [NamedPredicate] rather than a bare SAM conversion, so two leaves built from the same Kotlin
-     * function value compare equal the way two leaves sharing a Java [Predicate] instance do. A fresh SAM object has
-     * identity equality and would never match another one, even one wrapping the exact same function.
+     * Wraps [predicate] with [wrapPredicate] rather than a bare SAM conversion, so two leaves built from the same
+     * Kotlin function value compare equal the way two leaves sharing a Java [Predicate] instance do. A fresh SAM
+     * object has identity equality and would never match another one, even one wrapping the exact same function.
      */
     inline fun <reified T : E> event(count: Int = 1, predicateId: String, noinline predicate: (T) -> Boolean): StepCondition<E> =
-        StepCondition.event<E, T>(T::class.java, count, predicateId, NamedPredicate(predicate))
+        StepCondition.event<E, T>(T::class.java, count, predicateId, wrapPredicate(predicate))
 
     /** [allOf] over an existing [StepCondition] tree, fulfilled once every one of [first] plus [rest] is. */
     fun allOf(first: StepCondition<out E>, vararg rest: StepCondition<out E>): StepCondition<E> =

--- a/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
+++ b/dsl/saga-dsl/common/src/main/kotlin/org/occurrent/dsl/saga/flow/SagaFlowExtensions.kt
@@ -67,20 +67,19 @@ fun <E : Any, C : Any> saga(block: FlowSagaBuilder<E, C>.() -> Unit): Saga<E, Fl
 fun stepTimer(stepName: String): TimerName = FlowSaga.stepTimer(stepName)
 
 /**
- * Wraps a Kotlin function as a [Predicate] with equals/hashCode delegating to [delegate], since a bare SAM conversion
- * allocates a fresh object on every call and two leaves built from the very same function value would then never be
- * recognized as counting the same events, or as sharing an [allOf] child's requirement (see [StepScope.event]). Parity
- * only. Two separately-declared lambdas, even functionally identical ones, still compare unequal here, exactly as two
- * separately-declared Java lambdas do.
- *
- * Equality here is decided by [delegate]'s own equals. A bound method reference such as `thing::test` compares equal
- * to another one whenever their receivers do, even if that receiver's equals happens to ignore a field the method
- * itself reads.
+ * Wraps a Kotlin function as a [Predicate] with equals/hashCode over [delegate]'s own identity, since a bare SAM
+ * conversion allocates a fresh object on every call and two leaves built from the very same function value would
+ * then never be recognized as counting the same events, or as sharing an [allOf] child's requirement (see
+ * [StepScope.event]). Identity rather than [delegate]'s own equals, so a bound method reference such as
+ * `thing::test` is only interchangeable with a call passing that exact reference again, never with a second
+ * `thing::test` over an equal but distinct receiver whose equals happens to ignore a field the method reads. Parity
+ * only. Two separately-declared lambdas, even functionally identical ones, still compare unequal here, exactly as
+ * two separately-declared Java lambdas do.
  */
 private class FunctionPredicate<T>(private val delegate: (T) -> Boolean) : Predicate<T> {
     override fun test(candidate: T): Boolean = delegate(candidate)
-    override fun equals(other: Any?): Boolean = other is FunctionPredicate<*> && delegate == other.delegate
-    override fun hashCode(): Int = delegate.hashCode()
+    override fun equals(other: Any?): Boolean = other is FunctionPredicate<*> && delegate === other.delegate
+    override fun hashCode(): Int = System.identityHashCode(delegate)
 }
 
 /** Constructs [FunctionPredicate], kept out of the two inline [StepScope.event] bodies so the class itself can stay private. */

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
@@ -45,6 +45,11 @@ class SagaFlowKotlinPredicateIdentityTest {
 
     sealed interface CapCommand
 
+    /** A receiver whose bound `::test` reference is what [SagaFlowKotlinPredicateIdentityTest] tests identity over. */
+    class ScoreFilter(private val threshold: Int) {
+        fun test(approved: Approved): Boolean = approved.score > threshold
+    }
+
     @Test
     fun `two leaves sharing a name and the same function value are accepted under the cap`() {
         val approvedHigh: (Approved) -> Boolean = { it.score > 10 }
@@ -118,5 +123,25 @@ class SagaFlowKotlinPredicateIdentityTest {
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("allOf children 0 and 1")
             .hasMessageContaining("Approved")
+    }
+
+    @Test
+    fun `two textually separate bound method references over the same receiver are refused the cap`() {
+        val filter = ScoreFilter(10)
+
+        assertThatThrownBy {
+            saga<CapEvent, CapCommand> {
+                stepWindow(2)
+                startsOn<Opened>()
+                correlateAll { it.id }
+                step("decide") {
+                    on(event<Approved>(1, "big", filter::test), then = end)
+                    on(event<Approved>(1, "big", filter::test), then = end)
+                }
+            }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("step 'decide'")
+            .hasMessageContaining("share the predicate name 'big'")
     }
 }

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.saga.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.occurrent.dsl.saga.SagaInput
+
+/**
+ * Kotlin parity for the Java-side pair in `FlowSagaTest`
+ * (`two_leaves_sharing_a_name_and_a_predicate_are_accepted_under_the_cap` /
+ * `two_leaves_sharing_a_name_while_holding_different_predicates_are_refused_the_cap`), kept out of
+ * SagaFlowExtensionsTest.kt as its own file, the same way StepConditionKotlinVarianceTest.kt is.
+ *
+ * `event<T>(count, predicateId, predicate)` used to wrap [predicate] in a fresh Java `Predicate` on every call, which
+ * has identity equality, so two leaves built from the very same Kotlin function value never matched each other even
+ * though the equivalent Java leaves, built from one shared `Predicate` instance, do. [NamedPredicate] closes that gap
+ * without changing the negative case. Two separately-declared lambdas, even functionally identical ones, still
+ * compare unequal.
+ */
+class SagaFlowKotlinPredicateIdentityTest {
+
+    sealed interface CapEvent {
+        val id: String
+    }
+
+    data class Opened(override val id: String) : CapEvent
+    data class Approved(override val id: String, val score: Int) : CapEvent
+
+    sealed interface CapCommand
+
+    @Test
+    fun `two leaves sharing a name and the same function value are accepted under the cap`() {
+        val approvedHigh: (Approved) -> Boolean = { it.score > 10 }
+        val flowSaga = saga<CapEvent, CapCommand> {
+            stepWindow(2)
+            startsOn<Opened>()
+            correlateAll { it.id }
+            step("wait") {
+                on(event<Approved>(2, "isBig", approvedHigh), then = transitionTo("wait"))
+                on(event<Approved>(1, "isBig", approvedHigh), then = end)
+            }
+        }
+
+        val opened = flowSaga.evolve(flowSaga.initialState(), SagaInput.event(Opened("c1")))
+        val afterOneApproval = flowSaga.evolve(opened, SagaInput.event(Approved("c1", 50)))
+
+        assertThat(flowSaga.isTerminal(afterOneApproval))
+            .`as`("both leaves count the same events, so the count-1 leaf fires and crossing them would change nothing")
+            .isTrue()
+    }
+
+    @Test
+    fun `two leaves sharing a name while holding different lambdas are refused the cap`() {
+        assertThatThrownBy {
+            saga<CapEvent, CapCommand> {
+                stepWindow(2)
+                startsOn<Opened>()
+                correlateAll { it.id }
+                step("decide") {
+                    on(event<Approved>(1, "big") { it.score > 100 }, then = end)
+                    on(event<Approved>(1, "big") { it.score < 0 }, then = end)
+                }
+            }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("step 'decide'")
+            .hasMessageContaining("share the predicate name 'big'")
+    }
+}

--- a/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
+++ b/dsl/saga-dsl/common/src/test/kotlin/org/occurrent/dsl/saga/flow/SagaFlowKotlinPredicateIdentityTest.kt
@@ -22,16 +22,17 @@ import org.junit.jupiter.api.Test
 import org.occurrent.dsl.saga.SagaInput
 
 /**
- * Kotlin parity for the Java-side pair in `FlowSagaTest`
+ * Kotlin parity for two Java-side pairs, kept out of SagaFlowExtensionsTest.kt as its own file, the same way
+ * StepConditionKotlinVarianceTest.kt is: `FlowSagaTest`'s
  * (`two_leaves_sharing_a_name_and_a_predicate_are_accepted_under_the_cap` /
- * `two_leaves_sharing_a_name_while_holding_different_predicates_are_refused_the_cap`), kept out of
- * SagaFlowExtensionsTest.kt as its own file, the same way StepConditionKotlinVarianceTest.kt is.
+ * `two_leaves_sharing_a_name_while_holding_different_predicates_are_refused_the_cap`), and
+ * `StepConditionTest.allOf_rejects_two_children_over_one_predicate_whatever_names_they_give_it`.
  *
- * `event<T>(count, predicateId, predicate)` used to wrap [predicate] in a fresh Java `Predicate` on every call, which
- * has identity equality, so two leaves built from the very same Kotlin function value never matched each other even
- * though the equivalent Java leaves, built from one shared `Predicate` instance, do. [NamedPredicate] closes that gap
- * without changing the negative case. Two separately-declared lambdas, even functionally identical ones, still
- * compare unequal.
+ * Both `event` overloads used to wrap a Kotlin function in a fresh Java `Predicate` on every call, which has identity
+ * equality, so two leaves built from the very same Kotlin function value never matched each other even though the
+ * equivalent Java leaves, built from one shared `Predicate` instance, do. `wrapPredicate` closes that gap without
+ * changing the negative case. Two separately-declared lambdas, even functionally identical ones, still compare
+ * unequal.
  */
 class SagaFlowKotlinPredicateIdentityTest {
 
@@ -81,5 +82,41 @@ class SagaFlowKotlinPredicateIdentityTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("step 'decide'")
             .hasMessageContaining("share the predicate name 'big'")
+    }
+
+    @Test
+    fun `allOf refuses two unnamed children matching the same event via a shared function value`() {
+        val sameTest: (Approved) -> Boolean = { true }
+
+        assertThatThrownBy {
+            saga<CapEvent, CapCommand> {
+                startsOn<Opened>()
+                correlateAll { it.id }
+                step("wait") {
+                    on(allOf(event<Approved>(2, sameTest), event<Approved>(3, sameTest)), then = end)
+                }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("allOf children 0 and 1")
+            .hasMessageContaining("Approved")
+    }
+
+    @Test
+    fun `allOf refuses two named children over one shared function value whatever names they give it`() {
+        val sameTest: (Approved) -> Boolean = { true }
+
+        assertThatThrownBy {
+            saga<CapEvent, CapCommand> {
+                startsOn<Opened>()
+                correlateAll { it.id }
+                step("wait") {
+                    on(allOf(event<Approved>(2, "twoOfThem", sameTest), event<Approved>(3, "threeOfThem", sameTest)), then = end)
+                }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("allOf children 0 and 1")
+            .hasMessageContaining("Approved")
     }
 }


### PR DESCRIPTION
`event<T>(count, predicateId, predicate)` wraps the Kotlin function in a fresh Java `Predicate` on every call. A fresh SAM object has identity equality, so `StepCondition.EventMatcher.matchesTheSameEvents` and the leaf grouping in `FlowSagaImpl.StepLeaves.of` (both compare with `Objects.equals`) reject two leaves built from the very same Kotlin function value, where the Java side's shared-`Predicate`-instance pattern is accepted. `FlowSagaTest` already covers both sides for Java (lines 924 and 943), and there was no Kotlin test touching `predicateId` at all.

I added `NamedPredicate`, a small wrapper in `SagaFlowExtensions.kt` whose equals/hashCode delegate to the captured function, and changed the named `event` overload to use it instead of a bare SAM conversion. Two leaves sharing one Kotlin function value now compare equal, same as two leaves sharing one Java `Predicate` instance. Two separately-declared lambdas, even functionally identical ones, still compare unequal, exactly as in Java, so nothing about the negative case changes.

No persistence impact. The persisted fingerprint keys on event type and predicate name only, never the predicate object.

I added `SagaFlowKotlinPredicateIdentityTest.kt`, mirroring the Java pair. One test shares a single function value across two named leaves and expects it accepted under the cap, the other uses two distinct lambdas under the same name and expects it refused. Mutation-tested by breaking the wrapper's `equals` and confirming the positive test then fails with the exact "share the predicate name" error the negative test also asserts on, then restored from a saved copy.

No changelog entry, since this is dev-churn on unreleased 0.33 surface (step conditions and `stepWindow` have not shipped yet).
