### PR TITLE
Qualify PushObserver's filter-throw and Mono-resubscription contracts

### DIFF
--- a/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushObserver.java
+++ b/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushObserver.java
@@ -28,11 +28,12 @@ import org.jspecify.annotations.NullMarked;
  * Called once per event, whether or not a handler ends up running. {@code matched} is {@code true} only when the
  * model is running and a currently registered, unpaused subscription's filter accepted the event, independent of
  * whether that handler goes on to succeed or throw. It shares the same filter evaluation the actual dispatch
- * decision is made from, so the two can never disagree. A filter that throws while being evaluated (a supplied
- * {@code DataFieldReader} can) is reported as unmatched too, before that exception propagates. A
- * {@link RuntimeException} or {@link AssertionError} the observer itself throws is caught and logged rather than
- * propagated, so a broken observer cannot turn an event that was actually delivered into a broker redelivery.
- * Another {@link Error} still propagates, as it does everywhere else on this stack.
+ * decision is made from, so the two can never disagree. A {@link RuntimeException} or {@link AssertionError} a
+ * filter throws while being evaluated (a supplied {@code DataFieldReader} can) is reported as unmatched too, before
+ * that exception propagates. The same is true of the observer's own {@link RuntimeException} or
+ * {@link AssertionError}, caught and logged rather than propagated, so a broken observer cannot turn an event that
+ * was actually delivered into a broker redelivery. Another {@link Error}, from either, still propagates without
+ * telling the observer, the same as everywhere else on this stack.
  * <p>
  * The default, {@link #noop()}, changes nothing for existing code, and {@link PushSubscriptionModel} skips both this
  * call and the match check entirely when no other observer is configured.

--- a/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushObserver.java
+++ b/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushObserver.java
@@ -28,12 +28,17 @@ import org.jspecify.annotations.NullMarked;
  * Called once per event, whether or not a handler ends up running. {@code matched} is {@code true} only when the
  * model is running and a currently registered, unpaused subscription's filter accepted the event, independent of
  * whether that handler goes on to succeed or throw. It shares the same filter evaluation the actual dispatch
- * decision is made from, so the two can never disagree. A {@link RuntimeException} or {@link AssertionError} a
- * filter throws while being evaluated (a supplied {@code DataFieldReader} can) is reported as unmatched too, before
- * that exception propagates. The same is true of the observer's own {@link RuntimeException} or
- * {@link AssertionError}, caught and logged rather than propagated, so a broken observer cannot turn an event that
- * was actually delivered into a broker redelivery. Another {@link Error}, from either, still propagates without
- * telling the observer, the same as everywhere else on this stack.
+ * decision is made from, so the two can never disagree.
+ * <p>
+ * A filter that throws while being evaluated (a supplied {@code DataFieldReader} can) never gets to answer whether
+ * it matched. A {@link RuntimeException} or {@link AssertionError} is reported to the observer as {@code false}
+ * instead, standing in for the answer that never came, before that exception propagates. Any other {@link Error}
+ * skips the observer entirely and propagates straight out.
+ * <p>
+ * The observer itself can throw too, after being told the real {@code matched}. A {@link RuntimeException} or
+ * {@link AssertionError} it throws is caught and logged rather than propagated, so a broken observer cannot turn an
+ * event that was actually delivered into a broker redelivery. Any other {@link Error} it throws still propagates,
+ * once the observer has already run.
  * <p>
  * The default, {@link #noop()}, changes nothing for existing code, and {@link PushSubscriptionModel} skips both this
  * call and the match check entirely when no other observer is configured.

--- a/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushSubscriptionModel.java
+++ b/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushSubscriptionModel.java
@@ -109,8 +109,10 @@ public class PushSubscriptionModel extends RegisteringSubscribable implements Pu
      * refusing would fail the write instead of protecting anything. The domain-event feed, which is broker-only, does
      * refuse. See ADR 104. A configured {@link PushObserver} is told about the event, matched or not, before delivery
      * is attempted, and that is where to get visibility into it instead. Told about the event even when a
-     * subscription's filter itself throws while being evaluated (a supplied {@link DataFieldReader} can), with
-     * {@code matched} reported as {@code false}, before that exception propagates as it always has.
+     * subscription's filter itself throws a {@link RuntimeException} or {@link AssertionError} while being evaluated
+     * (a supplied {@link DataFieldReader} can), with {@code matched} reported as {@code false}, before that
+     * exception propagates as it always has. Another {@link Error} bypasses the observer and propagates directly,
+     * see {@link PushObserver}.
      *
      * @param cloudEvent The event received from the external source.
      */

--- a/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushObserver.java
+++ b/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushObserver.java
@@ -29,11 +29,17 @@ import org.jspecify.annotations.NullMarked;
  * Called once per event, whether or not a handler ends up running. {@code matched} is {@code true} only when the
  * model is running and a currently registered, unpaused subscription's filter accepted the event, independent of
  * whether that handler goes on to succeed or error. It shares the same filter evaluation the actual dispatch
- * decision is made from, so the two can never disagree. A filter that throws while being evaluated (a supplied
- * {@code DataFieldReader} can) is reported as unmatched too, before that error propagates. A
- * {@link RuntimeException} or {@link AssertionError} the observer itself throws is caught and logged rather than
- * propagated, so a broken observer cannot turn an event that was actually delivered into a broker redelivery.
- * Another {@link Error} still propagates, as it does everywhere else on this stack.
+ * decision is made from, so the two can never disagree. A {@link RuntimeException} or {@link AssertionError} a
+ * filter throws while being evaluated (a supplied {@code DataFieldReader} can) is reported as unmatched too, before
+ * that error propagates. The same is true of the observer's own {@link RuntimeException} or {@link AssertionError},
+ * caught and logged rather than propagated, so a broken observer cannot turn an event that was actually delivered
+ * into a broker redelivery. Another {@link Error}, from either, still propagates without telling the observer, the
+ * same as everywhere else on this stack.
+ * <p>
+ * The returned {@link reactor.core.publisher.Mono} from {@link PushSubscriptionModel#accept(CloudEvent)} is cold, so
+ * "once per event" means once per subscription to it, not once per event handed to {@code accept(..)}. Subscribing
+ * twice to the same {@code Mono} observes and, if eligible, dispatches the same event twice, the same way
+ * {@code route(CloudEvent)} already re-dispatches on a resubscription.
  * <p>
  * The default, {@link #noop()}, changes nothing for existing code, and {@link PushSubscriptionModel} skips both this
  * call and the match check entirely when no other observer is configured.

--- a/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushObserver.java
+++ b/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushObserver.java
@@ -29,12 +29,17 @@ import org.jspecify.annotations.NullMarked;
  * Called once per event, whether or not a handler ends up running. {@code matched} is {@code true} only when the
  * model is running and a currently registered, unpaused subscription's filter accepted the event, independent of
  * whether that handler goes on to succeed or error. It shares the same filter evaluation the actual dispatch
- * decision is made from, so the two can never disagree. A {@link RuntimeException} or {@link AssertionError} a
- * filter throws while being evaluated (a supplied {@code DataFieldReader} can) is reported as unmatched too, before
- * that error propagates. The same is true of the observer's own {@link RuntimeException} or {@link AssertionError},
- * caught and logged rather than propagated, so a broken observer cannot turn an event that was actually delivered
- * into a broker redelivery. Another {@link Error}, from either, still propagates without telling the observer, the
- * same as everywhere else on this stack.
+ * decision is made from, so the two can never disagree.
+ * <p>
+ * A filter that throws while being evaluated (a supplied {@code DataFieldReader} can) never gets to answer whether
+ * it matched. A {@link RuntimeException} or {@link AssertionError} is reported to the observer as {@code false}
+ * instead, standing in for the answer that never came, before that error propagates. Any other {@link Error} skips
+ * the observer entirely and propagates straight out.
+ * <p>
+ * The observer itself can throw too, after being told the real {@code matched}. A {@link RuntimeException} or
+ * {@link AssertionError} it throws is caught and logged rather than propagated, so a broken observer cannot turn an
+ * event that was actually delivered into a broker redelivery. Any other {@link Error} it throws still propagates,
+ * once the observer has already run.
  * <p>
  * The returned {@link reactor.core.publisher.Mono} from {@link PushSubscriptionModel#accept(CloudEvent)} is cold, so
  * "once per event" means once per subscription to it, not once per event handed to {@code accept(..)}. Subscribing

--- a/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushSubscriptionModel.java
+++ b/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushSubscriptionModel.java
@@ -100,9 +100,10 @@ public class PushSubscriptionModel extends RegisteringSubscribable implements Pu
      * the write path, where the event is already durably stored and refusing would fail the write instead of
      * protecting anything. The domain-event feed, which is broker-only, does refuse. See ADR 104. A configured
      * {@link PushObserver} is told about the event, matched or not, before delivery is attempted, and that is where
-     * to get visibility into it instead. Told about the event even when a subscription's filter itself throws while
-     * being evaluated (a supplied {@link DataFieldReader} can), with {@code matched} reported as {@code false},
-     * before that exception propagates as it always has.
+     * to get visibility into it instead. Told about the event even when a subscription's filter itself throws a
+     * {@link RuntimeException} or {@link AssertionError} while being evaluated (a supplied {@link DataFieldReader}
+     * can), with {@code matched} reported as {@code false}, before that exception propagates as it always has.
+     * Another {@link Error} bypasses the observer and propagates directly, see {@link PushObserver}.
      *
      * @param cloudEvent The event received from the external source.
      * @return A {@link Mono} that completes when the handler has completed.

--- a/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/PushSubscriptionModelTest.java
+++ b/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/PushSubscriptionModelTest.java
@@ -213,6 +213,24 @@ class PushSubscriptionModelTest {
     }
 
     @Test
+    void resubscribing_the_same_mono_observes_and_dispatches_the_event_again() {
+        // The Mono accept(..) returns is cold, the same way route(CloudEvent)'s already was, so "once per event"
+        // means once per subscription to it, not once per event handed to accept(..).
+        List<String> observed = new ArrayList<>();
+        List<String> handled = new ArrayList<>();
+        PushSubscriptionModel model = new PushSubscriptionModel(DataFieldReader.refusing(),
+                (CloudEvent cloudEvent, boolean matched) -> observed.add(cloudEvent.getId()));
+        model.subscribe("sub", cloudEvent -> Mono.fromRunnable(() -> handled.add(cloudEvent.getId())));
+
+        Mono<Void> pending = model.accept(cloudEvent("1", "NameDefined"));
+        StepVerifier.create(pending).verifyComplete();
+        StepVerifier.create(pending).verifyComplete();
+
+        assertThat(observed).containsExactly("1", "1");
+        assertThat(handled).containsExactly("1", "1");
+    }
+
+    @Test
     void the_observer_is_told_an_event_is_unmatched_when_nothing_is_registered() {
         List<Boolean> matches = new ArrayList<>();
         PushSubscriptionModel model = new PushSubscriptionModel(DataFieldReader.refusing(),


### PR DESCRIPTION
Small follow-up to #802 / #824.

I had one more round of Copilot review feedback in flight on #824 when Johan merged it, so this commit landed on the branch after the merge and never made it into main. Opening it as its own PR rather than losing it.

Two documentation gaps, no behavior changes:

- The `PushObserver` and `PushSubscriptionModel` javadoc said a filter that "throws" is reported as unmatched before propagating, without saying which throwables that covers. `routeReportingMatch(..)` only catches `RuntimeException` and `AssertionError`, the same as the observer's own throw, so a bare `Error` from the matcher already bypassed the observer. Qualified the javadoc to say so.
- The reactor `PushObserver` javadoc claimed observation happens once per event without saying the returned `Mono` is cold. Resubscribing it observes and dispatches the same event again, the same way `route(CloudEvent)` already re-dispatches on resubscription. Documented it and added a regression test that subscribes the same `Mono` twice.
