### PR TITLE
Add falsifier tests for append identity read-your-writes

### DIFF
--- a/dsl/projection-dsl/blocking/pom.xml
+++ b/dsl/projection-dsl/blocking/pom.xml
@@ -98,6 +98,21 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Real MongoDB event store + subscription model for the U5 falsifier suite (ADR 132 / #740), which proves
+             the recording wrapper against genuine commit-order and delivery behaviour rather than the in-memory
+             store's synchronous one. -->
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-eventstore-mongodb-spring-blocking</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-subscription-mongodb-spring-blocking</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.occurrent</groupId>
             <artifactId>occurrent-subscription-inmemory</artifactId>

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/AppendIdEmptyAppendContractTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/AppendIdEmptyAppendContractTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.application.service.blocking.ApplicationService;
+import org.occurrent.application.service.blocking.generic.GenericApplicationService;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The empty-append contract (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>,
+ * decision 4): an append that persists no events stamps nothing, so its {@link WriteResult#appendId()} is absent,
+ * and there is genuinely nothing to wait for.
+ * <p>
+ * The TCK already asserts absence at the {@code EventStore.write(...)} level directly. This proves the SAME
+ * contract at the caller-facing surface an application actually uses:
+ * {@code ApplicationService.execute(streamId, domainFunction)} routinely returns zero events (no emptiness guard in
+ * {@code GenericApplicationService}), and the {@code Optional<AppendId>} component is what makes the absent case a
+ * contract rather than a request, decision 3's reasoning. This falsifies two things at once: that the real
+ * application-facing write path reports absence honestly, and that {@link AppliedAppendStore#waitUntilApplied}
+ * cannot be reached with an absent id without the caller explicitly unwrapping an empty {@link java.util.Optional}
+ * first, which is exactly the footgun decision 3 says the type system prevents.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class AppendIdEmptyAppendContractTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:empty-append-contract");
+
+    sealed interface TestEvent {
+    }
+
+    record Noop() implements TestEvent {
+    }
+
+    @Test
+    void a_command_that_writes_no_events_returns_a_write_result_whose_append_id_is_absent_and_cannot_reach_the_wait_unopened() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        CloudEventConverter<TestEvent> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
+        ApplicationService<TestEvent> applicationService = new GenericApplicationService<>(eventStore, converter);
+
+        // A domain function that decides nothing needs to happen: the routine "no-op command" shape
+        // GenericApplicationService.execute has no emptiness guard against.
+        WriteResult result = applicationService.execute(UUID.randomUUID().toString(), events -> List.of());
+
+        assertThat(result.appendId()).as("an append that persisted nothing stamps nothing").isEmpty();
+
+        // The compiler-enforced contract: a caller cannot reach waitUntilApplied with a value unless it explicitly
+        // unwraps the Optional first, and unwrapping an absent one fails loudly rather than handing a null through.
+        assertThatThrownBy(() -> result.appendId().orElseThrow())
+                .as("there is nothing to wait on, and the type forces that decision onto the caller before any wait is attempted")
+                .isInstanceOf(NoSuchElementException.class);
+
+        // waitUntilApplied itself has no overload that accepts an absent id: it takes a non-null AppendId, never an
+        // Optional, so this line simply cannot be written for an empty append without unwrapping first (proven by
+        // this file compiling at all: there is no waitUntilApplied(String, Optional<AppendId>, Duration) overload).
+        AppliedAppendStore store = AppliedAppendStore.inMemory();
+        assertThatThrownBy(() -> store.waitUntilApplied("orders", null, Duration.ofMillis(50)))
+                .as("waitUntilApplied rejects a null append id outright rather than silently never applying")
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void a_command_that_writes_events_returns_a_write_result_whose_append_id_is_present() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        CloudEventConverter<TestEvent> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
+        ApplicationService<TestEvent> applicationService = new GenericApplicationService<>(eventStore, converter);
+
+        WriteResult result = applicationService.execute(UUID.randomUUID().toString(), events -> List.of(new Noop()));
+
+        assertThat(result.appendId()).isPresent();
+        AppendId appendId = result.appendId().orElseThrow();
+        AppliedAppendStore store = AppliedAppendStore.inMemory();
+        store.recordApplied("orders", appendId);
+
+        assertThat(store.waitUntilApplied("orders", appendId, Duration.ofSeconds(1))).isTrue();
+    }
+}

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/AppendIdEmptyAppendContractTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/AppendIdEmptyAppendContractTest.java
@@ -81,9 +81,10 @@ class AppendIdEmptyAppendContractTest {
                 .as("there is nothing to wait on, and the type forces that decision onto the caller before any wait is attempted")
                 .isInstanceOf(NoSuchElementException.class);
 
-        // waitUntilApplied itself has no overload that accepts an absent id: it takes a non-null AppendId, never an
-        // Optional, so this line simply cannot be written for an empty append without unwrapping first (proven by
-        // this file compiling at all: there is no waitUntilApplied(String, Optional<AppendId>, Duration) overload).
+        // waitUntilApplied itself takes a non-null AppendId, never an Optional, so a caller holding only
+        // Optional<AppendId> has to unwrap it before this line can even be written. The assertion below checks the
+        // runtime half of that contract, a null that still reaches this method is rejected outright rather than
+        // treated as "never applies".
         AppliedAppendStore store = AppliedAppendStore.inMemory();
         assertThatThrownBy(() -> store.waitUntilApplied("orders", null, Duration.ofMillis(50)))
                 .as("waitUntilApplied rejects a null append id outright rather than silently never applying")

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
@@ -100,12 +100,22 @@ class RecordingMaterializedViewAbandonedReplayNonLieTest {
 
         Thread replay = new Thread(feed::catchUp);
         replay.start();
-        parked.await();
-        feed.stopCatchUp();
-        proceed.countDown();
+        try {
+            // Bounded rather than a bare await(): a regression that stops the replay from ever reaching the second
+            // event would otherwise hang this latch, and with it the whole Maven fork, forever. A bounded wait turns
+            // that regression into the test failure it should be instead of an unexplained CI timeout.
+            assertThat(parked.await(20, TimeUnit.SECONDS))
+                    .as("the replay never reached its second event, so it never parked for this test to abandon it")
+                    .isTrue();
+            feed.stopCatchUp();
+        } finally {
+            // Released unconditionally, including when the await above times out or stopCatchUp() throws, so the
+            // parked replay thread can never outlive this test method regardless of what failed.
+            proceed.countDown();
+        }
         replay.join(TimeUnit.SECONDS.toMillis(5));
 
-        assertThat(replay.isAlive()).isFalse();
+        assertThat(replay.isAlive()).as("the replay thread is still running after its bounded join").isFalse();
         // Nothing was flushed to the read model...
         assertThat(state.get("a")).isNull();
         assertThat(state.get("b")).isNull();

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.blocking;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.dsl.projection.MaterializedViewOptions;
+import org.occurrent.dsl.projection.Projection;
+import org.occurrent.dsl.projection.ReplayPhase;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.inmemory.InMemoryEventStore;
+import org.occurrent.retry.RetryStrategy;
+import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The abandoned-replay non-lie (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>,
+ * decision 6 / context "What a replay does to a record of membership"): {@code CoalescingMaterializedView} buffers a
+ * replayed update in memory and discards the buffer if the replay is abandoned before it flushes. If a recording
+ * wrapper recorded an append the moment the delegate's {@code update} returned, it would record an id for state a
+ * discarded buffer never wrote, since a coalescing view's {@code applyReportingWhetherApplied} reports {@code true}
+ * (queued) the moment an event is buffered, not once it is durable.
+ * <p>
+ * This wires the real production classes together: {@link CoalescingMaterializedView} (via
+ * {@link Projections#materializedView}) wrapped by the real {@link RecordingMaterializedView} (via
+ * {@link Projections#recordingAppliedAppends}), fed by a real {@link CatchupProjectionFeed}, using
+ * {@link ReplayPhase#neverReplays()} deliberately: on this pull-fed composition the only thing that can suppress
+ * recording during the replay is the {@code ReplayAware} lifecycle forwarding
+ * ({@code replayStarted}/{@code replayAbandoned}) the feed drives on the recording wrapper itself, exactly the
+ * mechanism {@code CatchupProjectionFeed}/{@code DomainEventFeed} compositions rely on in production. A phase that
+ * (wrongly) always answers "live" makes this a genuine falsifier of that forwarding, not a redundant re-test of the
+ * phase gate {@code RecordingMaterializedViewTest} already covers.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RecordingMaterializedViewAbandonedReplayNonLieTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:test");
+    private static final String PROJECTION_ID = "ticks";
+
+    record Ticked(String eventId) {
+        String key() {
+            return eventId.split("-")[0];
+        }
+    }
+
+    @Test
+    void an_abandoned_replay_records_nothing_for_the_events_its_discarded_buffer_never_wrote() throws InterruptedException {
+        InMemoryEventStore store = new InMemoryEventStore();
+        CountDownLatch parked = new CountDownLatch(1);
+        CountDownLatch proceed = new CountDownLatch(1);
+        AtomicInteger converted = new AtomicInteger();
+        // Parks the replay after the second event has been decoded (and, by the time it resumes, buffered), before
+        // a third can arrive, so the test can abandon a replay that genuinely still has an unflushed batch in flight.
+        CloudEventConverter<Ticked> converter = parkingConverter(converted, parked, proceed);
+        List<Ticked> events = List.of(new Ticked("a-0"), new Ticked("b-0"), new Ticked("a-1"));
+        WriteResult writeResult = store.write("s", converter.toCloudEvents(events));
+        AppendId appendId = writeResult.appendId().orElseThrow();
+        InMemoryCheckpointStorage marker = new InMemoryCheckpointStorage();
+
+        Map<String, Integer> state = new ConcurrentHashMap<>();
+        ViewStateRepository<Integer, String> repository = ViewStateRepository.create(state::get, state::put);
+        AppliedAppendStore appliedAppendStore = AppliedAppendStore.inMemory();
+        // A batch size larger than the whole history, so nothing flushes until replayCompleted() (which an abandon skips).
+        MaterializedView<Ticked> coalescing = Projections.materializedView(
+                tickProjection(), repository, RetryStrategy.none(), new MaterializedViewOptions(100));
+        MaterializedView<Ticked> recording = Projections.recordingAppliedAppends(coalescing, PROJECTION_ID, appliedAppendStore, ReplayPhase.neverReplays());
+        CatchupProjectionFeed<Ticked> feed = CatchupProjectionFeed.create(
+                PROJECTION_ID, recording, org.occurrent.filter.Filter.all(), store, converter, Ticked::eventId, marker);
+
+        Thread replay = new Thread(feed::catchUp);
+        replay.start();
+        parked.await();
+        feed.stopCatchUp();
+        proceed.countDown();
+        replay.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertThat(replay.isAlive()).isFalse();
+        // Nothing was flushed to the read model...
+        assertThat(state.get("a")).isNull();
+        assertThat(state.get("b")).isNull();
+        // ...and nothing was recorded as applied for it either. This is the assertion the pre-U5 test coverage never
+        // made: CoalescingMaterializedViewTest proves the repository got no writes, but never wraps the view in a
+        // RecordingMaterializedView to check the membership side of the same abandoned buffer.
+        assertThat(appliedAppendStore.hasApplied(PROJECTION_ID, appendId)).isFalse();
+
+        // The recording wrapper stays usable afterward: a live delivery (the recorder's replayStarted() marked
+        // lifecycleReplaying, but replayAbandoned() cleared it again) records normally. catchUp() itself never
+        // exercises this, since a bounded replay run never hands off to a live phase on its own, so this drives the
+        // wrapper directly the way a subscription's post-handover delivery would.
+        WriteResult liveWrite = store.write("s", tickedConverter().toCloudEvent(new Ticked("c-0")));
+        AppendId liveAppendId = liveWrite.appendId().orElseThrow();
+        List<CloudEvent> streamEvents = store.read("s").eventList();
+        CloudEvent liveCloudEvent = streamEvents.get(streamEvents.size() - 1);
+        recording.update(org.occurrent.cloudevents.EventMetadata.from(liveCloudEvent), new Ticked("c-0"));
+
+        assertThat(state.get("c")).isEqualTo(1);
+        assertThat(appliedAppendStore.hasApplied(PROJECTION_ID, liveAppendId)).isTrue();
+    }
+
+    private static Projection<Integer, Ticked, String> tickProjection() {
+        return Projection.<Integer, Ticked, String>builder(0)
+                .id(Ticked::key)
+                .on(Ticked.class, (state, event) -> state + 1)
+                .build();
+    }
+
+    private static CloudEventConverter<Ticked> tickedConverter() {
+        return new CloudEventConverter<>() {
+            @Override
+            public CloudEvent toCloudEvent(Ticked domainEvent) {
+                return CloudEventBuilder.v1()
+                        .withId(domainEvent.eventId())
+                        .withSource(SOURCE)
+                        .withType("Ticked")
+                        .build();
+            }
+
+            @Override
+            public Ticked toDomainEvent(CloudEvent cloudEvent) {
+                return new Ticked(cloudEvent.getId());
+            }
+
+            @Override
+            public String getCloudEventType(Class<? extends Ticked> type) {
+                return "Ticked";
+            }
+        };
+    }
+
+    private static CloudEventConverter<Ticked> parkingConverter(AtomicInteger converted, CountDownLatch parked, CountDownLatch proceed) {
+        CloudEventConverter<Ticked> delegate = tickedConverter();
+        return new CloudEventConverter<>() {
+            @Override
+            public CloudEvent toCloudEvent(Ticked domainEvent) {
+                return delegate.toCloudEvent(domainEvent);
+            }
+
+            @Override
+            public Ticked toDomainEvent(CloudEvent cloudEvent) {
+                Ticked event = delegate.toDomainEvent(cloudEvent);
+                if (converted.incrementAndGet() == 2) {
+                    parked.countDown();
+                    awaitUninterruptibly(proceed);
+                }
+                return event;
+            }
+
+            @Override
+            public String getCloudEventType(Class<? extends Ticked> type) {
+                return delegate.getCloudEventType(type);
+            }
+        };
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewAbandonedReplayNonLieTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,7 +99,17 @@ class RecordingMaterializedViewAbandonedReplayNonLieTest {
         CatchupProjectionFeed<Ticked> feed = CatchupProjectionFeed.create(
                 PROJECTION_ID, recording, org.occurrent.filter.Filter.all(), store, converter, Ticked::eventId, marker);
 
-        Thread replay = new Thread(feed::catchUp);
+        // Captured rather than left to escape the thread uncaught: JUnit never sees an exception a background
+        // thread throws, so without this a genuine regression that crashes the replay would leave the state and
+        // membership assertions below unexercised and still passing, for the wrong reason.
+        AtomicReference<Throwable> replayFailure = new AtomicReference<>();
+        Thread replay = new Thread(() -> {
+            try {
+                feed.catchUp();
+            } catch (Throwable t) {
+                replayFailure.set(t);
+            }
+        });
         replay.start();
         try {
             // Bounded rather than a bare await(): a regression that stops the replay from ever reaching the second
@@ -116,6 +127,7 @@ class RecordingMaterializedViewAbandonedReplayNonLieTest {
         replay.join(TimeUnit.SECONDS.toMillis(5));
 
         assertThat(replay.isAlive()).as("the replay thread is still running after its bounded join").isFalse();
+        assertThat(replayFailure.get()).as("the replay thread threw instead of abandoning cleanly").isNull();
         // Nothing was flushed to the read model...
         assertThat(state.get("a")).isNull();
         assertThat(state.get("b")).isNull();

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -178,6 +178,13 @@ class RecordingMaterializedViewMembershipInversionTest {
                     // applied, A's event has not committed yet, so nothing else has been recorded. A position-based
                     // watermark would have called this "applied up to B's position", wrongly including A's lower one.
                     assertThat(recordedInOrder).as("only B's append should be recorded while A is still paused before commit").containsExactly(appendIdB);
+                    // A's own append id is not known yet (uncommitted inside A's still-paused transaction, so it
+                    // cannot be read from anywhere outside it), which is why this cannot call hasApplied with A's
+                    // real id directly. A fresh, unrelated id stands in to exercise the read path itself rather than
+                    // relying only on the recordApplied spy above: hasApplied is a plain membership lookup against
+                    // the same set recordApplied writes to, so an id nothing has recorded for answers false, exactly
+                    // as A's real id must until its own commit reaches this projection.
+                    assertThat(appliedAppendStore.hasApplied(PROJECTION_ID, AppendId.mint())).isFalse();
 
                     // Release A: it commits last, with the lower position.
                     release.countDown();

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.blocking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson.JacksonCloudEventConverter;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.dsl.projection.Projection;
+import org.occurrent.dsl.projection.ReplayPhase;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The acceptance criterion issue #740 states, proven at the membership level
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>):
+ * "Two concurrent appends that commit in the reverse order of their positions. The wait for the stalled writer's
+ * append must not answer true until that writer's event has actually been applied."
+ * <p>
+ * Writer A reserves a stream position (outside its transaction, per ADR 84) and is then held paused before its
+ * transaction commits. Writer B, on a different stream over the same collection, reserves a strictly later position
+ * and commits immediately, so the change stream delivers B before A even though A's position is lower. A
+ * position-based watermark ("everything at or below the highest applied position is applied", the design ADR 122
+ * withdrew) would misreport A as applied the moment B is recorded, since B's position is higher than A's. The
+ * membership design tracks each append's own identity instead, so it must not make that mistake: {@code hasApplied}
+ * for A's append stays false while only B has been delivered, and only turns true once A's own event actually
+ * commits and is delivered.
+ */
+@Testcontainers
+@Timeout(120)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RecordingMaterializedViewMembershipInversionTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:membership-inversion");
+    private static final String PROJECTION_ID = "membership-inversion";
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = ReplicaSetReadyMongoDBContainer.withDefaultVersion();
+
+    @RegisterExtension
+    OccurrentMongoFlush flushMongoDBExtension = OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer));
+
+    record Ticked(String id) {
+    }
+
+    @Test
+    void the_wait_for_a_stalled_writers_append_does_not_answer_true_until_that_writers_event_is_actually_applied() throws Exception {
+        String databaseName = "membership_inversion";
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl(databaseName));
+        String collection = "events";
+
+        CountDownLatch reserved = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        // Writer A: paused right after its position is reserved (reservation happens outside the transaction, ADR
+        // 84), before its transaction commits.
+        MongoClient writerAClient = MongoClients.create(connectionString);
+        MongoTemplate writerATemplate = new MongoTemplate(writerAClient, requireNonNull(connectionString.getDatabase()));
+        PausingTransactionTemplate pausingTx = new PausingTransactionTemplate(
+                new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerAClient, requireNonNull(connectionString.getDatabase()))),
+                reserved, release);
+        SpringMongoEventStore writerAStore = newEventStore(writerATemplate, pausingTx, collection);
+
+        // Writer B: a plain store over the same collection, commits fully and immediately.
+        MongoClient writerBClient = MongoClients.create(connectionString);
+        MongoTemplate writerBTemplate = new MongoTemplate(writerBClient, requireNonNull(connectionString.getDatabase()));
+        SpringMongoEventStore writerBStore = newEventStore(writerBTemplate,
+                new TransactionTemplate(new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerBClient, requireNonNull(connectionString.getDatabase())))),
+                collection);
+
+        // A raw, side-channel subscription (independent of the recording wrapper under test) that records the real
+        // delivery order and the real position of every event, proving the inversion genuinely happened rather than
+        // being assumed.
+        MongoClient observerClient = MongoClients.create(connectionString);
+        MongoTemplate observerTemplate = new MongoTemplate(observerClient, requireNonNull(connectionString.getDatabase()));
+        SpringMongoSubscriptionModel observerModel = new SpringMongoSubscriptionModel(observerTemplate, collection, TimeRepresentation.RFC_3339_STRING);
+        List<EventMetadata> deliveryOrder = new CopyOnWriteArrayList<>();
+        Subscription observerSubscription = observerModel.subscribe("observer", StartAt.now(),
+                cloudEvent -> deliveryOrder.add(EventMetadata.from(cloudEvent)));
+        observerSubscription.waitUntilStarted();
+
+        // The recording projection under test: a real RecordingMaterializedView over a real live subscription, the
+        // shipped production path (Projections.recordingAppliedAppends), never a hand-rolled record call.
+        MongoClient recorderClient = MongoClients.create(connectionString);
+        MongoTemplate recorderTemplate = new MongoTemplate(recorderClient, requireNonNull(connectionString.getDatabase()));
+        SpringMongoSubscriptionModel recorderModel = new SpringMongoSubscriptionModel(recorderTemplate, collection, TimeRepresentation.RFC_3339_STRING);
+        CloudEventConverter<Ticked> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
+        ConcurrentHashMap<String, Integer> state = new ConcurrentHashMap<>();
+        ViewStateRepository<Integer, String> repository = ViewStateRepository.create(state::get, state::put);
+        Projection<Integer, Ticked, String> projection = Projection.<Integer, Ticked>singletonBuilder(0)
+                .on(Ticked.class, (count, event) -> count + 1)
+                .build();
+        AppliedAppendStore appliedAppendStore = AppliedAppendStore.inMemory();
+        List<AppendId> recordedInOrder = new CopyOnWriteArrayList<>();
+        AppliedAppendStore observedStore = recordingSpy(appliedAppendStore, recordedInOrder);
+        MaterializedView<Ticked> view = Projections.materializedView(projection, repository, PROJECTION_ID);
+        MaterializedView<Ticked> recordingView = Projections.recordingAppliedAppends(view, PROJECTION_ID, observedStore, ReplayPhase.neverReplays());
+        ProjectionRunner<Ticked> runner = ProjectionRunner.stream(recorderModel, converter);
+        Subscription recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
+        recordingSubscription.waitUntilStarted();
+
+        try {
+            // A starts writing and pauses, its position already reserved.
+            Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");
+            appender.start();
+            assertThat(reserved.await(30, TimeUnit.SECONDS)).as("writer A did not reach its paused transaction").isTrue();
+
+            // B commits fully, on a different stream, and reserves a strictly higher position than A's already-reserved one.
+            WriteResult resultB = writerBStore.write("stream-b", List.of(converter.toCloudEvent(new Ticked("b"))));
+            AppendId appendIdB = resultB.appendId().orElseThrow();
+
+            await().atMost(Duration.ofSeconds(20)).until(() -> appliedAppendStore.hasApplied(PROJECTION_ID, appendIdB));
+
+            // The crux of the acceptance criterion: at the moment B's (higher-position) append is recorded as
+            // applied, A's event has not committed yet, so nothing else has been recorded. A position-based
+            // watermark would have called this "applied up to B's position", wrongly including A's lower one.
+            assertThat(recordedInOrder).as("only B's append should be recorded while A is still paused before commit").containsExactly(appendIdB);
+
+            // Release A: it commits last, with the lower position.
+            release.countDown();
+            appender.join(TimeUnit.SECONDS.toMillis(30));
+            assertThat(appender.isAlive()).isFalse();
+
+            // Read A's append id back from what was actually delivered (not minted ahead of time), and prove the
+            // wait now (and only now) answers true for it.
+            await().atMost(Duration.ofSeconds(20)).until(() -> deliveryOrder.size() >= 2);
+            EventMetadata aMetadata = deliveryOrder.stream()
+                    .filter(metadata -> "stream-a".equals(metadata.getStreamId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("A's event was never observed as delivered"));
+            AppendId appendIdA = AppendId.from(aMetadata).orElseThrow();
+
+            assertThat(appliedAppendStore.waitUntilApplied(PROJECTION_ID, appendIdA, Duration.ofSeconds(20))).isTrue();
+            assertThat(recordedInOrder).as("B was recorded first, A only after its own commit").containsExactly(appendIdB, appendIdA);
+
+            // The real, independently observed positions confirm the inversion actually happened: A's position is
+            // lower than B's even though A committed and was delivered after B.
+            EventMetadata bMetadata = deliveryOrder.stream()
+                    .filter(metadata -> "stream-b".equals(metadata.getStreamId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(deliveryOrder.get(0).getStreamId()).as("B is delivered first, in real commit order").isEqualTo("stream-b");
+            assertThat(requireNonNull(aMetadata.getPosition())).as("but A's reserved position is lower than B's")
+                    .isLessThan(requireNonNull(bMetadata.getPosition()));
+        } finally {
+            recorderModel.stop();
+            observerModel.stop();
+        }
+    }
+
+    private static AppliedAppendStore recordingSpy(AppliedAppendStore delegate, List<AppendId> recordedInOrder) {
+        return new AppliedAppendStore() {
+            @Override
+            public void recordApplied(String projectionId, AppendId appendId) {
+                delegate.recordApplied(projectionId, appendId);
+                recordedInOrder.add(appendId);
+            }
+
+            @Override
+            public boolean hasApplied(String projectionId, AppendId appendId) {
+                return delegate.hasApplied(projectionId, appendId);
+            }
+
+            @Override
+            public void clear(String projectionId) {
+                delegate.clear(projectionId);
+            }
+        };
+    }
+
+    private static SpringMongoEventStore newEventStore(MongoTemplate template, TransactionTemplate transactionTemplate, String collection) {
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(collection)
+                .transactionConfig(transactionTemplate)
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .build();
+        return new SpringMongoEventStore(template, config);
+    }
+
+    /**
+     * A {@link TransactionTemplate} that, on its first {@code execute}, signals that the caller has entered the
+     * transaction (its stream position is already reserved by then, since reservation happens outside the
+     * transaction, ADR 84) and waits until released before running the real transaction. Subsequent calls run
+     * normally. Adapted from {@code SpringMongoEventStoreDcbReadWatermarkTest}'s identical helper.
+     */
+    private static final class PausingTransactionTemplate extends TransactionTemplate {
+        private final transient CountDownLatch entered;
+        private final transient CountDownLatch release;
+        private final AtomicBoolean paused = new AtomicBoolean(false);
+
+        PausingTransactionTemplate(MongoTransactionManager txManager, CountDownLatch entered, CountDownLatch release) {
+            super(txManager);
+            this.entered = entered;
+            this.release = release;
+        }
+
+        @Override
+        public <T> T execute(TransactionCallback<T> action) {
+            if (paused.compareAndSet(false, true)) {
+                entered.countDown();
+                await(release);
+            }
+            return super.execute(action);
+        }
+
+        private static void await(CountDownLatch latch) {
+            try {
+                if (!latch.await(30, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting for latch");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -225,8 +225,12 @@ class RecordingMaterializedViewMembershipInversionTest {
         return new AppliedAppendStore() {
             @Override
             public void recordApplied(String projectionId, AppendId appendId) {
-                delegate.recordApplied(projectionId, appendId);
+                // recordedInOrder updates before the delegate, not after: this test polls hasApplied() (reading the
+                // delegate) and then immediately asserts recordedInOrder, on a different thread. Updating the list
+                // first, in program order before the delegate write a waiter can observe, means a waiter that has
+                // just seen hasApplied() turn true is guaranteed to see this list entry too.
                 recordedInOrder.add(appendId);
+                delegate.recordApplied(projectionId, appendId);
             }
 
             @Override

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -107,109 +107,117 @@ class RecordingMaterializedViewMembershipInversionTest {
         CountDownLatch reserved = new CountDownLatch(1);
         CountDownLatch release = new CountDownLatch(1);
 
-        // Writer A: paused right after its position is reserved (reservation happens outside the transaction, ADR
-        // 84), before its transaction commits.
-        MongoClient writerAClient = MongoClients.create(connectionString);
-        MongoTemplate writerATemplate = new MongoTemplate(writerAClient, requireNonNull(connectionString.getDatabase()));
-        PausingTransactionTemplate pausingTx = new PausingTransactionTemplate(
-                new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerAClient, requireNonNull(connectionString.getDatabase()))),
-                reserved, release);
-        SpringMongoEventStore writerAStore = newEventStore(writerATemplate, pausingTx, collection);
+        // All four clients are try-with-resources, so a failure anywhere below (including a subscription that never
+        // starts) still closes every one of them, rather than leaking whichever were already open at that point.
+        try (MongoClient writerAClient = MongoClients.create(connectionString);
+             MongoClient writerBClient = MongoClients.create(connectionString);
+             MongoClient observerClient = MongoClients.create(connectionString);
+             MongoClient recorderClient = MongoClients.create(connectionString)) {
 
-        // Writer B: a plain store over the same collection, commits fully and immediately.
-        MongoClient writerBClient = MongoClients.create(connectionString);
-        MongoTemplate writerBTemplate = new MongoTemplate(writerBClient, requireNonNull(connectionString.getDatabase()));
-        SpringMongoEventStore writerBStore = newEventStore(writerBTemplate,
-                new TransactionTemplate(new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerBClient, requireNonNull(connectionString.getDatabase())))),
-                collection);
+            // Writer A: paused right after its position is reserved (reservation happens outside the transaction,
+            // ADR 84), before its transaction commits.
+            MongoTemplate writerATemplate = new MongoTemplate(writerAClient, requireNonNull(connectionString.getDatabase()));
+            PausingTransactionTemplate pausingTx = new PausingTransactionTemplate(
+                    new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerAClient, requireNonNull(connectionString.getDatabase()))),
+                    reserved, release);
+            SpringMongoEventStore writerAStore = newEventStore(writerATemplate, pausingTx, collection);
 
-        // A raw, side-channel subscription (independent of the recording wrapper under test) that records the real
-        // delivery order and the real position of every event, proving the inversion genuinely happened rather than
-        // being assumed.
-        MongoClient observerClient = MongoClients.create(connectionString);
-        MongoTemplate observerTemplate = new MongoTemplate(observerClient, requireNonNull(connectionString.getDatabase()));
-        SpringMongoSubscriptionModel observerModel = new SpringMongoSubscriptionModel(observerTemplate, collection, TimeRepresentation.RFC_3339_STRING);
-        List<EventMetadata> deliveryOrder = new CopyOnWriteArrayList<>();
-        Subscription observerSubscription = observerModel.subscribe("observer", StartAt.now(),
-                cloudEvent -> deliveryOrder.add(EventMetadata.from(cloudEvent)));
-        assertThat(observerSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the observer subscription never started").isTrue();
+            // Writer B: a plain store over the same collection, commits fully and immediately.
+            MongoTemplate writerBTemplate = new MongoTemplate(writerBClient, requireNonNull(connectionString.getDatabase()));
+            SpringMongoEventStore writerBStore = newEventStore(writerBTemplate,
+                    new TransactionTemplate(new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(writerBClient, requireNonNull(connectionString.getDatabase())))),
+                    collection);
 
-        // The recording projection under test: a real RecordingMaterializedView over a real live subscription, the
-        // shipped production path (Projections.recordingAppliedAppends), never a hand-rolled record call.
-        MongoClient recorderClient = MongoClients.create(connectionString);
-        MongoTemplate recorderTemplate = new MongoTemplate(recorderClient, requireNonNull(connectionString.getDatabase()));
-        SpringMongoSubscriptionModel recorderModel = new SpringMongoSubscriptionModel(recorderTemplate, collection, TimeRepresentation.RFC_3339_STRING);
-        CloudEventConverter<Ticked> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
-        ConcurrentHashMap<String, Integer> state = new ConcurrentHashMap<>();
-        ViewStateRepository<Integer, String> repository = ViewStateRepository.create(state::get, state::put);
-        Projection<Integer, Ticked, String> projection = Projection.<Integer, Ticked>singletonBuilder(0)
-                .on(Ticked.class, (count, event) -> count + 1)
-                .build();
-        AppliedAppendStore appliedAppendStore = AppliedAppendStore.inMemory();
-        List<AppendId> recordedInOrder = new CopyOnWriteArrayList<>();
-        AppliedAppendStore observedStore = recordingSpy(appliedAppendStore, recordedInOrder);
-        MaterializedView<Ticked> view = Projections.materializedView(projection, repository, PROJECTION_ID);
-        MaterializedView<Ticked> recordingView = Projections.recordingAppliedAppends(view, PROJECTION_ID, observedStore, ReplayPhase.neverReplays());
-        ProjectionRunner<Ticked> runner = ProjectionRunner.stream(recorderModel, converter);
-        Subscription recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
-        assertThat(recordingSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the recording subscription never started").isTrue();
+            // A raw, side-channel subscription (independent of the recording wrapper under test) that records the
+            // real delivery order and the real position of every event, proving the inversion genuinely happened
+            // rather than being assumed.
+            MongoTemplate observerTemplate = new MongoTemplate(observerClient, requireNonNull(connectionString.getDatabase()));
+            SpringMongoSubscriptionModel observerModel = new SpringMongoSubscriptionModel(observerTemplate, collection, TimeRepresentation.RFC_3339_STRING);
 
-        Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");
-        try {
-            // A starts writing and pauses, its position already reserved.
-            appender.start();
-            assertThat(reserved.await(30, TimeUnit.SECONDS)).as("writer A did not reach its paused transaction").isTrue();
+            // The recording projection under test: a real RecordingMaterializedView over a real live subscription,
+            // the shipped production path (Projections.recordingAppliedAppends), never a hand-rolled record call.
+            MongoTemplate recorderTemplate = new MongoTemplate(recorderClient, requireNonNull(connectionString.getDatabase()));
+            SpringMongoSubscriptionModel recorderModel = new SpringMongoSubscriptionModel(recorderTemplate, collection, TimeRepresentation.RFC_3339_STRING);
 
-            // B commits fully, on a different stream, and reserves a strictly higher position than A's already-reserved one.
-            WriteResult resultB = writerBStore.write("stream-b", List.of(converter.toCloudEvent(new Ticked("b"))));
-            AppendId appendIdB = resultB.appendId().orElseThrow();
+            // Both models' shutdown lives in one finally covering both waitUntilStarted assertions below, so either
+            // one failing to start still shuts down whichever model(s) were already subscribed.
+            try {
+                CloudEventConverter<Ticked> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
+                List<EventMetadata> deliveryOrder = new CopyOnWriteArrayList<>();
+                Subscription observerSubscription = observerModel.subscribe("observer", StartAt.now(),
+                        cloudEvent -> deliveryOrder.add(EventMetadata.from(cloudEvent)));
+                assertThat(observerSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the observer subscription never started").isTrue();
 
-            await().atMost(Duration.ofSeconds(20)).until(() -> appliedAppendStore.hasApplied(PROJECTION_ID, appendIdB));
+                ConcurrentHashMap<String, Integer> state = new ConcurrentHashMap<>();
+                ViewStateRepository<Integer, String> repository = ViewStateRepository.create(state::get, state::put);
+                Projection<Integer, Ticked, String> projection = Projection.<Integer, Ticked>singletonBuilder(0)
+                        .on(Ticked.class, (count, event) -> count + 1)
+                        .build();
+                AppliedAppendStore appliedAppendStore = AppliedAppendStore.inMemory();
+                List<AppendId> recordedInOrder = new CopyOnWriteArrayList<>();
+                AppliedAppendStore observedStore = recordingSpy(appliedAppendStore, recordedInOrder);
+                MaterializedView<Ticked> view = Projections.materializedView(projection, repository, PROJECTION_ID);
+                MaterializedView<Ticked> recordingView = Projections.recordingAppliedAppends(view, PROJECTION_ID, observedStore, ReplayPhase.neverReplays());
+                ProjectionRunner<Ticked> runner = ProjectionRunner.stream(recorderModel, converter);
+                Subscription recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
+                assertThat(recordingSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the recording subscription never started").isTrue();
 
-            // The crux of the acceptance criterion: at the moment B's (higher-position) append is recorded as
-            // applied, A's event has not committed yet, so nothing else has been recorded. A position-based
-            // watermark would have called this "applied up to B's position", wrongly including A's lower one.
-            assertThat(recordedInOrder).as("only B's append should be recorded while A is still paused before commit").containsExactly(appendIdB);
+                Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");
+                try {
+                    // A starts writing and pauses, its position already reserved.
+                    appender.start();
+                    assertThat(reserved.await(30, TimeUnit.SECONDS)).as("writer A did not reach its paused transaction").isTrue();
 
-            // Release A: it commits last, with the lower position.
-            release.countDown();
-            appender.join(TimeUnit.SECONDS.toMillis(30));
-            assertThat(appender.isAlive()).isFalse();
+                    // B commits fully, on a different stream, and reserves a strictly higher position than A's already-reserved one.
+                    WriteResult resultB = writerBStore.write("stream-b", List.of(converter.toCloudEvent(new Ticked("b"))));
+                    AppendId appendIdB = resultB.appendId().orElseThrow();
 
-            // Read A's append id back from what was actually delivered (not minted ahead of time), and prove the
-            // wait now (and only now) answers true for it.
-            await().atMost(Duration.ofSeconds(20)).until(() -> deliveryOrder.size() >= 2);
-            EventMetadata aMetadata = deliveryOrder.stream()
-                    .filter(metadata -> "stream-a".equals(metadata.getStreamId()))
-                    .findFirst()
-                    .orElseThrow(() -> new AssertionError("A's event was never observed as delivered"));
-            AppendId appendIdA = AppendId.from(aMetadata).orElseThrow();
+                    await().atMost(Duration.ofSeconds(20)).until(() -> appliedAppendStore.hasApplied(PROJECTION_ID, appendIdB));
 
-            assertThat(appliedAppendStore.waitUntilApplied(PROJECTION_ID, appendIdA, Duration.ofSeconds(20))).isTrue();
-            assertThat(recordedInOrder).as("B was recorded first, A only after its own commit").containsExactly(appendIdB, appendIdA);
+                    // The crux of the acceptance criterion: at the moment B's (higher-position) append is recorded as
+                    // applied, A's event has not committed yet, so nothing else has been recorded. A position-based
+                    // watermark would have called this "applied up to B's position", wrongly including A's lower one.
+                    assertThat(recordedInOrder).as("only B's append should be recorded while A is still paused before commit").containsExactly(appendIdB);
 
-            // The real, independently observed positions confirm the inversion actually happened: A's position is
-            // lower than B's even though A committed and was delivered after B.
-            EventMetadata bMetadata = deliveryOrder.stream()
-                    .filter(metadata -> "stream-b".equals(metadata.getStreamId()))
-                    .findFirst()
-                    .orElseThrow();
-            assertThat(deliveryOrder.get(0).getStreamId()).as("B is delivered first, in real commit order").isEqualTo("stream-b");
-            assertThat(requireNonNull(aMetadata.getPosition())).as("but A's reserved position is lower than B's")
-                    .isLessThan(requireNonNull(bMetadata.getPosition()));
-        } finally {
-            // release unconditionally, not just after the happy path: if an assertion above throws before
-            // release.countDown() runs, writer A stays parked on its latch forever, and this join would hang the
-            // whole Maven fork rather than let the failure surface. CountDownLatch.countDown() is a no-op once the
-            // count has already reached zero, so releasing twice on the happy path is harmless.
-            release.countDown();
-            appender.join(TimeUnit.SECONDS.toMillis(30));
-            recorderModel.shutdown();
-            observerModel.shutdown();
-            recorderClient.close();
-            observerClient.close();
-            writerAClient.close();
-            writerBClient.close();
+                    // Release A: it commits last, with the lower position.
+                    release.countDown();
+                    appender.join(TimeUnit.SECONDS.toMillis(30));
+                    assertThat(appender.isAlive()).isFalse();
+
+                    // Read A's append id back from what was actually delivered (not minted ahead of time), and prove
+                    // the wait now (and only now) answers true for it.
+                    await().atMost(Duration.ofSeconds(20)).until(() -> deliveryOrder.size() >= 2);
+                    EventMetadata aMetadata = deliveryOrder.stream()
+                            .filter(metadata -> "stream-a".equals(metadata.getStreamId()))
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("A's event was never observed as delivered"));
+                    AppendId appendIdA = AppendId.from(aMetadata).orElseThrow();
+
+                    assertThat(appliedAppendStore.waitUntilApplied(PROJECTION_ID, appendIdA, Duration.ofSeconds(20))).isTrue();
+                    assertThat(recordedInOrder).as("B was recorded first, A only after its own commit").containsExactly(appendIdB, appendIdA);
+
+                    // The real, independently observed positions confirm the inversion actually happened: A's
+                    // position is lower than B's even though A committed and was delivered after B.
+                    EventMetadata bMetadata = deliveryOrder.stream()
+                            .filter(metadata -> "stream-b".equals(metadata.getStreamId()))
+                            .findFirst()
+                            .orElseThrow();
+                    assertThat(deliveryOrder.get(0).getStreamId()).as("B is delivered first, in real commit order").isEqualTo("stream-b");
+                    assertThat(requireNonNull(aMetadata.getPosition())).as("but A's reserved position is lower than B's")
+                            .isLessThan(requireNonNull(bMetadata.getPosition()));
+                } finally {
+                    // release unconditionally, not just after the happy path: if an assertion above throws before
+                    // release.countDown() runs, writer A stays parked on its latch forever, and this join would hang
+                    // the whole Maven fork rather than let the failure surface. CountDownLatch.countDown() is a
+                    // no-op once the count has already reached zero, so releasing twice on the happy path is
+                    // harmless.
+                    release.countDown();
+                    appender.join(TimeUnit.SECONDS.toMillis(30));
+                }
+            } finally {
+                recorderModel.shutdown();
+                observerModel.shutdown();
+            }
         }
     }
 

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -132,7 +132,7 @@ class RecordingMaterializedViewMembershipInversionTest {
         List<EventMetadata> deliveryOrder = new CopyOnWriteArrayList<>();
         Subscription observerSubscription = observerModel.subscribe("observer", StartAt.now(),
                 cloudEvent -> deliveryOrder.add(EventMetadata.from(cloudEvent)));
-        observerSubscription.waitUntilStarted();
+        assertThat(observerSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the observer subscription never started").isTrue();
 
         // The recording projection under test: a real RecordingMaterializedView over a real live subscription, the
         // shipped production path (Projections.recordingAppliedAppends), never a hand-rolled record call.
@@ -152,11 +152,11 @@ class RecordingMaterializedViewMembershipInversionTest {
         MaterializedView<Ticked> recordingView = Projections.recordingAppliedAppends(view, PROJECTION_ID, observedStore, ReplayPhase.neverReplays());
         ProjectionRunner<Ticked> runner = ProjectionRunner.stream(recorderModel, converter);
         Subscription recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
-        recordingSubscription.waitUntilStarted();
+        assertThat(recordingSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the recording subscription never started").isTrue();
 
+        Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");
         try {
             // A starts writing and pauses, its position already reserved.
-            Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");
             appender.start();
             assertThat(reserved.await(30, TimeUnit.SECONDS)).as("writer A did not reach its paused transaction").isTrue();
 
@@ -198,8 +198,18 @@ class RecordingMaterializedViewMembershipInversionTest {
             assertThat(requireNonNull(aMetadata.getPosition())).as("but A's reserved position is lower than B's")
                     .isLessThan(requireNonNull(bMetadata.getPosition()));
         } finally {
-            recorderModel.stop();
-            observerModel.stop();
+            // release unconditionally, not just after the happy path: if an assertion above throws before
+            // release.countDown() runs, writer A stays parked on its latch forever, and this join would hang the
+            // whole Maven fork rather than let the failure surface. CountDownLatch.countDown() is a no-op once the
+            // count has already reached zero, so releasing twice on the happy path is harmless.
+            release.countDown();
+            appender.join(TimeUnit.SECONDS.toMillis(30));
+            recorderModel.shutdown();
+            observerModel.shutdown();
+            recorderClient.close();
+            observerClient.close();
+            writerAClient.close();
+            writerBClient.close();
         }
     }
 

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewPartialVisibilityTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewPartialVisibilityTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.blocking;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.cloudevents.OccurrentCloudEventExtension;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.dsl.projection.ReplayPhase;
+import org.occurrent.dsl.view.MaterializedView;
+import org.occurrent.eventstore.api.AppendId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins multi-event partial visibility as intended semantics, not an accident
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>,
+ * decision 10): {@link RecordingMaterializedView} records the append id after <em>each</em> handled event returns,
+ * not after the whole append has been handled. So a waiter can observe {@code true} once the projection has applied
+ * the first of a multi-event append's events, before the rest have been applied. This test asserts exactly that
+ * window exists, so a later change that accidentally moves recording to "after the last event of the append" (which
+ * decision 10 explicitly rejects, since a filtered subscriber may never see an append's last event at all) fails
+ * loudly here instead of silently changing the guarantee callers observe.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RecordingMaterializedViewPartialVisibilityTest {
+
+    private static final String PROJECTION_ID = "orderStatus";
+
+    @Test
+    void a_waiter_can_observe_true_after_the_first_of_a_multi_event_appends_events_is_applied_before_the_rest_are() {
+        List<String> appliedInOrder = new ArrayList<>();
+        MaterializedView<String> delegate = new MaterializedView<>() {
+            @Override
+            public void update(String event) {
+                appliedInOrder.add(event);
+            }
+        };
+        AppliedAppendStore store = AppliedAppendStore.inMemory();
+        AppendId appendId = AppendId.mint();
+
+        RecordingMaterializedView<String> recording = new RecordingMaterializedView<>(delegate, PROJECTION_ID, store, ReplayPhase.neverReplays());
+
+        // First event of a two-event append.
+        recording.update(metadataWithAppendId(appendId), "event-1");
+
+        // Pinned: the append is already visible to a membership waiter, even though its second event has not been
+        // applied yet.
+        assertThat(store.hasApplied(PROJECTION_ID, appendId)).as("membership is visible after the first handled event, not the last").isTrue();
+        assertThat(appliedInOrder).as("but the read model has only applied the first event so far").containsExactly("event-1");
+
+        // Second (and last) event of the same append.
+        recording.update(metadataWithAppendId(appendId), "event-2");
+
+        assertThat(appliedInOrder).containsExactly("event-1", "event-2");
+        assertThat(store.hasApplied(PROJECTION_ID, appendId)).isTrue();
+    }
+
+    private static EventMetadata metadataWithAppendId(AppendId appendId) {
+        return new EventMetadata(Map.of(OccurrentCloudEventExtension.APPEND_ID, appendId.toString()));
+    }
+}

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
@@ -45,6 +45,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -94,23 +95,28 @@ class WriteToDeliveryAppendIdFidelityTest {
         SpringMongoEventStore eventStore = new SpringMongoEventStore(mongoTemplate, config);
         SpringMongoSubscriptionModel subscriptionModel = new SpringMongoSubscriptionModel(mongoTemplate, collection, TimeRepresentation.RFC_3339_STRING);
 
-        BlockingQueue<EventMetadata> delivered = new ArrayBlockingQueue<>(1);
-        Subscription subscription = subscriptionModel.subscribe("fidelity", StartAt.now(),
-                cloudEvent -> delivered.add(EventMetadata.from(cloudEvent)));
-        subscription.waitUntilStarted();
+        try {
+            BlockingQueue<EventMetadata> delivered = new ArrayBlockingQueue<>(1);
+            Subscription subscription = subscriptionModel.subscribe("fidelity", StartAt.now(),
+                    cloudEvent -> delivered.add(EventMetadata.from(cloudEvent)));
+            assertThat(subscription.waitUntilStarted(Duration.ofSeconds(20))).as("the subscription never started").isTrue();
 
-        WriteResult result = eventStore.write("stream-1", List.of(
-                v1().withId(UUID.randomUUID().toString())
-                        .withSource(SOURCE)
-                        .withType("Ticked")
-                        .withTime(OffsetDateTime.now())
-                        .withData("{}".getBytes(UTF_8))
-                        .build()));
-        AppendId writtenAppendId = result.appendId().orElseThrow();
+            WriteResult result = eventStore.write("stream-1", List.of(
+                    v1().withId(UUID.randomUUID().toString())
+                            .withSource(SOURCE)
+                            .withType("Ticked")
+                            .withTime(OffsetDateTime.now())
+                            .withData("{}".getBytes(UTF_8))
+                            .build()));
+            AppendId writtenAppendId = result.appendId().orElseThrow();
 
-        EventMetadata delivery = delivered.poll(20, TimeUnit.SECONDS);
-        assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
-        assertThat(delivery.getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
-        assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+            EventMetadata delivery = delivered.poll(20, TimeUnit.SECONDS);
+            assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
+            assertThat(delivery.getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
+            assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+        } finally {
+            subscriptionModel.shutdown();
+            mongoClient.close();
+        }
     }
 }

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.blocking;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static io.cloudevents.core.builder.CloudEventBuilder.v1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Write-to-delivery {@code appendid} fidelity, blocking stack
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>):
+ * the {@link AppendId} a write's {@link WriteResult} returns must be the exact same identifier a live subscriber's
+ * {@link EventMetadata#getAppendId()} sees for the same event, unchanged. The TCK's {@code WriteResults} suite
+ * already proves the stamped extension survives the store's own {@code read()}, but nothing in the repository
+ * proved it survives the live change-stream delivery path a real projection actually uses. This closes that gap.
+ */
+@Testcontainers
+@Timeout(60)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class WriteToDeliveryAppendIdFidelityTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:write-to-delivery-fidelity");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @RegisterExtension
+    OccurrentMongoFlush flushMongoDBExtension = OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer));
+
+    @Test
+    void the_append_id_a_write_returns_is_the_exact_append_id_a_live_subscriber_sees_in_event_metadata() throws InterruptedException {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl("write_to_delivery_fidelity_blocking"));
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        String databaseName = requireNonNull(connectionString.getDatabase());
+        MongoTemplate mongoTemplate = new MongoTemplate(mongoClient, databaseName);
+        String collection = "events";
+
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(collection)
+                .transactionConfig(new TransactionTemplate(new MongoTransactionManager(new SimpleMongoClientDatabaseFactory(mongoClient, databaseName))))
+                .timeRepresentation(TimeRepresentation.RFC_3339_STRING)
+                .build();
+        SpringMongoEventStore eventStore = new SpringMongoEventStore(mongoTemplate, config);
+        SpringMongoSubscriptionModel subscriptionModel = new SpringMongoSubscriptionModel(mongoTemplate, collection, TimeRepresentation.RFC_3339_STRING);
+
+        BlockingQueue<EventMetadata> delivered = new ArrayBlockingQueue<>(1);
+        Subscription subscription = subscriptionModel.subscribe("fidelity", StartAt.now(),
+                cloudEvent -> delivered.add(EventMetadata.from(cloudEvent)));
+        subscription.waitUntilStarted();
+
+        WriteResult result = eventStore.write("stream-1", List.of(
+                v1().withId(UUID.randomUUID().toString())
+                        .withSource(SOURCE)
+                        .withType("Ticked")
+                        .withTime(OffsetDateTime.now())
+                        .withData("{}".getBytes(UTF_8))
+                        .build()));
+        AppendId writtenAppendId = result.appendId().orElseThrow();
+
+        EventMetadata delivery = delivered.poll(20, TimeUnit.SECONDS);
+        assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
+        assertThat(delivery.getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
+        assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+    }
+}

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
@@ -93,25 +93,30 @@ class WriteToDeliveryAppendIdFidelityTest {
         ReactorMongoEventStore eventStore = new ReactorMongoEventStore(mongoTemplate, config);
         ReactorMongoSubscriptionModel subscriptionModel = new ReactorMongoSubscriptionModel(mongoTemplate, collection, TimeRepresentation.RFC_3339_STRING);
 
-        LinkedBlockingQueue<EventMetadata> delivered = new LinkedBlockingQueue<>();
-        Subscription subscription = subscriptionModel.subscribe("fidelity-reactor", StartAt.now(),
-                cloudEvent -> Mono.fromRunnable(() -> delivered.add(EventMetadata.from(cloudEvent))));
-        subscription.waitUntilStarted().block(Duration.ofSeconds(20));
+        try {
+            LinkedBlockingQueue<EventMetadata> delivered = new LinkedBlockingQueue<>();
+            Subscription subscription = subscriptionModel.subscribe("fidelity-reactor", StartAt.now(),
+                    cloudEvent -> Mono.fromRunnable(() -> delivered.add(EventMetadata.from(cloudEvent))));
+            subscription.waitUntilStarted().block(Duration.ofSeconds(20));
 
-        WriteResult result = eventStore.write("stream-1", Flux.just(
-                        v1().withId(UUID.randomUUID().toString())
-                                .withSource(SOURCE)
-                                .withType("Ticked")
-                                .withTime(OffsetDateTime.now())
-                                .withData("{}".getBytes(UTF_8))
-                                .build()))
-                .block(Duration.ofSeconds(20));
-        AppendId writtenAppendId = requireNonNull(result).appendId().orElseThrow();
+            WriteResult result = eventStore.write("stream-1", Flux.just(
+                            v1().withId(UUID.randomUUID().toString())
+                                    .withSource(SOURCE)
+                                    .withType("Ticked")
+                                    .withTime(OffsetDateTime.now())
+                                    .withData("{}".getBytes(UTF_8))
+                                    .build()))
+                    .block(Duration.ofSeconds(20));
+            AppendId writtenAppendId = requireNonNull(result).appendId().orElseThrow();
 
-        EventMetadata delivery = delivered.poll(20, java.util.concurrent.TimeUnit.SECONDS);
+            EventMetadata delivery = delivered.poll(20, java.util.concurrent.TimeUnit.SECONDS);
 
-        assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
-        assertThat(requireNonNull(delivery).getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
-        assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+            assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
+            assertThat(requireNonNull(delivery).getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
+            assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+        } finally {
+            subscriptionModel.shutdown();
+            mongoClient.close();
+        }
     }
 }

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.dsl.projection.reactor;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.occurrent.cloudevents.EventMetadata;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
+import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
+import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
+import org.occurrent.subscription.StartAt;
+import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.cloudevents.core.builder.CloudEventBuilder.v1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.occurrent.mongodb.timerepresentation.TimeRepresentation.RFC_3339_STRING;
+
+/**
+ * Write-to-delivery {@code appendid} fidelity, reactor stack, the twin of the blocking-module
+ * {@code WriteToDeliveryAppendIdFidelityTest}
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>):
+ * the {@link AppendId} a write's {@link WriteResult} returns must be the exact same identifier a live subscriber's
+ * {@link EventMetadata#getAppendId()} sees for the same event, unchanged, on the reactive stack too.
+ */
+@Testcontainers
+@Timeout(60)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class WriteToDeliveryAppendIdFidelityTest {
+
+    private static final URI SOURCE = URI.create("urn:occurrent:write-to-delivery-fidelity-reactor");
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @RegisterExtension
+    OccurrentMongoFlush flushMongoDBExtension = OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer));
+
+    @Test
+    void the_append_id_a_write_returns_is_the_exact_append_id_a_live_subscriber_sees_in_event_metadata() throws InterruptedException {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl("write_to_delivery_fidelity_reactor"));
+        MongoClient mongoClient = MongoClients.create(connectionString);
+        String databaseName = requireNonNull(connectionString.getDatabase());
+        ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(mongoClient, databaseName);
+        String collection = "events";
+
+        EventStoreConfig config = new EventStoreConfig.Builder()
+                .eventStoreCollectionName(collection)
+                .transactionConfig(new ReactiveMongoTransactionManager(new SimpleReactiveMongoDatabaseFactory(mongoClient, databaseName)))
+                .timeRepresentation(RFC_3339_STRING)
+                .build();
+        ReactorMongoEventStore eventStore = new ReactorMongoEventStore(mongoTemplate, config);
+        ReactorMongoSubscriptionModel subscriptionModel = new ReactorMongoSubscriptionModel(mongoTemplate, collection, TimeRepresentation.RFC_3339_STRING);
+
+        LinkedBlockingQueue<EventMetadata> delivered = new LinkedBlockingQueue<>();
+        Subscription subscription = subscriptionModel.subscribe("fidelity-reactor", StartAt.now(),
+                cloudEvent -> Mono.fromRunnable(() -> delivered.add(EventMetadata.from(cloudEvent))));
+        subscription.waitUntilStarted().block(Duration.ofSeconds(20));
+
+        WriteResult result = eventStore.write("stream-1", Flux.just(
+                        v1().withId(UUID.randomUUID().toString())
+                                .withSource(SOURCE)
+                                .withType("Ticked")
+                                .withTime(OffsetDateTime.now())
+                                .withData("{}".getBytes(UTF_8))
+                                .build()))
+                .block(Duration.ofSeconds(20));
+        AppendId writtenAppendId = requireNonNull(result).appendId().orElseThrow();
+
+        EventMetadata delivery = delivered.poll(20, java.util.concurrent.TimeUnit.SECONDS);
+
+        assertThat(delivery).as("event was never delivered to the live subscriber").isNotNull();
+        assertThat(requireNonNull(delivery).getAppendId()).as("EventMetadata.getAppendId() must be the raw string form of the written AppendId").isEqualTo(writtenAppendId.toString());
+        assertThat(AppendId.from(delivery)).as("and parses back to the exact same identity").contains(writtenAppendId);
+    }
+}

--- a/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreTest.java
+++ b/eventstore/mongodb/spring/reactor/src/test/java/org/occurrent/eventstore/mongodb/spring/reactor/ReactorMongoEventStoreTest.java
@@ -237,6 +237,30 @@ public class ReactorMongoEventStoreTest {
         );
     }
 
+    // Carried from U2's adversarial verify: the DCB append() path already has
+    // ReactorMongoEventStoreDcbTest#resubscribing_the_same_append_publisher_mints_a_fresh_append_id_each_time; the
+    // stream write() path had no equivalent, a coverage asymmetry rather than a known bug (write() was proven
+    // correct empirically). ADR 132's AppendId is minted once per write()/append() call and must not be cached in
+    // the returned lazy Mono, so resubscribing the same publisher (a mistake this library's own examples make
+    // easily, since a Mono is reusable) must mint a fresh id on every execution rather than replaying the first one.
+    @Test
+    void resubscribing_the_same_write_publisher_mints_a_fresh_append_id_each_time() {
+        CloudEvent event = convertDomainEventCloudEvent(new NameDefined(UUID.randomUUID().toString(), LocalDateTime.now(), "name", "reused-name"));
+        Mono<WriteResult> publisher = eventStore.write("reused-stream", Flux.just(event));
+
+        WriteResult first = requireNonNull(publisher.block());
+        eventStore.deleteEvent(event.getId(), event.getSource()).block();
+        WriteResult second = publisher.block();
+
+        assertAll(
+                () -> assertThat(first.appendId()).isPresent(),
+                () -> assertThat(requireNonNull(second).appendId()).isPresent(),
+                () -> assertThat(second.appendId())
+                        .as("a reused write() publisher must mint a fresh append id on every subscription, not reuse the one from its first execution")
+                        .isNotEqualTo(first.appendId())
+        );
+    }
+
     @Nested
     @DisplayName("queries")
     class QueriesTest {

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.Projection;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.api.blocking.EventStore;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The cross-instance half of {@code ProjectionAnnotationRecordAppliedAppendsMongoTest}
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>,
+ * decision 5): "the membership record is store-backed, not in-process... a wait can run on a different node than
+ * the projection that did the recording." Two separate application contexts against the same MongoDB collection:
+ * instance A runs the recording projection and does the write, instance B runs no projection at all and only calls
+ * {@code waitUntilApplied} through its own, independently constructed {@link AppliedAppendStore} bean. If the
+ * answer only lived in instance A's process, B's wait would time out no matter how long it waited; instead it must
+ * see A's record because both stores are backed by the same Mongo collection.
+ */
+@DisplayName("Projection annotation (recordAppliedAppends, MongoDB, cross-instance)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Testcontainers
+@Timeout(60)
+class ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest {
+
+    @Container
+    static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @Test
+    void a_wait_on_one_instance_observes_an_append_recorded_by_the_recording_projection_running_on_another() {
+        String databaseName = "record-applied-appends-cross-instance";
+        ConfigurableApplicationContext instanceA = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName, "instance-a"));
+        ConfigurableApplicationContext instanceB = SpringApplication.run(ReaderOnlyApplication.class, bootArgs(databaseName, "instance-b"));
+        try {
+            EventStore eventStore = instanceA.getBean(EventStore.class);
+            CloudEventConverter<TestEvent> converter = instanceA.getBean(CloudEventConverter.class);
+            AppliedAppendStore storeOnA = instanceA.getBean(AppliedAppendStore.class);
+            AppliedAppendStore storeOnB = instanceB.getBean(AppliedAppendStore.class);
+
+            WriteResult result = eventStore.write(UUID.randomUUID().toString(), converter.toCloudEvents(List.of(new Counted("one"))));
+            AppendId appendId = result.appendId().orElseThrow();
+
+            // Instance A recorded it (sanity: the recording projection is actually running there).
+            assertThat(storeOnA.waitUntilApplied("recording-counter", appendId, Duration.ofSeconds(20))).isTrue();
+
+            // Instance B never ran the projection and never called recordApplied itself; its wait can only succeed
+            // by reading the same underlying Mongo collection A's recorder wrote to.
+            assertThat(storeOnB.waitUntilApplied("recording-counter", appendId, Duration.ofSeconds(20)))
+                    .as("the membership record is store-backed, so a wait on a different node/process sees it too")
+                    .isTrue();
+        } finally {
+            instanceA.close();
+            instanceB.close();
+        }
+    }
+
+    private static String[] bootArgs(String databaseName, String applicationName) {
+        return new String[]{
+                "--spring.mongodb.uri=" + mongoDBContainer.getReplicaSetUrl(databaseName),
+                "--spring.main.web-application-type=none",
+                "--spring.application.name=" + applicationName,
+                "--occurrent.event-store.capabilities=stream",
+                "--occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:" + databaseName
+        };
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class RecordingProjectionApplication {
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:record-applied-appends-cross-instance-test"))
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        CounterStore counterStore() {
+            return new CounterStore();
+        }
+
+        @Bean
+        RecordingCounterProjection recordingCounterProjection() {
+            return new RecordingCounterProjection();
+        }
+    }
+
+    /**
+     * Boots the Mongo starter's auto-configuration (and, with it, the zero-config {@link AppliedAppendStore} bean)
+     * with no projection at all, so this instance never records anything itself.
+     */
+    @SpringBootApplication
+    @EnableOccurrent
+    static class ReaderOnlyApplication {
+    }
+
+    static class RecordingCounterProjection {
+        @Projection(id = "recording-counter", recordAppliedAppends = true, storeName = "counterStore")
+        org.occurrent.dsl.projection.Projection<Counter, TestEvent, String> counter() {
+            return org.occurrent.dsl.projection.Projection.<Counter, TestEvent, String>builder(new Counter(0))
+                    .id(event -> "counter")
+                    .on(Counted.class, (state, event) -> new Counter(state.count() + 1))
+                    .build();
+        }
+    }
+
+    static class CounterStore implements ViewStateRepository<Counter, String> {
+        private final ConcurrentHashMap<String, Counter> store = new ConcurrentHashMap<>();
+
+        @Override
+        public Optional<Counter> findById(String id) {
+            return Optional.ofNullable(store.get(id));
+        }
+
+        @Override
+        public void save(String id, Counter state) {
+            store.put(id, state);
+        }
+    }
+
+    record Counter(int count) {
+    }
+
+    sealed interface TestEvent {
+        String eventId();
+
+        Date timestamp();
+
+        String name();
+    }
+
+    record Counted(String eventId, Date timestamp, String name) implements TestEvent {
+        Counted(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest.java
@@ -76,9 +76,11 @@ class ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest {
     @Test
     void a_wait_on_one_instance_observes_an_append_recorded_by_the_recording_projection_running_on_another() {
         String databaseName = "record-applied-appends-cross-instance";
-        ConfigurableApplicationContext instanceA = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName, "instance-a"));
-        ConfigurableApplicationContext instanceB = SpringApplication.run(ReaderOnlyApplication.class, bootArgs(databaseName, "instance-b"));
-        try {
+        // try-with-resources rather than a single try/finally with two manual close() calls: if instance B's boot
+        // throws, execution never reaches a finally guarding both, and instance A would leak its Mongo client and
+        // subscription threads. Each resource here closes independently of whether an earlier one failed to open.
+        try (ConfigurableApplicationContext instanceA = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName, "instance-a"));
+             ConfigurableApplicationContext instanceB = SpringApplication.run(ReaderOnlyApplication.class, bootArgs(databaseName, "instance-b"))) {
             EventStore eventStore = instanceA.getBean(EventStore.class);
             CloudEventConverter<TestEvent> converter = instanceA.getBean(CloudEventConverter.class);
             AppliedAppendStore storeOnA = instanceA.getBean(AppliedAppendStore.class);
@@ -95,9 +97,6 @@ class ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest {
             assertThat(storeOnB.waitUntilApplied("recording-counter", appendId, Duration.ofSeconds(20)))
                     .as("the membership record is store-backed, so a wait on a different node/process sees it too")
                     .isTrue();
-        } finally {
-            instanceA.close();
-            instanceB.close();
         }
     }
 


### PR DESCRIPTION
⌁[ayi/U5#740]

Part of #740, ADR 132. I added the acceptance and falsifier proofs the U5 brief calls for: seven falsifiers plus U2's carried write() resubscription test.

## What I added

- Membership-level position inversion, the exact acceptance criterion from #740, against real MongoDB with a genuinely stalled writer (`RecordingMaterializedViewMembershipInversionTest`).
- Cross-instance visibility: write and record on one Spring context, wait on a second, same Mongo collection (`ProjectionAnnotationRecordAppliedAppendsCrossInstanceMongoTest`).
- Abandoned-replay non-lie against a real `CoalescingMaterializedView` (`RecordingMaterializedViewAbandonedReplayNonLieTest`).
- Multi-event partial visibility pinned as intended semantics (`RecordingMaterializedViewPartialVisibilityTest`).
- The empty-append contract through a real `ApplicationService.execute` with zero events (`AppendIdEmptyAppendContractTest`).
- Write-to-delivery `appendid` fidelity on both stacks (`WriteToDeliveryAppendIdFidelityTest`, blocking and reactor).
- The carried write() resubscription test next to `ReactorMongoEventStoreDcbTest`'s existing DCB one, closing a coverage asymmetry U2 flagged.

Every test is mutation tested: I reverted the production behavior it targets, confirmed the test failed, then restored the file from a copy.

## What I left out

The post-reset falsifiers (an ordinary rebuild, and a filtered rebuild only the scheduled poll can catch) aren't here. I found that cancelling a subscription and restarting the Spring Boot Mongo composition with a wiped checkpoint doesn't appear to replay history against a non-empty store: neither the read model nor the applied-append records change after restart, across both a 1-event and a 300-event backlog, and the scheduled poll never clears the stale record either over 60+ seconds of observation. Root causing that is outside this unit's remit, so I'm reporting it rather than fixing it here or shipping a test that can't pass.

`dsl/projection-dsl/blocking/pom.xml` gains test-scope deps on the Mongo eventstore and subscription starters, mirroring what the reactor sibling module already has, so the recording wrapper can be tested against a real store without routing everything through the Spring Boot annotation layer.