### PR TITLE
Correct four inaccurate claims in 0.33.0 checkpoint-storage prose

### DIFF
--- a/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
+++ b/doc/architecture/decisions/0116-a-checkpoint-write-from-a-lease-that-has-moved-on-is-refused.md
@@ -426,6 +426,16 @@ crossing slots, and the two names cannot be brought into one slot without renami
 checkpoint key. That failure is immediate and reaches only a cluster user who turned the fence on, while
 an unfenced cluster user is untouched.
 
+> **Amended for 0.33.0.** The two names are brought into one slot without renaming the existing
+> checkpoint key after all. The version key's own name carries a hash tag built from whatever the
+> checkpoint key hashes on, so Cluster places both in the same slot and the script never crosses one.
+> `SpringRedisCheckpointStorage`'s two original constructors still refuse one subscription id shape
+> outright for `notOlderThan` and `ifAbsent`, the one Cluster itself would fall back to hashing on the
+> whole id for, so that failure is still immediate where it happens, but it is no longer every id in a
+> fenced cluster. `SpringRedisCheckpointStorage.forStandalone(..)`, new in this release, accepts that
+> shape too, for a deployment where slot alignment is not a concept the server has. An unfenced cluster
+> user remains untouched.
+
 **The same-value edge is storage-dependent.** Mongo's `ifAbsent` gates on presence, not value, so a
 second write offering the exact same checkpoint value as the one already stored is indistinguishable from
 a first write and is reported as success rather than refused, though nothing is stored twice

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -115,10 +115,12 @@ A store whose answer to a conditional write depends on the subscription id, the 
 say so precisely with `evaluatesWriteConditionsFor(String subscriptionId)`, a second new default method that answers
 `evaluatesWriteConditions()` for every id unless overridden. The blocking Spring Boot starter's own fencing check
 reads it too, see section 8. The reactor stack has no startup check like that one, but the override is not merely
-advisory there either. `ReactorDurableSubscriptionModel.pinStartPosition` reads it on every reactive durable
-subscription's first run whose start position resolves to the subscription model default, and the answer decides
-between a conditional `ifAbsent()` write that can refuse a losing race and an unconditional write logged at `WARN`
-that keeps 0.32.0's race open for that subscription. A storage whose `ifAbsent()` otherwise works but whose
+advisory there either. `ReactorDurableSubscriptionModel.pinStartPosition` reads it the first time a reactive
+durable subscription registers with no checkpoint stored yet and a seed position to pin. An existing checkpoint
+skips this path entirely, and so does a seed that resolves to nothing, which `globalCheckpoint()` documents as a
+real, non-hypothetical outcome. When it does run, the answer decides between a conditional `ifAbsent()` write
+that can refuse a losing race and an unconditional write logged at `WARN` that keeps 0.32.0's race open for that
+subscription. A storage whose `ifAbsent()` otherwise works but whose
 predicate stays at the default `false` here does not fail loudly for it. It compiles, runs, and keeps the 0.32.0
 race open with nothing louder than that `WARN`. Leaving the override unanswered is a real choice with a real
 cost, not optional polish, see section 8.

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -50,13 +50,15 @@ The reactor twin gets the same four members, `Mono<Checkpoint> save(String, Chec
 with an empty `Mono` meaning no version is stored. A refusal on that stack signals `Mono.error`, it never throws from
 assembly.
 
-`evaluatesWriteConditions()` and `evaluatesWriteConditionsFor(String)` are the two of the four with a default, and
-both default to `false`, so a storage that writes unconditionally compiles and keeps working without answering
-either. Say `true` from `evaluatesWriteConditions()` when your storage accepts and refuses `notOlderThan` and
-`ifAbsent` as documented and leaves a stored version untouched under `any()`. Override `evaluatesWriteConditionsFor`
-too when that answer varies by subscription id, see section 2. A caller that depends on a conditional write asks
-first, which is how the Spring Boot starter refuses a wiring that would otherwise throw on the first checkpoint
-write. Section 8 covers that failure.
+`evaluatesWriteConditions()` and `evaluatesWriteConditionsFor(String)` are the two of the four with a default.
+`evaluatesWriteConditions()` defaults to `false`. `evaluatesWriteConditionsFor(String)` has no default of its own,
+it delegates to `evaluatesWriteConditions()`, so it inherits `true` for every id once a storage overrides that one,
+unless the storage overrides `evaluatesWriteConditionsFor` too to answer differently by id. A storage that answers
+neither writes unconditionally and compiles and keeps working regardless. Say `true` from `evaluatesWriteConditions()`
+when your storage accepts and refuses `notOlderThan` and `ifAbsent` as documented and leaves a stored version
+untouched under `any()`. Override `evaluatesWriteConditionsFor` too when that answer varies by subscription id, see
+section 2. A caller that depends on a conditional write asks first, which is how the Spring Boot starter refuses a
+wiring that would otherwise throw on the first checkpoint write. Section 8 covers that failure.
 
 A test double that overrides the two-argument `save` to observe writes stops seeing them, because the subscription
 models now call the three-argument `save` directly, so override that one instead.

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -39,17 +39,24 @@ OptionalLong writeVersion(String subscriptionId);
 default boolean evaluatesWriteConditions() {
     return false;
 }
+
+default boolean evaluatesWriteConditionsFor(String subscriptionId) {
+    return evaluatesWriteConditions();
+}
 ```
 
-The reactor twin gets the same three members, `Mono<Checkpoint> save(String, Checkpoint, CheckpointWriteCondition)`,
-`Mono<Long> writeVersion(String)` and the same `evaluatesWriteConditions()`, with an empty `Mono` meaning no version
-is stored. A refusal on that stack signals `Mono.error`, it never throws from assembly.
+The reactor twin gets the same four members, `Mono<Checkpoint> save(String, Checkpoint, CheckpointWriteCondition)`,
+`Mono<Long> writeVersion(String)`, and the same `evaluatesWriteConditions()` and `evaluatesWriteConditionsFor(String)`,
+with an empty `Mono` meaning no version is stored. A refusal on that stack signals `Mono.error`, it never throws from
+assembly.
 
-`evaluatesWriteConditions()` is the only one of the three with a default, and the default is `false`, so a storage that
-writes unconditionally compiles and keeps working without answering it. Say `true` when your storage accepts and
-refuses `notOlderThan` and `ifAbsent` as documented and leaves a stored version untouched under `any()`. A caller that
-depends on a conditional write asks first, which is how the Spring Boot starter refuses a wiring that would otherwise
-throw on the first checkpoint write. Section 8 covers that failure.
+`evaluatesWriteConditions()` and `evaluatesWriteConditionsFor(String)` are the two of the four with a default, and
+both default to `false`, so a storage that writes unconditionally compiles and keeps working without answering
+either. Say `true` from `evaluatesWriteConditions()` when your storage accepts and refuses `notOlderThan` and
+`ifAbsent` as documented and leaves a stored version untouched under `any()`. Override `evaluatesWriteConditionsFor`
+too when that answer varies by subscription id, see section 2. A caller that depends on a conditional write asks
+first, which is how the Spring Boot starter refuses a wiring that would otherwise throw on the first checkpoint
+write. Section 8 covers that failure.
 
 A test double that overrides the two-argument `save` to observe writes stops seeing them, because the subscription
 models now call the three-argument `save` directly, so override that one instead.
@@ -105,8 +112,14 @@ same as it always accepted every subscription id outside the version key's own r
 A store whose answer to a conditional write depends on the subscription id, the way the two Redis modes above do, can
 say so precisely with `evaluatesWriteConditionsFor(String subscriptionId)`, a second new default method that answers
 `evaluatesWriteConditions()` for every id unless overridden. The blocking Spring Boot starter's own fencing check
-reads it too, see section 8. No such check exists on the reactor stack yet, so a reactor `CheckpointStorage`
-implementer overrides it only for callers that ask directly.
+reads it too, see section 8. The reactor stack has no startup check like that one, but the override is not merely
+advisory there either. `ReactorDurableSubscriptionModel.pinStartPosition` reads it on every reactive durable
+subscription's first run whose start position resolves to the subscription model default, and the answer decides
+between a conditional `ifAbsent()` write that can refuse a losing race and an unconditional write logged at `WARN`
+that keeps 0.32.0's race open for that subscription. A storage whose `ifAbsent()` otherwise works but whose
+predicate stays at the default `false` here does not fail loudly for it. It compiles, runs, and keeps the 0.32.0
+race open with nothing louder than that `WARN`. Leaving the override unanswered is a real choice with a real
+cost, not optional polish, see section 8.
 
 If your store can evaluate a condition for real, the two rules that matter are the same two the TCK asserts on every
 storage that declares it supports them. `any()` must leave whatever version is stored untouched, carrying it

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -54,11 +54,13 @@ assembly.
 `evaluatesWriteConditions()` defaults to `false`. `evaluatesWriteConditionsFor(String)` has no default of its own,
 it delegates to `evaluatesWriteConditions()`, so it inherits `true` for every id once a storage overrides that one,
 unless the storage overrides `evaluatesWriteConditionsFor` too to answer differently by id. A storage that answers
-neither writes unconditionally and compiles and keeps working regardless. Say `true` from `evaluatesWriteConditions()`
-when your storage accepts and refuses `notOlderThan` and `ifAbsent` as documented and leaves a stored version
-untouched under `any()`. Override `evaluatesWriteConditionsFor` too when that answer varies by subscription id, see
-section 2. A caller that depends on a conditional write asks first, which is how the Spring Boot starter refuses a
-wiring that would otherwise throw on the first checkpoint write. Section 8 covers that failure.
+neither only guarantees that a caller treats it as unable to evaluate a condition. It compiles and keeps working
+either way, whether or not `save` actually does evaluate one without saying so, and section 2 has that case. Say
+`true` from `evaluatesWriteConditions()` when your storage accepts and refuses `notOlderThan` and `ifAbsent` as
+documented and leaves a stored version untouched under `any()`. Override `evaluatesWriteConditionsFor` too when
+that answer varies by subscription id, see section 2. A caller that depends on a conditional write asks first,
+which is how the Spring Boot starter refuses a wiring that would otherwise throw on the first checkpoint write.
+Section 8 covers that failure.
 
 A test double that overrides the two-argument `save` to observe writes stops seeing them, because the subscription
 models now call the three-argument `save` directly, so override that one instead.

--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -118,14 +118,15 @@ say so precisely with `evaluatesWriteConditionsFor(String subscriptionId)`, a se
 `evaluatesWriteConditions()` for every id unless overridden. The blocking Spring Boot starter's own fencing check
 reads it too, see section 8. The reactor stack has no startup check like that one, but the override is not merely
 advisory there either. `ReactorDurableSubscriptionModel.pinStartPosition` reads it the first time a reactive
-durable subscription registers with no checkpoint stored yet and a seed position to pin. An existing checkpoint
-skips this path entirely, and so does a seed that resolves to nothing, which `globalCheckpoint()` documents as a
-real, non-hypothetical outcome. When it does run, the answer decides between a conditional `ifAbsent()` write
-that can refuse a losing race and an unconditional write logged at `WARN` that keeps 0.32.0's race open for that
-subscription. A storage whose `ifAbsent()` otherwise works but whose
-predicate stays at the default `false` here does not fail loudly for it. It compiles, runs, and keeps the 0.32.0
-race open with nothing louder than that `WARN`. Leaving the override unanswered is a real choice with a real
-cost, not optional polish, see section 8.
+durable subscription's start position resolves with no checkpoint stored yet and a seed position to pin,
+whether that is at registration on a running model or later, when a subscription registered while the model
+was stopped is actually started or resumed. An existing checkpoint skips this path entirely, and so does a seed
+that resolves to nothing, which `globalCheckpoint()` documents as a real, non-hypothetical outcome. When it does
+run, the answer decides between a conditional `ifAbsent()` write that can refuse a losing race and an
+unconditional write logged at `WARN` that keeps 0.32.0's race open for that subscription. A storage whose
+`ifAbsent()` otherwise works but whose predicate stays at the default `false` here does not fail loudly for it.
+It compiles, runs, and keeps the 0.32.0 race open with nothing louder than that `WARN`. Leaving the override
+unanswered is a real choice with a real cost, not optional polish, see section 8.
 
 If your store can evaluate a condition for real, the two rules that matter are the same two the TCK asserts on every
 storage that declares it supports them. `any()` must leave whatever version is stored untouched, carrying it
@@ -212,11 +213,13 @@ server has. Built that way, `save` accepts that shape too for `notOlderThan` and
 `evaluatesWriteConditionsFor` agrees, answering `true` for it. Do not build a Cluster deployment's storage with
 `forStandalone`. A conditional write for an id the standalone mode accepts but Cluster cannot align a slot for then
 fails with Redis's own `CROSSSLOT` error instead of the refusal above. `any()` never refuses one for slot alignment,
-in either mode, since it writes only the checkpoint key. `delete` never refuses one either. An id of this shape can
-only ever have had a checkpoint written for it through `any()` in Cluster-safe mode, since a conditional write
-already refuses one before touching Redis, so its version key can never exist to strand. On a
-`CROSSSLOT` failure `delete` falls back to two single-key deletes instead, which is provably safe for that reason and
-not merely convenient.
+in either mode, since it writes only the checkpoint key. `delete` never refuses one either. In Cluster-safe mode a
+conditional write already refuses an id of this shape before touching Redis, so a version key this mode itself
+wrote for one never exists. One can still be there if the same Redis data was written earlier through
+`forStandalone`'s `notOlderThan`, the case of standalone Redis later migrated into Cluster (`ifAbsent` never
+writes the version key, in either mode, only `notOlderThan` does). On a `CROSSSLOT` failure `delete` falls back
+to two single-key deletes, which removes a version key a migration like that left behind and is a no-op
+otherwise.
 
 This also assumes the `RedisOperations` passed in serializes a key to its own literal bytes, the same assumption
 the checkpoint's plain `GET` already makes.

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -109,11 +109,12 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * accept this shape, the case of standalone Redis later migrated into Cluster with the same subscription ids
  * carried over. The fallback deletes both keys as two single-key commands regardless, which removes a version
  * key when one is there and is a no-op against one that never was. {@link #forStandalone(RedisOperations)}
- * carries no refusal of its own, so a conditional write against it does write a version key for this shape
- * directly, and its own {@code delete} never even reaches {@code CROSSSLOT}. A standalone or replicated server
- * has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
- * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
- * depends on. If a version key ever did exist and outlived its checkpoint here, deleting it first and failing
+ * carries no refusal of its own, so a conditional {@code notOlderThan} write against it does write a version key
+ * for this shape directly. {@code ifAbsent} never touches the version key, in either mode, it only checks and
+ * sets the checkpoint key. Its own {@code delete} never even reaches {@code CROSSSLOT} in the first place. A
+ * standalone or replicated server has no slots to cross, so the two-key {@code DEL} always succeeds there and
+ * the fallback above never runs. The checkpoint key is deleted first regardless, a defensive ordering rather
+ * than one either mode's safety depends on. If a version key ever did exist here, deleting it first and failing
  * before the checkpoint would leave a checkpoint with no stored version, which a later {@code notOlderThan}
  * write would then accept unconditionally, letting a lease-holder that has already moved on win a write it
  * should have lost.
@@ -487,12 +488,12 @@ public class SpringRedisCheckpointStorage implements CheckpointStorage {
                 // forStandalone(..) has no slots to cross, so it never returns CROSSSLOT here in the first place.
                 // In Cluster-safe mode, only the one subscription id shape requireClusterSlotAlignable refuses can
                 // land here. This mode's own conditional writes already refuse that shape before ever writing a
-                // version key, but the same Redis data can carry one in from an earlier forStandalone(..) use that
-                // did accept it, for example after migrating standalone Redis into Cluster. The two deletes below
-                // remove it when it is there and no-op against it otherwise. The checkpoint is still deleted
-                // first, defensively. If a version key ever did exist, deleting it first and failing before the
-                // checkpoint would leave a checkpoint with no stored version, which a later notOlderThan write
-                // would then accept unconditionally.
+                // version key, but the same Redis data can carry one in from an earlier forStandalone(..) call to
+                // notOlderThan against it, for example after migrating standalone Redis into Cluster. The two
+                // deletes below remove it when it is there and no-op against it otherwise. The checkpoint is
+                // still deleted first, defensively. If a version key ever did exist, deleting it first and
+                // failing before the checkpoint would leave a checkpoint with no stored version, which a later
+                // notOlderThan write would then accept unconditionally.
                 redis.delete(subscriptionId);
                 redis.delete(versionKey(subscriptionId));
                 return 0L;

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -110,14 +110,14 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * carried over. The fallback deletes both keys as two single-key commands regardless, which removes a version
  * key when one is there and is a no-op against one that never was. {@link #forStandalone(RedisOperations)}
  * carries no refusal of its own, so a conditional {@code notOlderThan} write against it does write a version key
- * for this shape directly. {@code ifAbsent} never touches the version key, in either mode, it only checks and
- * sets the checkpoint key. Its own {@code delete} never even reaches {@code CROSSSLOT} in the first place. A
- * standalone or replicated server has no slots to cross, so the two-key {@code DEL} always succeeds there and
- * the fallback above never runs. The checkpoint key is deleted first regardless, a defensive ordering rather
- * than one either mode's safety depends on. If a version key ever did exist here, deleting it first and failing
- * before the checkpoint would leave a checkpoint with no stored version, which a later {@code notOlderThan}
- * write would then accept unconditionally, letting a lease-holder that has already moved on win a write it
- * should have lost.
+ * for this shape directly. {@code ifAbsent} never writes the version key, in either mode. It may read the
+ * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. Its own
+ * {@code delete} never even reaches {@code CROSSSLOT} in the first place. A standalone or replicated server
+ * has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
+ * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
+ * depends on. If a version key ever did exist here, deleting it first and failing before the checkpoint would
+ * leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then accept
+ * unconditionally, letting a lease-holder that has already moved on win a write it should have lost.
  * <p>
  * This also assumes the {@link RedisOperations} passed in serializes a key to its own literal bytes, the same
  * assumption the checkpoint's plain {@code GET} already makes. A key serializer that reshapes the string changes

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -102,14 +102,18 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * {@link CheckpointWriteCondition#any()} never refuses an id for slot alignment in either mode, since it writes only
  * the checkpoint key and never touches the version key at all.
  * <p>
- * {@link #delete(String)} never refuses one. A subscription id of this shape can only ever have had a checkpoint
- * written for it through {@code any()}, since a conditional write already refuses one before touching Redis at
- * all, so its version key can never exist to strand. On a {@code CROSSSLOT} failure, falling back to two
- * single-key deletes is provably safe for that reason, not merely convenient. The checkpoint key is deleted first
- * regardless, a defensive ordering rather than one this specific fallback depends on. If a version key ever did
- * exist here, deleting it first and failing before the checkpoint would leave a checkpoint with no stored version,
- * which a later {@code notOlderThan} write would then accept unconditionally, letting a lease-holder that has
- * already moved on win a write it should have lost.
+ * {@link #delete(String)} never refuses one, in either mode, though the two modes get there differently. In
+ * Cluster-safe mode, a subscription id of this shape can only ever have had a checkpoint written for it through
+ * {@code any()}, since a conditional write already refuses one before touching Redis at all, so its version key
+ * can never exist to strand there, and falling back to two single-key deletes on a {@code CROSSSLOT} failure is
+ * provably safe for that reason, not merely convenient. {@link #forStandalone(RedisOperations)} carries no such
+ * refusal, so a conditional write against it does write a version key for this shape. Nothing strands there
+ * either, but for a different reason. A standalone or replicated server has no slots to cross, so the two-key
+ * {@code DEL} never fails with {@code CROSSSLOT} in that mode, and the fallback above never runs. The checkpoint
+ * key is deleted first regardless, a defensive ordering rather than one either mode's safety depends on. If a
+ * version key ever did exist and outlived its checkpoint here, deleting it first and failing before the
+ * checkpoint would leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then
+ * accept unconditionally, letting a lease-holder that has already moved on win a write it should have lost.
  * <p>
  * This also assumes the {@link RedisOperations} passed in serializes a key to its own literal bytes, the same
  * assumption the checkpoint's plain {@code GET} already makes. A key serializer that reshapes the string changes
@@ -476,12 +480,14 @@ public class SpringRedisCheckpointStorage implements CheckpointStorage {
                 if (!isClusterSlotMismatch(e)) {
                     throw e;
                 }
-                // Only the one subscription id shape requireClusterSlotAlignable refuses can land here, and a
-                // conditional write already refuses that shape before ever writing a version key, so this id's
-                // version key can never exist to strand. The second delete below is provably a no-op, not merely
-                // convenient. The checkpoint is still deleted first, defensively. If a version key ever did exist,
-                // deleting it first and failing before the checkpoint would leave a checkpoint with no stored
-                // version, which a later notOlderThan write would then accept unconditionally.
+                // This branch is Cluster-safe-mode-only in practice. A standalone or replicated server behind
+                // forStandalone(..) has no slots to cross, so it never returns CROSSSLOT here in the first place.
+                // In Cluster-safe mode, only the one subscription id shape requireClusterSlotAlignable refuses can
+                // land here, and a conditional write already refuses that shape before ever writing a version
+                // key, so this id's version key can never exist to strand. The second delete below is provably a
+                // no-op, not merely convenient. The checkpoint is still deleted first, defensively. If a version
+                // key ever did exist, deleting it first and failing before the checkpoint would leave a checkpoint
+                // with no stored version, which a later notOlderThan write would then accept unconditionally.
                 redis.delete(subscriptionId);
                 redis.delete(versionKey(subscriptionId));
                 return 0L;

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -102,18 +102,21 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * {@link CheckpointWriteCondition#any()} never refuses an id for slot alignment in either mode, since it writes only
  * the checkpoint key and never touches the version key at all.
  * <p>
- * {@link #delete(String)} never refuses one, in either mode, though the two modes get there differently. In
- * Cluster-safe mode, a subscription id of this shape can only ever have had a checkpoint written for it through
- * {@code any()}, since a conditional write already refuses one before touching Redis at all, so its version key
- * can never exist to strand there, and falling back to two single-key deletes on a {@code CROSSSLOT} failure is
- * provably safe for that reason, not merely convenient. {@link #forStandalone(RedisOperations)} carries no such
- * refusal, so a conditional write against it does write a version key for this shape. Nothing strands there
- * either, but for a different reason. A standalone or replicated server has no slots to cross, so the two-key
- * {@code DEL} never fails with {@code CROSSSLOT} in that mode, and the fallback above never runs. The checkpoint
- * key is deleted first regardless, a defensive ordering rather than one either mode's safety depends on. If a
- * version key ever did exist and outlived its checkpoint here, deleting it first and failing before the
- * checkpoint would leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then
- * accept unconditionally, letting a lease-holder that has already moved on win a write it should have lost.
+ * {@link #delete(String)} never refuses one, in either mode, though what the {@code CROSSSLOT} fallback finds
+ * differs between them. Cluster-safe mode's own conditional writes already refuse a subscription id of this shape
+ * before touching Redis at all, so a version key this mode itself wrote for one never exists. One can still be
+ * there if the same Redis data was written earlier through {@link #forStandalone(RedisOperations)}, which does
+ * accept this shape, the case of standalone Redis later migrated into Cluster with the same subscription ids
+ * carried over. The fallback deletes both keys as two single-key commands regardless, which removes a version
+ * key when one is there and is a no-op against one that never was. {@link #forStandalone(RedisOperations)}
+ * carries no refusal of its own, so a conditional write against it does write a version key for this shape
+ * directly, and its own {@code delete} never even reaches {@code CROSSSLOT}. A standalone or replicated server
+ * has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
+ * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
+ * depends on. If a version key ever did exist and outlived its checkpoint here, deleting it first and failing
+ * before the checkpoint would leave a checkpoint with no stored version, which a later {@code notOlderThan}
+ * write would then accept unconditionally, letting a lease-holder that has already moved on win a write it
+ * should have lost.
  * <p>
  * This also assumes the {@link RedisOperations} passed in serializes a key to its own literal bytes, the same
  * assumption the checkpoint's plain {@code GET} already makes. A key serializer that reshapes the string changes
@@ -483,11 +486,13 @@ public class SpringRedisCheckpointStorage implements CheckpointStorage {
                 // This branch is Cluster-safe-mode-only in practice. A standalone or replicated server behind
                 // forStandalone(..) has no slots to cross, so it never returns CROSSSLOT here in the first place.
                 // In Cluster-safe mode, only the one subscription id shape requireClusterSlotAlignable refuses can
-                // land here, and a conditional write already refuses that shape before ever writing a version
-                // key, so this id's version key can never exist to strand. The second delete below is provably a
-                // no-op, not merely convenient. The checkpoint is still deleted first, defensively. If a version
-                // key ever did exist, deleting it first and failing before the checkpoint would leave a checkpoint
-                // with no stored version, which a later notOlderThan write would then accept unconditionally.
+                // land here. This mode's own conditional writes already refuse that shape before ever writing a
+                // version key, but the same Redis data can carry one in from an earlier forStandalone(..) use that
+                // did accept it, for example after migrating standalone Redis into Cluster. The two deletes below
+                // remove it when it is there and no-op against it otherwise. The checkpoint is still deleted
+                // first, defensively. If a version key ever did exist, deleting it first and failing before the
+                // checkpoint would leave a checkpoint with no stored version, which a later notOlderThan write
+                // would then accept unconditionally.
                 redis.delete(subscriptionId);
                 redis.delete(versionKey(subscriptionId));
                 return 0L;


### PR DESCRIPTION
Four claims about the 0.33.0 CheckpointStorage write-condition epic went stale, or were only half corrected, once the shipped design landed. I fixed all four:

- Migration guide said no check reads `evaluatesWriteConditionsFor` on the reactor stack. `ReactorDurableSubscriptionModel.pinStartPosition` actually reads it on every reactive durable subscription's first run, choosing between a conditional `ifAbsent()` write and an unconditional write logged at `WARN`. Overriding it matters even without a Spring Boot startup check to catch a `false` answer.
- ADR 116 still claimed Redis Cluster's two keys can't share a slot without renaming the checkpoint key, and that the failure is immediate. The shipped hash-tag version-key design solved this. It is the uncorrected twin of a claim the ADR already amended in its Consequences section, so I fixed it the same way, with a dated amendment block rather than a retro-edit.
- `SpringRedisCheckpointStorage`'s javadoc and an inline comment claimed a conditional write always refuses before a version key can exist, which is what makes delete's two-key fallback provably safe. That is false in `forStandalone` mode, which does write version keys for the one id shape in question. I scoped both sites to Cluster-safe mode and stated the real reason standalone mode stays safe. It has no Redis slots to cross, so `CROSSSLOT` never fires there.
- Migration guide section 1's "what changed" block listed three new `CheckpointStorage` members and said the reactor twin gets the same three. A fourth member, `evaluatesWriteConditionsFor`, shipped on both stacks and was missing from the list.

No behavior change. Docs, an ADR amendment, and Java comments only.
