### PR TITLE
Record that a released ADR is immutable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Three things this protocol has already been caught out by:
 
 ADRs live in `doc/architecture/decisions/`, **not** `doc/adr/`. Filenames are `NNNN-kebab-case-title.md`, numbered sequentially from the highest existing number. Write one for architectural decisions, not for minor implementation details.
 
-An ADR that has shipped in a release is immutable. Correct or change a released decision with a new ADR that supersedes or amends the old one by reference, and touch the released file only to update its Status section with a pointer to the successor, the way [ADR 111](doc/architecture/decisions/0111-record-applied-projection-position.md) points at its withdrawer. An ADR that has not shipped in any release yet may still be updated in place when that is the best option.
+An ADR that has shipped in a release is immutable. Correct or change a released decision with a new ADR that supersedes or amends the old one by reference, and touch the released file only to update its Status section with a pointer to the successor, the way [ADR 111](doc/architecture/decisions/0111-a-projection-records-the-position-it-has-applied.md) points at its withdrawer. An ADR that has not shipped in any release yet may still be updated in place when that is the best option.
 
 ## Changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ Three things this protocol has already been caught out by:
 
 ADRs live in `doc/architecture/decisions/`, **not** `doc/adr/`. Filenames are `NNNN-kebab-case-title.md`, numbered sequentially from the highest existing number. Write one for architectural decisions, not for minor implementation details.
 
+An ADR that has shipped in a release is immutable. Correct or change a released decision with a new ADR that supersedes or amends the old one by reference, and touch the released file only to update its Status section with a pointer to the successor, the way [ADR 111](doc/architecture/decisions/0111-record-applied-projection-position.md) points at its withdrawer. An ADR that has not shipped in any release yet may still be updated in place when that is the best option.
+
 ## Changelog
 
 Update `changelog.md` after any change that affects code behavior, a public API, build or runtime behavior, or a notable user-facing capability. Small documentation-only edits do not need an entry.


### PR DESCRIPTION
A released decision changes through a new ADR that supersedes or amends it by reference, with the released file touched only for a Status pointer to the successor. An unreleased ADR may still be updated in place when that is the best option. Ruled by Johan 2026-08-17, prompted by the 0.34.0 cycle amending released ADR 54 in place.