### PR TITLE
Bump the broker clients past their open CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,12 +127,12 @@
             <dependency>
                 <groupId>com.rabbitmq</groupId>
                 <artifactId>amqp-client</artifactId>
-                <version>5.21.0</version>
+                <version>5.33.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.1.0</version>
+                <version>4.1.2</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION
⌁[brk/U14] I bumped the two broker client versions this epic introduced past their open dependabot alerts, amqp-client from 5.21.0 to 5.33.1 (three highs, two mediums, one low) and kafka-clients from 4.1.0 to 4.1.2 (one critical in the OAUTHBEARER JWT validation and one high describing producer message corruption via buffer misrouting, which is directly relevant to a sink whose whole contract is that an acknowledged send was stored correctly).

The `integration-tests.kafka.version` broker image stays at 4.1.0 on purpose, since the alerts are against the client jars, not the broker image, and the image version tracks what deployments run rather than what the build links against.

Every broker module's Testcontainers suite exercises both clients against real brokers, so a behavioural regression from either bump fails CI here rather than at a user.
