### PR TITLE
Amend ADR 0127 with the descriptor's execution path and a catch-all handler

### DIFF
--- a/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
+++ b/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
@@ -391,3 +391,74 @@ The blocking and reactor descriptors are separate types, unlike `Projection`, so
 and run on both stacks. That is a genuine loss against the projection precedent. It comes from the handler being an
 effect, and there is no honest way to give a blocking handler to a reactive runner, so a shared type would only be
 possible by making one of the two stacks pretend to be the other.
+
+## Amended on 2026-08-22: the runner becomes the single execution path, and the descriptor gains a catch-all
+
+Decision 1 designs the descriptor and Decision 6 scopes rewriting the annotation registrars as epic work, but reading
+every call site those registrars hold surfaces two things neither says, what a descriptor path executes through and a
+hole in the builder's own coverage found while answering that question. Both are decided here.
+
+### A catch-all handler joins the explicit selector
+
+Decision 1 lets an explicit `Filter` override the type-derived selector, the way `Projection.filter()` does, and
+separately says an event the selector admits that no handler handles is ignored. Put those two together and a
+descriptor built from an explicit `Filter` has nowhere to put an event it admits, because every registration on the
+builder is keyed to a type, so a caller who wants "handle everything this filter matches" cannot say so, and the
+descriptor that results has zero registrations and drops every event it receives. That is a gap in the descriptor's own
+design, not something the epic introduced, and it falls hardest on exactly the caller most likely to use an explicit
+`Filter`, since that caller has already said the type-derived selector is not what they want.
+
+The builder gains a type-free catch-all handler, and it is public, alongside the type-keyed registrations Decision 1
+already defines. Which handler an event reaches follows the same rule Decision 1 already takes from
+`Projection.Builder.on`, an exact match first, then the nearest superclass, then an interface, and the catch-all runs
+only when nothing more specific claims the event, never in addition to a type-keyed handler that did. A descriptor built
+from one `Filter` and the catch-all alone now says exactly what a plain `subscribe(id, filter, startAt, (metadata,
+event) -> ..)` call says today, which keeps the descriptor able to express every subscription the DSL already can.
+
+### The registrars have never named what they call
+
+Five of the framework's annotation registrars reach the subscription DSL to run their handlers: `SubscriptionAnnotationRegistrar`
+on both stacks, the two files Decision 6 names, `ProjectionAnnotationRegistrar` on the blocking stack, and
+`SnapshotAnnotationRegistrar` on both stacks. The reactor `ProjectionAnnotationRegistrar` is not among them. It calls
+`ReactiveProjectionRunner` directly and never reaches the subscription DSL. Between the five there are 21 lookups, four
+per registrar, one stream against `StreamSubscriptions`, one agnostic against `Subscriptions`, one synchronous against a
+name-qualified `Subscriptions` bean over a `SynchronousSubscriptionModel`, and one DCB against `DcbSubscriptions` in
+`dsl/dcb-dsl`. All seventeen non-DCB calls share one shape, `subscribe(id, <Filter>, startAt,
+[waitUntilStarted], (metadata, event) -> ..)`, and not one of the 21 passes an event `Class`. The registrar derives its
+selector from the annotation before it ever reaches the DSL and hands over a finished filter and one handler, exactly
+the shape the catch-all handler above now lets a hand-built descriptor express too.
+
+### The runner is the single execution path, within 0.35.0
+
+Every one of those 21 lookups calls the runner instead of `StreamSubscriptions.subscribe`, `Subscriptions.subscribe`,
+or `DcbSubscriptions.subscribeWithMetadata`. `Subscriptions` and `StreamSubscriptions` are reshaped into a thin idiom
+layer that builds a `Subscription<E>` and hands it to the matching runner, covering the seventeen stream, agnostic, and
+synchronous sites, the synchronous ones for free since they are the same class reached through a different bean name.
+That reshape is unit U13 of the implementation epic this ADR scopes. `DcbSubscriptions` is reshaped the same way onto
+the two DCB runners, covering the remaining four sites, as unit U14. Both ship inside 0.35.0, so the runner becomes the
+one execution path across all 21 call sites within a single release rather than as a goal spread across two.
+
+### `waitUntilStarted` is forwarded, never moved
+
+The blocking `subscribe` overloads already have `waitUntilStarted` as a released parameter, with a default of `true`,
+and the registrars already compute its value before calling one, through
+`SubscriptionAnnotations.subscriptionsStartOnTheirOwn` reading the Spring `ApplicationContext`. A descriptor cannot
+compute that value itself: Decision 1 keeps `Subscription<E>` free of Spring, and reading the application context is
+exactly the coupling that freedom rules out. So the caller keeps computing it and passes it to the runner as an
+argument, the same way it already passes a start position, and the runner is what honours it. The reactor stack has no
+such parameter today, for the reason Decision 1 already gives, that a reactive handle returns its own `Mono<Void>`
+from `waitUntilStarted()` rather than blocking the caller to produce one, and this amendment does not add one there.
+
+### The Kotlin DSL classes stay real classes, and real Spring beans
+
+Reshaping `Subscriptions` and `StreamSubscriptions` into an idiom layer changes what their bodies do, not what they
+are. Both stay a `class`, and both stay the beans the Mongo auto-configuration exposes with `@Bean`. [ADR
+29](0029-rename-subscriptions-dsl-to-stream-subscriptions.md) is the one that still binds here, for the constraint
+rather than the description: `Subscriptions` has been released since 0.20.4, the auto-configuration exposes it as a
+bean, the annotation processor looks it up with `getBean`, and callers inject it, so removing the class or changing its
+identity would break source and binary compatibility that ADR 29 chose to keep. What ADR 29 decided the class would be,
+a deprecated empty subclass of `StreamSubscriptions`, is not what it is today. [ADR
+51](0051-capability-agnostic-subscription.md) revived `Subscriptions` as the capability-neutral default that delivers
+both stream and DCB events filtered only by type, superseding ADR 29's decision in part, which is what ADR 29's own
+Status now says. The reshape changes `Subscriptions` and `StreamSubscriptions` again, a third time for the same two
+classes, and it changes what is inside them, never whether they exist as classes and beans.

--- a/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
+++ b/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
@@ -420,22 +420,24 @@ event) -> ..)` call says today, which keeps the descriptor able to express every
 Five of the framework's annotation registrars reach the subscription DSL to run their handlers: `SubscriptionAnnotationRegistrar`
 on both stacks, the two files Decision 6 names, `ProjectionAnnotationRegistrar` on the blocking stack, and
 `SnapshotAnnotationRegistrar` on both stacks. The reactor `ProjectionAnnotationRegistrar` is not among them. It calls
-`ReactiveProjectionRunner` directly and never reaches the subscription DSL. Between the five there are 21 lookups, four
-per registrar, one stream against `StreamSubscriptions`, one agnostic against `Subscriptions`, one synchronous against a
-name-qualified `Subscriptions` bean over a `SynchronousSubscriptionModel`, and one DCB against `DcbSubscriptions` in
-`dsl/dcb-dsl`. All seventeen non-DCB calls share one shape, `subscribe(id, <Filter>, startAt,
-[waitUntilStarted], (metadata, event) -> ..)`, and not one of the 21 passes an event `Class`. The registrar derives its
-selector from the annotation before it ever reaches the DSL and hands over a finished filter and one handler, exactly
-the shape the catch-all handler above now lets a hand-built descriptor express too.
+`ReactiveProjectionRunner` directly and never reaches the subscription DSL. Between the five there are 21 lookups, five
+stream against `StreamSubscriptions`, five agnostic against `Subscriptions`, six synchronous against a name-qualified
+`Subscriptions` bean over a `SynchronousSubscriptionModel`, and five DCB against `DcbSubscriptions` in `dsl/dcb-dsl`.
+That is not four per registrar throughout, because the blocking `ProjectionAnnotationRegistrar` dispatches a
+`Projection` and a `DcbProjection` as two separate cases, and each case has its own synchronous fallback, which is
+where the sixth synchronous lookup comes from. All sixteen non-DCB calls share one shape, `subscribe(id, <Filter>,
+startAt, [waitUntilStarted], (metadata, event) -> ..)`, and not one of the 21 passes an event `Class`. The registrar
+derives its selector from the annotation before it ever reaches the DSL and hands over a finished filter and one
+handler, exactly the shape the catch-all handler above now lets a hand-built descriptor express too.
 
 ### The runner is the single execution path, within 0.35.0
 
 Every one of those 21 lookups calls the runner instead of `StreamSubscriptions.subscribe`, `Subscriptions.subscribe`,
 or `DcbSubscriptions.subscribeWithMetadata`. `Subscriptions` and `StreamSubscriptions` are reshaped into a thin idiom
-layer that builds a `Subscription<E>` and hands it to the matching runner, covering the seventeen stream, agnostic, and
+layer that builds a `Subscription<E>` and hands it to the matching runner, covering the sixteen stream, agnostic, and
 synchronous sites, the synchronous ones for free since they are the same class reached through a different bean name.
 That reshape is unit U13 of the implementation epic this ADR scopes. `DcbSubscriptions` is reshaped the same way onto
-the two DCB runners, covering the remaining four sites, as unit U14. Both ship inside 0.35.0, so the runner becomes the
+the two DCB runners, covering the remaining five sites, as unit U14. Both ship inside 0.35.0, so the runner becomes the
 one execution path across all 21 call sites within a single release rather than as a goal spread across two.
 
 ### `waitUntilStarted` is forwarded, never moved

--- a/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
+++ b/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
@@ -454,17 +454,21 @@ goal spread across two.
 ### `waitUntilStarted` is forwarded, never moved
 
 The blocking `subscribe` overloads on `StreamSubscriptions` and `Subscriptions` already have `waitUntilStarted` as a
-released argument, with a default of `true`. `DcbSubscriptions.subscribeWithMetadata` computes the same boolean but
-applies it differently today, since its convenience overload always passes `false` in, and the three blocking DCB call
-sites call `waitUntilStarted()` on the returned handle afterward instead, when `subscriptionsStartOnTheirOwn` says to.
-Either way, every one of the 21 sites computes that boolean itself, through
-`SubscriptionAnnotations.subscriptionsStartOnTheirOwn` reading the Spring `ApplicationContext`, and none of them get
-it from the DSL. A descriptor cannot compute that value itself: Decision 1 keeps `Subscription<E>` free of Spring, and
-reading the application context is exactly the coupling that freedom rules out. So the caller keeps computing it and
-hands it to the runner, whether as an argument or as a call on the handle the runner returns, the same way it already
-passes a start position, and the runner is what honours it. The reactor stack has no such parameter today, for the
-reason Decision 1 already gives, that a reactive handle returns its own `Mono<Void>` from `waitUntilStarted()` rather
-than blocking the caller to produce one, and this amendment does not add one there.
+released argument, with a default of `true`. Only the fifteen asynchronous sites, stream, agnostic and DCB on both
+stacks, compute a `waitUntilStarted` boolean at all, and all fifteen compute the same one, through
+`SubscriptionAnnotations.subscriptionsStartOnTheirOwn` reading the Spring `ApplicationContext`. They apply it two
+ways. One is a `subscribe` argument, wherever the DSL method being called has one, which today is the blocking stream
+and agnostic sites. The other is a call to `waitUntilStarted()` on the handle `subscribe` already returned, which is
+every reactor site (no reactor `subscribe` overload takes the argument) and the three blocking DCB sites
+(`DcbSubscriptions.subscribeWithMetadata`'s convenience overload always passes `false` in, so the registrar corrects
+it afterward on the handle). The six synchronous sites never compute the boolean at all. A synchronous subscription
+dispatches on the writer's thread with no background startup to wait for, so every synchronous call site is
+unconditionally not waiting, whether by passing `false` on the blocking side or by having no wait to apply on the
+reactor side. A descriptor cannot compute `waitUntilStarted` itself: Decision 1 keeps `Subscription<E>` free of
+Spring, and reading the application context is exactly the coupling that freedom rules out. So an asynchronous caller
+keeps computing the value and hands it to the runner, as an argument or as a call on the handle the runner returns,
+the same way it already passes a start position, and the runner is what honours it. A synchronous caller passes
+`false` the same way it always has.
 
 ### The Kotlin DSL classes stay real classes, and real Spring beans
 

--- a/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
+++ b/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
@@ -361,7 +361,7 @@ The work this ADR describes, listed so it can be scoped as its own epic:
    reflective path, which the deprecated annotations still need and which is deleted with them a release later.
 5. Seven new annotation types, seven deprecations, and normalization of both sets in the bean post processors.
 6. Recipes, declarative for the type and annotation renames, a Java visitor for the body rewrite with its three refusal cases.
-7. A section in `doc/migration/upgrading-to-0.34.0.md`, changelog entries, and a docs branch.
+7. A section in `doc/migration/upgrading-to-0.35.0.md`, changelog entries, and a docs branch.
 8. Updating 35 test classes, 13 example files, and the 79 lines of the documentation site's reference page on `main`
    that mention one of these annotations.
 

--- a/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
+++ b/doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md
@@ -402,23 +402,31 @@ hole in the builder's own coverage found while answering that question. Both are
 
 Decision 1 lets an explicit `Filter` override the type-derived selector, the way `Projection.filter()` does, and
 separately says an event the selector admits that no handler handles is ignored. Put those two together and a
-descriptor built from an explicit `Filter` has nowhere to put an event it admits, because every registration on the
-builder is keyed to a type, so a caller who wants "handle everything this filter matches" cannot say so, and the
-descriptor that results has zero registrations and drops every event it receives. That is a gap in the descriptor's own
-design, not something the epic introduced, and it falls hardest on exactly the caller most likely to use an explicit
-`Filter`, since that caller has already said the type-derived selector is not what they want.
+descriptor built from an explicit `Filter`, with no type-keyed handler for a type that `Filter` admits, has nowhere to
+put an event of that type, because every registration on the builder is keyed to a type, so a caller who wants "handle
+everything this filter matches" cannot say so. Such a descriptor has zero registrations and drops every event it
+receives. That is a gap in the descriptor's own design, not something the epic introduced, and it falls hardest on
+exactly the caller most likely to use an explicit `Filter`, since that caller has already said the type-derived
+selector is not what they want.
 
-The builder gains a type-free catch-all handler, and it is public, alongside the type-keyed registrations Decision 1
-already defines. Which handler an event reaches follows the same rule Decision 1 already takes from
-`Projection.Builder.on`, an exact match first, then the nearest superclass, then an interface, and the catch-all runs
-only when nothing more specific claims the event, never in addition to a type-keyed handler that did. A descriptor built
-from one `Filter` and the catch-all alone now says exactly what a plain `subscribe(id, filter, startAt, (metadata,
-event) -> ..)` call says today, which keeps the descriptor able to express every subscription the DSL already can.
+All four builders, `Subscription.Builder`, `ReactiveSubscription.Builder`, `DcbSubscription.Builder`, and
+`ReactiveDcbSubscription.Builder`, gain a type-free catch-all handler, alongside the type-keyed registrations Decision
+1 already defines. It is public rather than an internal hook the reshaped idiom layer alone uses, because the gap is
+not epic-internal. Any caller building a descriptor by hand and supplying an explicit `Filter` or DCB criteria hits it.
+Which handler an event reaches follows the same rule Decision 1 already takes from `Projection.Builder.on`, an exact
+match first, then the nearest superclass, then an interface, and the catch-all runs only when nothing more specific
+claims the event, never in addition to a type-keyed handler that did.
 
-### The registrars have never named what they call
+The catch-all contributes no type, so it never widens what the type-derived selector admits on its own. A descriptor
+built from the catch-all alone, with no explicit `Filter` or criteria, still derives an empty selector and receives
+nothing, exactly the failure this section exists to close. The catch-all closes the gap only paired with an explicit
+`Filter` or criteria, never as a replacement for one. A descriptor built from one `Filter` and the catch-all alone now
+says exactly what a plain `subscribe(id, filter, startAt, (metadata, event) -> ..)` call says today.
 
-Five of the framework's annotation registrars reach the subscription DSL to run their handlers: `SubscriptionAnnotationRegistrar`
-on both stacks, the two files Decision 6 names, `ProjectionAnnotationRegistrar` on the blocking stack, and
+### No decision has said what a registrar's lookup executes
+
+Five of the framework's annotation registrars reach the subscription DSL to run their handlers, `SubscriptionAnnotationRegistrar`
+on both stacks (the two files Decision 6 names), `ProjectionAnnotationRegistrar` on the blocking stack, and
 `SnapshotAnnotationRegistrar` on both stacks. The reactor `ProjectionAnnotationRegistrar` is not among them. It calls
 `ReactiveProjectionRunner` directly and never reaches the subscription DSL. Between the five there are 21 lookups, five
 stream against `StreamSubscriptions`, five agnostic against `Subscriptions`, six synchronous against a name-qualified
@@ -426,30 +434,37 @@ stream against `StreamSubscriptions`, five agnostic against `Subscriptions`, six
 That is not four per registrar throughout, because the blocking `ProjectionAnnotationRegistrar` dispatches a
 `Projection` and a `DcbProjection` as two separate cases, and each case has its own synchronous fallback, which is
 where the sixth synchronous lookup comes from. All sixteen non-DCB calls share one shape, `subscribe(id, <Filter>,
-startAt, [waitUntilStarted], (metadata, event) -> ..)`, and not one of the 21 passes an event `Class`. The registrar
-derives its selector from the annotation before it ever reaches the DSL and hands over a finished filter and one
-handler, exactly the shape the catch-all handler above now lets a hand-built descriptor express too.
+startAt, [waitUntilStarted], (metadata, event) -> ..)`, and not one of the 21 passes an event `Class`. Each call site
+builds its own filter before it ever reaches the DSL, from the annotation's declared types on `SubscriptionAnnotationRegistrar`,
+from the descriptor's own fold on `ProjectionAnnotationRegistrar`, and from the snapshot view on `SnapshotAnnotationRegistrar`,
+then hands the DSL a finished filter and one handler, exactly the shape the catch-all handler above now lets a hand-built
+descriptor express too.
 
 ### The runner is the single execution path, within 0.35.0
 
-Every one of those 21 lookups calls the runner instead of `StreamSubscriptions.subscribe`, `Subscriptions.subscribe`,
-or `DcbSubscriptions.subscribeWithMetadata`. `Subscriptions` and `StreamSubscriptions` are reshaped into a thin idiom
-layer that builds a `Subscription<E>` and hands it to the matching runner, covering the sixteen stream, agnostic, and
-synchronous sites, the synchronous ones for free since they are the same class reached through a different bean name.
-That reshape is unit U13 of the implementation epic this ADR scopes. `DcbSubscriptions` is reshaped the same way onto
-the two DCB runners, covering the remaining five sites, as unit U14. Both ship inside 0.35.0, so the runner becomes the
-one execution path across all 21 call sites within a single release rather than as a goal spread across two.
+All 21 of those lookups end up executing through the runner, because the classes they call are reshaped rather than
+replaced. `Subscriptions` and `StreamSubscriptions` keep their `subscribe` methods, but each one now builds a
+`Subscription<E>` internally and hands it to the matching runner instead of talking to the subscription model directly.
+That covers the sixteen stream, agnostic, and synchronous sites, the synchronous ones for free since they are the same
+class reached through a different bean name, as unit U13 of the implementation epic this ADR scopes. `DcbSubscriptions`
+is reshaped the same way onto the two DCB runners, covering the remaining five sites, as unit U14. Both ship inside
+0.35.0, so the runner becomes the one execution path across all 21 call sites within a single release rather than as a
+goal spread across two.
 
 ### `waitUntilStarted` is forwarded, never moved
 
-The blocking `subscribe` overloads already have `waitUntilStarted` as a released parameter, with a default of `true`,
-and the registrars already compute its value before calling one, through
-`SubscriptionAnnotations.subscriptionsStartOnTheirOwn` reading the Spring `ApplicationContext`. A descriptor cannot
-compute that value itself: Decision 1 keeps `Subscription<E>` free of Spring, and reading the application context is
-exactly the coupling that freedom rules out. So the caller keeps computing it and passes it to the runner as an
-argument, the same way it already passes a start position, and the runner is what honours it. The reactor stack has no
-such parameter today, for the reason Decision 1 already gives, that a reactive handle returns its own `Mono<Void>`
-from `waitUntilStarted()` rather than blocking the caller to produce one, and this amendment does not add one there.
+The blocking `subscribe` overloads on `StreamSubscriptions` and `Subscriptions` already have `waitUntilStarted` as a
+released argument, with a default of `true`. `DcbSubscriptions.subscribeWithMetadata` computes the same boolean but
+applies it differently today, since its convenience overload always passes `false` in, and the three blocking DCB call
+sites call `waitUntilStarted()` on the returned handle afterward instead, when `subscriptionsStartOnTheirOwn` says to.
+Either way, every one of the 21 sites computes that boolean itself, through
+`SubscriptionAnnotations.subscriptionsStartOnTheirOwn` reading the Spring `ApplicationContext`, and none of them get
+it from the DSL. A descriptor cannot compute that value itself: Decision 1 keeps `Subscription<E>` free of Spring, and
+reading the application context is exactly the coupling that freedom rules out. So the caller keeps computing it and
+hands it to the runner, whether as an argument or as a call on the handle the runner returns, the same way it already
+passes a start position, and the runner is what honours it. The reactor stack has no such parameter today, for the
+reason Decision 1 already gives, that a reactive handle returns its own `Mono<Void>` from `waitUntilStarted()` rather
+than blocking the caller to produce one, and this amendment does not add one there.
 
 ### The Kotlin DSL classes stay real classes, and real Spring beans
 
@@ -462,5 +477,6 @@ identity would break source and binary compatibility that ADR 29 chose to keep. 
 a deprecated empty subclass of `StreamSubscriptions`, is not what it is today. [ADR
 51](0051-capability-agnostic-subscription.md) revived `Subscriptions` as the capability-neutral default that delivers
 both stream and DCB events filtered only by type, superseding ADR 29's decision in part, which is what ADR 29's own
-Status now says. The reshape changes `Subscriptions` and `StreamSubscriptions` again, a third time for the same two
-classes, and it changes what is inside them, never whether they exist as classes and beans.
+Status now says. The reshape changes `Subscriptions` again, a third time after ADR 29 and ADR 51, and `StreamSubscriptions`
+a second time after ADR 29 alone, since ADR 51 left it untouched. Neither change is to whether they exist as classes
+and beans, only to what is inside them.


### PR DESCRIPTION
I amended [ADR 0127](doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md)
in place, since it has not shipped yet, to record four things the original decision left
unsaid.

The ADR designed the subscription descriptor and scoped rewriting the annotation
registrars as epic work, but never said what a descriptor path calls once it has a
`Subscription<E>` built. Reading every one of the 21 registrar call sites that decision
touches settled that, and surfaced a gap in the descriptor's own coverage along the
way.

I added a new "Amended on 2026-08-22" section covering:

- The builder gets a public, type-free catch-all handler, because an explicit `Filter`
  with no matching type-keyed handler currently drops every event it admits.
- The runner becomes the single execution path across all 21 call sites within 0.35.0,
  split across epic units U13 (the sixteen stream, agnostic and synchronous sites) and
  U14 (the five DCB sites).
- `waitUntilStarted` is forwarded to the runner rather than moved onto it, since a
  descriptor has to stay Spring-free and cannot read the application context itself.
- The Kotlin `Subscriptions` and `StreamSubscriptions` DSL classes stay real classes and
  real Spring beans, since ADR 29's binary-compatibility constraint still binds. Only
  their bodies get reshaped.

No changelog entry needed. This amends an unreleased ADR, and the release currently
landing under `changelog.md`'s heading is 0.34.0, a different release from the one this
work ships in.
