### PR TITLE
Correct four inaccurate claims in ADR 86, its javadoc, and its tests

### DIFF
--- a/doc/architecture/decisions/0086-a-manual-subscription-is-registered-not-started.md
+++ b/doc/architecture/decisions/0086-a-manual-subscription-is-registered-not-started.md
@@ -203,6 +203,16 @@ neither, the wrapper still works and a first run starts from the moment it is st
 > is asked about that is not a catch-up one. "Out of reach either way" still holds for what a subscription gets, for a
 > different reason than the one first written here. Under that position the first layer below the catch-up one
 > answers the model default on its own ask, so the walk records the position there and this second pass does not run.
+>
+> The amendment above also said, of that same start position, that "The Spring Boot starter's own stack answers on
+> the first ask, since it always puts a competing consumer layer on top, but its subscription model bean is
+> `@ConditionalOnMissingBean` and a stack wired by hand can put the catch-up layer outermost." That held only while
+> the competing consumer layer was asked directly and read as deciding the walk. It answers false to
+> `decidesWhereTheSubscriptionStarts()` now, so the walk passes over it unasked, and the paragraph above already
+> works out where that leaves the starter's own stack under the default position. Catch-up answers nothing on its
+> own ask, and the durable layer, the first one actually asked after that, answers the model default and is where
+> the walk records the position. The starter's own stack is the case that needs the walk to descend, the same case
+> the corrected sentence said only a hand-wired stack reaches.
 
 **`isPaused(id)` is true for a subscription that is registered and not started.** It is the question a
 caller is really asking, and `OccurrentSubscriptionsExtension.startAll()` filters on it. For the same

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
@@ -151,9 +151,9 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
      * its own and a subclass of it, including a proxy built by subclassing, is otherwise asked under a name
      * {@link StartAt.SubscriptionModelContext#hasSubscriptionModelType(Class)} does not match. A walk that ended on
      * its first ask has that one layer to ask again. The model default from any of those answers records the
-     * position. A dynamic function therefore runs once for each layer the walk asked, plus once for each class those
-     * layers inherit from when that second pass runs, on top of the calls it already gets when the subscription
-     * starts. Two shapes are
+     * position. A dynamic function therefore runs at most once for each layer the walk asked, plus at most once for
+     * each class those layers inherit from when that second pass runs, on top of the calls it already gets when the
+     * subscription starts. Two shapes are
      * still read differently here than the model that starts the subscription reads it. A layer that passes the
      * position down without deciding where the subscription starts and does not say so is asked all the same, and a
      * proxy that only implements a model's interfaces never shows that model's own class here, so a function naming

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
@@ -1070,7 +1070,7 @@ class ManualStartSubscriptionModelTest {
     void a_layer_that_decides_something_other_than_the_start_leaves_the_answer_to_the_model_below() {
         // The Spring Boot starter's own stack, where the competing consumer layer resolves the position to work out
         // whether to compete and leaves where the subscription starts to the durable model below it. Every start
-        // position Occurrent itself builds is safe from this, reaching the skip below takes a function written by
+        // position Occurrent itself builds is safe from this. Reaching the skip below takes a function written by
         // hand, and the StartAt here is one. Stopping at the competing consumer's answer records nothing, and the
         // durable model then records a position when the subscription starts, minutes later on a rolling deploy,
         // skipping everything written in between.

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
@@ -1069,9 +1069,11 @@ class ManualStartSubscriptionModelTest {
     @Test
     void a_layer_that_decides_something_other_than_the_start_leaves_the_answer_to_the_model_below() {
         // The Spring Boot starter's own stack, where the competing consumer layer resolves the position to work out
-        // whether to compete and leaves where the subscription starts to the durable model below it. Stopping at the
-        // competing consumer's answer records nothing, and the durable model then records a position when the
-        // subscription starts, minutes later on a rolling deploy, skipping everything written in between.
+        // whether to compete and leaves where the subscription starts to the durable model below it. Every start
+        // position Occurrent itself builds is safe from this, reaching the skip below takes a function written by
+        // hand, and the StartAt here is one. Stopping at the competing consumer's answer records nothing, and the
+        // durable model then records a position when the subscription starts, minutes later on a rolling deploy,
+        // skipping everything written in between.
         RecordingSubscriptionModel checkpointReadingModel = new RecordingSubscriptionModel();
         DeferringSubscriptionModel deferringModel = new DeferringSubscriptionModel(checkpointReadingModel);
         RecordingCheckpointStorage storage = new RecordingCheckpointStorage();

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
@@ -82,10 +82,11 @@ class CompetingConsumerStartPositionTest {
 
     @Test
     void a_registration_under_this_model_is_recorded_from_the_position_the_model_below_it_reads() {
-        // The Spring Boot starter's own stack under occurrent.subscription.mode=manual. A start position answering
-        // for each layer separately used to end the walk here, at an answer that does not decide where the
-        // subscription starts, and the durable model below then recorded a position when the subscription was
-        // started, skipping everything written since it was registered.
+        // ManualStartSubscriptionModel wrapping this competing consumer model wrapping a fake delegate, two layers
+        // under the walk rather than the four-layer starter stack. A start position answering for each layer
+        // separately used to end the walk at the competing consumer's answer, which does not decide where the
+        // subscription starts, leaving the delegate to record a position when the subscription started and skip
+        // everything written since registration.
         InMemoryCheckpointStorage storage = new InMemoryCheckpointStorage();
         ManualStartSubscriptionModel manualStart = ManualStartSubscriptionModel.stoppedByDefault(
                 model, () -> new StringCheckpoint("at-registration"), storage);

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
@@ -82,7 +82,7 @@ class CompetingConsumerStartPositionTest {
 
     @Test
     void a_registration_under_this_model_is_recorded_from_the_position_the_model_below_it_reads() {
-        // ManualStartSubscriptionModel wrapping this competing consumer model wrapping a fake delegate, two layers
+        // ManualStartSubscriptionModel wraps this competing consumer model, which wraps a fake delegate, two layers
         // under the walk rather than the four-layer starter stack. A start position answering for each layer
         // separately used to end the walk at the competing consumer's answer, which does not decide where the
         // subscription starts, leaving the delegate to record a position when the subscription started and skip


### PR DESCRIPTION
I corrected a sentence in ADR 86 that amendment 3's own `decidesWhereTheSubscriptionStarts()` change made false. It said the Spring Boot starter's own stack resolves a dynamic start position on the first ask, but the competing consumer layer now answers that method false, and the walk descends past it. I added the correction to the amendment's existing quote-and-correct list, in the same style as its other four corrections.

I also fixed three related comments the epic's final review round flagged. The javadoc's call-count claim for the two-pass walk now says "at most", since both passes short-circuit. One test comment now says every start position Occurrent itself builds is safe, and only a hand-written function reaches the skip it demonstrates. The other test comment stopped calling its two-layer stand-in fixture the real four-layer Spring Boot starter stack.

No behavior change. The diff is comments, javadoc, and one markdown file.
