### PR TITLE
Fix broker forwarder tests refusing to subscribe with no stored checkpoint

### DIFF
--- a/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/CloudEventForwarderTest.java
+++ b/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/CloudEventForwarderTest.java
@@ -59,7 +59,9 @@ class CloudEventForwarderTest {
 
         assertThatThrownBy(() -> wrappedModel.publish(event)).hasMessage("Simulated publish failure");
 
-        assertThat(checkpointStorage.read("subscription1")).isNull();
+        // Subscribing already recorded the wrapped model's start position; the failed publish must not move it
+        // past that.
+        assertThat(checkpointStorage.read("subscription1")).isEqualTo(GlobalCheckpoint.of(0));
     }
 
     @Test

--- a/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/DomainEventForwarderTest.java
+++ b/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/DomainEventForwarderTest.java
@@ -74,7 +74,9 @@ class DomainEventForwarderTest {
         assertThatThrownBy(() -> wrappedModel.publish(checkpointAwareEvent("hello", 1)))
                 .hasMessage("Simulated publish failure");
 
-        assertThat(checkpointStorage.read("subscription1")).isNull();
+        // Subscribing already recorded the wrapped model's start position; the failed publish must not move it
+        // past that.
+        assertThat(checkpointStorage.read("subscription1")).isEqualTo(GlobalCheckpoint.of(0));
     }
 
     @Test

--- a/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/FakeCheckpointAwareSubscriptionModel.java
+++ b/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/FakeCheckpointAwareSubscriptionModel.java
@@ -19,6 +19,7 @@ package org.occurrent.broker.api.blocking;
 import io.cloudevents.CloudEvent;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.Checkpoint;
+import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
@@ -34,7 +35,9 @@ import static java.util.Objects.requireNonNull;
  * channel, so a forwarder can be wrapped in a real {@link org.occurrent.subscription.blocking.durable.DurableSubscriptionModel}
  * and exercised without a broker, an event store, or an executor: {@link #publish(CloudEvent)} calls the registered
  * action synchronously, on the calling thread, so a test sees the checkpoint move (or not) before it makes its
- * assertions.
+ * assertions. {@link #globalCheckpoint()} answers {@link GlobalCheckpoint#of} {@code 0}, the position a real
+ * wrapped model reports for an empty stream, so {@code DurableSubscriptionModel} records that as the first
+ * position instead of refusing to start.
  */
 class FakeCheckpointAwareSubscriptionModel implements CheckpointAwareSubscriptionModel {
 
@@ -122,7 +125,7 @@ class FakeCheckpointAwareSubscriptionModel implements CheckpointAwareSubscriptio
     }
 
     @Override
-    public @Nullable Checkpoint globalCheckpoint() {
-        return null;
+    public Checkpoint globalCheckpoint() {
+        return GlobalCheckpoint.of(0);
     }
 }


### PR DESCRIPTION
I changed the `broker/api/blocking` forwarder test fixture so it stops tripping the durable-subscription refusal added in #854.

`FakeCheckpointAwareSubscriptionModel.globalCheckpoint()` always returned null, standing in for "no answer available". #854 added a check in `DurableSubscriptionModel.subscribe()` that refuses to start when checkpoint storage is empty and the wrapped model can't answer a position. That's correct for a wrapped model that genuinely can't answer, but the fake model was never meant to exercise that case. Once #854 merged, every default-position subscribe in `CloudEventForwarderTest` and `DomainEventForwarderTest` hit the refusal and threw, failing 5 tests on main on both JDKs.

I made `globalCheckpoint()` answer `GlobalCheckpoint.of(0)`, the position a real wrapped model reports for an empty stream, instead of null. Subscribing now records that starting position before any event is delivered, the way it would against a real subscription model. I updated the two "leaves the checkpoint unmoved" tests, one per forwarder test class, to assert that recorded starting checkpoint instead of null, since the checkpoint is no longer empty at that point.

Only the three test files in `broker/api/blocking/src/test` changed. Nothing in `src/main` moved.

**Verification**
- `mvn -pl broker/api/blocking -am test`: BUILD SUCCESS, 10 tests, 0 failures
- `mvn -pl subscription/util/blocking/durable-subscription -am test`: BUILD SUCCESS, 62 tests, 0 failures
