### PR TITLE
Correct four inaccurate claims in ADR and javadoc text

### DIFF
--- a/common/filter/src/main/java/org/occurrent/filter/internal/package-info.java
+++ b/common/filter/src/main/java/org/occurrent/filter/internal/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal implementation types for the filter layer. These are {@code public} only because the saga DSL and the
+ * subscription annotation support live in separate modules and call them directly. They are not part of the public API
+ * and may change or be removed at any time. End users work with {@code org.occurrent.filter} and never reference this
+ * package.
+ * <p>
+ * {@link org.occurrent.filter.internal.EventTypeExpansion#expandWhatCanBeFound} is best-effort. It returns only the
+ * concrete types reflection can find and, unlike {@code expand}, does not refuse a hierarchy it cannot find all of. It
+ * must not be mistaken for a complete expansion.
+ */
+@NullMarked
+package org.occurrent.filter.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
+++ b/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
@@ -659,6 +659,13 @@ did it correctly, including the case where `any()` must leave a stored version a
 Redis Cluster is not supported for conditional checkpoint writes, and asking for one there fails at the
 first write rather than quietly. A cluster user who supplies no source is unaffected.
 
+> **Amended for 0.33.0.** Redis Cluster is supported for conditional checkpoint writes after all.
+> `SpringRedisCheckpointStorage`'s original constructors build a Cluster-safe mode that refuses one
+> subscription id shape outright for `notOlderThan` and `ifAbsent`, whether or not the deployment is
+> actually Cluster. `SpringRedisCheckpointStorage.forStandalone(..)` builds a separate mode for a
+> standalone or replicated deployment, where slot alignment is not a concept the server has, and accepts
+> that shape too. A cluster user who supplies no source is still unaffected.
+
 This is the first place in Occurrent where a subscription refuses a checkpoint write made on behalf of
 application code. The exception is deliberately not retried, which is the opposite of how every other
 failure on the delivery path is treated, and the reason is written into the retry predicates rather than

--- a/doc/architecture/decisions/0124-a-saga-expands-a-declared-sealed-event-type.md
+++ b/doc/architecture/decisions/0124-a-saga-expands-a-declared-sealed-event-type.md
@@ -80,7 +80,7 @@ reasoning rather than evidence and it is recorded as unverified rather than clai
 
 ### A sealed declared type is joined by the concrete types it permits
 
-`EventTypeExpansion.expand(Set)` (`dsl/saga-dsl/common/src/main/java/org/occurrent/dsl/saga/internal/EventTypeExpansion.java`)
+`EventTypeExpansion.expand(Set)` (`common/filter/src/main/java/org/occurrent/filter/internal/EventTypeExpansion.java`, it did not stay in the saga module, see below)
 walks `getPermittedSubclasses()` transitively and returns the declared types plus every concrete type they permit. A
 saga declaring a sealed `OrderEvent` reports `OrderEvent`, `OrderPlaced` and `PaymentReserved` from `eventTypes()`, and
 its subscription asks for all three.

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ReplayAware.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/ReplayAware.java
@@ -26,10 +26,8 @@ package org.occurrent.dsl.view;
  * before this capability existed. Whoever drives a replay (a catch-up handover, for example) probes for it with an
  * {@code instanceof} check at the point of need, the same idiom {@code SagaInstances} uses for
  * {@code SagaStateStoreQueries}. There is deliberately no {@code static Optional<ReplayAware> findIn(...)}
- * helper. That shape exists elsewhere to unwrap a delegating view. The one delegating {@link MaterializedView} this
- * library builds, the position recorder from
- * <a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md">ADR 111</a>,
- * answers the {@code instanceof} probe itself and stays the outermost view, so it needs no unwrapping helper either.
+ * helper. That shape exists elsewhere to unwrap a delegating view. This library does not currently build one that wraps
+ * a {@link MaterializedView}, so there is nothing here that would need it.
  * <p>
  * {@link #replayCompleted()} runs before the replay's driver records the catch-up as complete, so an implementation
  * that buffers must have written every buffered update by the time this method returns. A write that fails here fails


### PR DESCRIPTION
I fixed four places where the docs or javadoc no longer match what the code does.

- ADR 116's Consequences said Redis Cluster is not supported for conditional checkpoint writes. That stopped being true once `SpringRedisCheckpointStorage.forStandalone(..)` shipped. The original constructors still refuse one subscription id shape in Cluster-safe mode, but `forStandalone` accepts it for a standalone or replicated deployment. I added a dated amendment rather than rewriting the original sentence, matching how this ADR already records its other corrections.
- `ReplayAware`'s javadoc cited "the position recorder from ADR 111" as the one delegating `MaterializedView` this library builds. ADR 111 was withdrawn and that implementation never shipped, so I recast the sentence to say the library builds no such delegating view today.
- ADR 0124 named the saga module as `EventTypeExpansion`'s location in one place and `occurrent-filter` in another. I fixed the stale path so the document agrees with itself.
- `common/filter/.../filter/internal` was missing the internal-package warning that roughly twenty sibling internal packages already have. I added it, including `@NullMarked`, and noted that `expandWhatCanBeFound` is best-effort and must not be mistaken for a complete expansion.

No behavior change. `mvn -pl common/filter -am compile` and the module's tests pass with the new `@NullMarked` package.
