### PR TITLE
Add the withheld post-reset falsifiers now that issue 865 is resolved

### DIFF
--- a/framework/spring-boot-starter-mongodb/pom.xml
+++ b/framework/spring-boot-starter-mongodb/pom.xml
@@ -218,6 +218,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.occurrent</groupId>
+            <artifactId>occurrent-testing-mongodb</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsResetMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsResetMongoTest.java
@@ -19,6 +19,8 @@ package org.occurrent.springboot.mongo.blocking;
 import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import org.occurrent.testing.mongodb.OccurrentMongoFlush;
+import org.occurrent.testsupport.mongodb.MongoTestDatabase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -88,6 +90,11 @@ class ProjectionAnnotationRecordAppliedAppendsResetMongoTest {
     @Test
     void an_ordinary_reset_clears_appends_recorded_before_it_and_a_replay_never_resurrects_them() {
         String databaseName = "record-applied-appends-ordinary-reset";
+        // mongoDBContainer.withReuse(true) keeps the container, and this fixed database name, alive across separate
+        // test-suite runs on the same machine, so without a flush a repeat local run would layer this run's writes
+        // on top of the last one's. OccurrentMongoFlush empties collections rather than dropping the database, which
+        // would invalidate the change stream this test's own live subscription depends on.
+        flushDatabase(databaseName);
         AppendId preResetAppendId;
         try (ConfigurableApplicationContext firstIncarnation = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName))) {
             EventStore eventStore = firstIncarnation.getBean(EventStore.class);
@@ -126,6 +133,10 @@ class ProjectionAnnotationRecordAppliedAppendsResetMongoTest {
     @Test
     void a_filtered_rebuild_whose_replay_delivers_no_matching_event_is_still_cleared_by_the_scheduled_poll() {
         String databaseName = "record-applied-appends-filtered-rebuild";
+        // Flushed for the same reason as the ordinary-reset test above, and doubly so here: this test pads the
+        // backlog with roughly 180MB per run, so an unflushed reused container would grow that database without
+        // bound across repeat runs.
+        flushDatabase(databaseName);
         AppendId staleAppendId;
         try (ConfigurableApplicationContext firstIncarnation = SpringApplication.run(FilteredRecordingProjectionApplication.class, bootArgs(databaseName))) {
             AppliedAppendStore appliedAppendStore = firstIncarnation.getBean(AppliedAppendStore.class);
@@ -176,6 +187,10 @@ class ProjectionAnnotationRecordAppliedAppendsResetMongoTest {
      * the application used ({@code ReplicaSetReadyMongoDBContainer.getReplicaSetUrl(databaseName)} scopes the
      * database name), not the raw {@code databaseName}, which would inspect an unrelated, empty database.
      */
+    private static void flushDatabase(String databaseName) {
+        OccurrentMongoFlush.everyCollectionIn(MongoTestDatabase.of(mongoDBContainer, databaseName)).run();
+    }
+
     private static void deleteCheckpoint(String databaseName, String subscriptionId) {
         ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl(databaseName));
         try (MongoClient client = MongoClients.create(connectionString)) {

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsResetMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsResetMongoTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.Projection;
+import org.occurrent.annotation.StartPosition;
+import org.occurrent.annotation.StartupMode;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.dsl.projection.AppliedAppendStore;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.eventstore.api.AppendId;
+import org.occurrent.eventstore.api.WriteResult;
+import org.occurrent.eventstore.api.blocking.EventStore;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The post-reset non-lie, in the two variants the plan calls for, written against {@code startAt = BEGINNING} where
+ * the reset premise actually holds
+ * (<a href="https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0132-an-append-has-an-identity-and-read-your-writes-becomes-a-membership-question.md">ADR 132</a>
+ * decision 7, corrected by issue #865 / PR #869): a projection left at the default start position never replays on
+ * Occurrent's own shipped composition, so the withheld U5 falsifiers against that configuration could never have
+ * passed for the right reason. {@code startAt = StartPosition.BEGINNING} is the configuration decision 7's replay
+ * guarantee actually describes.
+ * <p>
+ * Deleting the durable checkpoint directly rather than through {@code CancellableSubscriptions.cancelSubscription},
+ * because the default {@code ResumeBehavior} would otherwise resume from an intact checkpoint rather than replay
+ * again (issue #865's round-6 finding, also why {@code Projection#recordAppliedAppends}'s javadoc now says to clear
+ * the checkpoint alongside declaring {@code startAt = BEGINNING}). {@code ReplicaSetReadyMongoDBContainer} scopes
+ * the database name, so the checkpoint collection is reached through the same scoped connection string the
+ * application itself used, not the raw database name.
+ */
+@DisplayName("Projection annotation (recordAppliedAppends, MongoDB, post-reset)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Testcontainers
+@Timeout(180)
+class ProjectionAnnotationRecordAppliedAppendsResetMongoTest {
+
+    @Container
+    static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    @Test
+    void an_ordinary_reset_clears_appends_recorded_before_it_and_a_replay_never_resurrects_them() {
+        String databaseName = "record-applied-appends-ordinary-reset";
+        AppendId preResetAppendId;
+        try (ConfigurableApplicationContext firstIncarnation = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName))) {
+            EventStore eventStore = firstIncarnation.getBean(EventStore.class);
+            CloudEventConverter<TestEvent> converter = firstIncarnation.getBean(CloudEventConverter.class);
+            AppliedAppendStore appliedAppendStore = firstIncarnation.getBean(AppliedAppendStore.class);
+
+            WriteResult result = eventStore.write(UUID.randomUUID().toString(), converter.toCloudEvents(List.of(new Counted("one"))));
+            preResetAppendId = result.appendId().orElseThrow();
+            assertThat(appliedAppendStore.waitUntilApplied("recording-counter", preResetAppendId, Duration.ofSeconds(20)))
+                    .as("sanity: the projection actually recorded the pre-reset append")
+                    .isTrue();
+        }
+
+        deleteCheckpoint(databaseName, "recording-counter");
+
+        try (ConfigurableApplicationContext secondIncarnation = SpringApplication.run(RecordingProjectionApplication.class, bootArgs(databaseName))) {
+            AppliedAppendStore appliedAppendStore = secondIncarnation.getBean(AppliedAppendStore.class);
+
+            // The pre-reset append must not come back, even though the replay redelivers the very same event.
+            await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(300)).untilAsserted(() ->
+                    assertThat(appliedAppendStore.hasApplied("recording-counter", preResetAppendId))
+                            .as("a replay records nothing, and the reset cleared the pre-reset record; the wait must not lie true")
+                            .isFalse());
+
+            // The projection is not permanently broken: a genuinely live write after the reset still gets recorded.
+            EventStore eventStore = secondIncarnation.getBean(EventStore.class);
+            CloudEventConverter<TestEvent> converter = secondIncarnation.getBean(CloudEventConverter.class);
+            WriteResult postResetWrite = eventStore.write(UUID.randomUUID().toString(), converter.toCloudEvents(List.of(new Counted("two"))));
+            AppendId postResetAppendId = postResetWrite.appendId().orElseThrow();
+            assertThat(appliedAppendStore.waitUntilApplied("recording-counter", postResetAppendId, Duration.ofSeconds(20)))
+                    .as("recording resumes normally for genuinely live appends after the reset")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void a_filtered_rebuild_whose_replay_delivers_no_matching_event_is_still_cleared_by_the_scheduled_poll() {
+        String databaseName = "record-applied-appends-filtered-rebuild";
+        AppendId staleAppendId;
+        try (ConfigurableApplicationContext firstIncarnation = SpringApplication.run(FilteredRecordingProjectionApplication.class, bootArgs(databaseName))) {
+            AppliedAppendStore appliedAppendStore = firstIncarnation.getBean(AppliedAppendStore.class);
+            // Padding: this projection's filter (NeverMatched.class) never matches any of these, but the catch-up
+            // layer still has to scan through them to determine it has reached "now", giving the second incarnation's
+            // replay real wall-clock duration instead of the empty-database edge case where a zero-document replay
+            // can complete inside a single poll tick and leave nothing for the poll to observe (decision 7's stated
+            // residual, not the case this test targets).
+            EventStore eventStore = firstIncarnation.getBean(EventStore.class);
+            CloudEventConverter<TestEvent> converter = firstIncarnation.getBean(CloudEventConverter.class);
+            // A large payload per event, not just a large count: an indexed or server-side-filtered scan can skip
+            // past many small non-matching documents almost instantly, but MongoDB still has to touch each
+            // document's bytes during a collection scan, so bulking up the payload forces genuine scan latency
+            // rather than hoping raw count alone outruns the poll.
+            String padding = "x".repeat(300_000);
+            for (int i = 0; i < 600; i++) {
+                eventStore.write(UUID.randomUUID().toString(), converter.toCloudEvents(List.of(new Counted("padding-" + i + "-" + padding))));
+            }
+            // This projection's filter (NeverMatched.class) matches no event this test ever writes, live or
+            // replayed, so a real delivery could never have produced a record for it in the first place. Seeding one
+            // directly stands in for a record a previous incarnation of this same projection id left behind, which
+            // is exactly the state decision 7's reset rule has to clear: membership rows key only by projection id
+            // and outlive whatever produced them.
+            staleAppendId = AppendId.mint();
+            appliedAppendStore.recordApplied("filtered-recording-counter", staleAppendId);
+            assertThat(appliedAppendStore.hasApplied("filtered-recording-counter", staleAppendId)).isTrue();
+        }
+
+        deleteCheckpoint(databaseName, "filtered-recording-counter");
+
+        try (ConfigurableApplicationContext secondIncarnation = SpringApplication.run(FilteredRecordingProjectionApplication.class, bootArgs(databaseName))) {
+            AppliedAppendStore appliedAppendStore = secondIncarnation.getBean(AppliedAppendStore.class);
+
+            // No delivery of any kind can reach this projection's recording wrapper (the filter matches nothing),
+            // so only the registrar's scheduled poll observing isCatchingUp can ever clear the stale row. Bounded by
+            // a generous multiple of the poll's default max interval (5s) rather than the per-delivery gate, which
+            // does not apply here.
+            await().atMost(Duration.ofSeconds(60)).pollInterval(Duration.ofMillis(200))
+                    .untilAsserted(() -> assertThat(appliedAppendStore.hasApplied("filtered-recording-counter", staleAppendId))
+                            .as("the scheduled poll must clear a stale record left by a predecessor incarnation, even with zero deliveries")
+                            .isFalse());
+        }
+    }
+
+
+    /**
+     * Deletes the durable checkpoint for {@code subscriptionId}, reached through the same scoped connection string
+     * the application used ({@code ReplicaSetReadyMongoDBContainer.getReplicaSetUrl(databaseName)} scopes the
+     * database name), not the raw {@code databaseName}, which would inspect an unrelated, empty database.
+     */
+    private static void deleteCheckpoint(String databaseName, String subscriptionId) {
+        ConnectionString connectionString = new ConnectionString(mongoDBContainer.getReplicaSetUrl(databaseName));
+        try (MongoClient client = MongoClients.create(connectionString)) {
+            client.getDatabase(connectionString.getDatabase()).getCollection("subscriptions")
+                    .deleteOne(new org.bson.Document("_id", subscriptionId));
+        }
+    }
+
+    // The poll's initial interval is far below the shipped default (200ms): the filtered-rebuild test's replay
+    // genuinely finishes in tens of milliseconds even with a padded backlog (confirmed by instrumenting the poll
+    // directly during development, every tick at the shipped default observed replaying=false, none ever caught the
+    // window), so this test needs a poll fast enough to observe a transient state real production traffic would
+    // rarely make this brief.
+    private static String[] bootArgs(String databaseName) {
+        return new String[]{
+                "--spring.mongodb.uri=" + mongoDBContainer.getReplicaSetUrl(databaseName),
+                "--spring.main.web-application-type=none",
+                "--occurrent.event-store.capabilities=stream",
+                "--occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:" + databaseName,
+                "--occurrent.projection.applied-append.replay-poll.initial=5ms",
+                "--occurrent.projection.applied-append.replay-poll.max=1s"
+        };
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class RecordingProjectionApplication {
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:record-applied-appends-reset-test"))
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        CounterStore counterStore() {
+            return new CounterStore();
+        }
+
+        @Bean
+        RecordingCounterProjection recordingCounterProjection() {
+            return new RecordingCounterProjection();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class FilteredRecordingProjectionApplication {
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:record-applied-appends-filtered-rebuild-test"))
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        CounterStore counterStore() {
+            return new CounterStore();
+        }
+
+        @Bean
+        FilteredRecordingCounterProjection filteredRecordingCounterProjection() {
+            return new FilteredRecordingCounterProjection();
+        }
+    }
+
+    static class RecordingCounterProjection {
+        @Projection(id = "recording-counter", recordAppliedAppends = true, storeName = "counterStore", startAt = StartPosition.BEGINNING)
+        org.occurrent.dsl.projection.Projection<Counter, TestEvent, String> counter() {
+            return org.occurrent.dsl.projection.Projection.<Counter, TestEvent, String>builder(new Counter(0))
+                    .id(event -> "counter")
+                    .on(Counted.class, (state, event) -> new Counter(state.count() + 1))
+                    .build();
+        }
+    }
+
+    /** Handles only {@link NeverMatched}, an event type this test never constructs, so its derived subscription
+     * filter matches nothing, live or replayed. */
+    static class FilteredRecordingCounterProjection {
+        // BACKGROUND rather than the default: DEFAULT blocks SpringApplication.run() until catch-up finishes, and a
+        // filtered, zero-match replay over Mongo finishes well under the poll's fastest tick (confirmed by
+        // instrumenting the poll directly: every tick observed replaying=false, none ever caught it), so the
+        // per-instance registrar's own scheduler never gets a chance to run concurrently with the replay under
+        // DEFAULT. BACKGROUND moves the replay off the startup path onto its own thread, so it and the poll's
+        // scheduler actually overlap in wall-clock time, which is what this test needs to exercise.
+        @Projection(id = "filtered-recording-counter", recordAppliedAppends = true, storeName = "counterStore", startAt = StartPosition.BEGINNING, startupMode = StartupMode.BACKGROUND)
+        org.occurrent.dsl.projection.Projection<Counter, TestEvent, String> counter() {
+            return org.occurrent.dsl.projection.Projection.<Counter, TestEvent, String>builder(new Counter(0))
+                    .id(event -> "counter")
+                    .on(NeverMatched.class, (state, event) -> new Counter(state.count() + 1))
+                    .build();
+        }
+    }
+
+    static class CounterStore implements ViewStateRepository<Counter, String> {
+        private final ConcurrentHashMap<String, Counter> store = new ConcurrentHashMap<>();
+
+        @Override
+        public Optional<Counter> findById(String id) {
+            return Optional.ofNullable(store.get(id));
+        }
+
+        @Override
+        public void save(String id, Counter state) {
+            store.put(id, state);
+        }
+    }
+
+    record Counter(int count) {
+    }
+
+    sealed interface TestEvent {
+        String eventId();
+
+        Date timestamp();
+
+        String name();
+    }
+
+    record Counted(String eventId, Date timestamp, String name) implements TestEvent {
+        Counted(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+
+    record NeverMatched(String eventId, Date timestamp, String name) implements TestEvent {
+    }
+}

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsWarningMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/ProjectionAnnotationRecordAppliedAppendsWarningMongoTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.mongo.blocking;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.occurrent.annotation.Projection;
+import org.occurrent.annotation.StartPosition;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.application.converter.jackson3.JacksonCloudEventConverter;
+import org.occurrent.application.converter.typemapper.CloudEventTypeMapper;
+import org.occurrent.application.converter.typemapper.ReflectionCloudEventTypeMapper;
+import org.occurrent.dsl.view.ViewStateRepository;
+import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The end-to-end pairing this falsifier suite's own withheld post-reset tests depend on, from the real shipped
+ * Spring Boot Mongo composition rather than {@code ProjectionAnnotationRecordAppliedAppendsWarningTest}'s
+ * mocked {@code Subscribable} (issue #865 / PR #869): the default start position warns naming the projection, and
+ * {@code startAt = StartPosition.BEGINNING}, the configuration
+ * {@code ProjectionAnnotationRecordAppliedAppendsResetMongoTest} actually uses, does not. Not a re-test of the
+ * wiring's truth table, that unit test module already covers every branch; this only pins that the real starter
+ * reaches the same two outcomes.
+ */
+@DisplayName("Projection annotation (recordAppliedAppends, MongoDB, never-replays warning)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Testcontainers
+@Timeout(60)
+class ProjectionAnnotationRecordAppliedAppendsWarningMongoTest {
+
+    @Container
+    static final MongoDBContainer mongoDBContainer =
+            ReplicaSetReadyMongoDBContainer.withDefaultVersion().withReuse(true);
+
+    // A manually attached logback appender does not survive SpringApplication.run(): Spring Boot's own logging
+    // system reinitializes logback on every call (LoggingApplicationListener reacting to context-preparation
+    // events), detaching whatever was attached beforehand, including an appender attached moments earlier in the
+    // same test. Capturing System.out around the call sidesteps that entirely, since the console appender Spring
+    // Boot (re)creates during this exact call binds to whatever System.out already is at that point.
+    private String bootConsoleOutput(Class<?> applicationClass, String databaseName) {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try (ConfigurableApplicationContext ignored = SpringApplication.run(applicationClass, bootArgs(databaseName))) {
+            return captured.toString(StandardCharsets.UTF_8);
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+
+    @Test
+    void the_default_start_position_warns_naming_the_projection_on_the_real_shipped_composition() {
+        String output = bootConsoleOutput(DefaultStartApplication.class, "record-applied-appends-warning-default");
+
+        assertThat(output)
+                .contains("WARN")
+                .contains("warning-default-counter")
+                .contains("recordAppliedAppends = true")
+                .contains("never replays");
+    }
+
+    @Test
+    void start_at_beginning_does_not_warn_on_the_real_shipped_composition_because_a_rebuild_actually_replays() {
+        String output = bootConsoleOutput(BeginningStartApplication.class, "record-applied-appends-warning-beginning");
+
+        assertThat(output).doesNotContain("never replays");
+    }
+
+    private static String[] bootArgs(String databaseName) {
+        return new String[]{
+                "--spring.mongodb.uri=" + mongoDBContainer.getReplicaSetUrl(databaseName),
+                "--spring.main.web-application-type=none",
+                "--occurrent.event-store.capabilities=stream",
+                "--occurrent.cloud-event-converter.cloud-event-source=urn:occurrent:" + databaseName
+        };
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class DefaultStartApplication {
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:record-applied-appends-warning-test"))
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        CounterStore counterStore() {
+            return new CounterStore();
+        }
+
+        @Bean
+        DefaultStartProjection defaultStartProjection() {
+            return new DefaultStartProjection();
+        }
+    }
+
+    @SpringBootApplication
+    @EnableOccurrent
+    static class BeginningStartApplication {
+        @Bean
+        CloudEventTypeMapper<TestEvent> testEventCloudEventTypeMapper() {
+            return ReflectionCloudEventTypeMapper.qualified();
+        }
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter(CloudEventTypeMapper<TestEvent> typeMapper) {
+            return new JacksonCloudEventConverter.Builder<TestEvent>(new ObjectMapper(), URI.create("urn:occurrent:record-applied-appends-warning-test"))
+                    .typeMapper(typeMapper)
+                    .idMapper(TestEvent::eventId)
+                    .timeMapper(event -> event.timestamp().toInstant().atOffset(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS))
+                    .build();
+        }
+
+        @Bean
+        CounterStore counterStore() {
+            return new CounterStore();
+        }
+
+        @Bean
+        BeginningStartProjection beginningStartProjection() {
+            return new BeginningStartProjection();
+        }
+    }
+
+    static class DefaultStartProjection {
+        @Projection(id = "warning-default-counter", recordAppliedAppends = true, storeName = "counterStore")
+        org.occurrent.dsl.projection.Projection<Counter, TestEvent, String> counter() {
+            return org.occurrent.dsl.projection.Projection.<Counter, TestEvent, String>builder(new Counter(0))
+                    .id(event -> "counter")
+                    .on(Counted.class, (state, event) -> new Counter(state.count() + 1))
+                    .build();
+        }
+    }
+
+    static class BeginningStartProjection {
+        @Projection(id = "warning-beginning-counter", recordAppliedAppends = true, storeName = "counterStore", startAt = StartPosition.BEGINNING)
+        org.occurrent.dsl.projection.Projection<Counter, TestEvent, String> counter() {
+            return org.occurrent.dsl.projection.Projection.<Counter, TestEvent, String>builder(new Counter(0))
+                    .id(event -> "counter")
+                    .on(Counted.class, (state, event) -> new Counter(state.count() + 1))
+                    .build();
+        }
+    }
+
+    static class CounterStore implements ViewStateRepository<Counter, String> {
+        private final ConcurrentHashMap<String, Counter> store = new ConcurrentHashMap<>();
+
+        @Override
+        public Optional<Counter> findById(String id) {
+            return Optional.ofNullable(store.get(id));
+        }
+
+        @Override
+        public void save(String id, Counter state) {
+            store.put(id, state);
+        }
+    }
+
+    record Counter(int count) {
+    }
+
+    sealed interface TestEvent {
+        String eventId();
+
+        Date timestamp();
+
+        String name();
+    }
+
+    record Counted(String eventId, Date timestamp, String name) implements TestEvent {
+        Counted(String name) {
+            this(UUID.randomUUID().toString(), new Date(), name);
+        }
+    }
+}


### PR DESCRIPTION
⌁[ayi/U5#740]

Part of #740, ADR 132. This is the second and final piece of U5, item 8 withheld from #863 pending issue #865's investigation.

## What I added

Issue #865 found that `@Projection(recordAppliedAppends = true)` left at the default start position never replays on Occurrent's own shipped composition, so the reset premise my original post-reset falsifiers depended on never held. PR #869 corrected ADR 132 (decision 7 is now scoped to a replaying start position, decision 9 gains the third bucket) and shipped a startup `WARN`, unblocking this work.

- `ProjectionAnnotationRecordAppliedAppendsResetMongoTest`: the ordinary reset and the filtered-rebuild variant, both against `startAt = StartPosition.BEGINNING`, where decision 7's guarantee actually applies. Both delete the durable checkpoint directly rather than through `cancelSubscription`, since the default `ResumeBehavior` resumes from an intact checkpoint instead of replaying again (issue #865's round-6 finding).
- `ProjectionAnnotationRecordAppliedAppendsWarningMongoTest`: an end-to-end pin, from this falsifier suite's own real-Mongo perspective, that the default start position warns and `BEGINNING` doesn't, on the actual shipped starter rather than the mocked `Subscribable` `ProjectionAnnotationRecordAppliedAppendsWarningTest` already covers.

Every falsifier is mutation tested: I reverted the production behavior it targets, confirmed the test failed, then restored the file from a copy.

## Notable while building this

The filtered-rebuild variant needed real, measurable replay duration before the scheduled poll could reliably observe it mid-flight. A local MongoDB scan skips past thousands of small, server-side-filtered-out documents in single-digit milliseconds regardless of count, so raw event volume alone couldn't win the race against even a fast poll interval. I confirmed this by instrumenting the poll directly during development: every tick came back `replaying=false`, none ever caught the window. What worked was a large-payload backlog (MongoDB still has to touch each document's bytes during a scan) paired with a much faster poll interval than the shipped default.

The warning pin needed a different fix: a manually attached logback appender doesn't survive `SpringApplication.run()`, since Spring Boot's own logging system reinitializes logback on every call and detaches whatever was attached beforehand. I switched to capturing `System.out` around the boot instead, which is unaffected by that reinitialization.
