### PR TITLE
Fix overclaimed projection filter safety, missing Sequence warnings, and ADR 54's read-side gap

### DIFF
--- a/doc/architecture/decisions/0054-list-instead-of-stream-for-event-store-writes.md
+++ b/doc/architecture/decisions/0054-list-instead-of-stream-for-event-store-writes.md
@@ -66,6 +66,31 @@ in-memory subscription model that consumes it, move from `Consumer<Stream<CloudE
 `Consumer<List<CloudEvent>>` for the same reason as the write API, since they are always handed an
 already-materialized batch.
 
+> **Amended on 2026-08-16, for #760.** This ADR argues the write side at length and never says anything about
+> the read that feeds a decision, which is a gap #760 found. `ApplicationService#execute` takes a
+> `Function<List<E>, List<E>>` for exactly the reason stated above, but the events reaching that function come
+> from a read, and this record's "the read side is untouched" claim does not cover them.
+>
+> `EventStore.read`, `query`, and `CloudEventConverter.toDomainEvents` are still lazy, and the stores still read
+> with a cursor, `autoClose(mongoTemplate.stream(...))` on the Spring store and
+> `StreamSupport.stream(FindIterable.spliterator(), false)` on the native driver. What changed is
+> `GenericApplicationService`, which now calls `cloudEventConverter.toDomainEvents(eventStream.events()).toList()`
+> before handing events to the domain function, where before 0.30.0 it passed the `Stream` straight through.
+>
+> `List` is still the right shape there, for reasons distinct from the write side's. A decider replays the whole
+> history to build its state, so it reads every event regardless of the input's shape. `CommandConversion` and
+> `StreamCommandComposition` already collected composed commands into a `List` before this change.
+> `SequentialFunctionComposer` re-reads the events already seen for each command in a chain, which a single-use
+> `Stream` cannot do. And `execute` retries the whole read-decide-write path when the write condition is not
+> fulfilled, which replays from the store regardless of what shape the first attempt read.
+>
+> A stream with a genuinely large number of events still has two ways out that keep the replay itself small.
+> `ExecuteOptions.fromStreamVersion(long)` tells `execute` to skip everything up to a version already reduced to
+> a known state, so it reads only the tail. The snapshot DSL from [ADR 61](0061-first-class-snapshot-support.md)
+> loads a snapshot, reads only the events after it, and saves a new snapshot automatically. A caller who wants to
+> reduce over a huge stream without loading it at all can still do so outside the application service, since
+> `eventStore.read(...)` and `toDomainEvents` stay lazy.
+
 The view DSL's `evolve`, `evolveAll`, and `evolveFrom` helpers gained `List` and `Iterable` overloads but keep
 their `Stream` (Java) and `Sequence` (Kotlin) forms. A view fold is a read-side operation, so a lazily-queried
 `Stream` or `Sequence` (for example a `queryForSequence` result) composes with it directly, without a caller

--- a/doc/architecture/decisions/0054-list-instead-of-stream-for-event-store-writes.md
+++ b/doc/architecture/decisions/0054-list-instead-of-stream-for-event-store-writes.md
@@ -86,10 +86,13 @@ already-materialized batch.
 >
 > A stream with a genuinely large number of events still has two ways out that keep the replay itself small.
 > `ExecuteOptions.fromStreamVersion(long)` tells `execute` to skip everything up to a version already reduced to
-> a known state, so it reads only the tail. The snapshot DSL from [ADR 61](0061-first-class-snapshot-support.md)
-> loads a snapshot, reads only the events after it, and saves a new snapshot automatically. A caller who wants to
-> reduce over a huge stream without loading it at all can still do so outside the application service, since
-> `eventStore.read(...)` and `toDomainEvents` stay lazy.
+> a known state, so it reads only the tail, as long as `ExecuteOptions` carries no `StreamReadFilter`.
+> `GenericApplicationService` turns the version into a plain `skip`, and both Mongo stores combine the stream's own
+> query with the filter before applying that skip, so a filtered read's skip count moves against the filtered
+> documents rather than against the stream's own version numbering. The snapshot DSL from
+> [ADR 61](0061-first-class-snapshot-support.md) loads a snapshot, reads only the events after it, and saves a new
+> snapshot automatically. A caller who wants to reduce over a huge stream without loading it at all can still do so
+> outside the application service, since `eventStore.read(...)` and `toDomainEvents` stay lazy.
 
 The view DSL's `evolve`, `evolveAll`, and `evolveFrom` helpers gained `List` and `Iterable` overloads but keep
 their `Stream` (Java) and `Sequence` (Kotlin) forms. A view fold is a read-side operation, so a lazily-queried

--- a/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
+++ b/dsl/projection-dsl/common/src/main/java/org/occurrent/dsl/projection/Projection.java
@@ -36,7 +36,10 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Build one with the type-safe {@link #builder(Object) handler builder}, registering a fold per event type with
  * {@link Builder#on(Class, BiFunction)}. The handled types become the subscription filter, and the fold leaves the state
- * unchanged for any event type it does not handle, so feeding it a broader stream is safe.
+ * unchanged for any event type it does not handle, so feeding it a broader stream is safe as long as every event the
+ * filter admits is still one the {@code CloudEventConverter} can turn into an {@code E}. One it cannot fails that
+ * delivery instead of being ignored, and a subscription that keeps redelivering a failing event holds up everything
+ * queued behind it. See {@link Builder#filter(Filter) filter} for how this bears on an explicit filter.
  * <p>
  * One descriptor runs two ways. Feed it a subscription to keep a stored read model up to date, with a
  * {@code ProjectionRunner} or the Kotlin {@code project} extensions, or fold it over a query for a strongly consistent
@@ -298,9 +301,12 @@ public final class Projection<S extends @Nullable Object, E, ID> {
 
         /**
          * Sets an explicit selector that overrides the event-type-derived one. Use it to select on more than event type
-         * (subject, source, data, time). A filter broader than the registered handlers is safe (the fold no-ops on
-         * events it does not handle). A filter narrower than the handlers deliberately starves those handlers. Can be
-         * set only once.
+         * (subject, source, data, time). A filter broader than the registered handlers is safe for the fold, which
+         * no-ops on events it does not handle, but every CloudEvent the filter admits is converted to a domain event
+         * before the fold sees it. One the {@code CloudEventConverter} cannot turn into an {@code E} fails that
+         * delivery instead of being ignored, and a subscription that keeps redelivering a failing event holds up
+         * everything queued behind it, so keep the filter inside what the converter can convert. A filter narrower
+         * than the handlers deliberately starves those handlers. Can be set only once.
          */
         public Builder<S, E, ID> filter(Filter filter) {
             if (this.filter != null) {

--- a/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
+++ b/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
@@ -30,6 +30,10 @@ import kotlin.streams.asSequence
 
 /**
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
+ *
  * @see DomainEventQueries.query
  */
 fun <T : Any> DomainEventQueries<in T>.queryForSequence(
@@ -43,6 +47,14 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 
 /**
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
+ *
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
+ * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
+ * for.
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
+ *
  * @see DomainEventQueries.query
  */
 fun <T : Any> DomainEventQueries<in T>.queryForSequence(
@@ -58,6 +70,13 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 /**
  * Query by type of domain event ([T]).
  *
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
+ * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
+ * for.
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
+ *
  * @see DomainEventQueries.query
  */
 fun <T : Any> DomainEventQueries<in T>.queryForSequence(
@@ -70,6 +89,14 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 
 /**
  * Query by type of domain event ([T]).
+ *
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
+ * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
+ * for.
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
+ *
  * @see DomainEventQueries.query
  */
 fun <T : Any> DomainEventQueries<T>.queryForSequence(

--- a/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
+++ b/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
@@ -49,8 +49,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
  *
  * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
- * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
- * already produced.
+ * `limit` is a parameter the query itself carries, telling it how many elements to return. `.take(n)` still leaves
+ * the query open to return everything and only stops pulling from it after `n`, which is exactly why closing it
+ * yourself, as below, still matters.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
@@ -71,8 +72,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
  * Query by type of domain event ([T]).
  *
  * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
- * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
- * already produced.
+ * `limit` is a parameter the query itself carries, telling it how many elements to return. `.take(n)` still leaves
+ * the query open to return everything and only stops pulling from it after `n`, which is exactly why closing it
+ * yourself, as below, still matters.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
@@ -91,8 +93,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
  * Query by type of domain event ([T]).
  *
  * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
- * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
- * already produced.
+ * `limit` is a parameter the query itself carries, telling it how many elements to return. `.take(n)` still leaves
+ * the query open to return everything and only stops pulling from it after `n`, which is exactly why closing it
+ * yourself, as below, still matters.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.

--- a/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
+++ b/dsl/query-dsl/blocking/src/main/kotlin/org/occurrent/dsl/query/blocking/DomainEventQueriesExtensions.kt
@@ -48,9 +48,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 /**
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
  *
- * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
- * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
- * for.
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
+ * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
+ * already produced.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
@@ -70,9 +70,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 /**
  * Query by type of domain event ([T]).
  *
- * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
- * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
- * for.
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
+ * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
+ * already produced.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.
@@ -90,9 +90,9 @@ fun <T : Any> DomainEventQueries<in T>.queryForSequence(
 /**
  * Query by type of domain event ([T]).
  *
- * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
- * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
- * for.
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
+ * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
+ * already produced.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [DomainEventQueries.query] instead and close the stream yourself.

--- a/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
+++ b/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
@@ -25,8 +25,9 @@ import kotlin.streams.asSequence
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
  *
  * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
- * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
- * already produced.
+ * `limit` is a parameter the query itself carries, telling it how many elements to return. `.take(n)` still leaves
+ * the query open to return everything and only stops pulling from it after `n`, which is exactly why closing it
+ * yourself, as below, still matters.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [EventStoreQueries.query] instead and close the stream yourself.

--- a/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
+++ b/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
@@ -24,9 +24,9 @@ import kotlin.streams.asSequence
 /**
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
  *
- * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
- * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
- * for.
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result.
+ * `limit` is a parameter the query itself carries, where `.take(n)` only trims what a fully iterated [Sequence]
+ * already produced.
  *
  * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
  * If you stop early, read through [EventStoreQueries.query] instead and close the stream yourself.

--- a/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
+++ b/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStoreQueriesExtensions.kt
@@ -23,6 +23,14 @@ import kotlin.streams.asSequence
 
 /**
  * Query that returns a [Sequence] instead of a [java.util.stream.Stream].
+ *
+ * If you only want the first few elements, pass [limit] here rather than calling `.take(n)` on the result. Passing
+ * it pushes the limit into the query, so the cursor exhausts on its own instead of staying open past what you asked
+ * for.
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [EventStoreQueries.query] instead and close the stream yourself.
+ *
  * @see EventStoreQueries.query
  */
 fun EventStoreQueries.queryForSequence(

--- a/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStreamExtensions.kt
+++ b/eventstore/api/blocking/src/main/kotlin/org/occurrent/eventstore/api/blocking/EventStreamExtensions.kt
@@ -20,5 +20,8 @@ import kotlin.streams.asSequence
 
 /**
  * Simply a convenience function that allows you to get the events as a [Sequence]
+ *
+ * A [Sequence] cannot be closed, and the underlying read may hold a database resource, so consume this to the end.
+ * If you stop early, read through [EventStream.events] instead and close the stream yourself.
  */
 fun <T : Any> EventStream<T>.eventSequence() = events().asSequence()


### PR DESCRIPTION
Three documentation-only fixes from the 0.34.0 doc sweep, none touching behavior.

`Projection`'s class and `Builder.filter(Filter)` javadoc said a broader filter is always safe because the fold no-ops on unhandled events, without saying an event the `CloudEventConverter` can't convert fails delivery and stalls the subscription instead. I scoped both to match the caveat PR #770 added for the saga twin, and corrected the same sentence in the docs-site projection chapter.

Six Kotlin `Sequence`-returning query extensions were missing the cursor-leak warning two siblings already carry. I copied it verbatim to all six, and for the ones taking a `limit`, pointed at pushing it into the query instead of chaining `take(n)`.

I amended ADR 54 with the read-side reasoning from the maintainer's reply on #760. The ADR argues the write side at length and never covers why `ApplicationService#execute`'s domain function also takes a `List`, which is a read-side surface its own "the read side is untouched" claim didn't cover.

This diff is entirely comments and markdown, semantically inert, so the head commit carries `[ci skip]`.

Fixes #775
Fixes #761

References #760 (the ADR amendment answers that issue's question, but closing it is the reporter's call, not this PR's)
