### PR TITLE
Correct the dynamic-StartAt refusal timing claim in the durable subscription javadoc

### DIFF
--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
@@ -131,9 +131,11 @@ import static org.occurrent.subscription.CheckpointAwareCloudEvent.getCheckpoint
  * and which of the two it answers decides whether the registration is refused. When the wrapped model manages named
  * subscriptions of its own that is resolved where {@link #subscribe(String, SubscriptionFilter, StartAt, Function)}
  * is called, so a refusal is thrown from that call like any other, with no handle involved. When this model drives
- * the cold primitive itself that resolution waits until the subscription starts, so its registration handle keeps
- * waiting rather than reporting a refusal that may never happen, and the refusal comes out on the handle
- * {@link #resumeSubscription(String)} returns.
+ * the cold primitive itself the function is resolved only once the subscription actually starts. A registration made
+ * while running starts immediately, so the refusal comes out on the handle
+ * {@link #subscribe(String, SubscriptionFilter, StartAt, Function)} itself returns. One made while stopped leaves
+ * that handle waiting instead, and the refusal comes out later, on the handle {@link #resumeSubscription(String)}
+ * returns.
  * <p>
  * Note that this implementation stores the checkpoint after _every_ action by default. If you have a lot of
  * events and duplication is not that much of a deal, consider changing this behavior by supplying an instance of

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
@@ -127,10 +127,13 @@ import static org.occurrent.subscription.CheckpointAwareCloudEvent.getCheckpoint
  * starts and settles the question before the registration read is consulted, so it starts even when that read could
  * not answer.
  * <p>
- * A {@link StartAt#dynamic(java.util.function.Supplier) dynamic} start position is read for all the same, since it is
- * not resolved until the subscription starts and may answer the model default then. Which of the two it answers is
- * what decides whether the registration is refused, so its registration handle keeps waiting rather than reporting a
- * refusal that may never happen, and the refusal comes out on the handle {@link #resumeSubscription(String)} returns.
+ * A {@link StartAt#dynamic(java.util.function.Supplier) dynamic} start position may answer the model default too,
+ * and which of the two it answers decides whether the registration is refused. When the wrapped model manages named
+ * subscriptions of its own that is resolved where {@link #subscribe(String, SubscriptionFilter, StartAt, Function)}
+ * is called, so a refusal is thrown from that call like any other, with no handle involved. When this model drives
+ * the cold primitive itself that resolution waits until the subscription starts, so its registration handle keeps
+ * waiting rather than reporting a refusal that may never happen, and the refusal comes out on the handle
+ * {@link #resumeSubscription(String)} returns.
  * <p>
  * Note that this implementation stores the checkpoint after _every_ action by default. If you have a lot of
  * events and duplication is not that much of a deal, consider changing this behavior by supplying an instance of


### PR DESCRIPTION
The class javadoc for `ReactorDurableSubscriptionModel` said a dynamic `StartAt`'s refusal always comes out on the `resumeSubscription(String)` handle. That's only true when this model drives the cold primitive itself.

On the delegating path (every in-tree named model), `durableStartAt` evaluates the dynamic function inside `subscribe(..)`, and a model-default answer reaches a blocking `.block()` read right there. A failed or empty read throws from `subscribe(..)` itself, with no handle or `resumeSubscription` involved.

I split the paragraph by path. It's thrown from `subscribe(..)` when the wrapped model manages named subscriptions of its own, and reported on the `resumeSubscription(String)` handle when this model drives the cold primitive itself.

Verified by reading `durableStartAt` (subscribe-time, synchronous, `.block()`) against `startInternalSubscription`/`resolveStartAt` (deferred, reactive, resolved when the subscription actually starts). Compiled and ran `javadoc:javadoc` for the module, both clean.
