### PR TITLE
Fix intermittent flakes in the Spring MongoDB subscription conformance suite

### DIFF
--- a/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelFixture.java
+++ b/subscription/mongodb/spring/blocking/src/test/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModelFixture.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.query.Query;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -94,6 +95,21 @@ class SpringMongoSubscriptionModelFixture implements SubscriptionModelFixture {
     @Override
     public boolean deliversEventsPublishedWhilePaused() {
         return true;
+    }
+
+    /**
+     * Wider than the 10 second default (#781). This model resumes through Spring Data's
+     * {@code DefaultMessageListenerContainer}, which reopens a change-stream cursor and hands it to a task
+     * executor rather than resuming on the calling thread, so a pause/resume round trip pays for a hop through
+     * that machinery on top of the change-stream reconnect itself. On a CI runner sharing its two vCPUs with
+     * everything else in the job, that hop is occasionally slow enough to brush the 10 second default, which
+     * this suite's own pause-then-redeliver assertions are the most exposed to. 12 seconds keeps the six-way
+     * stop/start test's twelve chained waits under its own 150 second method timeout without raising the
+     * shared TCK ceiling that every other model waits against too.
+     */
+    @Override
+    public Duration deliveryTimeout() {
+        return Duration.ofSeconds(12);
     }
 
     /**


### PR DESCRIPTION
I widened `SpringMongoSubscriptionModelFixture.deliveryTimeout()` from the 10 second default to 12 seconds. #781 reports the `subscription-mongodb-spring` shard failing three times in one afternoon, across two heads and two different pause/resume methods in `SubscriptionModelConformance$TheLifeCycle`, with every same-commit rerun green.

## What I ruled out

The issue's working theory was a reusable Testcontainers Mongo container plus a fixed database name, letting parallel CI activity cause `ChangeStreamHistoryLost` noise during a paused-hold assertion. I couldn't make that theory hold up:

- GitHub Actions runs each shard on its own ephemeral VM with its own Docker daemon, and modules inside a shard build sequentially (no `-T`), so no other process can share this container's oplog during a CI run. Cross-process contention isn't structurally possible here.
- `ReplicaSetReadyMongoDBContainer` already scopes every database name by process id and a per-container counter, so the "fixed database name" the class declares isn't actually fixed at the wire level.
- A freshly started container's oplog was about 3.6GB when I checked it locally. This test class writes at most a few hundred small documents, nowhere near enough to wrap an oplog that size.

## What I think is actually happening

`SpringMongoSubscriptionModel` resumes through Spring Data's `DefaultMessageListenerContainer`, which reopens a change-stream cursor by handing it to a task executor rather than resuming on the calling thread. A pause/resume round trip pays for that executor hop on top of the change-stream reconnect itself. On a CI runner sharing two vCPUs with the rest of the job, that occasionally takes long enough to brush the 10 second default `deliveryTimeout()`, and the two methods #781 saw fail are exactly the ones whose assertions wait on a pause/resume/redeliver round trip.

12 seconds keeps the six-subscription stop/start test's twelve chained waits under its existing 150 second method timeout (12 x 12 = 144s) without raising the shared TCK ceiling every other model waits against too.

## Where I'm not certain

I couldn't reproduce the failure. Five baseline runs of the conformance suite passed before this change, and four more passed after it, plus one run of the checkpoint conformance suite. #781 itself says these failures are rare, so a clean sample of this size doesn't prove much either way. I'm treating this as the lowest-risk mitigation available given the theory correction above, not as a confirmed fix, and I'd watch the shard's real CI incidence going forward rather than trust this PR's local numbers.

No changelog entry. Test infrastructure only, no runtime behavior changed.

Part of #781, which stays open, see the issue comment about the failure at 12 seconds

