### PR TITLE
Cover the replayAbandoned forwarding leg on both replay-aware bridges

### DIFF
--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/CatchupProjectionFeedTest.java
@@ -26,6 +26,7 @@ import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.cloudevents.OccurrentCloudEventExtension;
 import org.occurrent.dsl.projection.Projection;
 import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ReplayAware;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.eventstore.api.PositionRange;
 import org.occurrent.eventstore.api.blocking.PositionOrderedReader;
@@ -67,6 +68,25 @@ class CatchupProjectionFeedTest {
         // A live domain event is folded directly, no CloudEvent involved.
         feed.accept(new Counted("3"));
         assertThat(repo.get("counter")).isEqualTo(3);
+    }
+
+    @Test
+    void a_stopped_catch_up_forwards_replay_abandoned_to_a_replay_aware_view_instead_of_replay_completed() {
+        InMemoryEventStore store = new InMemoryEventStore();
+        CloudEventConverter<Counted> converter = countedConverter();
+        store.write("s", converter.toCloudEvents(List.of(new Counted("1"), new Counted("2"))));
+
+        List<String> calls = new CopyOnWriteArrayList<>();
+        ReplayAwareView view = new ReplayAwareView(calls);
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "counter", view, Filter.all(), store, converter, Counted::eventId, null);
+        // Stops from inside the first fold, so the stop is in place before the replay considers delivering "2" and
+        // the abandon runs on a replay genuinely still in flight.
+        view.onUpdate = feed::stopCatchUp;
+
+        feed.catchUp();
+
+        assertThat(calls).containsExactly("replayStarted", "update:1", "replayAbandoned");
     }
 
     @Test
@@ -517,5 +537,41 @@ class CatchupProjectionFeedTest {
                 callsReceived.add("metadata:" + event.eventId());
             }
         };
+    }
+
+    private static final class ReplayAwareView implements MaterializedView<Counted>, ReplayAware {
+        private final List<String> calls;
+        private Runnable onUpdate = () -> {
+        };
+
+        private ReplayAwareView(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public void update(Counted event) {
+            calls.add("update:" + event.eventId());
+            onUpdate.run();
+        }
+
+        @Override
+        public void update(EventMetadata metadata, Counted event) {
+            update(event);
+        }
+
+        @Override
+        public void replayStarted() {
+            calls.add("replayStarted");
+        }
+
+        @Override
+        public void replayCompleted() {
+            calls.add("replayCompleted");
+        }
+
+        @Override
+        public void replayAbandoned() {
+            calls.add("replayAbandoned");
+        }
     }
 }

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdateTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/BlockingMaterializedViewUpdateTest.java
@@ -59,6 +59,20 @@ class BlockingMaterializedViewUpdateTest {
     }
 
     @Test
+    void a_stopped_catch_up_forwards_replay_abandoned_to_the_wrapped_view_instead_of_replay_completed() {
+        FakeReplayAwareView view = new FakeReplayAwareView();
+        CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
+                "counter", Projections.reactiveUpdateWithMetadata(view), Filter.all(), reader("1", "2"), countedConverter(), Counted::eventId, null);
+        // Stops from inside the first fold, so the stop is in place before the replay considers delivering "2" and
+        // the abandon runs on a replay genuinely still in flight.
+        view.onUpdate = feed::stopCatchUp;
+
+        feed.catchUp().block();
+
+        assertThat(view.calls).containsExactly("replayStarted", "update:1:replaying", "replayAbandoned");
+    }
+
+    @Test
     void a_blocking_view_with_no_replay_awareness_is_driven_write_through_with_no_lifecycle_calls() {
         FakeView view = new FakeView();
         CatchupProjectionFeed<Counted> feed = CatchupProjectionFeed.create(
@@ -71,6 +85,8 @@ class BlockingMaterializedViewUpdateTest {
 
     private static final class FakeReplayAwareView implements MaterializedView<Counted>, ReplayAware {
         private final List<String> calls = new CopyOnWriteArrayList<>();
+        private volatile Runnable onUpdate = () -> {
+        };
         private boolean replaying = false;
 
         @Override
@@ -81,6 +97,7 @@ class BlockingMaterializedViewUpdateTest {
         @Override
         public void update(EventMetadata metadata, Counted event) {
             calls.add("update:" + event.eventId() + (replaying ? ":replaying" : ":live"));
+            onUpdate.run();
         }
 
         @Override


### PR DESCRIPTION
I added a test on each side of the `ReplayAware`/`ReactiveReplayAware` bridge for the one gap left in the coverage after #746's re-check: `replayStarted` and `replayCompleted` were both exercised on the blocking `CatchupProjectionFeed` and the reactor `BlockingMaterializedViewUpdate` bridge, but `replayAbandoned` (a stopped catch-up) was not on either. Deleting either forwarding call would not have failed the suite before this.

I confirmed each test by hand-reverting its forwarding line, watching the test fail, and restoring the original from a saved copy. No production code changed.
