### PR TITLE
Reject a negative skip instead of returning every event

### DIFF
--- a/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
+++ b/eventstore/inmemory/src/main/java/org/occurrent/eventstore/inmemory/InMemoryEventStore.java
@@ -605,6 +605,9 @@ public class InMemoryEventStore implements EventStore, EventStoreOperations, Eve
 
     @Override
     public EventStream<CloudEvent> read(String streamId, @Nullable StreamReadFilter filter, int skip, int limit) {
+        if (skip < 0) {
+            throw new IllegalArgumentException("skip cannot be negative");
+        }
         List<CloudEvent> events = state.get(streamId);
         if (events == null) {
             return new EventStreamImpl(streamId, 0, Collections.emptyList());

--- a/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
+++ b/eventstore/mongodb/native/src/main/java/org/occurrent/eventstore/mongodb/nativedriver/MongoEventStore.java
@@ -167,6 +167,9 @@ public class MongoEventStore implements EventStore, EventStoreOperations, EventS
     }
 
     private EventStreamImpl<Document> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
+        if (skip < 0) {
+            throw new IllegalArgumentException("skip cannot be negative");
+        }
         // Join the transaction an external executor opened on this thread, if any, so a read of the just-written
         // (still uncommitted) tail issued from inside that transaction sees the events. Without an ambient session
         // this reads non-transactionally, exactly as before.

--- a/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
+++ b/eventstore/mongodb/spring/blocking/src/main/java/org/occurrent/eventstore/mongodb/spring/blocking/SpringMongoEventStore.java
@@ -770,6 +770,9 @@ public class SpringMongoEventStore implements EventStore, EventStoreOperations, 
     }
 
     private EventStreamImpl<Document> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
+        if (skip < 0) {
+            throw new IllegalArgumentException("skip cannot be negative");
+        }
         long currentStreamVersion = currentStreamVersion(streamId);
         if (currentStreamVersion == 0) {
             return new EventStreamImpl<>(streamId, 0, Stream.empty());

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -618,6 +618,9 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
     }
 
     private Mono<EventStreamImpl> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
+        if (skip < 0) {
+            throw new IllegalArgumentException("skip cannot be negative");
+        }
         return currentStreamVersion(streamId)
                 .flatMap(currentStreamVersion -> {
                     // Uses "lte" currentStreamVersion instead of a transaction on read, so an event another thread

--- a/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
+++ b/eventstore/mongodb/spring/reactor/src/main/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStore.java
@@ -619,7 +619,7 @@ public class ReactorMongoEventStore implements EventStore, EventStoreOperations,
 
     private Mono<EventStreamImpl> readEventStream(String streamId, @Nullable StreamReadFilter streamReadFilter, int skip, int limit) {
         if (skip < 0) {
-            throw new IllegalArgumentException("skip cannot be negative");
+            return Mono.error(new IllegalArgumentException("skip cannot be negative"));
         }
         return currentStreamVersion(streamId)
                 .flatMap(currentStreamVersion -> {

--- a/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamEventStoreConformance.java
+++ b/tck/eventstore-blocking/src/main/java/org/occurrent/tck/eventstore/blocking/StreamEventStoreConformance.java
@@ -243,6 +243,22 @@ public abstract class StreamEventStoreConformance extends EventStoreConformance 
                     () -> assertThat(stream.eventList()).isEmpty()
             );
         }
+
+        @Test
+        void rejects_a_negative_skip() {
+            eventStore().write(STREAM_ID, List.of(event("event-1", DEFINED)));
+
+            Throwable thrown = catchThrowable(() -> eventStore().read(STREAM_ID, -1, 10));
+
+            assertThat(thrown).isExactlyInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void rejects_a_negative_skip_even_when_the_stream_does_not_exist() {
+            Throwable thrown = catchThrowable(() -> eventStore().read("never-written", -1, 10));
+
+            assertThat(thrown).isExactlyInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested
@@ -436,6 +452,15 @@ public abstract class StreamEventStoreConformance extends EventStoreConformance 
             EventStream<CloudEvent> stream = filteredReader().read(STREAM_ID, StreamReadFilter.type(CHANGED), 2, 10);
 
             assertThat(idsOf(stream.eventList())).containsExactly("event-3", "event-4");
+        }
+
+        @Test
+        void rejects_a_negative_skip() {
+            writeThreeEvents();
+
+            Throwable thrown = catchThrowable(() -> filteredReader().read(STREAM_ID, StreamReadFilter.type(CHANGED), -1, 10));
+
+            assertThat(thrown).isExactlyInstanceOf(IllegalArgumentException.class);
         }
 
         private void writeThreeEvents() {

--- a/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/ReactiveEventStoreConformance.java
+++ b/tck/eventstore-reactor/src/main/java/org/occurrent/tck/eventstore/reactor/ReactiveEventStoreConformance.java
@@ -214,6 +214,16 @@ public abstract class ReactiveEventStoreConformance {
             assertThatThrownBy(() -> await(write))
                     .isExactlyInstanceOf(DuplicateCloudEventException.class);
         }
+
+        @Test
+        void a_negative_skip_reaches_the_subscriber_rather_than_the_assembling_call() {
+            Mono<EventStream<CloudEvent>> read = assertDoesNotThrow(
+                    () -> eventStore().read(STREAM_1, -1, 10),
+                    "assembling a read that is going to fail must not throw, or the failure never reaches onErrorResume");
+
+            assertThatThrownBy(() -> await(read))
+                    .isExactlyInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested


### PR DESCRIPTION
I added a negative-skip check to all four event stores after Copilot's suppressed review comments on #814 caught a regression the skip fix introduced.

#814 (merged) fixed #810's three bugs. Those were skip-under-filter drift, a native Mongo cursor leak, and a dead-code cleanup mutation testing showed was never an active bug. Combining `skip` with a stream-version predicate (`streamVersion > skip`) fixed the drift, but it also turned a negative skip into `streamVersion > -1`, which matches every event instead of being rejected. I found and fixed that while addressing #814's review, but #814 merged before that fix was ready, so it never made it into main. This PR is just that fix, on its own.

I changed `MongoEventStore.java`, `SpringMongoEventStore.java`, `ReactorMongoEventStore.java`, and `InMemoryEventStore.java` to validate `skip >= 0` and throw `IllegalArgumentException` before the empty-stream early return, matching the convention `ExecuteOptions.fromStreamVersion` and `DcbReadOptions` already use.

I added conformance tests to `StreamEventStoreConformance` covering both the plain `read(streamId, skip, limit)` and filtered `read(streamId, filter, skip, limit)` paths, including a stream that doesn't exist yet, so one shared test covers all four stores.

I mutation-tested the native and in-memory stores by hand (removed the validation, confirmed the new tests failed, restored it). Spring blocking and reactor use the identical code shape, so I didn't mutation-test those separately.

The negative-skip behavior never shipped. It only ever existed on an unreleased branch, so there's no changelog entry, just a fix landing before release.

Related to #810.
