### PR TITLE
Prepare the changelog and migration guide for 0.34.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
-### Changelog 0.33.0 (2026-08-14)
+### Changelog next version
+
+#### Highlights
+
+#### Changes
+
+#### Breaking changes
+
+### Changelog 0.33.0 (2026-08-16)
 
 #### Highlights
 

--- a/doc/migration/upgrading-to-0.34.0.md
+++ b/doc/migration/upgrading-to-0.34.0.md
@@ -1,0 +1,5 @@
+# Upgrading to Occurrent 0.34.0
+
+This guide fills in as 0.34.0's breaking changes land. Each section describes one change that requires action from a
+caller on 0.33.0, what the `UpgradeToOccurrent_0_34` OpenRewrite recipe rewrites for you, and what you have to do by
+hand.

--- a/doc/migration/upgrading-to-0.34.0.md
+++ b/doc/migration/upgrading-to-0.34.0.md
@@ -1,5 +1,4 @@
 # Upgrading to Occurrent 0.34.0
 
-This guide fills in as 0.34.0's breaking changes land. Each section describes one change that requires action from a
-caller on 0.33.0, what the `UpgradeToOccurrent_0_34` OpenRewrite recipe rewrites for you, and what you have to do by
-hand.
+Each section describes one 0.34.0 change that requires action from a caller on 0.33.0, what the
+`UpgradeToOccurrent_0_34` OpenRewrite recipe rewrites for you, and what you have to do by hand.


### PR DESCRIPTION
Lays the ground the first 0.34.0 units need to write into: the next-version changelog skeleton and the migration guide shell for the UpgradeToOccurrent_0_34 recipe. Also corrects the 0.33.0 changelog date to 2026-08-16, matching the tag and the release news post.

Part of the r34 release-readiness epic, milestone 0.34.0.