### PR TITLE
Fix a Kafka pattern-subscription test racing its own consumer group rebalance

### DIFF
--- a/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeTest.java
+++ b/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeTest.java
@@ -621,6 +621,12 @@ class KafkaCloudEventBridgeTest extends KafkaTestSupport {
                 .resolver(resolver)
                 .pollTimeout(POLL_TIMEOUT)
                 .build()) {
+            // A pattern subscription only starts fetching topicA and topicB once this bridge's Consumer completes
+            // its own group rebalance, not the instant build() returns above. Publishing before that assignment is
+            // in place races the rebalance under load instead of proving anything about the bridge (#893 item 21),
+            // so this waits on the actual assignment rather than a fixed window.
+            awaitPartitionsAssigned(groupId, Set.of(new TopicPartition(topicA, 0), new TopicPartition(topicB, 0)));
+
             publishCloudEvent(topicA, "stream-1", CloudEventBuilder.v1()
                     .withId("id-a").withSource(URI.create("urn:test")).withType("TypeA")
                     .withExtension("streamid", "stream-1").build());

--- a/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaTestSupport.java
+++ b/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaTestSupport.java
@@ -51,8 +51,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * A single-node Kafka container, the native KRaft {@code apache/kafka} image
@@ -175,6 +177,27 @@ public abstract class KafkaTestSupport {
             adminClient.deleteTopics(List.of(name)).all().get(30, TimeUnit.SECONDS);
         } catch (Exception ignored) {
         }
+    }
+
+    /**
+     * Awaits until {@code groupId}'s consumer group assignment, read through {@link AdminClient#describeConsumerGroups},
+     * covers every partition in {@code expectedPartitions}. A pattern-subscribed {@code Consumer} only starts
+     * fetching a topic once its own group rebalance completes and hands it that topic's partitions, not the instant
+     * {@code Consumer.subscribe(Pattern)} (or the bridge's own {@code build()}) returns. A test that publishes right
+     * after {@code build()} races that rebalance instead of the bridge's actual readiness, a race #893 item 21 traced
+     * to exactly this gap. Polls the group description on a short interval rather than sleeping a fixed window, so
+     * this converges the moment the assignment is actually in place and never earlier, and never later than a real
+     * stall would need.
+     */
+    protected void awaitPartitionsAssigned(String groupId, Set<TopicPartition> expectedPartitions) {
+        await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(50)).untilAsserted(() -> {
+            ConsumerGroupDescription description = adminClient.describeConsumerGroups(List.of(groupId))
+                    .describedGroups().get(groupId).get(30, TimeUnit.SECONDS);
+            Set<TopicPartition> assigned = description.members().stream()
+                    .flatMap(member -> member.assignment().topicPartitions().stream())
+                    .collect(Collectors.toSet());
+            assertThat(assigned).containsAll(expectedPartitions);
+        });
     }
 
     /**


### PR DESCRIPTION
`KafkaCloudEventBridgeTest.resolver_alone_falls_back_to_catchAllDestination_subscribing_by_pattern_for_the_per_type_resolver` flaked in CI three times (#893 item 21, and again under #884's own symptom). I fixed the race in the test rather than in production code.

The test subscribes a `Consumer` by pattern, then publishes two events and expects both handled within five seconds. Both topics already exist before the subscribe call. The race is that a pattern-subscribed `Consumer` only starts fetching a topic once its own group rebalance completes and hands it that topic's partitions, not the instant `build()` returns. The test published right after `build()`, racing that rebalance under CI load.

I added `KafkaTestSupport.awaitPartitionsAssigned(groupId, expectedPartitions)`, which polls `AdminClient.describeConsumerGroups(groupId)` until the group's member assignment covers the expected partitions. The test now calls it after `build()` and before publishing, so it waits on the actual Kafka signal instead of racing an implicit one. No production code changed, since nothing here is a readiness gap in the bridge itself.

I looked into #884 too, since its body names this same test but describes a different symptom, a `TimeoutException: Topic parking-topic not present in metadata after 5000 ms`. I pulled the actual CI job log for the run it cites and found that exception is expected `WARN`-level output from `KafkaDeliveryFailureActionTest.a_park_publish_that_never_completes_redelivers_instead_of_losing_the_record`, a test that deliberately points its producer at an unreachable broker and passed with zero failures. It ran earlier in the same job's console output. The job's one actual test failure was the same `ConditionTimeout` on the same pattern-subscription test. So #884 is #893 item 21 under a misdiagnosed symptom, not a second defect, and this fix closes it too.

Closes #884

## Verification

- 10/10 local passes before this fix (the race needs CI-level load, it never reproduces locally)
- 10/10 local passes after this fix
- Mutation test: I reverted the new `awaitPartitionsAssigned` call (restored from a backed-up copy, not git) and it still passed 10/10 locally. That's expected rather than a hole in the fix, since this environment never trips the race either way. The fix waits on the real Kafka assignment signal by construction rather than a longer sleep, so it is correct regardless of what the local mutation run shows.
- Full `broker/kafka/blocking` module test suite passes
