### PR TITLE
Correct two overclaims from the fixpoint's final review round

### DIFF
--- a/doc/migration/upgrading-to-0.33.0.md
+++ b/doc/migration/upgrading-to-0.33.0.md
@@ -102,9 +102,10 @@ for a capability it was not built with.
 
 Such a store leaves `evaluatesWriteConditions()` alone, since the default already answers `false` for it. That answer
 is what lets a caller find out before it wires anything up, rather than on the first write, so leaving it at the
-default is part of the recipe rather than an omission. One place acts on it today. The Spring Boot Mongo starter
-refuses to start when it would pair your store with a competing-consumer lease, and section 8 says what to do about
-that.
+default is part of the recipe rather than an omission. Two places refuse such a store today. The Spring Boot
+Mongo starter refuses to start when it would pair it with a competing-consumer lease, and
+`ManualStartSubscriptionModel.stoppedByDefault(..)` throws at construction when it is built with one, because the
+start position it records at registration is written with `ifAbsent()`. Section 8 says what to do about both.
 
 Occurrent's own Mongo and Redis checkpoint storages do not need this recipe. They already evaluate `notOlderThan`
 and `ifAbsent` for real, on Redis Cluster too, see section 4. `SpringRedisCheckpointStorage`'s original two

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -111,9 +111,9 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * key when one is there and is a no-op against one that never was. {@link #forStandalone(RedisOperations)}
  * carries no refusal of its own, so a conditional {@code notOlderThan} write against it does write a version key
  * for this shape directly. {@code ifAbsent} never writes the version key, in either mode. It may read the
- * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. Its own
- * {@code delete} never even reaches {@code CROSSSLOT} in the first place. A standalone or replicated server
- * has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
+ * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. In
+ * standalone mode, {@code delete} never even reaches {@code CROSSSLOT} in the first place. A standalone or
+ * replicated server has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
  * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
  * depends on. If a version key ever did exist here, deleting it first and failing before the checkpoint would
  * leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then accept

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -111,9 +111,9 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * key when one is there and is a no-op against one that never was. {@link #forStandalone(RedisOperations)}
  * carries no refusal of its own, so a conditional {@code notOlderThan} write against it does write a version key
  * for this shape directly. {@code ifAbsent} never writes the version key, in either mode. It may read the
- * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. In
- * standalone mode, {@code delete} never even reaches {@code CROSSSLOT} in the first place. A standalone or
- * replicated server has no slots to cross, so the two-key {@code DEL} always succeeds there and the fallback above never runs.
+ * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. Against
+ * a standalone or replicated server, {@code delete} never even reaches {@code CROSSSLOT} in the first place,
+ * since such a server has no slots to cross, so the two-key {@code DEL} always succeeds and the fallback above never runs.
  * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
  * depends on. If a version key ever did exist here, deleting it first and failing before the checkpoint would
  * leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then accept

--- a/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
+++ b/subscription/redis/spring/blocking-checkpoint-storage/src/main/java/org/occurrent/subscription/redis/spring/blocking/SpringRedisCheckpointStorage.java
@@ -112,8 +112,8 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * carries no refusal of its own, so a conditional {@code notOlderThan} write against it does write a version key
  * for this shape directly. {@code ifAbsent} never writes the version key, in either mode. It may read the
  * stored version to report it back on a refusal, but the checkpoint key is the only one it ever sets. Against
- * a standalone or replicated server, {@code delete} never even reaches {@code CROSSSLOT} in the first place,
- * since such a server has no slots to cross, so the two-key {@code DEL} always succeeds and the fallback above never runs.
+ * a standalone or replicated server, {@code delete} never even reaches {@code CROSSSLOT} in the first place.
+ * Such a server has no slots to cross, so the two-key {@code DEL} always succeeds and the fallback above never runs.
  * The checkpoint key is deleted first regardless, a defensive ordering rather than one either mode's safety
  * depends on. If a version key ever did exist here, deleting it first and failing before the checkpoint would
  * leave a checkpoint with no stored version, which a later {@code notOlderThan} write would then accept


### PR DESCRIPTION
I corrected the migration guide's claim that one place acts on a false `evaluatesWriteConditions()` answer. `ManualStartSubscriptionModel.stoppedByDefault(..)` also throws at construction for such a storage, which section 8 of the same guide already describes, so the sentence now names both refusal sites. I also fixed a referent in `SpringRedisCheckpointStorage`'s javadoc where the CROSSSLOT sentence read as being about `ifAbsent`, which has no `delete`, when it is about standalone mode.