### PR TITLE
Record the guard and leaf predicate signature asymmetry in ADR 120

### DIFF
--- a/doc/architecture/decisions/0120-a-step-condition-is-a-monotone-matcher-tree.md
+++ b/doc/architecture/decisions/0120-a-step-condition-is-a-monotone-matcher-tree.md
@@ -282,3 +282,17 @@ secondary constructor that supplies `-1`, and degrades the same way. Two tests c
 old-document one seeds the document by hand, since a document this store wrote a moment ago only proves the store agrees
 with itself. Separately, this record claimed the self-loop window-reset rule appears in
 `StepBuilder.on(StepCondition, Continuation)`'s javadoc when it did not. It does now.
+
+## Amendment (2026-08-16): the guard and leaf predicates differ in what they can see, and that is the practical choice between them
+
+**The Decision section above states why a guard is not lowered into a window leaf but never states what each one is
+allowed to see, and that turned out to be the fact a caller actually needs when choosing between them.** `StepBuilder`'s
+guarded overload takes `BiPredicate<T, ReceivedEvents<E>>`, so `onlyIf` receives the arriving event and the whole
+retained history in one call. `StepCondition.event(Class, Predicate)` takes a bare `Predicate<T>`, the arriving event
+and nothing else. The narrower signature is not an oversight. A leaf's count is re-derived from the step window on
+every delivery, and again from scratch once a redeploy replays it, so its predicate has to answer the same way every
+time it sees the same event, or the recount and the original run disagree. A predicate that could read
+`ReceivedEvents` would have a way around that on every single call. This is also the practical rule for choosing
+between the two. A decision that depends on anything beyond the one event in front of it, an earlier event's
+contents, a running count, elapsed time, can only be written as a guard, because `event(...)`'s `Predicate<T>` has
+nothing else to look at.

--- a/doc/architecture/decisions/0120-a-step-condition-is-a-monotone-matcher-tree.md
+++ b/doc/architecture/decisions/0120-a-step-condition-is-a-monotone-matcher-tree.md
@@ -289,10 +289,13 @@ with itself. Separately, this record claimed the self-loop window-reset rule app
 allowed to see, and that turned out to be the fact a caller actually needs when choosing between them.** `StepBuilder`'s
 guarded overload takes `BiPredicate<T, ReceivedEvents<E>>`, so `onlyIf` receives the arriving event and the whole
 retained history in one call. `StepCondition.event(Class, Predicate)` takes a bare `Predicate<T>`, the arriving event
-and nothing else. The narrower signature is not an oversight. A leaf's count is re-derived from the step window on
-every delivery, and again from scratch once a redeploy replays it, so its predicate has to answer the same way every
-time it sees the same event, or the recount and the original run disagree. A predicate that could read
-`ReceivedEvents` would have a way around that on every single call. This is also the practical rule for choosing
-between the two. A decision that depends on anything beyond the one event in front of it, an earlier event's
-contents, a running count, elapsed time, can only be written as a guard, because `event(...)`'s `Predicate<T>` has
-nothing else to look at.
+and nothing else. `StepCondition`'s javadoc already states why that side has to stay narrow. A leaf's predicate has to
+be a deterministic function of the one event it is given, because it is re-run whenever a count is derived from the
+step window rather than read off a count the instance already carries. That happens on every delivery for a step with
+no `stepWindow` cap, and again on a rescan whenever a capped step's carried counts do not already describe its current
+declaration, its first delivery into the step included ([ADR 123](0123-a-step-conditions-counts-are-carried-so-the-steps-events-can-be-dropped.md)).
+That requirement is a contract stated on the javadoc, not one the `Predicate<T>` type itself can enforce, since a
+lambda can still close over a clock or mutable state regardless of what its parameter list says. The signature
+difference is still the practical rule for choosing between the two. A leaf's `Predicate<T>` can only look at the one
+event it is handed, so a decision that needs anything else, another event's contents or a running count among them,
+has to be a guard, which is exactly what handing it `ReceivedEvents` is for.


### PR DESCRIPTION
I added a paragraph to ADR 120's amendment history recording a fact that was true in the code but never written down anywhere.

`StepBuilder`'s guarded `onlyIf` overload takes `BiPredicate<T, ReceivedEvents<E>>`, so it sees the arriving event and the whole retained history. `StepCondition.event(Class, Predicate)` takes a bare `Predicate<T>`, so it sees only the arriving event. The existing "Guards are not window leaves" section already explains why a guard isn't lowered into a window leaf (different re-evaluation cadence), but it says nothing about what each one is allowed to see, and that's the fact that actually decides which one to use. The narrower signature is what makes a leaf's count safe to re-derive on every delivery and after a redeploy replays it, and it means anything state-dependent can only be written as a guard.

Md-only diff, no code changes.
