### PR TITLE
Fix stepWindow's false "declaration changed" refusal on pre-0.33.0 instances

### DIFF
--- a/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
+++ b/dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/flow/FlowSagaImpl.java
@@ -172,12 +172,17 @@ final class FlowSagaImpl<E, C> implements Saga<E, FlowState<E>, C> {
         }
         CompiledStep<E, C> step = stepsByName.get(state.currentStep());
         List<E> appended = append(state.received(), event);
-        // Drop the current step's oldest events past stepWindow before anything reads them, so a guard and a reaction in
+        // Counts are derived from the step's events as this delivery actually finds them, before stepWindow trims
+        // anything. A backlog that exceeds a newly configured cap is counted against what genuinely arrived, not
+        // against the sliver the same delivery is about to leave behind, and the refusal below reads the STORED
+        // (already-persisted) windowStart rather than the trim this delivery is computing, so it only fires when a
+        // prior capped delivery already advanced it past the step's entry.
+        List<Integer> counts = stepConditionCounts(state, step, appended, event);
+        // Drop the current step's oldest events past stepWindow now that counts exist, so a guard and a reaction in
         // this delivery see exactly what gets persisted.
         int windowStart = boundedWindowStart(state.stepEntryIndex(), state.windowStart(), appended.size());
         List<E> received = retain(appended, state.windowStart(), windowStart);
         List<E> window = received.subList(windowStartIndex(state.stepEntryIndex(), windowStart, received.size()), received.size());
-        List<Integer> counts = stepConditionCounts(state, step, windowStart, window, event);
         int[] leafCursor = {0};
         List<Branch<E, C>> branches = step.branches();
         for (int i = 0; i < branches.size(); i++) {
@@ -495,11 +500,13 @@ final class FlowSagaImpl<E, C> implements Saga<E, FlowState<E>, C> {
      * The counts to evaluate this step's conditions with, or {@code null} to count the window instead. The carried counts
      * are used once they were counted for the declaration this step has now, and are re-derived from the window when they
      * were not, which covers a document written before the field existed and a redeploy that changed a leaf. Re-deriving
-     * needs the events, so a step whose older events {@code stepWindow} already dropped has nothing left to fall back on
-     * and refuses the delivery instead of counting short.
+     * reads {@code appended} against the STATE's own stored {@code windowStart}, i.e. the window as it stood before this
+     * delivery's own stepWindow trim, so a backlog that a newly lowered cap is only now catching up on is still counted in
+     * full on the delivery that first trims it. The refusal below is judged on that same stored value: a step whose older
+     * events a PRIOR delivery already dropped has nothing left to fall back on and refuses instead of counting short, but
+     * this delivery's own trim, computed after counts, never itself triggers the refusal.
      */
-    private @Nullable List<Integer> stepConditionCounts(FlowStateImpl<E> state, CompiledStep<E, C> step, int windowStart,
-                                                        List<E> window, E event) {
+    private @Nullable List<Integer> stepConditionCounts(FlowStateImpl<E> state, CompiledStep<E, C> step, List<E> appended, E event) {
         StepLeaves<E> leaves = step.leaves();
         if (leaves.matchers().isEmpty() || !leaves.countable()) {
             return null;
@@ -508,22 +515,24 @@ final class FlowSagaImpl<E, C> implements Saga<E, FlowState<E>, C> {
         if (progress != null && describesTheSameLeaves(progress, leaves)) {
             return incremented(leaves.matchers(), progress.matchCounts(), event);
         }
-        if (droppedFromTheCurrentStep(state, windowStart)) {
+        if (droppedFromTheCurrentStep(state)) {
             throw new IllegalStateException("step '" + step.name() + "' cannot be evaluated for this instance, because the"
                     + " step's condition declaration changed while the instance was parked in it and stepWindow had already"
                     + " dropped the events its counts would be rebuilt from. Retrying the delivery cannot help. Put the"
                     + " previous condition declaration for this step back until the parked instances have moved on, or"
                     + " delete the instance");
         }
+        List<E> window = appended.subList(windowStartIndex(state.stepEntryIndex(), state.windowStart(), appended.size()), appended.size());
         return counted(leaves.matchers(), window);
     }
 
     // Whether any of the current step's own events are already gone, which is what leaves nothing to rebuild its counts
-    // from. Reading the tail as starting past the step's entry is the signal, and the entry check is what keeps a store's
-    // defaulting from looking like one, since an instance that has entered a step was entered at position 1 or later, while
-    // a defaulted entry reads as 0 and a defaulted tail start reads as 1 and so can never pass a real entry position.
-    private static boolean droppedFromTheCurrentStep(FlowStateImpl<?> state, int windowStart) {
-        return state.stepEntryIndex() >= 1 && windowStart > state.stepEntryIndex();
+    // from. Reading the STORED tail as starting past the step's entry is the signal, i.e. the state as a PRIOR delivery
+    // left it rather than the trim this delivery is computing, and the entry check is what keeps a store's defaulting
+    // from looking like one, since an instance that has entered a step was entered at position 1 or later, while a
+    // defaulted entry reads as 0 and a defaulted tail start reads as 1 and so can never pass a real entry position.
+    private static boolean droppedFromTheCurrentStep(FlowStateImpl<?> state) {
+        return state.stepEntryIndex() >= 1 && state.windowStart() > state.stepEntryIndex();
     }
 
     // Whether the carried counts were counted for the leaves this step declares now. The length check and the negative

--- a/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
+++ b/dsl/saga-dsl/common/src/test/java/org/occurrent/dsl/saga/flow/FlowSagaTest.java
@@ -853,6 +853,29 @@ class FlowSagaTest {
         }
 
         @Test
+        void a_pre_0_33_0_backlog_exceeding_a_newly_configured_cap_derives_counts_instead_of_refusing() {
+            // What a document written before stepWindow existed looks like: windowStart never trimmed (still 1), a real
+            // stepEntryIndex, and no carried counts (a store defaults the absent field to null). Turning stepWindow on then
+            // delivers into a step whose backlog already exceeds the new cap, and the first such delivery has to count the
+            // whole pre-trim backlog rather than either refusing (the bug this guards) or judging the condition on the
+            // sliver the same delivery is about to keep.
+            FlowStateImpl<CapEvent> seeded = new FlowStateImpl<>("wait",
+                    List.of(new Opened("c1"), new Approved("c1", 1), new Approved("c1", 2), new Approved("c1", 3), new Approved("c1", 4)),
+                    1, 1, false, null, -1, ActionKind.NONE, -1, null);
+            Saga<CapEvent, FlowState<CapEvent>, CapCommand> saga = waitingForThree(2, new ArrayList<>());
+
+            Saga.Step<FlowState<CapEvent>, CapCommand> fired = saga.step(seeded, SagaInput.event(new Approved("c1", 5)));
+
+            assertAll(
+                    () -> assertThat(saga.isTerminal(fired.state()))
+                            .as("five Approved had already arrived before stepWindow was even configured, well past the count of three")
+                            .isTrue(),
+                    () -> assertThat(fired.effects()).containsExactly(SagaEffect.issue(new Report("done"))),
+                    () -> assertThat(fired.state().received()).as("the newly configured cap still applies from this delivery on").hasSize(3)
+            );
+        }
+
+        @Test
         void two_predicated_leaves_over_one_type_keep_counting_the_window_and_refuse_the_cap() {
             List<String> fired = new ArrayList<>();
             FlowSaga.Builder<CapEvent, CapCommand> ambiguous = FlowSaga.<CapEvent, CapCommand>builder()

--- a/dsl/saga-dsl/mongodb-spring/src/test/java/org/occurrent/dsl/saga/mongodb/spring/SpringMongoSagaStateStoreFlowConditionRoundTripTest.java
+++ b/dsl/saga-dsl/mongodb-spring/src/test/java/org/occurrent/dsl/saga/mongodb/spring/SpringMongoSagaStateStoreFlowConditionRoundTripTest.java
@@ -28,10 +28,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.dsl.saga.Saga;
 import org.occurrent.dsl.saga.SagaEnvelope;
+import org.occurrent.dsl.saga.SagaInput;
 import org.occurrent.dsl.saga.SagaStateStore;
 import org.occurrent.dsl.saga.SagaStatus;
+import org.occurrent.dsl.saga.flow.Continuation;
+import org.occurrent.dsl.saga.flow.FlowSaga;
 import org.occurrent.dsl.saga.flow.FlowState;
+import org.occurrent.dsl.saga.flow.StepCondition;
 import org.occurrent.dsl.saga.flow.internal.FlowStateImpl;
 import org.occurrent.dsl.saga.flow.internal.FlowStateImpl.ActionKind;
 import org.occurrent.dsl.saga.flow.internal.FlowStateImpl.StepConditionProgress;
@@ -186,6 +191,62 @@ class SpringMongoSagaStateStoreFlowConditionRoundTripTest {
                 () -> assertThat(loaded.previousStepEntryIndex())
                         .as("absent means not known, and a window-condition reaction falls back to the whole retained history")
                         .isEqualTo(-1)
+        );
+    }
+
+    @Test
+    void a_pre_0_33_0_document_with_a_backlog_exceeding_a_newly_configured_step_window_derives_counts_instead_of_refusing() {
+        // The scenario ADR 123 says a pre-0.33.0 document can never reach: stepWindow turned on for a step whose instance
+        // already carries more of its own events than the new cap allows, with bookkeeping written before counts existed
+        // at all. Delivering into it must count the real backlog once, rather than refuse it or judge it against the
+        // sliver the same delivery is about to keep.
+        MongoOperations mongoOperations = mongoOperations();
+        CloudEventConverter<ReviewEvent> converter = converter();
+        SagaStateStore<FlowState<ReviewEvent>> store =
+                new SpringMongoSagaStateStore<>(mongoOperations, "saga-review", rawFlowStateType(), converter);
+        List<ReviewEvent> received = List.of(
+                new ReviewRequested("e1", "backlog"),
+                new Approved("e2", "backlog", 10),
+                new Approved("e3", "backlog", 20),
+                new Approved("e4", "backlog", 30),
+                new Approved("e5", "backlog", 40));
+
+        mongoOperations.insert(new Document("_id", "backlog")
+                .append("status", SagaStatus.ACTIVE.name())
+                .append("version", 1L)
+                .append("state", new Document("currentStep", "awaiting-decision")
+                        .append("windowStart", 1)
+                        .append("stepEntryIndex", 1)
+                        .append("completed", false)
+                        .append("previousStep", "awaiting-decision")
+                        .append("lastAction", ActionKind.NONE.name())
+                        .append("matchedBranchIndex", -1)
+                        .append("received", received.stream().map(event -> cloudEventJson(converter, event)).toList()))
+                .append("timers", List.of())
+                .append("streamWatermarks", new Document())
+                .append("createdAt", 1_000L)
+                .append("updatedAt", 1_000L), "saga-review");
+
+        FlowState<ReviewEvent> loaded = store.find("backlog").orElseThrow().state();
+        Saga<ReviewEvent, FlowState<ReviewEvent>, Object> saga = FlowSaga.<ReviewEvent, Object>builder()
+                .stepWindow(2)
+                .startsOn(ReviewRequested.class)
+                .correlateAll(ReviewEvent::reviewId)
+                .step("awaiting-decision", step -> step.on(StepCondition.event(Approved.class, 3), Continuation.end()))
+                .build();
+
+        FlowState<ReviewEvent> afterDelivery = saga.evolve(loaded, SagaInput.event(new Approved("e6", "backlog", 50)));
+        boolean saved = store.compareAndSave("backlog",
+                new SagaEnvelope<>("backlog", afterDelivery, SagaStatus.ACTIVE, 2, List.of(), Map.of(), null, null, null, null, null), 1);
+        FlowState<ReviewEvent> roundTripped = store.find("backlog").orElseThrow().state();
+
+        assertAll(
+                () -> assertThat(saga.isTerminal(afterDelivery))
+                        .as("five Approved had already arrived before stepWindow was even configured, well past the count of three")
+                        .isTrue(),
+                () -> assertThat(afterDelivery.received()).as("the newly configured cap still applies from this delivery on").hasSize(3),
+                () -> assertThat(saved).isTrue(),
+                () -> assertThat(roundTripped).as("the completed, capped state round-trips through Mongo unchanged").isEqualTo(afterDelivery)
         );
     }
 


### PR DESCRIPTION
I fixed a bug in `FlowSagaImpl.evolveOnEvent` where turning on `stepWindow` for a saga instance written before 0.33.0 could throw a false "step's condition declaration changed" error on its very first delivery, even though the step's declaration never changed and nothing had actually been dropped yet.

The method computed the `stepWindow` trim and applied it before deriving the step's missing condition counts, then checked whether counts could still be rebuilt against the freshly computed, already-trimmed `windowStart` instead of the value already stored in the saga's state. For an instance whose backlog already exceeded a newly configured `stepWindow`, that trim jumped `windowStart` past `stepEntryIndex` in one step, and the refusal check read that jump as a declaration change even on the first delivery under the new cap. ADR 123 already states that a pre-0.33.0 document can never reach this refusal, so the behavior contradicted the ADR's own contract rather than reflecting a real design tradeoff.

I changed the method to derive counts from the pre-trim window, sliced from the freshly appended events using the state's own stored `windowStart` and `stepEntryIndex`, and to judge the refusal against that same stored `windowStart`, applying the `stepWindow` cap only afterward. The refusal still fires correctly for the genuine case, where a prior delivery already advanced the stored `windowStart` past `stepEntryIndex`.

I added a `FlowSagaTest` case that hand-seeds the pre-0.33.0 shape, a real `stepEntryIndex`, `windowStart` still at 1, and no `stepConditionProgress`, and delivers into a newly capped saga. I added a matching `SpringMongoSagaStateStoreFlowConditionRoundTripTest` case that does the same through a hand-inserted Mongo document and a real store round trip.

I ran the full `saga-dsl/common` and `saga-dsl/mongodb-spring` Maven suites (532 and 7 tests, all green). I also confirmed the fix actually matters by temporarily reverting it, and the new `FlowSagaTest` case then fails with exactly the false refusal this PR fixes.

No ADR change and no changelog entry. The fix brings the implementation in line with what ADR 123 already claims, and `stepWindow` is still unreleased, so this is dev-churn on unreleased surface under `AGENTS.md`'s convention.
