### PR TITLE
Rename Subscription to SubscriptionHandle

### DIFF
--- a/broker/api/blocking/src/main/java/org/occurrent/broker/api/blocking/CloudEventForwarder.java
+++ b/broker/api/blocking/src/main/java/org/occurrent/broker/api/blocking/CloudEventForwarder.java
@@ -19,7 +19,7 @@ package org.occurrent.broker.api.blocking;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.blocking.durable.DurableSubscriptionModel;
 
 import static java.util.Objects.requireNonNull;
@@ -54,7 +54,7 @@ public class CloudEventForwarder {
     /**
      * Start forwarding at the subscription model's default start position, with no filter.
      */
-    public Subscription forward(String subscriptionId) {
+    public SubscriptionHandle forward(String subscriptionId) {
         return subscriptionModel.subscribe(subscriptionId, sink::publish);
     }
 
@@ -62,14 +62,14 @@ public class CloudEventForwarder {
      * Start forwarding at {@code startAt}, with no filter. See the class javadoc for what an explicit
      * {@code startAt} costs on a restart.
      */
-    public Subscription forward(String subscriptionId, StartAt startAt) {
+    public SubscriptionHandle forward(String subscriptionId, StartAt startAt) {
         return subscriptionModel.subscribe(subscriptionId, startAt, sink::publish);
     }
 
     /**
      * Start forwarding only events matching {@code filter}, at the subscription model's default start position.
      */
-    public Subscription forward(String subscriptionId, @Nullable SubscriptionFilter filter) {
+    public SubscriptionHandle forward(String subscriptionId, @Nullable SubscriptionFilter filter) {
         return subscriptionModel.subscribe(subscriptionId, filter, sink::publish);
     }
 
@@ -77,7 +77,7 @@ public class CloudEventForwarder {
      * Start forwarding only events matching {@code filter}, at {@code startAt}. See the class javadoc for what an
      * explicit {@code startAt} costs on a restart.
      */
-    public Subscription forward(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt) {
+    public SubscriptionHandle forward(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt) {
         return subscriptionModel.subscribe(subscriptionId, filter, startAt, sink::publish);
     }
 }

--- a/broker/api/blocking/src/main/java/org/occurrent/broker/api/blocking/DomainEventForwarder.java
+++ b/broker/api/blocking/src/main/java/org/occurrent/broker/api/blocking/DomainEventForwarder.java
@@ -22,7 +22,7 @@ import org.occurrent.application.converter.CloudEventConverter;
 import org.occurrent.cloudevents.EventMetadata;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.blocking.durable.DurableSubscriptionModel;
 
 import java.util.function.Consumer;
@@ -68,7 +68,7 @@ public class DomainEventForwarder<E> {
     /**
      * Start forwarding at the subscription model's default start position, with no filter.
      */
-    public Subscription forward(String subscriptionId) {
+    public SubscriptionHandle forward(String subscriptionId) {
         return subscriptionModel.subscribe(subscriptionId, decodeAndPublish());
     }
 
@@ -76,14 +76,14 @@ public class DomainEventForwarder<E> {
      * Start forwarding at {@code startAt}, with no filter. See the class javadoc for what an explicit
      * {@code startAt} costs on a restart.
      */
-    public Subscription forward(String subscriptionId, StartAt startAt) {
+    public SubscriptionHandle forward(String subscriptionId, StartAt startAt) {
         return subscriptionModel.subscribe(subscriptionId, startAt, decodeAndPublish());
     }
 
     /**
      * Start forwarding only events matching {@code filter}, at the subscription model's default start position.
      */
-    public Subscription forward(String subscriptionId, @Nullable SubscriptionFilter filter) {
+    public SubscriptionHandle forward(String subscriptionId, @Nullable SubscriptionFilter filter) {
         return subscriptionModel.subscribe(subscriptionId, filter, decodeAndPublish());
     }
 
@@ -91,7 +91,7 @@ public class DomainEventForwarder<E> {
      * Start forwarding only events matching {@code filter}, at {@code startAt}. See the class javadoc for what an
      * explicit {@code startAt} costs on a restart.
      */
-    public Subscription forward(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt) {
+    public SubscriptionHandle forward(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt) {
         return subscriptionModel.subscribe(subscriptionId, filter, startAt, decodeAndPublish());
     }
 

--- a/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/FakeCheckpointAwareSubscriptionModel.java
+++ b/broker/api/blocking/src/test/java/org/occurrent/broker/api/blocking/FakeCheckpointAwareSubscriptionModel.java
@@ -23,7 +23,7 @@ import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.function.Consumer;
@@ -47,12 +47,12 @@ class FakeCheckpointAwareSubscriptionModel implements CheckpointAwareSubscriptio
     private @Nullable Consumer<CloudEvent> action;
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         this.subscriptionId = requireNonNull(subscriptionId);
         this.filter = filter;
         this.startAt = requireNonNull(startAt);
         this.action = requireNonNull(action);
-        return new Subscription() {
+        return new SubscriptionHandle() {
             @Override
             public String id() {
                 return subscriptionId;
@@ -110,7 +110,7 @@ class FakeCheckpointAwareSubscriptionModel implements CheckpointAwareSubscriptio
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         throw new UnsupportedOperationException();
     }
 

--- a/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeCatchUpFailureParkTest.java
+++ b/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeCatchUpFailureParkTest.java
@@ -29,7 +29,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -73,7 +73,7 @@ class KafkaCloudEventBridgeCatchUpFailureParkTest extends KafkaTestSupport {
 
         // The replay fold throws for the one historical event, which BlockingHandover.catchUp(..) records as a
         // permanent catch-up failure (catchUpFailure), then rethrows.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated catch-up fold failure for " + ce.getId());
         });
 

--- a/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeNestedRefusalRedeliverTest.java
+++ b/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeNestedRefusalRedeliverTest.java
@@ -23,7 +23,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -63,7 +63,7 @@ class KafkaCloudEventBridgeNestedRefusalRedeliverTest extends KafkaTestSupport {
         InMemoryEventStore otherStore = new InMemoryEventStore();
         otherStore.write("s1", List.of(orderPlacedWithId("historical")));
         CatchupThenPushSubscriptionModel otherWrapper = new CatchupThenPushSubscriptionModel(otherStore, otherLiveFeed, null);
-        Subscription otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the unrelated model");
         });
         assertThatThrownBy(() -> otherSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeNestedRefusalTest.java
+++ b/broker/kafka/blocking/src/test/java/org/occurrent/broker/kafka/blocking/KafkaCloudEventBridgeNestedRefusalTest.java
@@ -28,7 +28,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -74,7 +74,7 @@ class KafkaCloudEventBridgeNestedRefusalTest extends KafkaTestSupport {
         InMemoryEventStore otherStore = new InMemoryEventStore();
         otherStore.write("s1", List.of(orderPlacedWithId("historical")));
         CatchupThenPushSubscriptionModel otherWrapper = new CatchupThenPushSubscriptionModel(otherStore, otherLiveFeed, null);
-        Subscription otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the unrelated model");
         });
         assertThatThrownBy(() -> otherSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/broker/kafka/spring-boot-starter/src/test/java/org/occurrent/springboot/broker/kafka/blocking/CatchupThenPushReadinessAmbiguousIdTest.java
+++ b/broker/kafka/spring-boot-starter/src/test/java/org/occurrent/springboot/broker/kafka/blocking/CatchupThenPushReadinessAmbiguousIdTest.java
@@ -27,7 +27,7 @@ import org.occurrent.broker.kafka.blocking.RoutingOutcomeChannel;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -77,7 +77,7 @@ class CatchupThenPushReadinessAmbiguousIdTest {
                 .withType(TestEvent.class.getName())
                 .build()));
         CatchupThenPushSubscriptionModel failingWrapper = new CatchupThenPushSubscriptionModel(failingStore, failingLiveFeed, null);
-        Subscription failingSubscription = failingWrapper.subscribe("orders", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle failingSubscription = failingWrapper.subscribe("orders", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the OTHER model sharing this id");
         });
         assertThatThrownBy(() -> failingSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeCatchUpFailureParkTest.java
+++ b/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeCatchUpFailureParkTest.java
@@ -24,7 +24,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -68,7 +68,7 @@ class RabbitMqCloudEventBridgeCatchUpFailureParkTest extends RabbitMqTestSupport
 
         // The replay fold throws for the one historical event, which BlockingHandover.catchUp(..) records as a
         // permanent catch-up failure (catchUpFailure), then rethrows.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated catch-up fold failure for " + ce.getId());
         });
 

--- a/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeNestedRefusalRedeliverTest.java
+++ b/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeNestedRefusalRedeliverTest.java
@@ -24,7 +24,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -63,7 +63,7 @@ class RabbitMqCloudEventBridgeNestedRefusalRedeliverTest extends RabbitMqTestSup
         InMemoryEventStore otherStore = new InMemoryEventStore();
         otherStore.write("s1", List.of(cloudEvent("historical", OrderPlaced.class.getName())));
         CatchupThenPushSubscriptionModel otherWrapper = new CatchupThenPushSubscriptionModel(otherStore, otherLiveFeed, null);
-        Subscription otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the unrelated model");
         });
         assertThatThrownBy(() -> otherSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeNestedRefusalTest.java
+++ b/broker/rabbitmq/blocking/src/test/java/org/occurrent/broker/rabbitmq/blocking/RabbitMqCloudEventBridgeNestedRefusalTest.java
@@ -24,7 +24,7 @@ import org.occurrent.broker.api.blocking.DeliveryFailurePolicy;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 
@@ -71,7 +71,7 @@ class RabbitMqCloudEventBridgeNestedRefusalTest extends RabbitMqTestSupport {
         InMemoryEventStore otherStore = new InMemoryEventStore();
         otherStore.write("s1", List.of(cloudEvent("historical", OrderPlaced.class.getName())));
         CatchupThenPushSubscriptionModel otherWrapper = new CatchupThenPushSubscriptionModel(otherStore, otherLiveFeed, null);
-        Subscription otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle otherSubscription = otherWrapper.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the unrelated model");
         });
         assertThatThrownBy(() -> otherSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/broker/rabbitmq/spring-boot-starter/src/test/java/org/occurrent/springboot/broker/rabbitmq/blocking/CatchupThenPushReadinessAmbiguousIdTest.java
+++ b/broker/rabbitmq/spring-boot-starter/src/test/java/org/occurrent/springboot/broker/rabbitmq/blocking/CatchupThenPushReadinessAmbiguousIdTest.java
@@ -32,7 +32,7 @@ import org.occurrent.broker.rabbitmq.blocking.RoutingOutcomeChannel;
 import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.filtermatching.DataFieldReader;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -112,7 +112,7 @@ class CatchupThenPushReadinessAmbiguousIdTest {
                 .withType(TestEvent.class.getName())
                 .build()));
         CatchupThenPushSubscriptionModel failingWrapper = new CatchupThenPushSubscriptionModel(failingStore, failingLiveFeed, null);
-        Subscription failingSubscription = failingWrapper.subscribe("orders", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle failingSubscription = failingWrapper.subscribe("orders", null, StartAt.subscriptionModelDefault(), ce -> {
             throw new RuntimeException("simulated permanent catch-up failure for the OTHER model sharing this id");
         });
         assertThatThrownBy(() -> failingSubscription.waitUntilStarted(Duration.ofSeconds(5)))

--- a/doc/migration/upgrading-to-0.35.0.md
+++ b/doc/migration/upgrading-to-0.35.0.md
@@ -7,6 +7,10 @@ All seven framework annotations are renamed to an `Occurrent`-prefixed name. Not
 you upgrade, because the old annotations are deprecated rather than deleted and keep behaving exactly as they did
 in 0.34.0. Read [section 1](#1-the-seven-framework-annotations-get-an-occurrent-prefix).
 
+`org.occurrent.subscription.api.blocking.Subscription` and its reactor twin are renamed to `SubscriptionHandle`.
+This one breaks compilation, since the old name is gone rather than deprecated. Read
+[section 2](#2-subscription-becomes-subscriptionhandle).
+
 ## 1. The seven framework annotations get an `Occurrent` prefix
 
 Every annotation in `org.occurrent.annotation` that marks a method has a new name:
@@ -115,3 +119,28 @@ not declare them. Delete those two and the handler compiles again.
 A handler that compiles again is still not what the new annotation is for. It has the new name on a method
 returning `void`, where the annotation expects a factory method returning a descriptor, so the conversion is
 still owed. Finish it rather than reading a green compile as a finished migration.
+
+## 2. `Subscription` becomes `SubscriptionHandle`
+
+`org.occurrent.subscription.api.blocking.Subscription` is renamed to `SubscriptionHandle`, and so is its reactor
+twin, `org.occurrent.subscription.api.reactor.Subscription`. The interface itself is unchanged: `id()`,
+`waitUntilStarted(Duration)` and the no-argument `waitUntilStarted()` default mean exactly what they meant
+before. Only the name moves.
+
+```java
+// Before
+Subscription handle = subscriptions.subscribe("mySubscription", OrderShipped.class, e -> mailer.shipped(e));
+
+// After
+SubscriptionHandle handle = subscriptions.subscribe("mySubscription", OrderShipped.class, e -> mailer.shipped(e));
+```
+
+The type is what a caller holds after starting a subscription, not the subscription itself, and the old name said
+the opposite. [ADR 127](../architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md)
+decision 2 has the reasoning.
+
+This is a plain rename with no deprecation period. The old name is gone, not kept around as a forwarding type, so
+a reference to `Subscription` in this package fails to compile until you run the recipe or rename it by hand.
+`UpgradeToOccurrent_0_35` covers it, in Java and Kotlin alike, alongside the annotation prefix rename in
+[section 1](#1-the-seven-framework-annotations-get-an-occurrent-prefix). See [Run the recipe](#run-the-recipe) for
+how to invoke it.

--- a/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/blocking/src/main/java/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.java
@@ -28,7 +28,7 @@ import org.occurrent.eventstore.api.dcb.DcbCriterion;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.api.blocking.DcbSubscriptionModel;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.util.function.BiConsumer;
@@ -44,8 +44,8 @@ import static java.util.Objects.requireNonNull;
  * by a {@link DcbCriteria}. They are not DCB reads, so they provide no DCB append-condition or high-watermark
  * guarantees.
  * <p>
- * Like {@link Subscribable}, the {@code subscribe} methods return the {@link Subscription} without waiting for it to
- * start. Call {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before
+ * Like {@link Subscribable}, the {@code subscribe} methods return the {@link SubscriptionHandle} without waiting for it to
+ * start. Call {@link SubscriptionHandle#waitUntilStarted()} on the returned subscription when you need it running before
  * you continue (for example to avoid missing the first events of a brand new subscription). Call {@link #cancel(String)}
  * to stop and remove a subscription, for example when a per-connection subscription is no longer needed.
  * <p>
@@ -99,14 +99,14 @@ public final class DcbSubscriptions<E> {
     /**
      * Subscribes to live DCB events that match {@code criteria}.
      */
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, Consumer<E> fn) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, Consumer<E> fn) {
         return subscribe(subscriptionId, criteria, null, fn);
     }
 
     /**
      * Subscribes to live DCB events that match {@code criteria}, starting at {@code startAt}.
      */
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, Consumer<E> fn) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, Consumer<E> fn) {
         requireNonNull(fn, "Subscription function cannot be null");
         return subscribeWithMetadata(subscriptionId, criteria, startAt, (metadata, event) -> fn.accept(event));
     }
@@ -116,7 +116,7 @@ public final class DcbSubscriptions<E> {
      * is {@code true} this blocks until the subscription has started, and for a replaying DCB subscription that means
      * until catch-up has completed, mirroring the Kotlin DSL default.
      */
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, boolean waitUntilStarted, Consumer<E> fn) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, boolean waitUntilStarted, Consumer<E> fn) {
         requireNonNull(fn, "Subscription function cannot be null");
         return subscribeWithMetadata(subscriptionId, criteria, startAt, waitUntilStarted, (metadata, event) -> fn.accept(event));
     }
@@ -127,7 +127,7 @@ public final class DcbSubscriptions<E> {
      * This is a distinct method rather than an overload of {@link #subscribe} so that a method reference like
      * {@code list::add} stays unambiguous on the {@link Consumer} overloads.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, BiConsumer<DcbEventMetadata, E> fn) {
+    public SubscriptionHandle subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, BiConsumer<DcbEventMetadata, E> fn) {
         return subscribeWithMetadata(subscriptionId, criteria, null, fn);
     }
 
@@ -135,7 +135,7 @@ public final class DcbSubscriptions<E> {
      * Subscribes to live DCB events that match {@code criteria}, starting at {@code startAt} and exposing DCB metadata
      * to the callback. Returns without waiting for the subscription to start.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, BiConsumer<DcbEventMetadata, E> fn) {
+    public SubscriptionHandle subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, BiConsumer<DcbEventMetadata, E> fn) {
         return subscribeWithMetadata(subscriptionId, criteria, startAt, false, fn);
     }
 
@@ -144,7 +144,7 @@ public final class DcbSubscriptions<E> {
      * to the callback. When {@code waitUntilStarted} is {@code true} this blocks until the subscription has started,
      * and for a replaying DCB subscription that means until catch-up has completed, mirroring the Kotlin DSL default.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, boolean waitUntilStarted, BiConsumer<DcbEventMetadata, E> fn) {
+    public SubscriptionHandle subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, boolean waitUntilStarted, BiConsumer<DcbEventMetadata, E> fn) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(criteria, "Criteria cannot be null");
         requireNonNull(fn, "Subscription function cannot be null");
@@ -157,7 +157,7 @@ public final class DcbSubscriptions<E> {
         };
 
         DcbStartAt startAtToUse = startAt == null ? DcbStartAt.subscriptionModelDefault() : startAt;
-        Subscription subscription = subscriptionModel.subscribe(subscriptionId, criteria, startAtToUse, consumer);
+        SubscriptionHandle subscription = subscriptionModel.subscribe(subscriptionId, criteria, startAtToUse, consumer);
         if (waitUntilStarted) {
             subscription.waitUntilStarted();
         }

--- a/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
+++ b/dsl/dcb-dsl/blocking/src/main/kotlin/org/occurrent/dsl/dcb/blocking/DcbSubscriptions.kt
@@ -19,7 +19,7 @@ package org.occurrent.dsl.dcb.blocking
 import org.occurrent.dsl.dcb.DcbEventMetadata
 import org.occurrent.eventstore.api.dcb.DcbCriteria
 import org.occurrent.subscription.DcbStartAt
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 
 /**
  * Kotlin-idiomatic sugar over [DcbSubscriptions], the canonical class-based DCB subscription entry-point. This is a
@@ -34,7 +34,7 @@ fun <E : Any> DcbSubscriptions<E>.subscribeDcb(
     startAt: DcbStartAt? = null,
     waitUntilStarted: Boolean = true,
     fn: (E) -> Unit
-): Subscription = subscribeWithMetadata(subscriptionId, criteria, startAt, waitUntilStarted) { _, event -> fn(event) }
+): SubscriptionHandle = subscribeWithMetadata(subscriptionId, criteria, startAt, waitUntilStarted) { _, event -> fn(event) }
 
 /**
  * Kotlin-idiomatic sugar over [DcbSubscriptions], including DCB metadata in the callback. See [subscribeDcb] for the
@@ -47,4 +47,4 @@ fun <E : Any> DcbSubscriptions<E>.subscribeDcbWithMetadata(
     startAt: DcbStartAt? = null,
     waitUntilStarted: Boolean = true,
     fn: (DcbEventMetadata, E) -> Unit
-): Subscription = subscribeWithMetadata(subscriptionId, criteria, startAt, waitUntilStarted, fn)
+): SubscriptionHandle = subscribeWithMetadata(subscriptionId, criteria, startAt, waitUntilStarted, fn)

--- a/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
+++ b/dsl/dcb-dsl/reactor/src/main/java/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.api.reactor.DcbSubscriptionModel;
 import org.occurrent.subscription.api.reactor.FluxSubscriptionModel;
 import org.occurrent.subscription.api.reactor.Subscribable;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -54,9 +54,9 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * The {@link #subscribe(String, DcbCriteria, Function)} and {@link #subscribeWithMetadata(String, DcbCriteria, BiFunction)}
  * methods below are the named, lifecycle-managed counterpart to the {@link Flux}-returning methods above, mirroring
- * {@link Subscribable}: they return a {@link Subscription} tracked by id, which can be cancelled with
+ * {@link Subscribable}: they return a {@link SubscriptionHandle} tracked by id, which can be cancelled with
  * {@link #cancel(String)}. Like {@link Subscribable}, they return without waiting for the subscription to start; call
- * {@link Subscription#waitUntilStarted()} on the returned subscription when you need it running before you continue.
+ * {@link SubscriptionHandle#waitUntilStarted()} on the returned subscription when you need it running before you continue.
  *
  * @param <E> the domain event type
  */
@@ -124,7 +124,7 @@ public final class DcbSubscriptions<E> {
     /**
      * Subscribes to live DCB events that match {@code criteria}, tracked by {@code subscriptionId}.
      */
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, Function<E, Mono<Void>> fn) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, Function<E, Mono<Void>> fn) {
         return subscribe(subscriptionId, criteria, null, fn);
     }
 
@@ -132,7 +132,7 @@ public final class DcbSubscriptions<E> {
      * Subscribes to live DCB events that match {@code criteria}, starting at {@code startAt}, tracked by
      * {@code subscriptionId}.
      */
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, Function<E, Mono<Void>> fn) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, Function<E, Mono<Void>> fn) {
         requireNonNull(fn, "Subscription function cannot be null");
         return subscribeWithMetadata(subscriptionId, criteria, startAt, (metadata, event) -> fn.apply(event));
     }
@@ -144,7 +144,7 @@ public final class DcbSubscriptions<E> {
      * This is a distinct method rather than an overload of {@link #subscribe} so that a method reference stays
      * unambiguous on the {@link Function} overloads.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
+    public SubscriptionHandle subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
         return subscribeWithMetadata(subscriptionId, criteria, null, fn);
     }
 
@@ -153,7 +153,7 @@ public final class DcbSubscriptions<E> {
      * {@code subscriptionId}, exposing DCB metadata to the callback. Returns without waiting for the subscription to
      * start.
      */
-    public Subscription subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
+    public SubscriptionHandle subscribeWithMetadata(String subscriptionId, DcbCriteria criteria, @Nullable DcbStartAt startAt, BiFunction<DcbEventMetadata, E, Mono<Void>> fn) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(criteria, "Criteria cannot be null");
         requireNonNull(fn, "Subscription function cannot be null");

--- a/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.kt
+++ b/dsl/dcb-dsl/reactor/src/main/kotlin/org/occurrent/dsl/dcb/reactor/DcbSubscriptions.kt
@@ -19,14 +19,14 @@ package org.occurrent.dsl.dcb.reactor
 import org.occurrent.dsl.dcb.DcbEventMetadata
 import org.occurrent.eventstore.api.dcb.DcbCriteria
 import org.occurrent.subscription.DcbStartAt
-import org.occurrent.subscription.api.reactor.Subscription
+import org.occurrent.subscription.api.reactor.SubscriptionHandle
 import reactor.core.publisher.Mono
 
 /**
  * Kotlin-idiomatic sugar over [DcbSubscriptions], the canonical class-based reactive DCB subscription entry-point,
  * mirroring the blocking counterpart in `org.occurrent.dsl.dcb.blocking`. Unlike the blocking DSL there is no
- * `waitUntilStarted` flag here: [Subscription] is returned immediately and exposes its own
- * [Subscription.waitUntilStarted] returning a `Mono<Void>` that the caller can compose into their own reactive
+ * `waitUntilStarted` flag here: [SubscriptionHandle] is returned immediately and exposes its own
+ * [SubscriptionHandle.waitUntilStarted] returning a `Mono<Void>` that the caller can compose into their own reactive
  * chain, mirroring the equivalent decision in the regular subscription DSL's reactor module.
  */
 @JvmName("subscribeDcb")
@@ -35,7 +35,7 @@ fun <E : Any> DcbSubscriptions<E>.subscribeDcb(
     criteria: DcbCriteria = DcbCriteria.all(),
     startAt: DcbStartAt? = null,
     fn: (E) -> Mono<Void>
-): Subscription = subscribeWithMetadata(subscriptionId, criteria, startAt) { _, event -> fn(event) }
+): SubscriptionHandle = subscribeWithMetadata(subscriptionId, criteria, startAt) { _, event -> fn(event) }
 
 /**
  * Kotlin-idiomatic sugar over [DcbSubscriptions], including DCB metadata in the callback. See [subscribeDcb] for why
@@ -47,4 +47,4 @@ fun <E : Any> DcbSubscriptions<E>.subscribeDcbWithMetadata(
     criteria: DcbCriteria = DcbCriteria.all(),
     startAt: DcbStartAt? = null,
     fn: (DcbEventMetadata, E) -> Mono<Void>
-): Subscription = subscribeWithMetadata(subscriptionId, criteria, startAt, fn)
+): SubscriptionHandle = subscribeWithMetadata(subscriptionId, criteria, startAt, fn)

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/DcbProjectionRunner.java
@@ -24,7 +24,7 @@ import org.occurrent.dsl.projection.DcbProjection;
 import org.occurrent.dsl.view.MaterializedView;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.subscription.DcbStartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import static java.util.Objects.requireNonNull;
@@ -78,7 +78,7 @@ public final class DcbProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
     }
 
@@ -95,7 +95,7 @@ public final class DcbProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");
         return project(subscriptionId, dcbProjection, Projections.materializedView(dcbProjection.projection(), repository, subscriptionId), startAt);
     }
@@ -104,7 +104,7 @@ public final class DcbProjectionRunner<E> {
      * Subscribes with the given id and calls {@code materializedView.update(event)} for every event matching the
      * projection's DCB criteria.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView) {
         return project(subscriptionId, dcbProjection, materializedView, null);
     }
 
@@ -112,11 +112,11 @@ public final class DcbProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and calls {@code materializedView.update(event)} for every event matching the projection's DCB criteria.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView, @Nullable DcbStartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView, @Nullable DcbStartAt startAt) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(dcbProjection, "dcbProjection cannot be null");
         requireNonNull(materializedView, "materializedView cannot be null");
-        Subscription subscription = dcbSubscriptions.subscribeWithMetadata(subscriptionId, dcbProjection.criteria(), startAt,
+        SubscriptionHandle subscription = dcbSubscriptions.subscribeWithMetadata(subscriptionId, dcbProjection.criteria(), startAt,
                 (dcbMetadata, event) -> materializedView.update(dcbMetadata.eventMetadata(), event));
         subscription.waitUntilStarted();
         return subscription;

--- a/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
+++ b/dsl/projection-dsl/blocking/src/main/java/org/occurrent/dsl/projection/blocking/ProjectionRunner.java
@@ -31,7 +31,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -48,7 +48,7 @@ import static java.util.Objects.requireNonNull;
  * ones. For a DCB consistency-boundary read model use {@link DcbProjectionRunner}.
  * <p>
  * The subscription filter comes from the projection (its explicit {@link Projection#filter() filter}, else a type filter
- * over its handled types). The returned {@link Subscription} is already started.
+ * over its handled types). The returned {@link SubscriptionHandle} is already started.
  *
  * @param <E> the domain event type
  */
@@ -96,7 +96,7 @@ public final class ProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
     }
 
@@ -114,7 +114,7 @@ public final class ProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return project(subscriptionId, projection, Projections.materializedView(projection, repository, subscriptionId), startAt);
     }
 
@@ -123,7 +123,7 @@ public final class ProjectionRunner<E> {
      * overload when you already have a {@link MaterializedView} (for example one built by the view DSL's
      * {@code materialized(...)} with its own retry/locking policy).
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView) {
         return project(subscriptionId, projection, materializedView, null);
     }
 
@@ -131,7 +131,7 @@ public final class ProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and calls {@code materializedView.update(event)} for every matching event.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt) {
         return project(subscriptionId, projection, materializedView, startAt, true);
     }
 
@@ -146,14 +146,14 @@ public final class ProjectionRunner<E> {
      * unavailable. A replay failure surfaces from the returned subscription's {@code waitUntilStarted} instead of from
      * here, so a caller that passes {@code false} and never waits will not see it.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt, boolean waitUntilStarted) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt, boolean waitUntilStarted) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(projection, "projection cannot be null");
         requireNonNull(materializedView, "materializedView cannot be null");
         SubscriptionFilter filter = toSubscriptionFilter.apply(ProjectionFilters.filterFor(cloudEventConverter, projection));
         Consumer<CloudEvent> action = cloudEvent -> materializedView.update(EventMetadata.from(cloudEvent), cloudEventConverter.toDomainEvent(cloudEvent));
         StartAt effectiveStartAt = startAt != null ? startAt : StartAt.subscriptionModelDefault();
-        Subscription subscription = subscriptionModel.subscribe(subscriptionId, filter, effectiveStartAt, action);
+        SubscriptionHandle subscription = subscriptionModel.subscribe(subscriptionId, filter, effectiveStartAt, action);
         if (waitUntilStarted) {
             subscription.waitUntilStarted();
         }

--- a/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/DcbProjectionExtensions.kt
+++ b/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/DcbProjectionExtensions.kt
@@ -22,11 +22,11 @@ import org.occurrent.dsl.projection.DcbProjection
 import org.occurrent.dsl.view.MaterializedView
 import org.occurrent.dsl.view.ViewStateRepository
 import org.occurrent.subscription.DcbStartAt
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 
 /**
  * Runs [dcbProjection] as an asynchronous, subscription-fed read model over its DCB consistency boundary: subscribes to
- * the events matching [DcbProjection.criteria] and updates [materializedView] from each. The returned [Subscription] is
+ * the events matching [DcbProjection.criteria] and updates [materializedView] from each. The returned [SubscriptionHandle] is
  * already started.
  *
  * Whether this catches up and resumes durably, or is live-only, depends on the `SubscriptionModel` behind this
@@ -34,7 +34,7 @@ import org.occurrent.subscription.api.blocking.Subscription
  * replays history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on
  * demand with the pull [DcbDomainEventQueries.project]. For a declarative read model use the `@Projection` annotation.
  */
-fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, materializedView: MaterializedView<E>, startAt: DcbStartAt? = null): Subscription =
+fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, materializedView: MaterializedView<E>, startAt: DcbStartAt? = null): SubscriptionHandle =
     subscribeWithMetadata(subscriptionId, dcbProjection.criteria(), startAt) { dcbMetadata, e -> materializedView.update(dcbMetadata.eventMetadata(), e) }.also { it.waitUntilStarted() }
 
 /**
@@ -42,7 +42,7 @@ fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection:
  * events whose id resolves to `null`. See the [MaterializedView] overload above for the live-only versus catch-up
  * and durability details, which depend on the subscription model the same way.
  */
-fun <S, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: DcbStartAt? = null): Subscription =
+fun <S, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: DcbStartAt? = null): SubscriptionHandle =
     project(subscriptionId, dcbProjection, Projections.materializedView(dcbProjection.projection(), repository, subscriptionId), startAt)
 
 /**

--- a/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/ProjectionExtensions.kt
@@ -24,14 +24,14 @@ import org.occurrent.dsl.view.MaterializedView
 import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.StreamSubscriptionFilter
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 
 /**
  * Runs [projection] as a capability-agnostic, subscription-fed read model: creates the subscription (its selector
  * derived from the projection) and updates [materializedView] from every matching event. On a store with both the
  * `STREAM` and `DCB` capabilities this delivers both stream-written and DCB-appended events.
  */
-fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): Subscription {
+fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, AgnosticSubscriptionFilter.filter(explicitFilter), startAt) { metadata, e -> materializedView.update(metadata, e) }
@@ -47,14 +47,14 @@ fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Proje
  * same instance supply a [MaterializedView] that re-reads and reapplies on conflict, for example the view DSL's
  * `materialized(...)`.
  */
-fun <S, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: org.occurrent.dsl.view.ViewStateRepository<S, ID>, startAt: StartAt? = null): Subscription =
+fun <S, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: org.occurrent.dsl.view.ViewStateRepository<S, ID>, startAt: StartAt? = null): SubscriptionHandle =
     project(subscriptionId, projection, Projections.materializedView(projection, repository, subscriptionId), startAt)
 
 /**
  * Runs [projection] as a stream-scoped, subscription-fed read model, excluding DCB-appended events. See the
  * capability-agnostic [Subscriptions.project] for the cross-capability variant.
  */
-fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): Subscription {
+fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, StreamSubscriptionFilter.filter(explicitFilter), startAt) { metadata, e -> materializedView.update(metadata, e) }
@@ -67,7 +67,7 @@ fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection:
  * Runs [projection] as a stream-scoped, subscription-fed read model materialized into [repository], skipping events
  * whose id resolves to `null`.
  */
-fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: org.occurrent.dsl.view.ViewStateRepository<S, ID>, startAt: StartAt? = null): Subscription =
+fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: org.occurrent.dsl.view.ViewStateRepository<S, ID>, startAt: StartAt? = null): SubscriptionHandle =
     project(subscriptionId, projection, Projections.materializedView(projection, repository, subscriptionId), startAt)
 
 /**

--- a/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/SpringMongoProjectionExtensions.kt
+++ b/dsl/projection-dsl/blocking/src/main/kotlin/org/occurrent/dsl/projection/blocking/SpringMongoProjectionExtensions.kt
@@ -26,7 +26,7 @@ import org.occurrent.dsl.view.internal.requireMatchingDocumentId
 import org.occurrent.dsl.view.viewStateRepository
 import org.occurrent.subscription.DcbStartAt
 import org.occurrent.subscription.StartAt
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 import org.springframework.data.mongodb.core.MongoOperations
 import org.springframework.data.mongodb.core.findById
 
@@ -53,17 +53,17 @@ inline fun <reified S : Any, ID : Any> mongoViewStateRepository(mongoOperations:
  * example the stream id) is resolved and folded with that metadata, an id that resolves to `null` is skipped, and a
  * projection keyed by metadata that never arrived throws with an accurate message instead of silently dropping the event.
  */
-inline fun <reified S : Any, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, mongoOperations: MongoOperations, startAt: StartAt? = null): Subscription =
+inline fun <reified S : Any, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, mongoOperations: MongoOperations, startAt: StartAt? = null): SubscriptionHandle =
     project(subscriptionId, projection, mongoViewStateRepository<S, ID>(mongoOperations), startAt)
 
 /**
  * Convenience over [StreamSubscriptions.project] that materializes [projection] into MongoDB via [mongoOperations].
  */
-inline fun <reified S : Any, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, mongoOperations: MongoOperations, startAt: StartAt? = null): Subscription =
+inline fun <reified S : Any, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, mongoOperations: MongoOperations, startAt: StartAt? = null): SubscriptionHandle =
     project(subscriptionId, projection, mongoViewStateRepository<S, ID>(mongoOperations), startAt)
 
 /**
  * Convenience over [DcbSubscriptions.project] that materializes [dcbProjection] into MongoDB via [mongoOperations].
  */
-inline fun <reified S : Any, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, mongoOperations: MongoOperations, startAt: DcbStartAt? = null): Subscription =
+inline fun <reified S : Any, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, mongoOperations: MongoOperations, startAt: DcbStartAt? = null): SubscriptionHandle =
     project(subscriptionId, dcbProjection, mongoViewStateRepository<S, ID>(mongoOperations), startAt)

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/RecordingMaterializedViewMembershipInversionTest.java
@@ -38,7 +38,7 @@ import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
@@ -143,7 +143,7 @@ class RecordingMaterializedViewMembershipInversionTest {
             try {
                 CloudEventConverter<Ticked> converter = new JacksonCloudEventConverter<>(new ObjectMapper(), SOURCE);
                 List<EventMetadata> deliveryOrder = new CopyOnWriteArrayList<>();
-                Subscription observerSubscription = observerModel.subscribe("observer", StartAt.now(),
+                SubscriptionHandle observerSubscription = observerModel.subscribe("observer", StartAt.now(),
                         cloudEvent -> deliveryOrder.add(EventMetadata.from(cloudEvent)));
                 assertThat(observerSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the observer subscription never started").isTrue();
 
@@ -158,7 +158,7 @@ class RecordingMaterializedViewMembershipInversionTest {
                 MaterializedView<Ticked> view = Projections.materializedView(projection, repository, PROJECTION_ID);
                 MaterializedView<Ticked> recordingView = Projections.recordingAppliedAppends(view, PROJECTION_ID, observedStore);
                 ProjectionRunner<Ticked> runner = ProjectionRunner.stream(recorderModel, converter);
-                Subscription recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
+                SubscriptionHandle recordingSubscription = runner.project(PROJECTION_ID, projection, recordingView, StartAt.now());
                 assertThat(recordingSubscription.waitUntilStarted(Duration.ofSeconds(20))).as("the recording subscription never started").isTrue();
 
                 Thread appender = new Thread(() -> writerAStore.write("stream-a", List.of(converter.toCloudEvent(new Ticked("a")))), "writer-a");

--- a/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/blocking/src/test/java/org/occurrent/dsl/projection/blocking/WriteToDeliveryAppendIdFidelityTest.java
@@ -31,7 +31,7 @@ import org.occurrent.eventstore.mongodb.spring.blocking.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
@@ -97,7 +97,7 @@ class WriteToDeliveryAppendIdFidelityTest {
 
         try {
             BlockingQueue<EventMetadata> delivered = new ArrayBlockingQueue<>(1);
-            Subscription subscription = subscriptionModel.subscribe("fidelity", StartAt.now(),
+            SubscriptionHandle subscription = subscriptionModel.subscribe("fidelity", StartAt.now(),
                     cloudEvent -> delivered.add(EventMetadata.from(cloudEvent)));
             assertThat(subscription.waitUntilStarted(Duration.ofSeconds(20))).as("the subscription never started").isTrue();
 

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveDcbProjectionRunner.java
@@ -26,7 +26,7 @@ import org.occurrent.dsl.view.MaterializedView;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.subscription.DcbStartAt;
 import org.occurrent.subscription.api.reactor.FluxSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import reactor.core.publisher.Mono;
 
 import java.util.function.BiFunction;
@@ -76,7 +76,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * Subscribes with the given id and applies {@code update} for every event matching the projection's DCB criteria.
      * The primitive overload: {@code update} owns the reactive load-evolve-save against a reactive store.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, Function<E, Mono<Void>> update) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, Function<E, Mono<Void>> update) {
         return project(subscriptionId, dcbProjection, update, null);
     }
 
@@ -84,7 +84,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and applies {@code update} for every event matching the projection's DCB criteria.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, Function<E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, Function<E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(dcbProjection, "dcbProjection cannot be null");
         requireNonNull(update, "update cannot be null");
@@ -96,7 +96,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * The metadata-carrying sibling of {@link #project(String, DcbProjection, Function)}, for a caller that owns the
      * reactive load-evolve-save but still needs the delivering event's {@link EventMetadata}.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update) {
         return project(subscriptionId, dcbProjection, update, null);
     }
 
@@ -105,7 +105,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * and applies {@code update} for every event matching the projection's DCB criteria, exposing the event's
      * {@link EventMetadata}.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
         return projectWithMetadata(subscriptionId, dcbProjection, update, startAt);
     }
 
@@ -122,7 +122,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, dcbProjection, repository, null);
     }
 
@@ -140,7 +140,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, DcbProjection<S, E, ID> dcbProjection, ViewStateRepository<S, ID> repository, @Nullable DcbStartAt startAt) {
         requireNonNull(dcbProjection, "dcbProjection cannot be null");
         return projectWithMetadata(subscriptionId, dcbProjection, Projections.reactiveUpdateWithMetadata(dcbProjection.projection(), repository, subscriptionId), startAt);
     }
@@ -149,7 +149,7 @@ public final class ReactiveDcbProjectionRunner<E> {
      * Subscribes with the given id and drives the blocking {@code materializedView} (scheduled on {@code boundedElastic})
      * for every event matching the projection's DCB criteria.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView) {
         return project(subscriptionId, dcbProjection, materializedView, null);
     }
 
@@ -158,13 +158,13 @@ public final class ReactiveDcbProjectionRunner<E> {
      * and drives the blocking {@code materializedView} (scheduled on {@code boundedElastic}) for every event matching
      * the projection's DCB criteria.
      */
-    public Subscription project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView, @Nullable DcbStartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, MaterializedView<E> materializedView, @Nullable DcbStartAt startAt) {
         return projectWithMetadata(subscriptionId, dcbProjection, Projections.reactiveUpdateWithMetadata(materializedView), startAt);
     }
 
     // Routes through subscribeWithMetadata so the ViewStateRepository/MaterializedView overloads above carry real DCB
     // delivery metadata into the fold, instead of the plain subscribe() path, which has none to give.
-    private Subscription projectWithMetadata(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
+    private SubscriptionHandle projectWithMetadata(String subscriptionId, DcbProjection<?, E, ?> dcbProjection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable DcbStartAt startAt) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(dcbProjection, "dcbProjection cannot be null");
         requireNonNull(update, "update cannot be null");

--- a/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
+++ b/dsl/projection-dsl/reactor/src/main/java/org/occurrent/dsl/projection/reactor/ReactiveProjectionRunner.java
@@ -31,7 +31,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.reactor.Subscribable;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import reactor.core.publisher.Mono;
 
 import java.util.function.BiFunction;
@@ -89,7 +89,7 @@ public final class ReactiveProjectionRunner<E> {
      * {@code update} owns the reactive load-evolve-save against a reactive store, and is also the overload to use for
      * synchronous, in-transaction (read-your-writes) dispatch, since its work composes into the writer's reactive chain.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, Function<E, Mono<Void>> update) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, Function<E, Mono<Void>> update) {
         return project(subscriptionId, projection, update, null);
     }
 
@@ -97,7 +97,7 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and applies {@code update} for every matching event.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, Function<E, Mono<Void>> update, @Nullable StartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, Function<E, Mono<Void>> update, @Nullable StartAt startAt) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(projection, "projection cannot be null");
         requireNonNull(update, "update cannot be null");
@@ -112,7 +112,7 @@ public final class ReactiveProjectionRunner<E> {
      * {@link #project(String, Projection, Function)}, for a caller that owns the reactive load-evolve-save but still
      * needs the delivering event's {@link EventMetadata}.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update) {
         return project(subscriptionId, projection, update, null);
     }
 
@@ -120,7 +120,7 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and applies {@code update} for every matching event, exposing the event's {@link EventMetadata}.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable StartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable StartAt startAt) {
         return projectWithMetadata(subscriptionId, projection, update, startAt);
     }
 
@@ -137,7 +137,7 @@ public final class ReactiveProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository) {
         return project(subscriptionId, projection, repository, null);
     }
 
@@ -155,7 +155,7 @@ public final class ReactiveProjectionRunner<E> {
      * single-instance. An id function that returns {@code null} for one event means that event is skipped,
      * and the projection is still keyed.</p>
      */
-    public <S extends @Nullable Object, ID> Subscription project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
+    public <S extends @Nullable Object, ID> SubscriptionHandle project(String subscriptionId, Projection<S, E, ID> projection, ViewStateRepository<S, ID> repository, @Nullable StartAt startAt) {
         return projectWithMetadata(subscriptionId, projection, Projections.reactiveUpdateWithMetadata(projection, repository, subscriptionId), startAt);
     }
 
@@ -163,7 +163,7 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id and drives the blocking {@code materializedView} (scheduled on {@code boundedElastic})
      * for every matching event. Use this to reuse a {@link MaterializedView} with its own retry/locking policy.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView) {
         return project(subscriptionId, projection, materializedView, null);
     }
 
@@ -171,7 +171,7 @@ public final class ReactiveProjectionRunner<E> {
      * Subscribes with the given id, starting at {@code startAt} ({@code null} means the subscription model's default),
      * and drives the blocking {@code materializedView} (scheduled on {@code boundedElastic}) for every matching event.
      */
-    public Subscription project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt) {
+    public SubscriptionHandle project(String subscriptionId, Projection<?, E, ?> projection, MaterializedView<E> materializedView, @Nullable StartAt startAt) {
         return projectWithMetadata(subscriptionId, projection, Projections.reactiveUpdateWithMetadata(materializedView), startAt);
     }
 
@@ -179,7 +179,7 @@ public final class ReactiveProjectionRunner<E> {
     // event-only, since a caller-supplied reactive update composes at the domain-event level; the BiFunction overload,
     // and the repository and MaterializedView overloads, route here so a metadata-keyed projection folds with real
     // metadata.
-    private Subscription projectWithMetadata(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable StartAt startAt) {
+    private SubscriptionHandle projectWithMetadata(String subscriptionId, Projection<?, E, ?> projection, BiFunction<EventMetadata, E, Mono<Void>> update, @Nullable StartAt startAt) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(projection, "projection cannot be null");
         requireNonNull(update, "update cannot be null");

--- a/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/DcbProjectionExtensions.kt
+++ b/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/DcbProjectionExtensions.kt
@@ -25,7 +25,7 @@ import org.occurrent.dsl.projection.DcbProjection
 import org.occurrent.dsl.view.MaterializedView
 import org.occurrent.dsl.view.ViewStateRepository
 import org.occurrent.subscription.DcbStartAt
-import org.occurrent.subscription.api.reactor.Subscription
+import org.occurrent.subscription.api.reactor.SubscriptionHandle
 import reactor.core.publisher.Mono
 
 /**
@@ -38,21 +38,21 @@ import reactor.core.publisher.Mono
  * replays history and resumes across restarts, a plain live model does neither. For a strongly consistent read, fold on
  * demand with the pull [DcbDomainEventQueries.project]. For a declarative read model use the `@Projection` annotation.
  */
-fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, update: (E) -> Mono<Void>, startAt: DcbStartAt? = null): Subscription =
+fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, update: (E) -> Mono<Void>, startAt: DcbStartAt? = null): SubscriptionHandle =
     subscribeDcb(subscriptionId, dcbProjection.criteria(), startAt) { e -> update(e) }
 
 /**
  * As the [update] overload above, but [update] also sees the delivering event's [EventMetadata], for a caller that owns
  * the reactive load-evolve-save but still needs the stream id, stream version, or other metadata.
  */
-fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: DcbStartAt? = null): Subscription =
+fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: DcbStartAt? = null): SubscriptionHandle =
     subscribeDcbWithMetadata(subscriptionId, dcbProjection.criteria(), startAt) { dcbMetadata, e -> update(dcbMetadata.eventMetadata(), e) }
 
 /**
  * Runs [dcbProjection] as an asynchronous, subscription-fed DCB read model materialized into the blocking [repository]
  * (scheduled on `boundedElastic`), skipping events whose id resolves to `null`.
  */
-fun <S, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: DcbStartAt? = null): Subscription {
+fun <S, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: DcbStartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(dcbProjection.projection(), repository, subscriptionId)
     return subscribeDcbWithMetadata(subscriptionId, dcbProjection.criteria(), startAt) { dcbMetadata, e -> update.apply(dcbMetadata.eventMetadata(), e) }
 }
@@ -61,7 +61,7 @@ fun <S, E : Any, ID : Any> DcbSubscriptions<E>.project(subscriptionId: String, d
  * Runs [dcbProjection] as an asynchronous, subscription-fed DCB read model driving the blocking [materializedView]
  * (scheduled on `boundedElastic`).
  */
-fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, materializedView: MaterializedView<E>, startAt: DcbStartAt? = null): Subscription {
+fun <E : Any> DcbSubscriptions<E>.project(subscriptionId: String, dcbProjection: DcbProjection<*, E, *>, materializedView: MaterializedView<E>, startAt: DcbStartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(materializedView)
     return subscribeDcbWithMetadata(subscriptionId, dcbProjection.criteria(), startAt) { dcbMetadata, e -> update.apply(dcbMetadata.eventMetadata(), e) }
 }

--- a/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
+++ b/dsl/projection-dsl/reactor/src/main/kotlin/org/occurrent/dsl/projection/reactor/ProjectionExtensions.kt
@@ -26,7 +26,7 @@ import org.occurrent.dsl.view.ViewStateRepository
 import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.StreamSubscriptionFilter
-import org.occurrent.subscription.api.reactor.Subscription
+import org.occurrent.subscription.api.reactor.SubscriptionHandle
 import reactor.core.publisher.Mono
 
 /**
@@ -36,7 +36,7 @@ import reactor.core.publisher.Mono
  * (read-your-writes) dispatch. On a store with both the `STREAM` and `DCB` capabilities this delivers both
  * stream-written and DCB-appended events.
  */
-fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (E) -> Mono<Void>, startAt: StartAt? = null): Subscription {
+fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (E) -> Mono<Void>, startAt: StartAt? = null): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, AgnosticSubscriptionFilter.filter(explicitFilter), startAt) { e -> update(e) }
@@ -49,14 +49,14 @@ fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Proje
  * As the [update] overload above, but [update] also sees the delivering event's [EventMetadata], for a caller that owns
  * the reactive load-evolve-save but still needs the stream id, stream version, or other metadata.
  */
-fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt? = null): Subscription =
+fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt? = null): SubscriptionHandle =
     projectWithMetadata(subscriptionId, projection, update, startAt)
 
 /**
  * Runs [projection] as a capability-agnostic, subscription-fed read model materialized into the blocking [repository]
  * (scheduled on `boundedElastic`), skipping events whose id resolves to `null`.
  */
-fun <S, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: StartAt? = null): Subscription {
+fun <S, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: StartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(projection, repository, subscriptionId)
     return projectWithMetadata(subscriptionId, projection, { metadata, e -> update.apply(metadata, e) }, startAt)
 }
@@ -65,7 +65,7 @@ fun <S, E : Any, ID : Any> Subscriptions<E>.project(subscriptionId: String, proj
  * Runs [projection] as a capability-agnostic, subscription-fed read model driving the blocking [materializedView]
  * (scheduled on `boundedElastic`).
  */
-fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): Subscription {
+fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(materializedView)
     return projectWithMetadata(subscriptionId, projection, { metadata, e -> update.apply(metadata, e) }, startAt)
 }
@@ -74,7 +74,7 @@ fun <E : Any> Subscriptions<E>.project(subscriptionId: String, projection: Proje
 // public (E) -> Mono<Void> primitive project stays event-only, since a caller-supplied reactive update composes at the
 // domain-event level; the repository and MaterializedView overloads route here so a metadata-keyed projection folds
 // with real metadata.
-private fun <E : Any> Subscriptions<E>.projectWithMetadata(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt?): Subscription {
+private fun <E : Any> Subscriptions<E>.projectWithMetadata(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt?): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, AgnosticSubscriptionFilter.filter(explicitFilter), startAt) { metadata, e -> update(metadata, e) }
@@ -86,7 +86,7 @@ private fun <E : Any> Subscriptions<E>.projectWithMetadata(subscriptionId: Strin
 /**
  * Runs [projection] as a stream-scoped, subscription-fed read model, excluding DCB-appended events.
  */
-fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (E) -> Mono<Void>, startAt: StartAt? = null): Subscription {
+fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (E) -> Mono<Void>, startAt: StartAt? = null): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, StreamSubscriptionFilter.filter(explicitFilter), startAt) { e -> update(e) }
@@ -99,14 +99,14 @@ fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection:
  * As the [update] overload above, but [update] also sees the delivering event's [EventMetadata], for a caller that owns
  * the reactive load-evolve-save but still needs the stream id, stream version, or other metadata.
  */
-fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt? = null): Subscription =
+fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt? = null): SubscriptionHandle =
     projectWithMetadata(subscriptionId, projection, update, startAt)
 
 /**
  * Runs [projection] as a stream-scoped, subscription-fed read model materialized into the blocking [repository]
  * (scheduled on `boundedElastic`), skipping events whose id resolves to `null`.
  */
-fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: StartAt? = null): Subscription {
+fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<S, E, ID>, repository: ViewStateRepository<S, ID>, startAt: StartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(projection, repository, subscriptionId)
     return projectWithMetadata(subscriptionId, projection, { metadata, e -> update.apply(metadata, e) }, startAt)
 }
@@ -115,13 +115,13 @@ fun <S, E : Any, ID : Any> StreamSubscriptions<E>.project(subscriptionId: String
  * Runs [projection] as a stream-scoped, subscription-fed read model driving the blocking [materializedView]
  * (scheduled on `boundedElastic`).
  */
-fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): Subscription {
+fun <E : Any> StreamSubscriptions<E>.project(subscriptionId: String, projection: Projection<*, E, *>, materializedView: MaterializedView<E>, startAt: StartAt? = null): SubscriptionHandle {
     val update = Projections.reactiveUpdateWithMetadata(materializedView)
     return projectWithMetadata(subscriptionId, projection, { metadata, e -> update.apply(metadata, e) }, startAt)
 }
 
 // See the agnostic projectWithMetadata above: threads EventMetadata into the update, stream-scoped.
-private fun <E : Any> StreamSubscriptions<E>.projectWithMetadata(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt?): Subscription {
+private fun <E : Any> StreamSubscriptions<E>.projectWithMetadata(subscriptionId: String, projection: Projection<*, E, *>, update: (EventMetadata, E) -> Mono<Void>, startAt: StartAt?): SubscriptionHandle {
     val explicitFilter = projection.filter()
     return if (explicitFilter != null) {
         subscribe(subscriptionId, StreamSubscriptionFilter.filter(explicitFilter), startAt) { metadata, e -> update(metadata, e) }

--- a/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
+++ b/dsl/projection-dsl/reactor/src/test/java/org/occurrent/dsl/projection/reactor/WriteToDeliveryAppendIdFidelityTest.java
@@ -31,7 +31,7 @@ import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
@@ -95,7 +95,7 @@ class WriteToDeliveryAppendIdFidelityTest {
 
         try {
             LinkedBlockingQueue<EventMetadata> delivered = new LinkedBlockingQueue<>();
-            Subscription subscription = subscriptionModel.subscribe("fidelity-reactor", StartAt.now(),
+            SubscriptionHandle subscription = subscriptionModel.subscribe("fidelity-reactor", StartAt.now(),
                     cloudEvent -> Mono.fromRunnable(() -> delivered.add(EventMetadata.from(cloudEvent))));
             subscription.waitUntilStarted().block(Duration.ofSeconds(20));
 

--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaRunner.java
@@ -32,7 +32,7 @@ import org.occurrent.subscription.StreamSubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -191,7 +191,7 @@ public final class SagaRunner<E, C> {
         SubscriptionFilter filter = toSubscriptionFilter.apply(SagaFilters.filterFor(cloudEventConverter, saga));
         Consumer<CloudEvent> action = execution::onCloudEvent;
         StartAt effectiveStartAt = startAt != null ? startAt : StartAt.subscriptionModelDefault();
-        Subscription subscription = subscriptionModel.subscribe(subscriptionId, filter, effectiveStartAt, action);
+        SubscriptionHandle subscription = subscriptionModel.subscribe(subscriptionId, filter, effectiveStartAt, action);
         // Deliberately above the lease registration and the poller's executor below. A replay failure thrown here
         // aborts before either is allocated, so nothing leaks and the caller never receives a SagaSubscription it
         // would have to close. Skipping the wait skips that protection too, which is what timersEnabled is for.

--- a/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaSubscription.java
+++ b/dsl/saga-dsl/blocking/src/main/java/org/occurrent/dsl/saga/blocking/SagaSubscription.java
@@ -19,7 +19,7 @@ package org.occurrent.dsl.saga.blocking;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.dsl.saga.SagaInstances;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.internal.ExecutorShutdown;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,21 +31,21 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A running saga: the underlying event {@link Subscription} plus the timer poller. Closing it stops the poller and, when
+ * A running saga: the underlying event {@link SubscriptionHandle} plus the timer poller. Closing it stops the poller and, when
  * the poller was lease-gated, releases the timer lease so another instance can take over. The event subscription is
  * cancelled through the subscription model the way any subscription is (this handle only owns the poller it started).
  */
 public final class SagaSubscription implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(SagaSubscription.class);
 
-    private final Subscription subscription;
+    private final SubscriptionHandle subscription;
     private final ExecutorService timerPoller;
     private final SagaInstances instances;
     private final @Nullable CompetingConsumerStrategy competingConsumerStrategy;
     private final @Nullable String leaseKey;
     private final @Nullable String holderId;
 
-    SagaSubscription(Subscription subscription, ExecutorService timerPoller, SagaInstances instances,
+    SagaSubscription(SubscriptionHandle subscription, ExecutorService timerPoller, SagaInstances instances,
                      @Nullable CompetingConsumerStrategy competingConsumerStrategy,
                      @Nullable String leaseKey, @Nullable String holderId) {
         this.subscription = requireNonNull(subscription, "subscription cannot be null");
@@ -71,7 +71,7 @@ public final class SagaSubscription implements AutoCloseable {
     }
 
     /** The underlying event subscription. */
-    public Subscription subscription() {
+    public SubscriptionHandle subscription() {
         return subscription;
     }
 

--- a/dsl/subscription-dsl/blocking/src/main/kotlin/org/occurrent/dsl/subscription/blocking/Subscriptions.kt
+++ b/dsl/subscription-dsl/blocking/src/main/kotlin/org/occurrent/dsl/subscription/blocking/Subscriptions.kt
@@ -27,7 +27,7 @@ import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.StreamSubscriptionFilter
 import org.occurrent.subscription.api.blocking.Subscribable
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 import java.util.function.BiConsumer
 import java.util.function.Consumer
 import kotlin.reflect.KClass
@@ -89,7 +89,7 @@ open class StreamSubscriptions<E : Any>(val subscriptionModel: Subscribable, pri
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
     }
 
@@ -97,37 +97,37 @@ open class StreamSubscriptions<E : Any>(val subscriptionModel: Subscribable, pri
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Unit): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Unit): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
     }
 
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Unit): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
     }
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Unit): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Consumer<E1>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Consumer<E1>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
             @Suppress("UNCHECKED_CAST")
             fn.accept(e as E1)
@@ -135,7 +135,7 @@ open class StreamSubscriptions<E : Any>(val subscriptionModel: Subscribable, pri
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E1>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E1>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
             @Suppress("UNCHECKED_CAST")
             fn.accept(metadata, e as E1)
@@ -143,26 +143,26 @@ open class StreamSubscriptions<E : Any>(val subscriptionModel: Subscribable, pri
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Consumer<E>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Consumer<E>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.accept(e) }
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.accept(metadata, e) }
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): SubscriptionHandle {
         val filter = subscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted, fn)
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (EventMetadata, E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         val filter = subscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted, fn)
     }
 
-    fun subscribe(subscriptionId: String, filter: StreamSubscriptionFilter = StreamSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, filter: StreamSubscriptionFilter = StreamSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted) { _, e -> fn(e) }
     }
 
@@ -173,7 +173,7 @@ open class StreamSubscriptions<E : Any>(val subscriptionModel: Subscribable, pri
         startAt: StartAt? = null,
         waitUntilStarted: Boolean = true,
         fn: (EventMetadata, E) -> Unit
-    ): Subscription {
+    ): SubscriptionHandle {
         val consumer: (CloudEvent) -> Unit = { cloudEvent ->
             val event = cloudEventConverter[cloudEvent]
             val eventMetadata = EventMetadata.from(cloudEvent)
@@ -216,7 +216,7 @@ class Subscriptions<E : Any>(val subscriptionModel: Subscribable, private val cl
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
     }
 
@@ -224,37 +224,37 @@ class Subscriptions<E : Any>(val subscriptionModel: Subscribable, private val cl
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Unit): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Unit): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
     }
 
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Unit): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
     }
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Unit): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Consumer<E1>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Consumer<E1>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
             @Suppress("UNCHECKED_CAST")
             fn.accept(e as E1)
@@ -262,7 +262,7 @@ class Subscriptions<E : Any>(val subscriptionModel: Subscribable, private val cl
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E1>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E1>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
             @Suppress("UNCHECKED_CAST")
             fn.accept(metadata, e as E1)
@@ -270,26 +270,26 @@ class Subscriptions<E : Any>(val subscriptionModel: Subscribable, private val cl
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Consumer<E>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Consumer<E>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.accept(e) }
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiConsumer<EventMetadata, E>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.accept(metadata, e) }
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): SubscriptionHandle {
         val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted, fn)
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (EventMetadata, E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (EventMetadata, E) -> Unit): SubscriptionHandle {
         val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted, fn)
     }
 
-    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): Subscription {
+    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, waitUntilStarted: Boolean = true, fn: (E) -> Unit): SubscriptionHandle {
         return subscribe(subscriptionId, filter, startAt, waitUntilStarted) { _, e -> fn(e) }
     }
 
@@ -300,7 +300,7 @@ class Subscriptions<E : Any>(val subscriptionModel: Subscribable, private val cl
         startAt: StartAt? = null,
         waitUntilStarted: Boolean = true,
         fn: (EventMetadata, E) -> Unit
-    ): Subscription {
+    ): SubscriptionHandle {
         val consumer: (CloudEvent) -> Unit = { cloudEvent ->
             val event = cloudEventConverter[cloudEvent]
             val eventMetadata = EventMetadata.from(cloudEvent)

--- a/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
+++ b/dsl/subscription-dsl/reactor/src/main/kotlin/org/occurrent/dsl/subscription/reactor/Subscriptions.kt
@@ -27,7 +27,7 @@ import org.occurrent.subscription.AgnosticSubscriptionFilter
 import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.StreamSubscriptionFilter
 import org.occurrent.subscription.api.reactor.Subscribable
-import org.occurrent.subscription.api.reactor.Subscription
+import org.occurrent.subscription.api.reactor.SubscriptionHandle
 import reactor.core.publisher.Mono
 import java.util.function.BiFunction
 import java.util.function.Function
@@ -66,7 +66,7 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
     }
 
@@ -74,37 +74,37 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
     }
 
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
     }
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
             @Suppress("UNCHECKED_CAST")
             fn.apply(e as E1)
@@ -112,7 +112,7 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
             @Suppress("UNCHECKED_CAST")
             fn.apply(metadata, e as E1)
@@ -120,33 +120,33 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.apply(e) }
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.apply(metadata, e) }
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         val filter = subscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, fn)
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         val filter = subscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, fn)
     }
 
-    fun subscribe(subscriptionId: String, filter: StreamSubscriptionFilter = StreamSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, filter: StreamSubscriptionFilter = StreamSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, filter, startAt) { _, e -> fn(e) }
     }
 
     /**
      * Unlike the blocking DSL this overload has no `waitUntilStarted` flag. The blocking DSL blocks the calling
-     * thread until the subscription has started, which only makes sense for a synchronous API. Here [Subscription]
-     * is returned immediately and exposes its own [Subscription.waitUntilStarted] returning a `Mono<Void>` that the
+     * thread until the subscription has started, which only makes sense for a synchronous API. Here [SubscriptionHandle]
+     * is returned immediately and exposes its own [SubscriptionHandle.waitUntilStarted] returning a `Mono<Void>` that the
      * caller can compose into their own reactive chain if they need to wait, so no extra parameter is needed on `subscribe` itself.
      */
     @JvmOverloads
@@ -155,7 +155,7 @@ class StreamSubscriptions<E : Any>(private val subscriptionModel: Subscribable, 
         filter: StreamSubscriptionFilter = StreamSubscriptionFilter.filter(Filter.all()),
         startAt: StartAt? = null,
         fn: (EventMetadata, E) -> Mono<Void>
-    ): Subscription {
+    ): SubscriptionHandle {
         val action: (CloudEvent) -> Mono<Void> = { cloudEvent ->
             val event = cloudEventConverter[cloudEvent]
             val eventMetadata = EventMetadata.from(cloudEvent)
@@ -209,7 +209,7 @@ class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, privat
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, startAt) { _, e -> fn(e) }
     }
 
@@ -217,37 +217,37 @@ class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, privat
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
     @JvmName("subscribeAll")
-    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, *emptyArray(), startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (E1) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { _, e -> fn(e as E1) }
     }
 
     /**
      * Create a new subscription that is invoked after a specific domain event is written to the event store
      */
-    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E> subscribe(subscriptionId: String = defaultSubscriptionId(E1::class), startAt: StartAt? = null, crossinline fn: (EventMetadata, E1) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, startAt = startAt) { metadata, e -> fn(metadata, e as E1) }
     }
 
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { _, e -> fn(e) }
     }
 
     @JvmName("subscribeAnyOf")
-    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    inline fun <reified E1 : E, reified E2 : E> subscribe(subscriptionId: String, startAt: StartAt? = null, crossinline fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, E1::class, E2::class, startAt = startAt) { metadata, e -> fn(metadata, e) }
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: Function<E1, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { e: E ->
             @Suppress("UNCHECKED_CAST")
             fn.apply(e as E1)
@@ -255,7 +255,7 @@ class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, privat
     }
 
     @JvmOverloads
-    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): Subscription {
+    fun <E1 : E> subscribe(subscriptionId: String, eventType: Class<E1>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E1, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, listOf(eventType), startAt) { metadata, e ->
             @Suppress("UNCHECKED_CAST")
             fn.apply(metadata, e as E1)
@@ -263,33 +263,33 @@ class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, privat
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: Function<E, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { e -> fn.apply(e) }
     }
 
     @JvmOverloads
-    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): Subscription {
+    fun subscribe(subscriptionId: String, eventTypes: List<Class<out E>>, startAt: StartAt? = null, fn: BiFunction<EventMetadata, E, Mono<Void>>): SubscriptionHandle {
         return subscribe(subscriptionId, *eventTypes.map { c -> c.kotlin }.toTypedArray(), startAt = startAt) { metadata, e -> fn.apply(metadata, e) }
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, fn)
     }
 
-    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, vararg eventTypes: KClass<out E>, startAt: StartAt? = null, fn: (EventMetadata, E) -> Mono<Void>): SubscriptionHandle {
         val filter = agnosticSubscriptionFilterFromEventTypes(cloudEventConverter, eventTypes)
         return subscribe(subscriptionId, filter, startAt, fn)
     }
 
-    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): Subscription {
+    fun subscribe(subscriptionId: String, filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()), startAt: StartAt? = null, fn: (E) -> Mono<Void>): SubscriptionHandle {
         return subscribe(subscriptionId, filter, startAt) { _, e -> fn(e) }
     }
 
     /**
      * Unlike the blocking DSL this overload has no `waitUntilStarted` flag. The blocking DSL blocks the calling
-     * thread until the subscription has started, which only makes sense for a synchronous API. Here [Subscription]
-     * is returned immediately and exposes its own [Subscription.waitUntilStarted] returning a `Mono<Void>` that the
+     * thread until the subscription has started, which only makes sense for a synchronous API. Here [SubscriptionHandle]
+     * is returned immediately and exposes its own [SubscriptionHandle.waitUntilStarted] returning a `Mono<Void>` that the
      * caller can compose into their own reactive chain if they need to wait, so no extra parameter is needed on `subscribe` itself.
      */
     @JvmOverloads
@@ -298,7 +298,7 @@ class Subscriptions<E : Any>(private val subscriptionModel: Subscribable, privat
         filter: AgnosticSubscriptionFilter = AgnosticSubscriptionFilter.filter(Filter.all()),
         startAt: StartAt? = null,
         fn: (EventMetadata, E) -> Mono<Void>
-    ): Subscription {
+    ): SubscriptionHandle {
         val action: (CloudEvent) -> Mono<Void> = { cloudEvent ->
             val event = cloudEventConverter[cloudEvent]
             val eventMetadata = EventMetadata.from(cloudEvent)

--- a/dsl/subscription-dsl/reactor/src/test/kotlin/org/occurrent/dsl/subscription/reactor/SubscriptionModelCapabilitiesTest.kt
+++ b/dsl/subscription-dsl/reactor/src/test/kotlin/org/occurrent/dsl/subscription/reactor/SubscriptionModelCapabilitiesTest.kt
@@ -25,7 +25,7 @@ import org.occurrent.subscription.StartAt
 import org.occurrent.subscription.SubscriptionFilter
 import org.occurrent.subscription.api.reactor.IntrospectableSubscriptions
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions
-import org.occurrent.subscription.api.reactor.Subscription
+import org.occurrent.subscription.api.reactor.SubscriptionHandle
 import org.occurrent.subscription.api.reactor.SubscriptionModel
 import reactor.core.publisher.Mono
 import java.util.function.Function
@@ -62,7 +62,7 @@ class SubscriptionModelCapabilitiesTest {
     }
 
     private open class PlainModel : SubscriptionModel {
-        override fun subscribe(subscriptionId: String, filter: SubscriptionFilter?, startAt: StartAt, action: Function<CloudEvent, Mono<Void>>): Subscription =
+        override fun subscribe(subscriptionId: String, filter: SubscriptionFilter?, startAt: StartAt, action: Function<CloudEvent, Mono<Void>>): SubscriptionHandle =
             throw UnsupportedOperationException()
 
         override fun cancelSubscription(subscriptionId: String) {}
@@ -71,7 +71,7 @@ class SubscriptionModelCapabilitiesTest {
         override fun isRunning(): Boolean = false
         override fun isRunning(subscriptionId: String): Boolean = false
         override fun isPaused(subscriptionId: String): Boolean = false
-        override fun resumeSubscription(subscriptionId: String): Subscription = throw UnsupportedOperationException()
+        override fun resumeSubscription(subscriptionId: String): SubscriptionHandle = throw UnsupportedOperationException()
         override fun pauseSubscription(subscriptionId: String) {}
     }
 

--- a/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/SubscriptionExtensions.kt
+++ b/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/SubscriptionExtensions.kt
@@ -20,9 +20,9 @@ package org.occurrent.dsl.view
 import org.occurrent.cloudevents.EventMetadata
 import org.occurrent.dsl.subscription.blocking.StreamSubscriptions
 import org.occurrent.subscription.StartAt
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 
-inline fun <reified E : Any> StreamSubscriptions<E>.updateView(viewName: String, startAt: StartAt? = null, crossinline updateFunction: (EventMetadata, E) -> Unit): Subscription {
+inline fun <reified E : Any> StreamSubscriptions<E>.updateView(viewName: String, startAt: StartAt? = null, crossinline updateFunction: (EventMetadata, E) -> Unit): SubscriptionHandle {
     val eventTypes: List<Class<out E>> = if (E::class.isSealed) {
         E::class.sealedSubclasses.map { it.java }.toList()
     } else {
@@ -33,14 +33,14 @@ inline fun <reified E : Any> StreamSubscriptions<E>.updateView(viewName: String,
     })
 }
 
-inline fun <reified E : Any> StreamSubscriptions<E>.updateView(viewName: String, startAt: StartAt? = null, crossinline updateFunction: (E) -> Unit): Subscription =
+inline fun <reified E : Any> StreamSubscriptions<E>.updateView(viewName: String, startAt: StartAt? = null, crossinline updateFunction: (E) -> Unit): SubscriptionHandle =
     updateView(viewName, startAt) { _, e -> updateFunction(e) }
 
 inline fun <reified E : Any> StreamSubscriptions<E>.updateView(
     viewName: String, materializedView: MaterializedView<E>, startAt: StartAt? = null,
     crossinline doBeforeUpdate: (E) -> Unit = {},
     crossinline doAfterUpdate: (E) -> Unit = {}
-): Subscription =
+): SubscriptionHandle =
     updateView(
         viewName,
         converter = { _, e -> e },
@@ -57,7 +57,7 @@ inline fun <reified E : Any, reified E2 : Any> StreamSubscriptions<E>.updateView
     startAt: StartAt? = null,
     crossinline doBeforeUpdate: (E2) -> Unit = { },
     crossinline doAfterUpdate: (E2) -> Unit = { }
-): Subscription =
+): SubscriptionHandle =
     updateView(viewName, startAt) { metadata, e ->
         val e2 = converter(metadata, e)
         doBeforeUpdate(e2)

--- a/example/domain/uno/mongodb/spring/blocking/src/main/kotlin/org/occurrent/example/domain/uno/es/spring/blocking/ReportProgressWhenGameIsPlayed.kt
+++ b/example/domain/uno/mongodb/spring/blocking/src/main/kotlin/org/occurrent/example/domain/uno/es/spring/blocking/ReportProgressWhenGameIsPlayed.kt
@@ -18,7 +18,7 @@ package org.occurrent.example.domain.uno.es.spring.blocking
 
 import org.occurrent.application.converter.CloudEventConverter
 import org.occurrent.example.domain.uno.*
-import org.occurrent.subscription.api.blocking.Subscription
+import org.occurrent.subscription.api.blocking.SubscriptionHandle
 import org.occurrent.subscription.api.blocking.SubscriptionModel
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -34,7 +34,7 @@ class ReportProgressWhenGameIsPlayed(
     private val log = loggerFor<ReportProgressWhenGameIsPlayed>()
 
     @Bean
-    fun reportGameProgressDuringGamePlaySubscription(): Subscription {
+    fun reportGameProgressDuringGamePlaySubscription(): SubscriptionHandle {
         return subscriptionModel.subscribe("reportGameProgressDuringGamePlay",
             cloudEventConverter::toDomainEvent andThen { e: Event ->
                 val turnCountForGame = if (e is CardPlayed) {

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
@@ -55,7 +55,7 @@ import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModelCapability;
 import org.occurrent.subscription.push.blocking.CatchupThenPushSubscriptionModel;
 import org.occurrent.subscription.push.blocking.PushSubscriptionModel;
@@ -588,7 +588,7 @@ class ProjectionAnnotationRegistrar {
         if (SubscriptionAnnotations.subscriptionsStartOnTheirOwn(applicationContext)) {
             // With waitUntilStarted the catch-up replay finishes here before handing over to the live push feed;
             // without it the replay runs on its own thread and this returns straight away.
-            Subscription subscription = runner.project(id, projection, materializedView, null, waitUntilStarted);
+            SubscriptionHandle subscription = runner.project(id, projection, materializedView, null, waitUntilStarted);
             if (!waitUntilStarted) {
                 // Nobody is left to see this replay fail, so join it on a thread of this registrar's own purely to
                 // record the failure. Stopping it is close()'s job through the model, so this needs no stop of its own.
@@ -602,7 +602,7 @@ class ProjectionAnnotationRegistrar {
         // same work: ManualStartPushSources.start returns void, so the application never sees the handle and could
         // not watch a background replay for itself.
         applicationContext.getBean(ManualStartPushSources.class).register(id, () -> {
-            Subscription deferred = runner.project(id, projection, materializedView, null, waitUntilStarted);
+            SubscriptionHandle deferred = runner.project(id, projection, materializedView, null, waitUntilStarted);
             if (!waitUntilStarted) {
                 runInBackground("occurrent-push-catchup-watch", id, deferred::waitUntilStarted, () -> {
                 });

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/ProjectionAnnotationRecordAppliedAppendsWarningTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/ProjectionAnnotationRecordAppliedAppendsWarningTest.java
@@ -38,7 +38,7 @@ import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -104,7 +104,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
         ComposedDefaultStartPosition composedDefaultStartPosition = new ComposedDefaultStartPosition();
         composedDefaultStartPosition.suppliedBy(model);
         composedDefaultStartPosition.defaultBypassesCatchup();
@@ -135,7 +135,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(true);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
         ComposedDefaultStartPosition composedDefaultStartPosition = new ComposedDefaultStartPosition();
         composedDefaultStartPosition.suppliedBy(model);
         composedDefaultStartPosition.defaultBypassesCatchup();
@@ -168,7 +168,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) customModel)).when(customModel).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) customModel).isCatchingUp(anyString())).thenReturn(true);
         when(customModel.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
 
         new ApplicationContextRunner()
                 .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)
@@ -197,7 +197,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) customModel)).when(customModel).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) customModel).isCatchingUp(anyString())).thenReturn(true);
         when(customModel.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
 
         new ApplicationContextRunner()
                 .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)
@@ -222,7 +222,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
         ComposedDefaultStartPosition composedDefaultStartPosition = new ComposedDefaultStartPosition();
         composedDefaultStartPosition.suppliedBy(model);
         composedDefaultStartPosition.defaultBypassesCatchup();
@@ -256,7 +256,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) customModel)).when(customModel).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) customModel).isCatchingUp(anyString())).thenReturn(true);
         when(customModel.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
 
         new ApplicationContextRunner()
                 .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)
@@ -279,7 +279,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
         ComposedDefaultStartPosition composedDefaultStartPosition = new ComposedDefaultStartPosition();
         composedDefaultStartPosition.suppliedBy(model);
         composedDefaultStartPosition.defaultBypassesCatchup();
@@ -339,7 +339,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
 
         new ApplicationContextRunner()
                 .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)
@@ -400,7 +400,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         Subscribable model = mock(Subscribable.class);
         doReturn(java.util.Optional.empty()).when(model).capability(ReplayAwareSubscriptions.class);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
         return model;
     }
 
@@ -411,7 +411,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(mock(Subscription.class));
+                .thenReturn(mock(SubscriptionHandle.class));
 
         new ApplicationContextRunner()
                 .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new)

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/ProjectionAnnotationRecordingListenerSourceTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/ProjectionAnnotationRecordingListenerSourceTest.java
@@ -34,7 +34,7 @@ import org.occurrent.subscription.CatchupListener;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -87,7 +87,7 @@ class ProjectionAnnotationRecordingListenerSourceTest {
             @SuppressWarnings("unchecked")
             Consumer<CloudEvent> action = invocation.getArgument(3);
             action.accept(cloudEvent(appendId));
-            return mock(Subscription.class);
+            return mock(SubscriptionHandle.class);
         });
 
         Subscribable distractorModel = mock(Subscribable.class, withSettings().extraInterfaces(ReplayAwareSubscriptions.class));

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrarTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrarTest.java
@@ -31,7 +31,7 @@ import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.springboot.common.StartupWorkaround;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
@@ -63,7 +63,7 @@ class SagaAnnotationRegistrarTest {
 
     @Test
     void registers_the_saga_and_populates_the_registry_but_skips_the_named_singleton() throws Exception {
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         Subscribable subscribable = mock(Subscribable.class);
         when(subscribable.subscribe(any(), any(), any(), any())).thenReturn(subscription);
 

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationTimerPollerCompetingConsumerTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationTimerPollerCompetingConsumerTest.java
@@ -28,7 +28,7 @@ import org.occurrent.dsl.saga.SagaStateStore;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -126,7 +126,7 @@ class SagaAnnotationTimerPollerCompetingConsumerTest {
         @Bean
         Subscribable subscribable() {
             Subscribable subscribable = mock(Subscribable.class);
-            when(subscribable.subscribe(any(), any(), any(), any())).thenReturn(mock(Subscription.class));
+            when(subscribable.subscribe(any(), any(), any(), any())).thenReturn(mock(SubscriptionHandle.class));
             return subscribable;
         }
 

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaTimerGateTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaTimerGateTest.java
@@ -26,7 +26,7 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.SubscriptionModelWrapper;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.util.function.BooleanSupplier;
@@ -104,7 +104,7 @@ class SagaTimerGateTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new UnsupportedOperationException();
         }
 
@@ -136,7 +136,7 @@ class SagaTimerGateTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException();
         }
 

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ProjectionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ProjectionAnnotationRegistrar.java
@@ -728,7 +728,7 @@ class ProjectionAnnotationRegistrar {
     }
 
     @SuppressWarnings("unchecked")
-    private <E, S, ID> org.occurrent.subscription.api.reactor.Subscription projectAgnosticOrStream(ReactiveProjectionRunner<E> runner, String id, org.occurrent.annotation.Projection annotation, Projection<S, E, ID> projection, Object store, @Nullable StartAt startAt, @Nullable CatchupResolution recordingResolution) {
+    private <E, S, ID> org.occurrent.subscription.api.reactor.SubscriptionHandle projectAgnosticOrStream(ReactiveProjectionRunner<E> runner, String id, org.occurrent.annotation.Projection annotation, Projection<S, E, ID> projection, Object store, @Nullable StartAt startAt, @Nullable CatchupResolution recordingResolution) {
         if (recordingResolution == null) {
             if (store instanceof MaterializedView) {
                 return runner.project(id, projection, (MaterializedView<E>) store, startAt);
@@ -745,7 +745,7 @@ class ProjectionAnnotationRegistrar {
     }
 
     @SuppressWarnings("unchecked")
-    private <E, S, ID> org.occurrent.subscription.api.reactor.Subscription projectDcb(ReactiveDcbProjectionRunner<E> runner, String id, org.occurrent.annotation.Projection annotation, DcbProjection<S, E, ID> dcbProjection, Object store, @Nullable DcbStartAt startAt, @Nullable CatchupResolution recordingResolution) {
+    private <E, S, ID> org.occurrent.subscription.api.reactor.SubscriptionHandle projectDcb(ReactiveDcbProjectionRunner<E> runner, String id, org.occurrent.annotation.Projection annotation, DcbProjection<S, E, ID> dcbProjection, Object store, @Nullable DcbStartAt startAt, @Nullable CatchupResolution recordingResolution) {
         if (recordingResolution == null) {
             if (store instanceof MaterializedView) {
                 return runner.project(id, dcbProjection, (MaterializedView<E>) store, startAt);

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ProjectionAnnotationRecordAppliedAppendsWarningTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/ProjectionAnnotationRecordAppliedAppendsWarningTest.java
@@ -37,7 +37,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions;
 import org.occurrent.subscription.api.reactor.Subscribable;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -102,7 +102,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         Subscribable model = mock(Subscribable.class, withSettings().extraInterfaces(ReplayAwareSubscriptions.class));
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(subscription);
@@ -135,7 +135,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         Subscribable model = mock(Subscribable.class, withSettings().extraInterfaces(ReplayAwareSubscriptions.class));
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(true);
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(subscription);
@@ -201,7 +201,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         Subscribable model = mock(Subscribable.class, withSettings().extraInterfaces(ReplayAwareSubscriptions.class));
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(subscription);
@@ -270,7 +270,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
     private static Subscribable unobservableModel() {
         Subscribable model = mock(Subscribable.class);
         doReturn(java.util.Optional.empty()).when(model).capability(ReplayAwareSubscriptions.class);
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(subscription);
@@ -283,7 +283,7 @@ class ProjectionAnnotationRecordAppliedAppendsWarningTest {
         // told directly what it exposes.
         doReturn(java.util.Optional.of((ReplayAwareSubscriptions) model)).when(model).capability(ReplayAwareSubscriptions.class);
         when(((ReplayAwareSubscriptions) model).isCatchingUp(anyString())).thenReturn(false);
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         when(model.subscribe(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(StartAt.class), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(subscription);

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/SnapshotAnnotationJdkProxyTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/SnapshotAnnotationJdkProxyTest.java
@@ -157,13 +157,13 @@ class SnapshotAnnotationJdkProxyTest {
         }
 
         // Default (non-synchronous, non-stream) registration resolves this by type to subscribe, then calls
-        // waitUntilStarted() on whatever it returns, so the mock needs a real (mocked) Subscription back rather
+        // waitUntilStarted() on whatever it returns, so the mock needs a real (mocked) SubscriptionHandle back rather
         // than Mockito's default null.
         @SuppressWarnings("unchecked")
         @Bean
         Subscriptions<TestEvent> subscriptions() {
             Subscriptions<TestEvent> subscriptions = mock(Subscriptions.class);
-            org.occurrent.subscription.api.reactor.Subscription subscription = mock(org.occurrent.subscription.api.reactor.Subscription.class);
+            org.occurrent.subscription.api.reactor.SubscriptionHandle subscription = mock(org.occurrent.subscription.api.reactor.SubscriptionHandle.class);
             when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
             // Every argument typed to pick the (String, AgnosticSubscriptionFilter, StartAt, Function2) overload
             // out of the several Subscriptions declares (sealed-type array selector, Function1 event-only handler).

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAsynchronousSubscribableResolutionTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/OccurrentReactiveMongoAsynchronousSubscribableResolutionTest.java
@@ -25,7 +25,7 @@ import org.occurrent.dsl.subscription.reactor.Subscriptions;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -65,7 +65,7 @@ class OccurrentReactiveMongoAsynchronousSubscribableResolutionTest {
 
     @Test
     void an_application_supplied_asynchronous_subscription_model_without_primary_still_starts_and_the_dsl_binds_to_it() {
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         SubscriptionModel own = mock(SubscriptionModel.class);
         when(own.subscribe(any(), any(), any(), any())).thenReturn(subscription);
 

--- a/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ProjectionAnnotationAsynchronousSubscribableResolutionTest.java
+++ b/framework/spring-boot-starter-mongodb-reactive/src/test/java/org/occurrent/springboot/mongo/reactor/ProjectionAnnotationAsynchronousSubscribableResolutionTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.occurrent.annotation.Projection;
 import org.occurrent.dsl.view.ViewStateRepository;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -64,7 +64,7 @@ class ProjectionAnnotationAsynchronousSubscribableResolutionTest {
 
     @Test
     void an_application_supplied_asynchronous_subscription_model_without_primary_still_starts_and_a_default_projection_binds_to_it() {
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         when(subscription.waitUntilStarted()).thenReturn(Mono.empty());
         SubscriptionModel own = mock(SubscriptionModel.class);
         when(own.subscribe(any(), any(), any(), any())).thenReturn(subscription);

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/DcbDualModeCatchupAutoConfigurationMongoTest.java
@@ -38,7 +38,7 @@ import org.occurrent.eventstore.api.dcb.DcbEventStore;
 import org.occurrent.eventstore.api.dcb.Tag;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.catchup.StartAtTime;
 import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
@@ -381,7 +381,7 @@ class DcbDualModeCatchupAutoConfigurationMongoTest {
 
         CopyOnWriteArrayList<TestEvent> received = new CopyOnWriteArrayList<>();
 
-        Subscription subscription = subscriptionModel.subscribe(
+        SubscriptionHandle subscription = subscriptionModel.subscribe(
                         "neutral-live-" + UUID.randomUUID(),
                         AgnosticSubscriptionFilter.filter(Filter.type(cloudEventConverter.getCloudEventType(TestEvent.class))),
                         StartAt.checkpoint(GlobalCheckpoint.of(0)),

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAsynchronousSubscribableResolutionTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/OccurrentMongoAsynchronousSubscribableResolutionTest.java
@@ -26,7 +26,7 @@ import org.occurrent.dsl.subscription.blocking.Subscriptions;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -63,7 +63,7 @@ class OccurrentMongoAsynchronousSubscribableResolutionTest {
 
     @Test
     void an_application_supplied_asynchronous_subscription_model_without_primary_still_starts_and_the_dsl_binds_to_it() {
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         SubscriptionModel own = mock(SubscriptionModel.class);
         when(own.subscribe(any(), any(), any(), any())).thenReturn(subscription);
 

--- a/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SagaAnnotationAsynchronousSubscribableResolutionTest.java
+++ b/framework/spring-boot-starter-mongodb/src/test/java/org/occurrent/springboot/mongo/blocking/SagaAnnotationAsynchronousSubscribableResolutionTest.java
@@ -23,7 +23,7 @@ import org.occurrent.annotation.Saga;
 import org.occurrent.command.CommandDispatcher;
 import org.occurrent.dsl.saga.SagaStateStore;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -64,7 +64,7 @@ class SagaAnnotationAsynchronousSubscribableResolutionTest {
 
     @Test
     void an_application_supplied_asynchronous_subscription_model_without_primary_still_starts_and_a_non_push_saga_binds_to_it() {
-        Subscription subscription = mock(Subscription.class);
+        SubscriptionHandle subscription = mock(SubscriptionHandle.class);
         SubscriptionModel own = mock(SubscriptionModel.class);
         when(own.subscribe(any(), any(), any(), any())).thenReturn(subscription);
 

--- a/rewrite/src/main/resources/META-INF/rewrite/renames-subscription-handle-0_35.yml
+++ b/rewrite/src/main/resources/META-INF/rewrite/renames-subscription-handle-0_35.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2026 Johan Haleby
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.occurrent.MigrateSubscriptionHandleRename_0_35
+displayName: Rename Subscription to SubscriptionHandle (0.34.0 -> 0.35.0)
+description: >-
+  Renames org.occurrent.subscription.api.blocking.Subscription to SubscriptionHandle, and its reactor twin
+  org.occurrent.subscription.api.reactor.Subscription likewise. Both interfaces are what a caller holds after
+  starting a subscription, not the subscription itself, which is what the new name says (ADR 127 decision 2). It
+  is a plain type rename with no signature or behaviour change, so declarative ChangeType covers it the same way
+  renames-0_33.yml already covers five subscription-model interfaces. See doc/migration/upgrading-to-0.35.0.md
+  for what this rename covers.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.subscription.api.blocking.Subscription
+      newFullyQualifiedTypeName: org.occurrent.subscription.api.blocking.SubscriptionHandle
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.occurrent.subscription.api.reactor.Subscription
+      newFullyQualifiedTypeName: org.occurrent.subscription.api.reactor.SubscriptionHandle
+      ignoreDefinition: true

--- a/rewrite/src/main/resources/META-INF/rewrite/upgrade-0_35.yml
+++ b/rewrite/src/main/resources/META-INF/rewrite/upgrade-0_35.yml
@@ -28,6 +28,10 @@ description: >-
   it wants. This recipe renames the annotations, in Java and Kotlin alike, and does not turn a void handler into
   a descriptor, which is a separate change with its own recipe. A renamed annotation on a void handler is still
   valid source, so only a use of the removed eventTypes, or of tags on @DcbSubscription, fails to compile after
-  this recipe has run. See doc/migration/upgrading-to-0.35.0.md for what the rename covers and what it leaves.
+  this recipe has run. It also renames org.occurrent.subscription.api.blocking.Subscription and its reactor twin
+  to SubscriptionHandle (ADR 127 decision 2), the type a caller holds after starting a subscription rather than
+  the subscription itself. See doc/migration/upgrading-to-0.35.0.md for what the rename covers and what it
+  leaves.
 recipeList:
   - org.occurrent.MigrateOccurrentAnnotationRenames_0_35
+  - org.occurrent.MigrateSubscriptionHandleRename_0_35

--- a/rewrite/src/test/java/org/occurrent/rewrite/MigrateSubscriptionHandleRename_0_35Test.java
+++ b/rewrite/src/test/java/org/occurrent/rewrite/MigrateSubscriptionHandleRename_0_35Test.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.occurrent.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+/**
+ * Covers {@code MigrateSubscriptionHandleRename_0_35}: {@code org.occurrent.subscription.api.blocking.Subscription}
+ * and its reactor twin become {@code SubscriptionHandle} (ADR 127 decision 2). Neither interface declares any other
+ * member the recipe could disturb, so each case only has to show the import and the type usage move together.
+ */
+class MigrateSubscriptionHandleRename_0_35Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/renames-subscription-handle-0_35.yml",
+                "org.occurrent.MigrateSubscriptionHandleRename_0_35");
+    }
+
+    @Test
+    void theBlockingSubscriptionIsRenamedToSubscriptionHandle() {
+        rewriteRun(
+                java(
+                        """
+                        package org.occurrent.subscription.api.blocking;
+
+                        public interface Subscription {
+                            String id();
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        import org.occurrent.subscription.api.blocking.Subscription;
+
+                        class Foo {
+                            Subscription handle;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.occurrent.subscription.api.blocking.SubscriptionHandle;
+
+                        class Foo {
+                            SubscriptionHandle handle;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void theReactorSubscriptionIsRenamedToSubscriptionHandle() {
+        rewriteRun(
+                java(
+                        """
+                        package org.occurrent.subscription.api.reactor;
+
+                        public interface Subscription {
+                            String id();
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        import org.occurrent.subscription.api.reactor.Subscription;
+
+                        class Foo {
+                            Subscription handle;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.occurrent.subscription.api.reactor.SubscriptionHandle;
+
+                        class Foo {
+                            SubscriptionHandle handle;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void theRenameAppliesInKotlinToo() {
+        rewriteRun(
+                kotlin(
+                        """
+                        package org.occurrent.subscription.api.blocking
+
+                        interface Subscription {
+                            fun id(): String
+                        }
+                        """
+                ),
+                kotlin(
+                        """
+                        package com.example
+
+                        import org.occurrent.subscription.api.blocking.Subscription
+
+                        class Foo(val handle: Subscription)
+                        """,
+                        """
+                        package com.example
+
+                        import org.occurrent.subscription.api.blocking.SubscriptionHandle
+
+                        class Foo(val handle: SubscriptionHandle)
+                        """
+                )
+        );
+    }
+}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/AbstractSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/AbstractSubscriptionModelAdapter.java
@@ -59,7 +59,7 @@ abstract class AbstractSubscriptionModelAdapter implements SubscriptionModelLife
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return delegate.resumeSubscription(subscriptionId);
     }
 

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModel.java
@@ -39,19 +39,19 @@ public interface DcbSubscriptionModel extends SubscriptionModelLifeCycle {
     /**
      * Subscribe to DCB events matching {@code criteria}, starting at {@code startAt}.
      */
-    Subscription subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Consumer<CloudEvent> action);
+    SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Consumer<CloudEvent> action);
 
     /**
      * Subscribe to DCB events matching {@code criteria} at the subscription model default position.
      */
-    default Subscription subscribe(String subscriptionId, DcbCriteria criteria, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, criteria, DcbStartAt.subscriptionModelDefault(), action);
     }
 
     /**
      * Subscribe to every DCB event at the subscription model default position.
      */
-    default Subscription subscribe(String subscriptionId, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, DcbCriteria.all(), action);
     }
 

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/DcbSubscriptionModelAdapter.java
@@ -40,7 +40,7 @@ final class DcbSubscriptionModelAdapter extends AbstractSubscriptionModelAdapter
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(criteria, "Criteria cannot be null");
         requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModel.java
@@ -229,7 +229,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
 
     /**
      * Register a subscription. While this model is withholding, nothing is passed to the wrapped model and the returned
-     * {@link Subscription} is a placeholder standing for the registration. Its {@code waitUntilStarted} answers
+     * {@link SubscriptionHandle} is a placeholder standing for the registration. Its {@code waitUntilStarted} answers
      * {@code false} straight away, since the subscription has not started and will not until you ask. Once the
      * subscription is started, {@link #resumeSubscription(String)} returns the wrapped model's own subscription, which
      * is the handle to wait on.
@@ -249,7 +249,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
      *                                                   the source can answer is what a node does.
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
         requireNonNull(action, "Action cannot be null");
@@ -271,7 +271,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
                     return new DeferredSubscription(subscriptionId);
                 }
             }
-            Subscription subscription = delegate.subscribe(subscriptionId, filter, startAt, action);
+            SubscriptionHandle subscription = delegate.subscribe(subscriptionId, filter, startAt, action);
             registrations.put(subscriptionId, new Registration.Live(subscription));
             return subscription;
         } catch (RuntimeException e) {
@@ -294,7 +294,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
      *                                             thread started this registration first.
      */
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Registration registration = registrations.get(subscriptionId);
         // Another thread is between claiming this registration and subscribing it, so the wrapped model does not have
@@ -304,7 +304,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
                     "Subscription " + subscriptionId + " is already being started by another thread.");
         }
         if (!(registration instanceof Registration.Deferred deferred)) {
-            Subscription subscription = delegate.resumeSubscription(subscriptionId);
+            SubscriptionHandle subscription = delegate.resumeSubscription(subscriptionId);
             reopenAfterStop();
             return subscription;
         }
@@ -315,7 +315,7 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
         }
 
         try {
-            Subscription subscription = delegate.subscribe(subscriptionId, deferred.filter(), deferred.startAt(), deferred.action());
+            SubscriptionHandle subscription = delegate.subscribe(subscriptionId, deferred.filter(), deferred.startAt(), deferred.action());
             // Subscribing to a stopped model registers a paused subscription rather than a running one, so this is what
             // makes starting work after stop(). Without it the caller is handed a subscription that never delivers.
             if (delegate.isPaused(subscriptionId)) {
@@ -646,14 +646,14 @@ public final class ManualStartSubscriptionModel implements SubscriptionModel, Su
         record Starting() implements Registration {
         }
 
-        record Live(Subscription subscription) implements Registration {
+        record Live(SubscriptionHandle subscription) implements Registration {
         }
     }
 
     // Stands for a registration that has not been started. It answers at once instead of waiting out the timeout,
     // because nothing changes until the application starts the subscription, and waiting would hang every caller that
     // uses the no-argument waitUntilStarted().
-    private record DeferredSubscription(String id) implements Subscription {
+    private record DeferredSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return false;

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/RegisteringSubscribable.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/RegisteringSubscribable.java
@@ -202,7 +202,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     }
 
     @Override
-    public final Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public final SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(action, "action cannot be null");
         return doSubscribe(subscriptionId, filter, startAt, (cloudEvent, bufferIfNotLive) -> {
             action.accept(cloudEvent);
@@ -217,11 +217,11 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
      * delivery ahead of it. {@link Consumers#ONE} only, the same restriction
      * {@link #routeReportingMatch(CloudEvent, boolean, BiConsumer)} itself already enforces at routing time.
      */
-    protected final Subscription subscribeReportingDelivery(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
+    protected final SubscriptionHandle subscribeReportingDelivery(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
         return doSubscribe(subscriptionId, filter, startAt, action);
     }
 
-    private Subscription doSubscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
+    private SubscriptionHandle doSubscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Objects.requireNonNull(startAt, "startAt cannot be null");
         Objects.requireNonNull(action, "action cannot be null");
@@ -303,7 +303,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     }
 
     @Override
-    public final Subscription resumeSubscription(String subscriptionId) {
+    public final SubscriptionHandle resumeSubscription(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireKnown(subscriptionId);
         if (!isPaused(subscriptionId)) {
@@ -572,7 +572,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     // Answers for the one registration it was created for. There is no background thread to wait for, so registering
     // on a running model starts the subscription there and then, and registering on a stopped model does not.
     // A subscription started later takes its handle from resumeSubscription.
-    private record RegisteredSubscription(String id, boolean started) implements Subscription {
+    private record RegisteredSubscription(String id, boolean started) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return started;

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/RepositionableSubscriptions.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/RepositionableSubscriptions.java
@@ -43,7 +43,7 @@ public interface RepositionableSubscriptions extends SubscriptionModelCapability
      * @throws UnknownSubscriptionException        If this subscription model has no subscription with that id.
      * @throws SubscriptionAlreadyRunningException If the subscription is already running.
      */
-    Subscription resumeSubscription(String subscriptionId, StartAt startAt);
+    SubscriptionHandle resumeSubscription(String subscriptionId, StartAt startAt);
 
     /**
      * The repositionable model behind {@code subscriptionModel}, unwrapping a {@link SubscriptionModelWrapper}

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModel.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModel.java
@@ -36,19 +36,19 @@ public interface StreamSubscriptionModel extends SubscriptionModelLifeCycle {
     /**
      * Subscribe to events matching {@code filter}, starting at {@code startAt}.
      */
-    Subscription subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action);
+    SubscriptionHandle subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action);
 
     /**
      * Subscribe to events matching {@code filter} at the subscription model default position.
      */
-    default Subscription subscribe(String subscriptionId, Filter filter, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, Filter filter, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), action);
     }
 
     /**
      * Subscribe to every event at the subscription model default position.
      */
-    default Subscription subscribe(String subscriptionId, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, Filter.all(), action);
     }
 

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModelAdapter.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/StreamSubscriptionModelAdapter.java
@@ -39,7 +39,7 @@ final class StreamSubscriptionModelAdapter extends AbstractSubscriptionModelAdap
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, Filter filter, StartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(filter, Filter.class.getSimpleName() + " cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/Subscribable.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/Subscribable.java
@@ -33,7 +33,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @throws UnsupportedSubscriptionFilterException If this model cannot apply a filter of that shape.
      * @throws UnsupportedStartAtException            If this model does not accept that start position.
      */
-    Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action);
+    SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action);
 
     /**
      * Start listening to cloud events persisted to the event store at the supplied start position.
@@ -44,7 +44,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @throws DuplicateSubscriptionIdException If {@code subscriptionId} is already in use on this subscription model instance.
      * @throws UnsupportedStartAtException      If this model does not accept that start position.
      */
-    default Subscription subscribe(String subscriptionId, StartAt startAt, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, StartAt startAt, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, null, startAt, action);
     }
 
@@ -57,7 +57,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @throws DuplicateSubscriptionIdException       If {@code subscriptionId} is already in use on this subscription model instance.
      * @throws UnsupportedSubscriptionFilterException If this model cannot apply a filter of that shape.
      */
-    default Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), action);
     }
 
@@ -68,7 +68,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @param action         This action will be invoked for each cloud event that is stored in the EventStore.
      * @throws DuplicateSubscriptionIdException If {@code subscriptionId} is already in use on this subscription model instance.
      */
-    default Subscription subscribe(String subscriptionId, Consumer<CloudEvent> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, null, StartAt.subscriptionModelDefault(), action);
     }
 }

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionHandle.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionHandle.java
@@ -26,7 +26,7 @@ import java.time.temporal.ChronoUnit;
  * and you may wish to wait ({@link #waitUntilStarted(Duration)} for them to start before continuing.
  */
 @NullMarked
-public interface Subscription {
+public interface SubscriptionHandle {
 
     /**
      * @return The id of the subscription
@@ -34,7 +34,7 @@ public interface Subscription {
     String id();
 
     /**
-     * Synchronous, <strong>blocking</strong> call returns once the {@link Subscription} has started.
+     * Synchronous, <strong>blocking</strong> call returns once the {@link SubscriptionHandle} has started.
      * <p>
      * This overload waits forever and throws away the answer, so a subscription that never started looks exactly like
      * one that did. Use {@link #waitUntilStarted(Duration)} when you need to know which happened.
@@ -44,7 +44,7 @@ public interface Subscription {
     }
 
     /**
-     * Synchronous, <strong>blocking</strong> call returns once the {@link Subscription} has started or
+     * Synchronous, <strong>blocking</strong> call returns once the {@link SubscriptionHandle} has started or
      * {@link Duration timeout} exceeds.
      * <p>
      * This handle answers for the one start it was created for, and it reports started once nothing further is

--- a/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModelLifeCycle.java
+++ b/subscription/api/blocking/src/main/java/org/occurrent/subscription/api/blocking/SubscriptionModelLifeCycle.java
@@ -99,7 +99,7 @@ public interface SubscriptionModelLifeCycle extends CancellableSubscriptions {
      *                                             not the caller's doing, which on a competing consumer model means
      *                                             another node currently holds the subscription.
      */
-    Subscription resumeSubscription(String subscriptionId);
+    SubscriptionHandle resumeSubscription(String subscriptionId);
 
     /**
      * Pause an individual subscription. It'll be paused <i>temporarily</i>, which means that it can be

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/IntrospectableSubscriptionsTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/IntrospectableSubscriptionsTest.java
@@ -74,7 +74,7 @@ class IntrospectableSubscriptionsTest {
 
     private static class PlainModel implements SubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new UnsupportedOperationException();
         }
 
@@ -106,7 +106,7 @@ class IntrospectableSubscriptionsTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException();
         }
 

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ManualStartSubscriptionModelTest.java
@@ -60,7 +60,7 @@ class ManualStartSubscriptionModelTest {
         ManualStartSubscriptionModel model = ManualStartSubscriptionModel.stoppedByDefault(delegate);
         List<CloudEvent> received = new CopyOnWriteArrayList<>();
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.now(), received::add);
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.now(), received::add);
         delegate.feed(cloudEvent("1"));
 
         assertThat(delegate.subscribeCalls).isEmpty();
@@ -76,11 +76,11 @@ class ManualStartSubscriptionModelTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel();
         ManualStartSubscriptionModel model = ManualStartSubscriptionModel.stoppedByDefault(delegate);
 
-        Subscription deferred = model.subscribe(SUBSCRIPTION_ID, null, StartAt.now(), __ -> {
+        SubscriptionHandle deferred = model.subscribe(SUBSCRIPTION_ID, null, StartAt.now(), __ -> {
         });
         assertThat(deferred.waitUntilStarted(ofSeconds(1))).isFalse();
 
-        Subscription started = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle started = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThat(started.waitUntilStarted(ofSeconds(1))).isTrue();
     }
@@ -120,7 +120,7 @@ class ManualStartSubscriptionModelTest {
         };
 
         model.subscribe(SUBSCRIPTION_ID, filter, startAt, action);
-        Subscription subscription = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle subscription = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThat(delegate.subscribeCalls).hasSize(1);
         SubscribeCall call = delegate.subscribeCalls.getFirst();
@@ -410,7 +410,7 @@ class ManualStartSubscriptionModelTest {
 
         ExecutorService pool = Executors.newSingleThreadExecutor();
         try {
-            Future<Subscription> registering = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> {
+            Future<SubscriptionHandle> registering = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> {
             }));
             assertThat(registrationInProgress.await(10, TimeUnit.SECONDS)).isTrue();
             model.start(true);
@@ -442,7 +442,7 @@ class ManualStartSubscriptionModelTest {
 
         ExecutorService pool = Executors.newSingleThreadExecutor();
         try {
-            Future<Subscription> registering = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> {
+            Future<SubscriptionHandle> registering = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> {
             }));
             assertThat(registrationInProgress.await(10, TimeUnit.SECONDS))
                     .as("this registration asks for the model default, so its position is read whatever the state "
@@ -1144,7 +1144,7 @@ class ManualStartSubscriptionModelTest {
         model.start(true);
         StartAt callersOwnStartAt = StartAt.subscriptionModelDefault();
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, callersOwnStartAt, __ -> {
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, callersOwnStartAt, __ -> {
         });
 
         assertThat(delegate.subscribeCalls).hasSize(1);
@@ -1484,7 +1484,7 @@ class ManualStartSubscriptionModelTest {
     // subscription instead of a running one.
     private static class RecordingSubscriptionModel implements CheckpointAwareSubscriptionModel, IntrospectableSubscriptions {
         final List<SubscribeCall> subscribeCalls = new CopyOnWriteArrayList<>();
-        final Map<String, Subscription> subscriptions = new HashMap<>();
+        final Map<String, SubscriptionHandle> subscriptions = new HashMap<>();
         final List<String> resumeCalls = new CopyOnWriteArrayList<>();
         final List<String> cancelCalls = new CopyOnWriteArrayList<>();
         final Set<String> paused = new LinkedHashSet<>();
@@ -1505,7 +1505,7 @@ class ManualStartSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             if (subscribeEntered != null) {
                 subscribeEntered.countDown();
             }
@@ -1520,7 +1520,7 @@ class ManualStartSubscriptionModelTest {
                 throw new IllegalStateException("Cannot subscribe " + subscriptionId);
             }
             subscribeCalls.add(new SubscribeCall(subscriptionId, filter, startAt, action));
-            Subscription subscription = new RecordedSubscription(subscriptionId);
+            SubscriptionHandle subscription = new RecordedSubscription(subscriptionId);
             subscriptions.put(subscriptionId, subscription);
             if (parkOnSubscribe) {
                 paused.add(subscriptionId);
@@ -1531,7 +1531,7 @@ class ManualStartSubscriptionModelTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             if (!paused.remove(subscriptionId)) {
                 throw new IllegalArgumentException("Subscription " + subscriptionId + " is not paused");
             }
@@ -1629,12 +1629,12 @@ class ManualStartSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             return wrapped.subscribe(subscriptionId, filter, startAt, action);
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return wrapped.resumeSubscription(subscriptionId);
         }
 
@@ -1689,12 +1689,12 @@ class ManualStartSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             return wrapped.subscribe(subscriptionId, filter, startAt, action);
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return wrapped.resumeSubscription(subscriptionId);
         }
 
@@ -1739,7 +1739,7 @@ class ManualStartSubscriptionModelTest {
         }
     }
 
-    private record RecordedSubscription(String id) implements Subscription {
+    private record RecordedSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ReplayAwareSubscriptionsTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/ReplayAwareSubscriptionsTest.java
@@ -119,7 +119,7 @@ class ReplayAwareSubscriptionsTest {
 
     private static class PlainModel implements SubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new UnsupportedOperationException();
         }
 
@@ -151,7 +151,7 @@ class ReplayAwareSubscriptionsTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException();
         }
 

--- a/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/SubscriptionModelCapabilityTest.java
+++ b/subscription/api/blocking/src/test/java/org/occurrent/subscription/api/blocking/SubscriptionModelCapabilityTest.java
@@ -78,7 +78,7 @@ class SubscriptionModelCapabilityTest {
 
     private static class PlainModel implements SubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new UnsupportedOperationException();
         }
 
@@ -110,7 +110,7 @@ class SubscriptionModelCapabilityTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException();
         }
 

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModel.java
@@ -76,7 +76,7 @@ public interface DcbSubscriptionModel {
      * @param action         This action will be invoked for each cloud event matching {@code criteria}. The next event
      *                       is not processed until the returned {@link Mono} completes.
      */
-    Subscription subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action);
+    SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action);
 
     /**
      * Subscribe to DCB events matching {@code criteria} at the subscription model default position, tracked by
@@ -84,7 +84,7 @@ public interface DcbSubscriptionModel {
      *
      * @see #subscribe(String, DcbCriteria, DcbStartAt, Function)
      */
-    default Subscription subscribe(String subscriptionId, DcbCriteria criteria, Function<CloudEvent, Mono<Void>> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, Function<CloudEvent, Mono<Void>> action) {
         return subscribe(subscriptionId, criteria, DcbStartAt.subscriptionModelDefault(), action);
     }
 

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapter.java
@@ -59,7 +59,7 @@ final class DcbSubscriptionModelAdapter implements DcbSubscriptionModel {
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, DcbCriteria criteria, DcbStartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "Subscription id cannot be null");
         requireNonNull(criteria, "Criteria cannot be null");
         requireNonNull(startAt, DcbStartAt.class.getSimpleName() + " cannot be null");

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/RegisteringSubscribable.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/RegisteringSubscribable.java
@@ -197,7 +197,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     }
 
     @Override
-    public final Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public final SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         Objects.requireNonNull(action, "action cannot be null");
         // Every event this released signature's action handles is reported delivered, matching what DELIVERED has
         // always meant here. The handler was genuinely invoked, whether it then completes or errors.
@@ -211,11 +211,11 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
      * delivery ahead of it. {@link Consumers#ONE} only, the same restriction
      * {@link #routeReportingMatch(CloudEvent, BiConsumer)} itself already enforces at routing time.
      */
-    protected final Subscription subscribeReportingDelivery(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
+    protected final SubscriptionHandle subscribeReportingDelivery(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
         return doSubscribe(subscriptionId, filter, startAt, action);
     }
 
-    private Subscription doSubscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
+    private SubscriptionHandle doSubscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RoutingAction action) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Objects.requireNonNull(startAt, "startAt cannot be null");
         Objects.requireNonNull(action, "action cannot be null");
@@ -284,7 +284,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     }
 
     @Override
-    public final Subscription resumeSubscription(String subscriptionId) {
+    public final SubscriptionHandle resumeSubscription(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireKnown(subscriptionId);
         if (!isPaused(subscriptionId)) {
@@ -583,7 +583,7 @@ public abstract class RegisteringSubscribable implements SubscriptionModel, Intr
     // Answers for the one registration it was created for. Nothing runs in the background, so registering on a running
     // model starts the subscription there and then. A registration made while the model was stopped never completes,
     // the way the reactor Mongo and durable models park theirs, and a later start hands back its own handle.
-    private record RegisteredSubscription(String id, boolean started) implements Subscription {
+    private record RegisteredSubscription(String id, boolean started) implements SubscriptionHandle {
         @Override
         public Mono<Void> waitUntilStarted() {
             return started ? Mono.empty() : Mono.never();

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/Subscribable.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/Subscribable.java
@@ -47,7 +47,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @param action         This action will be invoked for each cloud event that is stored in the EventStore. The
      *                       next event is not processed until the returned {@link Mono} completes.
      */
-    Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action);
+    SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action);
 
     /**
      * Start listening to cloud events persisted to the event store at the supplied start position.
@@ -59,7 +59,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @throws UnsupportedSubscriptionFilterException If this model cannot apply a filter of that shape.
      * @throws UnsupportedStartAtException            If this model does not accept that start position.
      */
-    default Subscription subscribe(String subscriptionId, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         return subscribe(subscriptionId, null, startAt, action);
     }
 
@@ -72,7 +72,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @throws DuplicateSubscriptionIdException       If {@code subscriptionId} is already in use on this subscription model instance.
      * @throws UnsupportedSubscriptionFilterException If this model cannot apply a filter of that shape.
      */
-    default Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, Function<CloudEvent, Mono<Void>> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, Function<CloudEvent, Mono<Void>> action) {
         return subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), action);
     }
 
@@ -83,7 +83,7 @@ public interface Subscribable extends SubscriptionModelCapability {
      * @param action         This action will be invoked for each cloud event that is stored in the EventStore.
      * @throws DuplicateSubscriptionIdException If {@code subscriptionId} is already in use on this subscription model instance.
      */
-    default Subscription subscribe(String subscriptionId, Function<CloudEvent, Mono<Void>> action) {
+    default SubscriptionHandle subscribe(String subscriptionId, Function<CloudEvent, Mono<Void>> action) {
         return subscribe(subscriptionId, null, StartAt.subscriptionModelDefault(), action);
     }
 }

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/SubscriptionHandle.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/SubscriptionHandle.java
@@ -28,13 +28,13 @@ import static java.util.Objects.requireNonNull;
  * started in a background thread and you may wish to wait ({@link #waitUntilStarted()}) for it to start before
  * continuing.
  * <p>
- * Unlike the blocking {@code Subscription}, {@link #waitUntilStarted()} returns a {@link Mono} rather than blocking
+ * Unlike the blocking {@code SubscriptionHandle}, {@link #waitUntilStarted()} returns a {@link Mono} rather than blocking
  * the calling thread. "Started" means the underlying change stream has been subscribed to, not that the server has
  * acknowledged the command and the cursor is positioned. This is weaker than the blocking and native subscription
  * models, whose equivalent signal only fires after that blocking round trip has already completed.
  */
 @NullMarked
-public interface Subscription {
+public interface SubscriptionHandle {
 
     /**
      * @return The id of the subscription

--- a/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/SubscriptionModelLifeCycle.java
+++ b/subscription/api/reactor/src/main/java/org/occurrent/subscription/api/reactor/SubscriptionModelLifeCycle.java
@@ -119,7 +119,7 @@ public interface SubscriptionModelLifeCycle extends CancellableSubscriptions {
      *                                             not the caller's doing, which on a competing consumer model means
      *                                             another node currently holds the subscription.
      */
-    Subscription resumeSubscription(String subscriptionId);
+    SubscriptionHandle resumeSubscription(String subscriptionId);
 
     /**
      * Pause an individual subscription. It'll be paused <i>temporarily</i>, which means that it can be

--- a/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
+++ b/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/DcbSubscriptionModelAdapterTest.java
@@ -81,7 +81,7 @@ class DcbSubscriptionModelAdapterTest {
             return Mono.empty();
         };
 
-        Subscription subscription = adapter.subscribe("sub-1", DcbCriteria.tags(Tag.parse("name:1")), DcbStartAt.afterPosition(5), action);
+        SubscriptionHandle subscription = adapter.subscribe("sub-1", DcbCriteria.tags(Tag.parse("name:1")), DcbStartAt.afterPosition(5), action);
 
         assertThat(subscription.id()).isEqualTo("sub-1");
         assertThat(delegate.capturedFilter).isInstanceOf(DcbSubscriptionFilter.class);
@@ -175,11 +175,11 @@ class DcbSubscriptionModelAdapterTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             this.capturedFilter = filter;
             this.capturedStartAt = startAt;
             this.capturedAction = action;
-            return new Subscription() {
+            return new SubscriptionHandle() {
                 @Override
                 public String id() {
                     return subscriptionId;
@@ -216,7 +216,7 @@ class DcbSubscriptionModelAdapterTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException("Not used by this test");
         }
 
@@ -240,7 +240,7 @@ class DcbSubscriptionModelAdapterTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             throw new UnsupportedOperationException("Not used by this test");
         }
 

--- a/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/SubscriptionModelCapabilityTest.java
+++ b/subscription/api/reactor/src/test/java/org/occurrent/subscription/api/reactor/SubscriptionModelCapabilityTest.java
@@ -104,7 +104,7 @@ class SubscriptionModelCapabilityTest {
 
     private static class PlainModel implements SubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             throw new UnsupportedOperationException();
         }
 
@@ -136,7 +136,7 @@ class SubscriptionModelCapabilityTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new UnsupportedOperationException();
         }
 

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscription.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.retry.RetryStrategy;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.DurationToTimeoutConverter.Timeout;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -40,7 +40,7 @@ import static org.occurrent.retry.internal.RetryExecution.executeWithRetry;
  * An in-memory subscription
  */
 @NullMarked
-public class InMemorySubscription implements Subscription, Runnable {
+public class InMemorySubscription implements SubscriptionHandle, Runnable {
     private final String id;
     private final BlockingQueue<CloudEvent> queue;
     private final Consumer<CloudEvent> consumer;

--- a/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
+++ b/subscription/inmemory/src/main/java/org/occurrent/subscription/inmemory/InMemorySubscriptionModel.java
@@ -34,7 +34,7 @@ import org.occurrent.subscription.SubscriptionNotRunningException;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.UnsupportedStartAtException;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.internal.ExecutorShutdown;
 
@@ -143,7 +143,7 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Introspecta
     }
 
     @Override
-    public synchronized Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public synchronized SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         if (shutdown) {
             throw new IllegalStateException("Cannot subscribe when shutdown");
         } else if (subscriptionId == null) {
@@ -314,7 +314,7 @@ public class InMemorySubscriptionModel implements SubscriptionModel, Introspecta
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         requireKnown(subscriptionId);
         if (!isPaused(subscriptionId)) {
             throw new SubscriptionAlreadyRunningException(subscriptionId);

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscription.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscription.java
@@ -19,13 +19,13 @@ package org.occurrent.subscription.mongodb.nativedriver.blocking;
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.DurationToTimeoutConverter.Timeout;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 
 @NullMarked
-public record NativeMongoSubscription(String subscriptionId, CountDownLatch subscriptionStartedLatch) implements Subscription {
+public record NativeMongoSubscription(String subscriptionId, CountDownLatch subscriptionStartedLatch) implements SubscriptionHandle {
 
     @Override
     public String id() {

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -40,7 +40,7 @@ import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
 import org.occurrent.subscription.api.blocking.RepositionableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.internal.ExecutorShutdown;
 import org.occurrent.subscription.mongodb.MongoFilterSpecification;
@@ -71,7 +71,7 @@ import static org.occurrent.subscription.mongodb.internal.MongoCommons.cannotFin
 
 /**
  * This is a subscription that uses the "native" MongoDB Java driver (sync) to listen to changes from the event store.
- * This Subscription doesn't maintain the checkpoint, you need to store it in order to continue the stream
+ * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it in order to continue the stream
  * from where it's left off on application restart/crash etc. You can do this yourself or use a
  * <a href="https://occurrent.org/documentation#blocking-subscription-checkpoint-storage">checkpoint storage implementation</a>
  * or use the {@code DurableSubscriptionModel} utility from the {@code org.occurrent:durable-subscription}
@@ -186,7 +186,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
     }
 
     @Override
-    public synchronized Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public synchronized SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -456,7 +456,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
      * @see #resumeSubscription(String, StartAt)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         return doResumeSubscription(subscriptionId, null);
     }
 
@@ -466,7 +466,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
      * @see RepositionableSubscriptions#resumeSubscription(String, StartAt)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId, StartAt startAt) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId, StartAt startAt) {
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
         MongoCommons.checkStartPosition(startAt, new SubscriptionModelContext(NativeMongoSubscriptionModel.class));
         return doResumeSubscription(subscriptionId, startAt);
@@ -475,7 +475,7 @@ public class NativeMongoSubscriptionModel implements CheckpointAwareSubscription
     // The shared resume path. repositionTo is the caller's explicit position from the two-arg overload, or null
     // from the one-arg overload, in which case the subscription's own currentStartAt reference is left untouched
     // and the resume continues from whatever it already holds.
-    private Subscription doResumeSubscription(String subscriptionId, @Nullable StartAt repositionTo) {
+    private SubscriptionHandle doResumeSubscription(String subscriptionId, @Nullable StartAt repositionTo) {
         if (shutdown) {
             throw new IllegalStateException(SubscriptionModel.class.getSimpleName() + " is shutdown");
         }

--- a/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
+++ b/subscription/mongodb/native/blocking/src/main/java/org/occurrent/subscription/mongodb/nativedriver/blocking/NativeMongoSubscriptionModel.java
@@ -71,7 +71,7 @@ import static org.occurrent.subscription.mongodb.internal.MongoCommons.cannotFin
 
 /**
  * This is a subscription that uses the "native" MongoDB Java driver (sync) to listen to changes from the event store.
- * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it in order to continue the stream
+ * This subscription model doesn't maintain the checkpoint, you need to store it in order to continue the stream
  * from where it's left off on application restart/crash etc. You can do this yourself or use a
  * <a href="https://occurrent.org/documentation#blocking-subscription-checkpoint-storage">checkpoint storage implementation</a>
  * or use the {@code DurableSubscriptionModel} utility from the {@code org.occurrent:durable-subscription}

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscription.java
@@ -19,7 +19,7 @@ package org.occurrent.subscription.mongodb.spring.blocking;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.DurationToTimeoutConverter;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @NullMarked
-public class SpringMongoSubscription implements Subscription {
+public class SpringMongoSubscription implements SubscriptionHandle {
 
     private final String subscriptionId;
     private final AtomicReference<org.springframework.data.mongodb.core.messaging.Subscription> subscriptionReference;

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
@@ -40,7 +40,7 @@ import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
 import org.occurrent.subscription.api.blocking.RepositionableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.MongoOperationTimeCheckpoint;
 import org.occurrent.subscription.mongodb.MongoResumeTokenCheckpoint;
 import org.occurrent.subscription.mongodb.internal.MongoCloudEventsToJsonDeserializer;
@@ -83,7 +83,7 @@ import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubs
 
 /**
  * This is a subscription that uses Spring and its {@link MessageListenerContainer} for MongoDB to listen to changes from an event store.
- * This Subscription doesn't maintain the checkpoint, you need to store it yourself in order to continue the stream
+ * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it yourself in order to continue the stream
  * from where it's left off on application restart/crash etc.
  */
 @NullMarked
@@ -171,7 +171,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
     }
 
     @Override
-    public synchronized Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public synchronized SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, "StartAt cannot be null");
@@ -330,7 +330,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
      * @see #resumeSubscription(String, StartAt)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         return doResumeSubscription(subscriptionId, null);
     }
 
@@ -340,7 +340,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
      * @see RepositionableSubscriptions#resumeSubscription(String, StartAt)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId, StartAt startAt) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId, StartAt startAt) {
         requireNonNull(startAt, "StartAt cannot be null");
         MongoCommons.checkStartPosition(startAt, new StartAt.SubscriptionModelContext(SpringMongoSubscriptionModel.class));
         return doResumeSubscription(subscriptionId, startAt);
@@ -349,7 +349,7 @@ public class SpringMongoSubscriptionModel implements CheckpointAwareSubscription
     // The shared resume path. repositionTo is the caller's explicit position from the two-arg overload, or null
     // from the one-arg overload, in which case currentStartAt is left untouched and the resume continues from
     // whatever it already holds.
-    private Subscription doResumeSubscription(String subscriptionId, @Nullable StartAt repositionTo) {
+    private SubscriptionHandle doResumeSubscription(String subscriptionId, @Nullable StartAt repositionTo) {
         logDebug("Resuming subscription for {}", subscriptionId);
         requireKnown(subscriptionId);
         InternalSubscription internalSubscription = pausedSubscriptions.remove(subscriptionId);

--- a/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/blocking/src/main/java/org/occurrent/subscription/mongodb/spring/blocking/SpringMongoSubscriptionModel.java
@@ -83,7 +83,7 @@ import static org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubs
 
 /**
  * This is a subscription that uses Spring and its {@link MessageListenerContainer} for MongoDB to listen to changes from an event store.
- * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it yourself in order to continue the stream
+ * This subscription model doesn't maintain the checkpoint, you need to store it yourself in order to continue the stream
  * from where it's left off on application restart/crash etc.
  */
 @NullMarked

--- a/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscription.java
+++ b/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscription.java
@@ -17,11 +17,11 @@
 package org.occurrent.subscription.mongodb.spring.reactor;
 
 import org.jspecify.annotations.NullMarked;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import reactor.core.publisher.Mono;
 
 @NullMarked
-public record ReactorMongoSubscription(String subscriptionId, Mono<Void> started) implements Subscription {
+public record ReactorMongoSubscription(String subscriptionId, Mono<Void> started) implements SubscriptionHandle {
 
     @Override
     public String id() {

--- a/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
@@ -69,7 +69,7 @@ import static org.occurrent.subscription.mongodb.internal.MongoCommons.cannotFin
 
 /**
  * This is a subscription that uses project reactor and Spring to listen to changes from an event store.
- * This Subscription doesn't maintain the checkpoint, you need to store it yourself
+ * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it yourself
  * (or use another pre-existing component in conjunction with this one) in order to continue the stream from where
  * it's left off on application restart/crash etc. It produces a {@link CloudEvent} implementation of type {@link CheckpointAwareCloudEvent}
  * that includes the checkpoint. Use {@link CheckpointAwareCloudEvent#getCheckpointOrThrowIAE(CloudEvent)}
@@ -138,7 +138,7 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
     }
 
     @Override
-    public synchronized Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public synchronized SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -163,7 +163,7 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
         return startInternalSubscription(subscriptionId, filter, new AtomicReference<>(startAt), action);
     }
 
-    private Subscription startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Function<CloudEvent, Mono<Void>> action) {
+    private SubscriptionHandle startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt, Function<CloudEvent, Mono<Void>> action) {
         if (!running) {
             // Model stopped: don't subscribe, so waitUntilStarted() doesn't complete for a subscription that
             // won't deliver anything until start(true)/resumeSubscription actually starts it.
@@ -345,7 +345,7 @@ public class ReactorMongoSubscriptionModel implements CheckpointAwareSubscriptio
      * @see #pauseSubscription(String)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         if (shutdown) {
             throw new IllegalStateException(ReactorMongoSubscriptionModel.class.getSimpleName() + " is shutdown");
         }

--- a/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
+++ b/subscription/mongodb/spring/reactor/src/main/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModel.java
@@ -69,7 +69,7 @@ import static org.occurrent.subscription.mongodb.internal.MongoCommons.cannotFin
 
 /**
  * This is a subscription that uses project reactor and Spring to listen to changes from an event store.
- * This SubscriptionHandle doesn't maintain the checkpoint, you need to store it yourself
+ * This subscription model doesn't maintain the checkpoint, you need to store it yourself
  * (or use another pre-existing component in conjunction with this one) in order to continue the stream from where
  * it's left off on application restart/crash etc. It produces a {@link CloudEvent} implementation of type {@link CheckpointAwareCloudEvent}
  * that includes the checkpoint. Use {@link CheckpointAwareCloudEvent#getCheckpointOrThrowIAE(CloudEvent)}

--- a/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionLifecycleTest.java
+++ b/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionLifecycleTest.java
@@ -33,7 +33,7 @@ import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StringBasedCheckpoint;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
 import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
@@ -132,7 +132,7 @@ public class ReactorMongoSubscriptionLifecycleTest {
     @Test
     void wait_until_started_with_a_timeout_throws_npe_when_timeout_is_null() {
         // Given
-        Subscription subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
+        SubscriptionHandle subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
 
         // When
         Throwable throwable = catchThrowable(() -> subscription.waitUntilStarted(null));
@@ -386,7 +386,7 @@ public class ReactorMongoSubscriptionLifecycleTest {
     void wait_until_started_does_not_complete_for_a_subscription_created_while_the_model_is_stopped() {
         // Given
         subscriptionModel.stop();
-        Subscription subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
+        SubscriptionHandle subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
 
         // Then: it never actually starts while paused, so waitUntilStarted() on this handle never completes,
         // unlike before the fix where it misleadingly completed via doOnSubscribe just before being disposed.

--- a/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModelResilienceTest.java
+++ b/subscription/mongodb/spring/reactor/src/test/java/org/occurrent/subscription/mongodb/spring/reactor/ReactorMongoSubscriptionModelResilienceTest.java
@@ -34,7 +34,7 @@ import org.occurrent.eventstore.mongodb.spring.reactor.EventStoreConfig;
 import org.occurrent.eventstore.mongodb.spring.reactor.ReactorMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
 import org.occurrent.testsupport.mongodb.ReplicaSetReadyMongoDBContainer;
@@ -298,7 +298,7 @@ public class ReactorMongoSubscriptionModelResilienceTest {
             ReactorMongoSubscriptionModel subscriptionModel = new ReactorMongoSubscriptionModel(throwingOperations, "events", TimeRepresentation.RFC_3339_STRING);
 
             // When
-            Subscription subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
+            SubscriptionHandle subscription = subscriptionModel.subscribe(UUID.randomUUID().toString(), __ -> Mono.empty());
 
             // Then
             StepVerifier.create(subscription.waitUntilStarted())

--- a/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModel.java
+++ b/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModel.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.api.blocking.CheckpointWriteVersionSource;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
 import org.occurrent.subscription.api.blocking.RegisteringSubscribable;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.api.blocking.internal.BlockingHandover;
 import org.occurrent.subscription.CatchupListener;
@@ -203,7 +203,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Objects.requireNonNull(startAt, "startAt cannot be null");
         Objects.requireNonNull(action, "action cannot be null");
@@ -695,7 +695,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
     }
 
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Future<Boolean> relaunched = relaunchInterruptedReplay(subscriptionId);
         if (relaunched != null) {
@@ -794,7 +794,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
      * cannot see it. Ask {@link #isCatchingUp(String)} or {@link #isRunning(String)} about a restarted replay, or take
      * the handle {@link #resumeSubscription(String)} hands back.
      */
-    private record CatchingUpSubscription(String id, Future<Boolean> replay) implements Subscription {
+    private record CatchingUpSubscription(String id, Future<Boolean> replay) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             Timeout safeTimeout = DurationToTimeoutConverter.convertDurationToTimeout(timeout);

--- a/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushSubscriptionModel.java
+++ b/subscription/push/blocking/src/main/java/org/occurrent/subscription/push/blocking/PushSubscriptionModel.java
@@ -26,7 +26,7 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.Pushable;
 import org.occurrent.subscription.api.blocking.RegisteringSubscribable;
 import org.occurrent.subscription.api.blocking.Subscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,7 +179,7 @@ public class PushSubscriptionModel extends RegisteringSubscribable implements Pu
     // same-package but not a subclass, so it cannot reach the protected RegisteringSubscribable method directly.
     // Lets it register an action that reports whether an event genuinely landed, instead of the plain
     // Consumer<CloudEvent> subscribe(..) takes.
-    Subscription subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RegisteringSubscribable.RoutingAction action) {
+    SubscriptionHandle subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RegisteringSubscribable.RoutingAction action) {
         return super.subscribeReportingDelivery(subscriptionId, filter, startAt, action);
     }
 

--- a/subscription/push/blocking/src/test/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModelLifecycleAtomicityTest.java
+++ b/subscription/push/blocking/src/test/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModelLifecycleAtomicityTest.java
@@ -32,7 +32,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.RegisteringSubscribable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.net.URI;
@@ -69,9 +69,9 @@ class CatchupThenPushSubscriptionModelLifecycleAtomicityTest {
         // subscribe(..) does, so it arrives while the rest of the tail is still to run.
         PushSubscriptionModel feed = new PushSubscriptionModel() {
             @Override
-            Subscription subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt,
+            SubscriptionHandle subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt,
                                                   RegisteringSubscribable.RoutingAction action) {
-                Subscription subscription = super.subscribeCatchupThenPush(subscriptionId, filter, startAt, action);
+                SubscriptionHandle subscription = super.subscribeCatchupThenPush(subscriptionId, filter, startAt, action);
                 Thread.ofVirtual().start(() -> {
                     cancelStarted.countDown();
                     modelRef.get().cancelSubscription(subscriptionId);
@@ -310,7 +310,7 @@ class CatchupThenPushSubscriptionModelLifecycleAtomicityTest {
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, marker);
         modelRef.set(model);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
             if (ce.getId().equals("live")) {
                 drainParked.countDown();
                 awaitLatch(releaseDrain, Duration.ofSeconds(60));
@@ -540,7 +540,7 @@ class CatchupThenPushSubscriptionModelLifecycleAtomicityTest {
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader(() -> Stream.of(cloudEvent("1"))), feed, marker);
         modelRef.set(model);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
             lastEventReached.countDown();
             awaitLatch(stopped);
         });

--- a/subscription/push/blocking/src/test/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModelTest.java
+++ b/subscription/push/blocking/src/test/java/org/occurrent/subscription/push/blocking/CatchupThenPushSubscriptionModelTest.java
@@ -32,7 +32,7 @@ import org.occurrent.subscription.DcbSubscriptionFilter;
 import org.occurrent.subscription.RoutingOutcome;
 import org.occurrent.subscription.CatchupListener;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.net.URI;
@@ -555,7 +555,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch replayReached = new CountDownLatch(1);
         CountDownLatch releaseReplay = new CountDownLatch(1);
 
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             replayReached.countDown();
             try {
                 releaseReplay.await(10, TimeUnit.SECONDS);
@@ -648,7 +648,7 @@ class CatchupThenPushSubscriptionModelTest {
         // Gate the LAST fold rather than the first. The reactor twin's handover records that gating the first does not
         // reproduce the analogous bug, because a prefetch can let the pipeline advance while an early item is still
         // folding.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             delivered.add(ce.getId());
             if (ce.getId().equals("3")) {
                 reachedLast.countDown();
@@ -677,7 +677,7 @@ class CatchupThenPushSubscriptionModelTest {
         List<String> delivered = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(store, feed, null);
 
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             delivered.add(ce.getId());
             if (ce.getId().equals("1")) {
                 replayStarted.countDown();
@@ -714,7 +714,7 @@ class CatchupThenPushSubscriptionModelTest {
         CatchupThenPushSubscriptionModel stopped = new CatchupThenPushSubscriptionModel(store, feed1, marker);
         // Park inside the first fold so stop() genuinely lands mid-replay. Without the park the three events replay
         // faster than the test can stop anything, and the assertions below would pass against a completed catch-up.
-        Subscription subscription = stopped.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = stopped.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             firstRun.add(ce.getId());
             firstFolded.countDown();
             awaitLatch(releaseFold);
@@ -756,7 +756,7 @@ class CatchupThenPushSubscriptionModelTest {
         List<String> folded = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(store, feed, marker);
         // Park inside the first fold so stop() lands mid-replay rather than after it.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             folded.add(ce.getId());
             firstFolded.countDown();
             awaitLatch(releaseFold);
@@ -823,7 +823,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch newReplayParked = new CountDownLatch(1);
         CountDownLatch releaseNewReplay = new CountDownLatch(1);
         List<String> newReplayFolded = new CopyOnWriteArrayList<>();
-        Subscription newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
             newReplayFolded.add(ce.getId());
             newReplayParked.countDown();
             awaitLatch(releaseNewReplay);
@@ -895,7 +895,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch newReplayParked = new CountDownLatch(1);
         CountDownLatch releaseNewReplay = new CountDownLatch(1);
         List<String> newReplayFolded = new CopyOnWriteArrayList<>();
-        Subscription newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
             newReplayFolded.add(ce.getId());
             newReplayParked.countDown();
             awaitLatch(releaseNewReplay);
@@ -1268,7 +1268,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch newReplayParkedOnFirstEvent = new CountDownLatch(1);
         CountDownLatch releaseNewReplay = new CountDownLatch(1);
         List<String> newReplayFolded = new CopyOnWriteArrayList<>();
-        Subscription newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle newSubscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
             newReplayFolded.add(ce.getId());
             newReplayParkedOnFirstEvent.countDown();
             awaitLatch(releaseNewReplay);
@@ -1320,7 +1320,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch releaseFold = new CountDownLatch(1);
         List<String> folded = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(store, feed, marker);
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             folded.add(ce.getId());
             firstFolded.countDown();
             awaitLatch(releaseFold);
@@ -1353,7 +1353,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader(), feed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
         });
         assertThat(catchThrowable(subscription::waitUntilStarted)).isInstanceOf(IllegalStateException.class);
 
@@ -1375,7 +1375,7 @@ class CatchupThenPushSubscriptionModelTest {
         }, 0);
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, liveFeed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
         });
         Throwable thrown = catchThrowable(subscription::waitUntilStarted);
 
@@ -1434,7 +1434,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch replayReached = new CountDownLatch(1);
         CountDownLatch releaseReplay = new CountDownLatch(1);
 
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             replayReached.countDown();
             awaitLatch(releaseReplay);
         });
@@ -1468,7 +1468,7 @@ class CatchupThenPushSubscriptionModelTest {
         List<String> delivered = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(store, feed, null);
 
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             delivered.add(ce.getId());
             replayStarted.countDown();
             awaitLatch(releaseReplay);
@@ -1498,7 +1498,7 @@ class CatchupThenPushSubscriptionModelTest {
         CountDownLatch releaseFold = new CountDownLatch(1);
         List<String> folded = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(store, feed, marker);
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce -> {
             folded.add(ce.getId());
             firstFolded.countDown();
             awaitLatch(releaseFold);
@@ -1526,7 +1526,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader(), feed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> {
         });
         assertThat(catchThrowable(subscription::waitUntilStarted)).isInstanceOf(IllegalStateException.class);
 

--- a/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModel.java
+++ b/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModel.java
@@ -31,7 +31,7 @@ import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.api.reactor.IntrospectableSubscriptions;
 import org.occurrent.subscription.api.reactor.RegisteringSubscribable;
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import org.occurrent.subscription.api.reactor.internal.ReactiveHandover;
 import org.occurrent.subscription.CatchupListener;
@@ -148,7 +148,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Objects.requireNonNull(startAt, "startAt cannot be null");
         Objects.requireNonNull(action, "action cannot be null");
@@ -522,7 +522,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
     }
 
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId cannot be null");
         Sinks.One<Boolean> relaunched = relaunchInterruptedReplay(subscriptionId);
         if (relaunched != null) {
@@ -643,7 +643,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
      * {@link #isRunning(String)} about a restarted replay, or take the handle {@link #resumeSubscription(String)}
      * hands back.
      */
-    private record CatchingUpSubscription(String id, Sinks.One<Boolean> replay) implements Subscription {
+    private record CatchingUpSubscription(String id, Sinks.One<Boolean> replay) implements SubscriptionHandle {
         @Override
         public Mono<Void> waitUntilStarted() {
             return replay.asMono().then();
@@ -651,7 +651,7 @@ public class CatchupThenPushSubscriptionModel implements SubscriptionModel, Intr
     }
 
     // A signal that is already done, for a handle handed back when there is no longer a replay to track. The blocking
-    // twin does the same with CompletableFuture.completedFuture(true) rather than a second Subscription type.
+    // twin does the same with CompletableFuture.completedFuture(true) rather than a second SubscriptionHandle type.
     private static Sinks.One<Boolean> finished() {
         Sinks.One<Boolean> done = Sinks.one();
         done.tryEmitValue(true);

--- a/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushSubscriptionModel.java
+++ b/subscription/push/reactor/src/main/java/org/occurrent/subscription/push/reactor/PushSubscriptionModel.java
@@ -26,7 +26,7 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.reactor.Pushable;
 import org.occurrent.subscription.api.reactor.RegisteringSubscribable;
 import org.occurrent.subscription.api.reactor.Subscribable;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -139,7 +139,7 @@ public class PushSubscriptionModel extends RegisteringSubscribable implements Pu
     // same-package but not a subclass, so it cannot reach the protected RegisteringSubscribable method directly.
     // Lets it register an action that reports whether an event genuinely landed, instead of the plain
     // Function<CloudEvent, Mono<Void>> subscribe(..) takes.
-    Subscription subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RegisteringSubscribable.RoutingAction action) {
+    SubscriptionHandle subscribeCatchupThenPush(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, RegisteringSubscribable.RoutingAction action) {
         return super.subscribeReportingDelivery(subscriptionId, filter, startAt, action);
     }
 

--- a/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelOwnershipTest.java
+++ b/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelOwnershipTest.java
@@ -28,7 +28,7 @@ import org.occurrent.filter.Filter;
 import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionAlreadyRunningException;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
@@ -635,7 +635,7 @@ class CatchupThenPushSubscriptionModelOwnershipTest {
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, marker);
 
         List<String> handled = new CopyOnWriteArrayList<>();
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.fromRunnable(() -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.fromRunnable(() -> {
             if (ce.getId().equals("2")) {
                 lastEventReached.countDown();
                 awaitLatch(cancelled);
@@ -683,7 +683,7 @@ class CatchupThenPushSubscriptionModelOwnershipTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader(() -> Flux.just(cloudEvent("1"))), feed, marker);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.fromRunnable(() -> {
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.fromRunnable(() -> {
             lastEventReached.countDown();
             awaitLatch(stopped);
         }));

--- a/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelPauseStopRaceVerificationTest.java
+++ b/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelPauseStopRaceVerificationTest.java
@@ -26,7 +26,7 @@ import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -76,7 +76,7 @@ class CatchupThenPushSubscriptionModelPauseStopRaceVerificationTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, marker);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
                 ce -> Mono.fromRunnable(() -> {
                 }));
 

--- a/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelTest.java
+++ b/subscription/push/reactor/src/test/java/org/occurrent/subscription/push/reactor/CatchupThenPushSubscriptionModelTest.java
@@ -34,7 +34,7 @@ import org.occurrent.subscription.RoutingOutcome;
 import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -249,7 +249,7 @@ class CatchupThenPushSubscriptionModelTest {
 
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, marker);
         // Nothing is pushed to the feed while the replay runs, so the live buffer is empty at the drain.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         // Parked inside the marker write, which is after the replay and after the drain point, and before the
         // handover has finished.
@@ -336,7 +336,7 @@ class CatchupThenPushSubscriptionModelTest {
         List<String> folded = new CopyOnWriteArrayList<>();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, marker);
         // Park inside the first fold so stop() lands mid-replay rather than after it.
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce ->
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce ->
                 Mono.fromRunnable(() -> {
                     folded.add(ce.getId());
                     firstFolded.countDown();
@@ -373,7 +373,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader(), feed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         assertThat(catchThrowable(() -> subscription.waitUntilStarted().block())).isInstanceOf(IllegalStateException.class);
 
         // Stopped and failed are not the same state. Restarting a replay that failed would turn a loud refusal into a
@@ -443,7 +443,7 @@ class CatchupThenPushSubscriptionModelTest {
 
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader, liveFeed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         Throwable replayFailure = catchThrowable(() -> subscription.waitUntilStarted().block());
         assertThat(replayFailure).isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
 
@@ -470,7 +470,7 @@ class CatchupThenPushSubscriptionModelTest {
         PositionOrderedReader failingReader = failingReader();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader, liveFeed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         Throwable replayFailure = catchThrowable(() -> subscription.waitUntilStarted().block());
         assertThat(replayFailure).isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
 
@@ -496,7 +496,7 @@ class CatchupThenPushSubscriptionModelTest {
         RuntimeException handlerFailure = new IllegalStateException("handler boom");
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader(Flux::empty, 0), liveFeed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
                 ce -> Mono.error(handlerFailure));
         assertThat(subscription.waitUntilStarted().block(Duration.ofSeconds(5))).isNull();
 
@@ -520,12 +520,12 @@ class CatchupThenPushSubscriptionModelTest {
 
         PushSubscriptionModel otherFeed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel otherModel = new CatchupThenPushSubscriptionModel(failingReader(), otherFeed, null);
-        Subscription otherSubscription = otherModel.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle otherSubscription = otherModel.subscribe("other", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         assertThat(catchThrowable(() -> otherSubscription.waitUntilStarted().block(Duration.ofSeconds(5))))
                 .isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
 
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader(Flux::empty, 0), liveFeed, null);
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(),
                 ce -> otherFeed.accept(ce));
         assertThat(subscription.waitUntilStarted().block(Duration.ofSeconds(5))).isNull();
 
@@ -543,7 +543,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel liveFeed = new PushSubscriptionModel();
 
         CatchupThenPushSubscriptionModel failingModel = new CatchupThenPushSubscriptionModel(failingReader(), liveFeed, null);
-        Subscription failed = failingModel.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle failed = failingModel.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         // The replay is subscribed on boundedElastic, so joining is what orders the failure against this thread.
         Throwable replayFailure = catchThrowable(() -> failed.waitUntilStarted().block());
         assertThat(replayFailure).isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
@@ -573,7 +573,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel healthyFeed = new PushSubscriptionModel();
 
         CatchupThenPushSubscriptionModel failingModel = new CatchupThenPushSubscriptionModel(failingReader(), failedFeed, null);
-        Subscription failed = failingModel.subscribe("failed", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle failed = failingModel.subscribe("failed", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         Throwable replayFailure = catchThrowable(() -> failed.waitUntilStarted().block());
         assertThat(replayFailure).isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
 
@@ -670,7 +670,7 @@ class CatchupThenPushSubscriptionModelTest {
         PositionOrderedReader reader = reader(() -> Flux.just(cloudEvent("1", "Created")), 1);
 
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(reader, feed, null);
-        Subscription subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce ->
+        SubscriptionHandle subscription = model.subscribe("proj", null, StartAt.subscriptionModelDefault(), ce ->
                 Mono.fromRunnable(() -> {
                     replayReached.countDown();
                     awaitLatch(releaseReplay);
@@ -703,7 +703,7 @@ class CatchupThenPushSubscriptionModelTest {
         PushSubscriptionModel feed = new PushSubscriptionModel();
         CatchupThenPushSubscriptionModel model = new CatchupThenPushSubscriptionModel(failingReader(), feed, null);
 
-        Subscription subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe("sub", null, StartAt.subscriptionModelDefault(), ce -> Mono.empty());
         Throwable replayFailure = catchThrowable(() -> subscription.waitUntilStarted().block());
         assertThat(replayFailure).isInstanceOf(IllegalStateException.class).hasMessageContaining("replay boom");
 

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModel.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.api.blocking.SubscriptionModelWrapper;
 import org.occurrent.subscription.api.blocking.RepositionableSubscriptions;
 import org.occurrent.subscription.CatchupListener;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.util.Objects;
@@ -211,7 +211,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, Subscription
      * subscriptionModel.subscribe(&lt;subscriptionId&gt;, &lt;filter&gt;, StartAtTime.beginningOfTime(), &lt;action&gt;);
      * </pre>
      */
-    public Subscription subscribeFromBeginningOfTime(String subscriptionId, SubscriptionFilter filter, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribeFromBeginningOfTime(String subscriptionId, SubscriptionFilter filter, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, filter, StartAtTime.beginningOfTime(), action);
     }
 
@@ -222,7 +222,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, Subscription
      * subscriptionModel.subscribe(&lt;subscriptionId&gt;, StartAtTime.beginningOfTime(), &lt;action&gt;);
      * </pre>
      */
-    public Subscription subscribeFromBeginningOfTime(String subscriptionId, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribeFromBeginningOfTime(String subscriptionId, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, StartAtTime.beginningOfTime(), action);
     }
 
@@ -230,7 +230,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, Subscription
     // every child is built with CatchupSubscriptionModel.class as its context type. This layer's answer is
     // therefore the one acted on, which is why decidesWhereTheSubscriptionStarts() stays true here.
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
         return route(filter, startAt).subscribe(subscriptionId, filter, startAt, action);
     }
@@ -336,7 +336,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, Subscription
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return getWrappedSubscriptionModel().resumeSubscription(subscriptionId);
     }
 
@@ -350,7 +350,7 @@ public class CatchupSubscriptionModel implements SubscriptionModel, Subscription
      * @throws UnsupportedOperationException if the wrapped model is not itself repositionable.
      */
     @Override
-    public Subscription resumeSubscription(String subscriptionId, StartAt startAt) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId, StartAt startAt) {
         return RepositionableSubscriptions.findIn(getWrappedSubscriptionModel())
                 .orElseThrow(() -> new UnsupportedOperationException(getWrappedSubscriptionModel().getClass().getSimpleName() + " is not repositionable"))
                 .resumeSubscription(subscriptionId, startAt);

--- a/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModel.java
@@ -31,7 +31,7 @@ import org.occurrent.subscription.StartAt.StartAtCheckpoint;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.catchup.CheckpointStorageConfig.UseCheckpointInStorage;
 import org.occurrent.subscription.internal.BoundedIdCache;
@@ -88,7 +88,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
         final StartAt firstStartAt;
         if (startAt.isDefault()) {
@@ -116,11 +116,11 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
             return subscribeLiveWithoutCatchup(subscriptionId, filter, firstStartAt, action);
         }
 
-        Future<Subscription> subscriptionCompletableFuture = startCatchupAsync(subscriptionId, () -> startDcbCatchupSubscription(subscriptionId, filter, startAt, action, firstStartAt));
+        Future<SubscriptionHandle> subscriptionCompletableFuture = startCatchupAsync(subscriptionId, () -> startDcbCatchupSubscription(subscriptionId, filter, startAt, action, firstStartAt));
         return new CatchupSubscription(subscriptionId, subscriptionCompletableFuture);
     }
 
-    private Subscription startLiveDcbSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAtToUse, Consumer<CloudEvent> action, @Nullable BoundedIdCache cache) {
+    private SubscriptionHandle startLiveDcbSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAtToUse, Consumer<CloudEvent> action, @Nullable BoundedIdCache cache) {
         return subscriptionModel.subscribe(subscriptionId, filter, startAtToUse, dcbLiveConsumer(action, cache));
     }
 
@@ -131,7 +131,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
      * claimed. Distinct from {@link #startLiveDcbSubscription}'s own use inside a finishing attempt's handover,
      * which has already gone through that lock and that decision and must not cancel itself.
      */
-    private Subscription subscribeLiveWithoutCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    private SubscriptionHandle subscribeLiveWithoutCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         cancelRunningCatchup(subscriptionId);
         return startLiveDcbSubscription(subscriptionId, filter, startAt, action, null);
     }
@@ -148,7 +148,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
         };
     }
 
-    private Subscription startDcbCatchupSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
+    private SubscriptionHandle startDcbCatchupSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
         long windowSize = config.dcbCatchupPositionWindowSize;
 
         StartAt nextStartAt = firstStartAt.get(generateSubscriptionModelContext());
@@ -225,7 +225,7 @@ class DcbCatchupSubscriptionModel extends AbstractCatchupSubscriptionModel {
                         }
                     }));
 
-            final Subscription subscription;
+            final SubscriptionHandle subscription;
             if (subscriptionsWasCancelledOrShutdown) {
                 // Same fix as the blocking stream side. Priming startAtToUse is skipped for an explicit cancellation of
                 // this exact id, since its get() call saves globalCheckpoint as a side effect, which would recreate the

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelDualModeLifecycleTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelDualModeLifecycleTest.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -172,7 +172,7 @@ class CatchupSubscriptionModelDualModeLifecycleTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new AssertionError("subscribe must not be called by this test");
         }
 
@@ -202,7 +202,7 @@ class CatchupSubscriptionModelDualModeLifecycleTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new AssertionError("resumeSubscription must not be called by this test");
         }
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelStopPropagationTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelStopPropagationTest.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.net.URI;
 import java.time.Duration;
@@ -61,7 +61,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         catchupSubscriptionModel.stop();
 
         CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
-        Subscription subscription = catchupSubscriptionModel.subscribe("someId", StartAtTime.beginningOfTime(), received::add);
+        SubscriptionHandle subscription = catchupSubscriptionModel.subscribe("someId", StartAtTime.beginningOfTime(), received::add);
         // The replay never ran a single iteration (stopped was already true), so this hands back a
         // CancelledSubscription rather than a live one, and that answers false, since nothing here is going to start it.
         assertThat(subscription.waitUntilStarted(Duration.ofSeconds(5))).isFalse();
@@ -78,7 +78,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         catchupSubscriptionModel.start(false);
 
         CopyOnWriteArrayList<CloudEvent> received = new CopyOnWriteArrayList<>();
-        Subscription subscription = catchupSubscriptionModel.subscribe("someId", StartAtTime.beginningOfTime(), received::add);
+        SubscriptionHandle subscription = catchupSubscriptionModel.subscribe("someId", StartAtTime.beginningOfTime(), received::add);
         assertThat(subscription.waitUntilStarted(Duration.ofSeconds(5))).isTrue();
 
         assertThat(received).extracting(CloudEvent::getId).containsExactly("1", "2", "3");
@@ -93,7 +93,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         CountDownLatch firstEventReached = new CountDownLatch(1);
         CountDownLatch releaseReplay = new CountDownLatch(1);
 
-        Subscription subscription = catchupSubscriptionModel.subscribe(subscriptionId, StartAtTime.beginningOfTime(), event -> {
+        SubscriptionHandle subscription = catchupSubscriptionModel.subscribe(subscriptionId, StartAtTime.beginningOfTime(), event -> {
             firstEventReached.countDown();
             awaitLatch(releaseReplay);
         });
@@ -124,7 +124,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         CountDownLatch firstEventReached = new CountDownLatch(1);
         CountDownLatch releaseReplay = new CountDownLatch(1);
 
-        Subscription subscription = catchupSubscriptionModel.subscribe(subscriptionId, StartAtTime.beginningOfTime(), event -> {
+        SubscriptionHandle subscription = catchupSubscriptionModel.subscribe(subscriptionId, StartAtTime.beginningOfTime(), event -> {
             firstEventReached.countDown();
             awaitLatch(releaseReplay);
         });
@@ -211,7 +211,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             return new NoOpSubscription(subscriptionId);
         }
 
@@ -239,7 +239,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return new NoOpSubscription(subscriptionId);
         }
 
@@ -256,7 +256,7 @@ class CatchupSubscriptionModelStopPropagationTest {
         }
     }
 
-    private record NoOpSubscription(String id) implements Subscription {
+    private record NoOpSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelCheckpointWriteVersionSourceTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelCheckpointWriteVersionSourceTest.java
@@ -39,7 +39,7 @@ import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
 
@@ -174,7 +174,7 @@ class DcbCatchupSubscriptionModelCheckpointWriteVersionSourceTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             StartAt resolved = startAt.get(new StartAt.SubscriptionModelContext(InMemorySubscriptionModel.class));
             StartAt startAtToUse = resolved != null && resolved.isDefault() ? StartAt.subscriptionModelDefault() : StartAt.now();
             return delegate.subscribe(subscriptionId, filter, startAtToUse, action);
@@ -211,7 +211,7 @@ class DcbCatchupSubscriptionModelCheckpointWriteVersionSourceTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return delegate.resumeSubscription(subscriptionId);
         }
 

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelMongoTest.java
@@ -36,7 +36,7 @@ import org.occurrent.eventstore.mongodb.spring.blocking.SpringMongoEventStore;
 import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoCheckpointStorage;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
@@ -198,7 +198,7 @@ class DcbCatchupSubscriptionModelMongoTest {
 
         // The catch-up runs asynchronously and blocks inside the bulk replay read, after it has read a snapshot that
         // excludes the removed event.
-        Subscription handle = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
+        SubscriptionHandle handle = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
 
         // While the replay is blocked (it has scanned past the hole without seeing it and has not captured any
         // post-replay token), commit the in-flight event by re-inserting its document, then let the replay finish.

--- a/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/DcbCatchupSubscriptionModelTest.java
@@ -35,7 +35,7 @@ import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
 
@@ -259,11 +259,11 @@ class DcbCatchupSubscriptionModelTest {
         };
         CatchupSubscriptionModel subscription = new CatchupSubscriptionModel(nullCheckpointSubscriptionModel, eventStore, DcbCriteria.tags(Tag.parse("name:1")));
 
-        Subscription started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
+        SubscriptionHandle started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
         });
 
         assertThat(started).isInstanceOf(CatchupSubscription.class);
-        Future<Subscription> delegatedSubscription = ((CatchupSubscription) started).delegatedSubscription();
+        Future<SubscriptionHandle> delegatedSubscription = ((CatchupSubscription) started).delegatedSubscription();
         assertThatThrownBy(() -> delegatedSubscription.get(10, TimeUnit.SECONDS))
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(IllegalStateException.class)
@@ -285,7 +285,7 @@ class DcbCatchupSubscriptionModelTest {
 
         CountDownLatch firstReplayReached = new CountDownLatch(1);
         CountDownLatch releaseFirstReplay = new CountDownLatch(1);
-        Subscription first = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
+        SubscriptionHandle first = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
             firstReplayReached.countDown();
             awaitLatch(releaseFirstReplay);
         });
@@ -297,7 +297,7 @@ class DcbCatchupSubscriptionModelTest {
 
         CountDownLatch secondReplayReached = new CountDownLatch(1);
         CountDownLatch releaseSecondReplay = new CountDownLatch(1);
-        Subscription second = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
+        SubscriptionHandle second = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
             secondReplayReached.countDown();
             awaitLatch(releaseSecondReplay);
         });
@@ -470,7 +470,7 @@ class DcbCatchupSubscriptionModelTest {
 
         DcbCatchupSubscriptionModel subscription = new DcbCatchupSubscriptionModel(subscriptionModel, eventStore, DcbCriteria.tags(Tag.parse("name:1")), new CatchupSubscriptionModelConfig(100));
 
-        Subscription staleAttempt = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
+        SubscriptionHandle staleAttempt = subscription.subscribe(subscriptionId, StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> {
             replayReached.countDown();
             awaitLatch(releaseReplay);
         });
@@ -484,7 +484,7 @@ class DcbCatchupSubscriptionModelTest {
 
         releaseReplay.countDown();
 
-        Future<Subscription> staleDelegatedSubscription = ((CatchupSubscription) staleAttempt).delegatedSubscription();
+        Future<SubscriptionHandle> staleDelegatedSubscription = ((CatchupSubscription) staleAttempt).delegatedSubscription();
         assertThat(staleDelegatedSubscription.get(5, TimeUnit.SECONDS))
                 .as("a live subscribe claiming an id while a same-id catch-up is still replaying must cancel that "
                         + "catch-up's finishing tail instead of leaving it to also subscribe the delegate once its "
@@ -530,7 +530,7 @@ class DcbCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             StartAt resolved = startAt.get(new StartAt.SubscriptionModelContext(InMemorySubscriptionModel.class));
             StartAt startAtToUse = resolved != null && resolved.isDefault() ? StartAt.subscriptionModelDefault() : StartAt.now();
             return delegate.subscribe(subscriptionId, filter, startAtToUse, action);
@@ -567,7 +567,7 @@ class DcbCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return delegate.resumeSubscription(subscriptionId);
         }
 

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscription.java
@@ -2,7 +2,7 @@ package org.occurrent.subscription.blocking.competingconsumers;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -10,17 +10,17 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 @NullMarked
-public class CompetingConsumerSubscription implements Subscription {
+public class CompetingConsumerSubscription implements SubscriptionHandle {
     private final String subscriptionId;
     private final String subscriberId;
     @Nullable
-    private final Subscription subscription;
+    private final SubscriptionHandle subscription;
 
     CompetingConsumerSubscription(String subscriptionId, String subscriberId) {
         this(subscriptionId, subscriberId, null);
     }
 
-    CompetingConsumerSubscription(String subscriptionId, String subscriberId, @Nullable Subscription subscription) {
+    CompetingConsumerSubscription(String subscriptionId, String subscriberId, @Nullable SubscriptionHandle subscription) {
         this.subscriptionId = subscriptionId;
         this.subscriberId = subscriberId;
         this.subscription = subscription;
@@ -30,7 +30,7 @@ public class CompetingConsumerSubscription implements Subscription {
         return subscriberId;
     }
 
-    Optional<Subscription> getSubscription() {
+    Optional<SubscriptionHandle> getSubscription() {
         return Optional.ofNullable(subscription);
     }
 

--- a/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModel.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/main/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModel.java
@@ -98,14 +98,14 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
      * @param action         This action will be invoked for each cloud event that is stored in the EventStore.
      * @throws DuplicateSubscriptionIdException If this subscription model instance already has a subscription with this id.
      */
-    public Subscription subscribe(String subscriberId, String subscriptionId, SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriberId, String subscriptionId, SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(subscriberId, "SubscriberId cannot be null");
         Objects.requireNonNull(subscriptionId, "SubscriptionId cannot be null");
         if (isSubscriptionIdInUse(subscriptionId)) {
             throw new DuplicateSubscriptionIdException(subscriptionId);
         }
 
-        final Subscription subscription;
+        final SubscriptionHandle subscription;
         if (startAt.get(new SubscriptionModelContext(CompetingConsumerSubscriptionModel.class)) == null) {
             // Not allowed to start the competing consumer subscription, delegate to parent instead. One case: a
             // non-durable in-memory subscription started on multiple nodes, where every node should receive every
@@ -125,7 +125,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
      * @see SubscriptionModel#subscribe(String, SubscriptionFilter, StartAt, Consumer)
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         return subscribe(UUID.randomUUID().toString(), subscriptionId, filter, startAt, action);
     }
 
@@ -243,7 +243,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
      * @see SubscriptionModelLifeCycle#resumeSubscription(String)
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         logDebug("Trying to resume CompetingConsumer subscription (subscriptionId={})", subscriptionId);
         requireKnown(subscriptionId);
         if (isRunning(subscriptionId)) {
@@ -268,7 +268,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
                         competingConsumer = competingConsumer.restoreWaiting();
                         competingConsumers.put(competingConsumer.subscriptionIdAndSubscriberId, competingConsumer);
                     }
-                    final Subscription subscription;
+                    final SubscriptionHandle subscription;
                     String subscriberId = competingConsumer.getSubscriberId();
                     boolean hasLock = hasLock(subscriptionId, subscriberId);
                     logDebug("Resuming CompetingConsumer (subscriberId={}, subscriptionId={}, state={}, hasLock={})", subscriberId, subscriptionId, competingConsumer.state.getClass().getSimpleName(), hasLock);
@@ -309,7 +309,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
         final CompetingConsumerSubscription competingConsumerSubscription;
         if (competingConsumerStrategy.registerCompetingConsumer(subscriptionId, subscriberId)) {
             logDebug("Successfully registered CompetingConsumer subscription (subscriberId={}, subscriptionId={})", subscriberId, subscriptionId);
-            Subscription subscription = delegate.subscribe(subscriptionId, filter, startAt, action);
+            SubscriptionHandle subscription = delegate.subscribe(subscriptionId, filter, startAt, action);
             competingConsumerSubscription = new CompetingConsumerSubscription(subscriptionId, subscriberId, subscription);
             // Winning the lock while stopped records the consumer as paused rather than running, the same way every
             // other subscription model registers into its paused collection when it is not running. The delegate has
@@ -499,7 +499,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
         }
     }
 
-    private Subscription startWaitingConsumer(CompetingConsumer cc) {
+    private SubscriptionHandle startWaitingConsumer(CompetingConsumer cc) {
         logDebug("Start CompetingConsumer that has previously been waiting (subscriberId={}, subscriptionId={})", cc.getSubscriberId(), cc.getSubscriptionId());
         String subscriptionId = cc.getSubscriptionId();
         competingConsumers.put(SubscriptionIdAndSubscriberId.from(subscriptionId, cc.getSubscriberId()), cc.registerRunning());
@@ -514,7 +514,7 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
      * callback, so the answer is read from the return value, and the state is re-read afterwards to see
      * whether the callback already acted on it.
      */
-    private Subscription registerAndStartIfGranted(CompetingConsumer cc) {
+    private SubscriptionHandle registerAndStartIfGranted(CompetingConsumer cc) {
         String subscriptionId = cc.getSubscriptionId();
         String subscriberId = cc.getSubscriberId();
         boolean acquiredLock = registerCompetingConsumer(subscriptionId, subscriberId);
@@ -609,13 +609,13 @@ public class CompetingConsumerSubscriptionModel implements SubscriptionModelWrap
         }
 
         final class Waiting implements CompetingConsumerState {
-            private final Supplier<Subscription> supplier;
+            private final Supplier<SubscriptionHandle> supplier;
 
-            Waiting(Supplier<Subscription> supplier) {
+            Waiting(Supplier<SubscriptionHandle> supplier) {
                 this.supplier = supplier;
             }
 
-            private Subscription startSubscription() {
+            private SubscriptionHandle startSubscription() {
                 return supplier.get();
             }
         }

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerStartPositionTest.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
 import org.occurrent.subscription.api.blocking.ManualStartSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.time.Duration;
@@ -153,7 +153,7 @@ class CompetingConsumerStartPositionTest {
         @Nullable StartAt startAtReceived = null;
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             startAtReceived = startAt;
             runningIds.add(subscriptionId);
             pausedIds.remove(subscriptionId);
@@ -192,7 +192,7 @@ class CompetingConsumerStartPositionTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             pausedIds.remove(subscriptionId);
             return new FakeSubscription(subscriptionId);
         }
@@ -203,7 +203,7 @@ class CompetingConsumerStartPositionTest {
         }
     }
 
-    private record FakeSubscription(String id) implements Subscription {
+    private record FakeSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelDelegatePauseRefusalTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelDelegatePauseRefusalTest.java
@@ -25,7 +25,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.time.Duration;
@@ -81,7 +81,7 @@ class CompetingConsumerSubscriptionModelDelegatePauseRefusalTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             return new FakeSubscription(subscriptionId);
         }
 
@@ -113,7 +113,7 @@ class CompetingConsumerSubscriptionModelDelegatePauseRefusalTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return new FakeSubscription(subscriptionId);
         }
 
@@ -125,7 +125,7 @@ class CompetingConsumerSubscriptionModelDelegatePauseRefusalTest {
         }
     }
 
-    private record FakeSubscription(String id) implements Subscription {
+    private record FakeSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelPausedWhileWaitingTest.java
+++ b/subscription/util/blocking/competing-consumer-subscription/src/test/java/org/occurrent/subscription/blocking/competingconsumers/CompetingConsumerSubscriptionModelPausedWhileWaitingTest.java
@@ -9,7 +9,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionNotRunningException;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.time.Duration;
@@ -156,7 +156,7 @@ class CompetingConsumerSubscriptionModelPausedWhileWaitingTest {
         private boolean running = true;
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             runningIds.add(subscriptionId);
             pausedIds.remove(subscriptionId);
             return new FakeSubscription(subscriptionId);
@@ -194,7 +194,7 @@ class CompetingConsumerSubscriptionModelPausedWhileWaitingTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             pausedIds.remove(subscriptionId);
             return new FakeSubscription(subscriptionId);
         }
@@ -205,7 +205,7 @@ class CompetingConsumerSubscriptionModelPausedWhileWaitingTest {
         }
     }
 
-    private record FakeSubscription(String id) implements Subscription {
+    private record FakeSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModel.java
+++ b/subscription/util/blocking/durable-subscription/src/main/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModel.java
@@ -178,7 +178,7 @@ public class DurableSubscriptionModel implements CheckpointAwareSubscriptionMode
      *                               {@link DurableSubscriptionModelConfig#startWhenNoStartPositionCanBeRecorded(boolean)}.
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, @Nullable StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, StartAt.class.getSimpleName() + " supplier cannot be null");
 
         // Held for the whole method, not just the opt-out branch, so subscribe, resumeSubscription and
@@ -207,7 +207,7 @@ public class DurableSubscriptionModel implements CheckpointAwareSubscriptionMode
                 }
             }
 
-            Subscription subscription = subscriptionModel.subscribe(subscriptionId, filter, startAtToUse, cloudEvent -> {
+            SubscriptionHandle subscription = subscriptionModel.subscribe(subscriptionId, filter, startAtToUse, cloudEvent -> {
                         action.accept(cloudEvent);
                         if (config.persistCloudEventPositionPredicate.test(cloudEvent)) {
                             Checkpoint checkpoint = getCheckpointOrThrowIAE(cloudEvent);
@@ -344,7 +344,7 @@ public class DurableSubscriptionModel implements CheckpointAwareSubscriptionMode
      * present and would silently drop whatever was published while this subscription was paused.
      */
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         // Held for the whole decision, reposition call included, so a concurrent subscribe or cancelSubscription
         // for this id cannot land between the marker check and acting on it.
         synchronized (lockFor(subscriptionId)) {

--- a/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelCheckpointWriteVersionSourceTest.java
+++ b/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelCheckpointWriteVersionSourceTest.java
@@ -28,7 +28,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.net.URI;
@@ -93,9 +93,9 @@ class DurableSubscriptionModelCheckpointWriteVersionSourceTest {
     private static CheckpointAwareSubscriptionModel oneEventSubscriptionModel() {
         return new CheckpointAwareSubscriptionModel() {
             @Override
-            public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+            public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
                 action.accept(checkpointAwareCloudEvent());
-                return new Subscription() {
+                return new SubscriptionHandle() {
                     @Override
                     public String id() {
                         return subscriptionId;
@@ -137,7 +137,7 @@ class DurableSubscriptionModelCheckpointWriteVersionSourceTest {
             }
 
             @Override
-            public Subscription resumeSubscription(String subscriptionId) {
+            public SubscriptionHandle resumeSubscription(String subscriptionId) {
                 throw new UnsupportedOperationException();
             }
 

--- a/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelFirstPositionRefusalTest.java
+++ b/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelFirstPositionRefusalTest.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.net.URI;
@@ -276,7 +276,7 @@ class DurableSubscriptionModelFirstPositionRefusalTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             StartAt resolved = startAt.isDynamic() ? startAt.get(new SubscriptionModelContext(InMemoryFeed.class)) : startAt;
             int position = resolved instanceof StartAt.StartAtCheckpoint startAtCheckpoint
                     ? Integer.parseInt(startAtCheckpoint.checkpoint.asString())
@@ -322,7 +322,7 @@ class DurableSubscriptionModelFirstPositionRefusalTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return dummySubscription(subscriptionId);
         }
 
@@ -335,8 +335,8 @@ class DurableSubscriptionModelFirstPositionRefusalTest {
             subscriptions.remove(subscriptionId);
         }
 
-        private static Subscription dummySubscription(String subscriptionId) {
-            return new Subscription() {
+        private static SubscriptionHandle dummySubscription(String subscriptionId) {
+            return new SubscriptionHandle() {
                 @Override
                 public String id() {
                     return subscriptionId;

--- a/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelMigratedCheckpointStorageTest.java
+++ b/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelMigratedCheckpointStorageTest.java
@@ -30,7 +30,7 @@ import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.net.URI;
 import java.time.Duration;
@@ -87,9 +87,9 @@ class DurableSubscriptionModelMigratedCheckpointStorageTest {
     private static CheckpointAwareSubscriptionModel oneEventSubscriptionModel() {
         return new CheckpointAwareSubscriptionModel() {
             @Override
-            public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+            public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
                 action.accept(checkpointAwareCloudEvent());
-                return new Subscription() {
+                return new SubscriptionHandle() {
                     @Override
                     public String id() {
                         return subscriptionId;
@@ -131,7 +131,7 @@ class DurableSubscriptionModelMigratedCheckpointStorageTest {
             }
 
             @Override
-            public Subscription resumeSubscription(String subscriptionId) {
+            public SubscriptionHandle resumeSubscription(String subscriptionId) {
                 throw new UnsupportedOperationException();
             }
 

--- a/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelResumeRepositioningTest.java
+++ b/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelResumeRepositioningTest.java
@@ -27,7 +27,7 @@ import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.RepositionableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.time.Duration;
@@ -283,11 +283,11 @@ class DurableSubscriptionModelResumeRepositioningTest {
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
-            Future<Subscription> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
+            Future<SubscriptionHandle> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
             }));
             assertThat(insideSubscribe.await(10, TimeUnit.SECONDS)).isTrue();
 
-            Future<Subscription> resumeFuture = pool.submit(() -> model.resumeSubscription(SUBSCRIPTION_ID));
+            Future<SubscriptionHandle> resumeFuture = pool.submit(() -> model.resumeSubscription(SUBSCRIPTION_ID));
 
             assertThatThrownBy(() -> resumeFuture.get(200, TimeUnit.MILLISECONDS))
                     .as("resumeSubscription must wait for this id's lock rather than deciding from a state the "
@@ -322,7 +322,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
-            Future<Subscription> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
+            Future<SubscriptionHandle> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
             }));
             assertThat(insideSubscribe.await(10, TimeUnit.SECONDS)).isTrue();
 
@@ -367,7 +367,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
             Future<?> cancelFuture = pool.submit(() -> model.cancelSubscription(SUBSCRIPTION_ID));
             assertThat(unregisteredAndPausing.await(10, TimeUnit.SECONDS)).isTrue();
 
-            Future<Subscription> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
+            Future<SubscriptionHandle> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, optOut, event -> {
             }));
 
             assertThatThrownBy(() -> subscribeFuture.get(200, TimeUnit.MILLISECONDS))
@@ -415,7 +415,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
             // A checkpoint-managed subscribe (not opt-out) reusing this id, racing the same in-flight cancel. Its
             // own generateStartAtPositionFrom writes this id's first checkpoint, which a concurrent cancel's
             // delete for the same id must not race.
-            Future<Subscription> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), event -> {
+            Future<SubscriptionHandle> subscribeFuture = pool.submit(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), event -> {
             }));
 
             assertThatThrownBy(() -> subscribeFuture.get(200, TimeUnit.MILLISECONDS))
@@ -455,7 +455,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
         private final Set<String> registeredIds = ConcurrentHashMap.newKeySet();
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             registeredIds.add(subscriptionId);
             return dummySubscription(subscriptionId);
         }
@@ -489,7 +489,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             plainResumeCalled = true;
             return dummySubscription(subscriptionId);
         }
@@ -503,8 +503,8 @@ class DurableSubscriptionModelResumeRepositioningTest {
             registeredIds.remove(subscriptionId);
         }
 
-        static Subscription dummySubscription(String subscriptionId) {
-            return new Subscription() {
+        static SubscriptionHandle dummySubscription(String subscriptionId) {
+            return new SubscriptionHandle() {
                 @Override
                 public String id() {
                     return subscriptionId;
@@ -525,19 +525,19 @@ class DurableSubscriptionModelResumeRepositioningTest {
         @Nullable StartAt repositionedTo = null;
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId, StartAt startAt) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId, StartAt startAt) {
             repositionedTo = startAt;
             return dummySubscription(subscriptionId);
         }
     }
 
     /**
-     * The same repositionable fake, but {@code subscribe} throws instead of returning a {@link Subscription},
+     * The same repositionable fake, but {@code subscribe} throws instead of returning a {@link SubscriptionHandle},
      * standing in for a delegate that rejects a subscription outright.
      */
     private static class ThrowingOnSubscribeRepositionableSubscriptionModel extends RecordingRepositionableSubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new RuntimeException("delegate refused the subscription");
         }
     }
@@ -548,7 +548,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
      */
     private static class ErrorThrowingOnSubscribeRepositionableSubscriptionModel extends RecordingRepositionableSubscriptionModel {
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             throw new Error("delegate crashed");
         }
     }
@@ -561,7 +561,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
         private final Set<String> subscribed = ConcurrentHashMap.newKeySet();
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             if (!subscribed.add(subscriptionId)) {
                 throw new RuntimeException("duplicate subscription id " + subscriptionId);
             }
@@ -579,7 +579,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
         @Nullable CountDownLatch holdSubscribeUntil;
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             if (subscribeEntered != null) {
                 subscribeEntered.countDown();
             }
@@ -604,7 +604,7 @@ class DurableSubscriptionModelResumeRepositioningTest {
         @Nullable CountDownLatch holdReturnUntil;
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             // A real delegate resolves a dynamic StartAt's supplier while subscribing, which is what actually
             // performs a first checkpoint write for the "default" case. This fake mirrors that instead of leaving
             // the supplier uninvoked, the way a dumb stub would.

--- a/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelStartPositionTest.java
+++ b/subscription/util/blocking/durable-subscription/src/test/java/org/occurrent/subscription/blocking/durable/DurableSubscriptionModelStartPositionTest.java
@@ -27,7 +27,7 @@ import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.ManualStartSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 
 import java.time.Duration;
@@ -93,7 +93,7 @@ class DurableSubscriptionModelStartPositionTest {
         private final Set<String> registeredIds = ConcurrentHashMap.newKeySet();
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             registeredIds.add(subscriptionId);
             return dummySubscription(subscriptionId);
         }
@@ -127,7 +127,7 @@ class DurableSubscriptionModelStartPositionTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return dummySubscription(subscriptionId);
         }
 
@@ -140,8 +140,8 @@ class DurableSubscriptionModelStartPositionTest {
             registeredIds.remove(subscriptionId);
         }
 
-        private static Subscription dummySubscription(String subscriptionId) {
-            return new Subscription() {
+        private static SubscriptionHandle dummySubscription(String subscriptionId) {
+            return new SubscriptionHandle() {
                 @Override
                 public String id() {
                     return subscriptionId;

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/AbstractCatchupSubscriptionModel.java
@@ -27,7 +27,7 @@ import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointWriteVersionSource;
 import org.occurrent.subscription.api.blocking.SubscriptionModelWrapper;
 import org.occurrent.subscription.api.blocking.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.catchup.CheckpointStorageConfig.UseCheckpointInStorage;
 
@@ -182,7 +182,7 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, Su
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         pauseRequestedDuringCatchup.remove(subscriptionId);
         return getWrappedSubscriptionModel().resumeSubscription(subscriptionId);
     }
@@ -462,7 +462,7 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, Su
      * {@link #endReplayIfStillCurrent} read the attempt's identity from {@link #CURRENT_ATTEMPT} instead of a
      * parameter. This is the only place that puts into {@link #runningCatchupSubscriptions}.
      */
-    protected Future<Subscription> startCatchupAsync(String subscriptionId, Callable<Subscription> catchup) {
+    protected Future<SubscriptionHandle> startCatchupAsync(String subscriptionId, Callable<SubscriptionHandle> catchup) {
         CatchupAttempt attempt = new CatchupAttempt();
         // Locked so this registration cannot land inside a still-finishing earlier attempt's own lockHandover span
         // for the same id. Unlocked, this attempt could start, and its replay could reach a checkpoint save, before
@@ -484,7 +484,7 @@ abstract class AbstractCatchupSubscriptionModel implements SubscriptionModel, Su
         // mode-specific classes). Neither path throws, so catching here only ever means the replay itself failed,
         // and is the one place both modes share to stop such a failure from leaving the subscription looking like
         // it is still running or catching up forever.
-        FutureTask<Subscription> task = new FutureTask<>(() -> {
+        FutureTask<SubscriptionHandle> task = new FutureTask<>(() -> {
             CURRENT_ATTEMPT.set(attempt);
             try {
                 return catchup.call();

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CancelledSubscription.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CancelledSubscription.java
@@ -22,7 +22,7 @@ import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import java.time.Duration;
 
 /**
- * A {@link SubscriptionHandle} handle for a catch-up that was cancelled or shut down before it could hand over to the
+ * A {@link SubscriptionHandle} for a catch-up that was cancelled or shut down before it could hand over to the
  * live delegate. {@link #waitUntilStarted(Duration)} answers {@code false}, since this subscription never started and
  * nothing will start it.
  */

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CancelledSubscription.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CancelledSubscription.java
@@ -17,17 +17,17 @@
 package org.occurrent.subscription.blocking.durable.catchup;
 
 import org.jspecify.annotations.NullMarked;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 
 /**
- * A {@link Subscription} handle for a catch-up that was cancelled or shut down before it could hand over to the
+ * A {@link SubscriptionHandle} handle for a catch-up that was cancelled or shut down before it could hand over to the
  * live delegate. {@link #waitUntilStarted(Duration)} answers {@code false}, since this subscription never started and
  * nothing will start it.
  */
 @NullMarked
-record CancelledSubscription(String subscriptionId) implements Subscription {
+record CancelledSubscription(String subscriptionId) implements SubscriptionHandle {
 
     @Override
     public String id() {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscription.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscription.java
@@ -20,7 +20,7 @@ package org.occurrent.subscription.blocking.durable.catchup;
 import org.jspecify.annotations.NullMarked;
 import org.occurrent.subscription.DurationToTimeoutConverter;
 import org.occurrent.subscription.DurationToTimeoutConverter.Timeout;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
@@ -29,17 +29,17 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A {@link Subscription} whose start is running asynchronously (the catch-up replay). Public so both the stream and
+ * A {@link SubscriptionHandle} whose start is running asynchronously (the catch-up replay). Public so both the stream and
  * DCB catch-up models can hand back the same kind of handle while the replay runs on a background thread.
  */
 @NullMarked
-record CatchupSubscription(String id, Future<Subscription> delegatedSubscription) implements Subscription {
+record CatchupSubscription(String id, Future<SubscriptionHandle> delegatedSubscription) implements SubscriptionHandle {
 
     @Override
     public boolean waitUntilStarted(Duration timeout) {
         final long timeStarted = System.currentTimeMillis();
         Timeout safeTimeout = DurationToTimeoutConverter.convertDurationToTimeout(timeout);
-        final Subscription subscription;
+        final SubscriptionHandle subscription;
         try {
             subscription = delegatedSubscription.get(safeTimeout.timeout(), safeTimeout.timeUnit());
         } catch (TimeoutException e) {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionModelConfig.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.eventstore.api.SortBy;
 import org.occurrent.eventstore.api.blocking.EventStoreQueries;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.util.Objects;
 
@@ -65,7 +65,7 @@ public class CatchupSubscriptionModelConfig {
      * during the catchup phase. You can change this by calling {@link #catchupPhaseSortBy(SortBy)}.
      *
      * @param cacheSize The number of cloud events id's to store in-memory when switching from "catch-up" mode (i.e. querying the {@link EventStoreQueries} API)
-     *                  and "subscription" mode ({@link Subscription}). The cache is needed to reduce the number of duplicate events the occurs when switching.
+     *                  and "subscription" mode ({@link SubscriptionHandle}). The cache is needed to reduce the number of duplicate events the occurs when switching.
      */
     public CatchupSubscriptionModelConfig(int cacheSize) {
         this(cacheSize, CheckpointStorageConfig.dontUseCheckpointStorage());
@@ -86,7 +86,7 @@ public class CatchupSubscriptionModelConfig {
      * during the catchup phase. You can change this by calling {@link #catchupPhaseSortBy(SortBy)}.
      *
      * @param cacheSize                 The number of cloud events id's to store in-memory when switching from "catch-up" mode (i.e. querying the {@link EventStoreQueries} API)
-     *                                  and "subscription" mode ({@link Subscription}). The cache is needed to reduce the number of duplicate events the occurs when switching.
+     *                                  and "subscription" mode ({@link SubscriptionHandle}). The cache is needed to reduce the number of duplicate events the occurs when switching.
      * @param subscriptionStorageConfig Configures if and how checkpoint persistence should be handled during the catch-up phase.
      */
     public CatchupSubscriptionModelConfig(int cacheSize, CheckpointStorageConfig subscriptionStorageConfig) {

--- a/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/main/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModel.java
@@ -30,7 +30,7 @@ import org.occurrent.subscription.*;
 import org.occurrent.subscription.StartAt.StartAtCheckpoint;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.subscription.blocking.durable.catchup.CheckpointStorageConfig.PersistCheckpointDuringCatchupPhase;
 import org.occurrent.subscription.blocking.durable.catchup.CheckpointStorageConfig.UseCheckpointInStorage;
@@ -127,14 +127,14 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     /**
      * Shortcut to start subscribing to events matching the supplied filter from beginning of time.
      */
-    public Subscription subscribeFromBeginningOfTime(String subscriptionId, SubscriptionFilter filter, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribeFromBeginningOfTime(String subscriptionId, SubscriptionFilter filter, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, filter, StartAtTime.beginningOfTime(), action);
     }
 
     /**
      * Shortcut to start subscribing to <i>all</i> events from beginning of time.
      */
-    public Subscription subscribeFromBeginningOfTime(String subscriptionId, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribeFromBeginningOfTime(String subscriptionId, Consumer<CloudEvent> action) {
         return subscribe(subscriptionId, StartAtTime.beginningOfTime(), action);
     }
 
@@ -147,7 +147,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Objects.requireNonNull(startAt, "Start at supplier cannot be null");
         // Position/time catch-up converts the filter into an Occurrent Filter for the historical query, so only the
         // filter types that wrap a plain Filter are supported here: StreamSubscriptionFilter (stream) and
@@ -210,7 +210,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
      * claimed. Distinct from the delegate subscribe call inside a finishing attempt's own handover, which has
      * already gone through that lock and that decision and must not cancel itself.
      */
-    private Subscription subscribeLiveWithoutCatchup(String subscriptionId, StreamSubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    private SubscriptionHandle subscribeLiveWithoutCatchup(String subscriptionId, StreamSubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         cancelRunningCatchup(subscriptionId);
         return getWrappedSubscriptionModel().subscribe(subscriptionId, filter, startAt, action);
     }
@@ -250,17 +250,17 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
                 && GlobalCheckpoint.isGlobalCheckpoint(position.checkpoint);
     }
 
-    private Subscription streamPositionCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt positionStartAt) {
-        Future<Subscription> future = startCatchupAsync(subscriptionId, () -> startPositionCatchupSubscriptionForStream(subscriptionId, filter, startAt, action, positionStartAt));
+    private SubscriptionHandle streamPositionCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt positionStartAt) {
+        Future<SubscriptionHandle> future = startCatchupAsync(subscriptionId, () -> startPositionCatchupSubscriptionForStream(subscriptionId, filter, startAt, action, positionStartAt));
         return new CatchupSubscription(subscriptionId, future);
     }
 
-    private Subscription streamTimeCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
-        Future<Subscription> future = startCatchupAsync(subscriptionId, () -> startCatchupSubscription(subscriptionId, filter, startAt, action, firstStartAt));
+    private SubscriptionHandle streamTimeCatchup(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
+        Future<SubscriptionHandle> future = startCatchupAsync(subscriptionId, () -> startCatchupSubscription(subscriptionId, filter, startAt, action, firstStartAt));
         return new CatchupSubscription(subscriptionId, future);
     }
 
-    private Subscription startCatchupSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
+    private SubscriptionHandle startCatchupSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
         StartAt nextStartAt = firstStartAt.get(generateSubscriptionModelContext());
         Checkpoint checkpoint = ((StartAtCheckpoint) Objects.requireNonNull(nextStartAt)).checkpoint;
 
@@ -388,8 +388,8 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
         }
     }
 
-    private Subscription startDelegatedSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, boolean subscriptionsWasCancelledOrShutdown, StartAt startAtToUse, Consumer<CloudEvent> liveConsumer) {
-        final Subscription subscription;
+    private SubscriptionHandle startDelegatedSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, boolean subscriptionsWasCancelledOrShutdown, StartAt startAtToUse, Consumer<CloudEvent> liveConsumer) {
+        final SubscriptionHandle subscription;
         if (subscriptionsWasCancelledOrShutdown) {
             // Priming startAtToUse is skipped for an explicit cancellation of this exact id, since its get() call
             // saves globalCheckpoint as a side effect, which would recreate the position cancelSubscription's own
@@ -417,7 +417,7 @@ public class StreamCatchupSubscriptionModel extends AbstractCatchupSubscriptionM
     // PositionOrderedReader instead of the legacy time-ordered path above.
     // ---------------------------------------------------------------------------------------------------------------
 
-    private Subscription startPositionCatchupSubscriptionForStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
+    private SubscriptionHandle startPositionCatchupSubscriptionForStream(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action, StartAt firstStartAt) {
         PositionOrderedReader positionOrderedReader = (PositionOrderedReader) eventStoreQueries;
         Filter streamFilter = withCapabilityScope(plainFilterOf(filter));
         long windowSize = config.dcbCatchupPositionWindowSize;

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/CatchupSubscriptionTest.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +43,7 @@ class CatchupSubscriptionTest {
         // The delegate itself reports false, for example a CancelledSubscription or another subscription whose own
         // start did not complete. The old behaviour hardcoded true once the future resolved at all, and this returns
         // whatever the delegate says.
-        Future<Subscription> future = CompletableFuture.completedFuture(new FixedAnswerSubscription("delegated", false));
+        Future<SubscriptionHandle> future = CompletableFuture.completedFuture(new FixedAnswerSubscription("delegated", false));
 
         boolean started = new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5));
 
@@ -52,7 +52,7 @@ class CatchupSubscriptionTest {
 
     @Test
     void returns_true_when_the_delegate_answers_true() {
-        Future<Subscription> future = CompletableFuture.completedFuture(new FixedAnswerSubscription("delegated", true));
+        Future<SubscriptionHandle> future = CompletableFuture.completedFuture(new FixedAnswerSubscription("delegated", true));
 
         boolean started = new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5));
 
@@ -61,7 +61,7 @@ class CatchupSubscriptionTest {
 
     @Test
     void a_future_that_does_not_resolve_within_the_timeout_answers_false() {
-        Future<Subscription> future = new CompletableFuture<>(); // Never completes.
+        Future<SubscriptionHandle> future = new CompletableFuture<>(); // Never completes.
 
         boolean started = new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofMillis(50));
 
@@ -73,7 +73,7 @@ class CatchupSubscriptionTest {
         // Same answer as CancelledSubscription. The replay was cancelled, so it never started and nothing will
         // start it, which is not a failure to report. CancellationException is a RuntimeException, so without an
         // explicit catch it would otherwise escape as a thrown exception instead of a false answer.
-        CompletableFuture<Subscription> future = new CompletableFuture<>();
+        CompletableFuture<SubscriptionHandle> future = new CompletableFuture<>();
         future.cancel(false);
 
         boolean started = new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5));
@@ -84,7 +84,7 @@ class CatchupSubscriptionTest {
     @Test
     void a_runtime_exception_from_a_failed_replay_is_rethrown_as_is() {
         IllegalStateException replayFailure = new IllegalStateException("replay blew up");
-        CompletableFuture<Subscription> future = new CompletableFuture<>();
+        CompletableFuture<SubscriptionHandle> future = new CompletableFuture<>();
         future.completeExceptionally(replayFailure);
 
         Throwable thrown = catchThrowable(() -> new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5)));
@@ -95,7 +95,7 @@ class CatchupSubscriptionTest {
     @Test
     void an_error_from_a_failed_replay_is_rethrown_as_is() {
         OutOfMemoryError replayFailure = new OutOfMemoryError("replay blew up");
-        CompletableFuture<Subscription> future = new CompletableFuture<>();
+        CompletableFuture<SubscriptionHandle> future = new CompletableFuture<>();
         future.completeExceptionally(replayFailure);
 
         Throwable thrown = catchThrowable(() -> new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5)));
@@ -106,7 +106,7 @@ class CatchupSubscriptionTest {
     @Test
     void a_checked_exception_from_a_failed_replay_is_wrapped_so_a_caller_that_discards_the_return_value_still_learns_about_it() {
         Exception checkedFailure = new java.io.IOException("could not read the stream");
-        CompletableFuture<Subscription> future = new CompletableFuture<>();
+        CompletableFuture<SubscriptionHandle> future = new CompletableFuture<>();
         future.completeExceptionally(checkedFailure);
 
         Throwable thrown = catchThrowable(() -> new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5)));
@@ -123,7 +123,7 @@ class CatchupSubscriptionTest {
         // again would let one call wait for nearly twice what the caller asked for, and a caller that overshot would
         // otherwise pass the delegate a negative duration, which nothing promises to tolerate.
         RecordingSubscription delegate = new RecordingSubscription("delegated");
-        CompletableFuture<Subscription> future = new CompletableFuture<>();
+        CompletableFuture<SubscriptionHandle> future = new CompletableFuture<>();
         CompletableFuture.delayedExecutor(200, TimeUnit.MILLISECONDS).execute(() -> future.complete(delegate));
 
         new CatchupSubscription("sub", future).waitUntilStarted(Duration.ofSeconds(5));
@@ -135,10 +135,10 @@ class CatchupSubscriptionTest {
                 .isGreaterThan(Duration.ZERO);
     }
 
-    // Stands for the Subscription a real replay hands over to once it completes, for example the wrapped model's own
+    // Stands for the SubscriptionHandle a real replay hands over to once it completes, for example the wrapped model's own
     // subscription or a CancelledSubscription. CatchupSubscription.waitUntilStarted must forward this answer rather
     // than assume it.
-    private record FixedAnswerSubscription(String id, boolean answer) implements Subscription {
+    private record FixedAnswerSubscription(String id, boolean answer) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return answer;
@@ -147,7 +147,7 @@ class CatchupSubscriptionTest {
 
     // Records the budget it was handed, so a test can check what is left over after the replay rather than only what
     // the answer was.
-    private static final class RecordingSubscription implements Subscription {
+    private static final class RecordingSubscription implements SubscriptionHandle {
         private final String id;
         private volatile @Nullable Duration received;
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupHandoverTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupHandoverTest.java
@@ -29,7 +29,7 @@ import org.occurrent.eventstore.api.blocking.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 
 import java.net.URI;
 import java.time.Duration;
@@ -195,7 +195,7 @@ class StreamCatchupHandoverTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             live.forEach(action);
             return new StartedSubscription(subscriptionId);
         }
@@ -229,7 +229,7 @@ class StreamCatchupHandoverTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return new StartedSubscription(subscriptionId);
         }
 
@@ -242,7 +242,7 @@ class StreamCatchupHandoverTest {
         }
     }
 
-    private record StartedSubscription(String id) implements Subscription {
+    private record StartedSubscription(String id) implements SubscriptionHandle {
         @Override
         public boolean waitUntilStarted(Duration timeout) {
             return true;

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelCheckpointWriteVersionSourceTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelCheckpointWriteVersionSourceTest.java
@@ -35,7 +35,7 @@ import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
 
@@ -167,7 +167,7 @@ class StreamCatchupSubscriptionModelCheckpointWriteVersionSourceTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             StartAt resolved = startAt.get(new StartAt.SubscriptionModelContext(InMemorySubscriptionModel.class));
             StartAt startAtToUse = resolved != null && resolved.isDefault() ? StartAt.subscriptionModelDefault() : StartAt.now();
             return delegate.subscribe(subscriptionId, filter, startAtToUse, action);
@@ -204,7 +204,7 @@ class StreamCatchupSubscriptionModelCheckpointWriteVersionSourceTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return delegate.resumeSubscription(subscriptionId);
         }
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelMongoTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelMongoTest.java
@@ -36,7 +36,7 @@ import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StreamSubscriptionFilter;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.blocking.SpringMongoSubscriptionModel;
 import org.occurrent.testing.mongodb.OccurrentMongoFlush;
 import org.occurrent.testsupport.mongodb.MongoTestDatabase;
@@ -123,7 +123,7 @@ class StreamCatchupSubscriptionModelMongoTest {
 
         StreamCatchupSubscriptionModel catchup = new StreamCatchupSubscriptionModel(subscriptionModel, eventStore, new CatchupSubscriptionModelConfig(100));
         CopyOnWriteArrayList<String> received = new CopyOnWriteArrayList<>();
-        Subscription subscription = catchup.subscribe("subscription", StreamSubscriptionFilter.filter(Filter.data("userId", eq("keep"))),
+        SubscriptionHandle subscription = catchup.subscribe("subscription", StreamSubscriptionFilter.filter(Filter.data("userId", eq("keep"))),
                 StartAt.checkpoint(GlobalCheckpoint.of(0)), toNames(received));
         subscription.waitUntilStarted();
 

--- a/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelTest.java
+++ b/subscription/util/blocking/stream-catchup-subscription/src/test/java/org/occurrent/subscription/blocking/durable/catchup/StreamCatchupSubscriptionModelTest.java
@@ -35,7 +35,7 @@ import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.InMemoryCheckpointStorage;
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
 
@@ -269,7 +269,7 @@ class StreamCatchupSubscriptionModelTest {
         CheckpointAwareSubscriptionModel reportsNoCheckpoint = new CheckpointAwareInMemorySubscriptionModel(inMemorySubscriptionModel, null);
         StreamCatchupSubscriptionModel subscription = new StreamCatchupSubscriptionModel(reportsNoCheckpoint, eventStore, new CatchupSubscriptionModelConfig(100));
 
-        Subscription started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
+        SubscriptionHandle started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
 
         // A start that failed and will not be retried throws rather than answering false, since false is reserved for a
         // subscription nothing has started yet but still could, and this one never will. Five seconds is a bound on a
@@ -307,7 +307,7 @@ class StreamCatchupSubscriptionModelTest {
         CopyOnWriteArrayList<DomainEvent> received = new CopyOnWriteArrayList<>();
         CheckpointAwareSubscriptionModel reportsNoCheckpoint = new CheckpointAwareInMemorySubscriptionModel(inMemorySubscriptionModel, null);
         StreamCatchupSubscriptionModel subscription = new StreamCatchupSubscriptionModel(reportsNoCheckpoint, eventStore, new CatchupSubscriptionModelConfig(100));
-        Subscription started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
+        SubscriptionHandle started = subscription.subscribe("subscription", StartAt.checkpoint(GlobalCheckpoint.of(0)), toDomainEvents(received));
         assertThatThrownBy(() -> started.waitUntilStarted(Duration.ofSeconds(5)));
 
         assertThatThrownBy(() -> subscription.pauseSubscription("subscription"))
@@ -329,7 +329,7 @@ class StreamCatchupSubscriptionModelTest {
         StreamCatchupSubscriptionModel subscription = new StreamCatchupSubscriptionModel(reportsNoCheckpoint, eventStore, new CatchupSubscriptionModelConfig(100));
         String subscriptionId = "subscription";
 
-        Subscription started = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> subscription.pauseSubscription(subscriptionId));
+        SubscriptionHandle started = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> subscription.pauseSubscription(subscriptionId));
 
         assertThatThrownBy(() -> started.waitUntilStarted(Duration.ofSeconds(5))).isInstanceOf(IllegalStateException.class);
         assertThat(subscription.isPaused(subscriptionId))
@@ -345,7 +345,7 @@ class StreamCatchupSubscriptionModelTest {
         AtomicBoolean runningMarkedBeforeCatchupRuns = new AtomicBoolean(false);
         StreamCatchupSubscriptionModel subscription = new StreamCatchupSubscriptionModel(subscriptionModel, eventStore, new CatchupSubscriptionModelConfig(100)) {
             @Override
-            protected Future<Subscription> startCatchupAsync(String subscriptionId, Callable<Subscription> catchup) {
+            protected Future<SubscriptionHandle> startCatchupAsync(String subscriptionId, Callable<SubscriptionHandle> catchup) {
                 return super.startCatchupAsync(subscriptionId, () -> {
                     runningMarkedBeforeCatchupRuns.set(runningCatchupSubscriptions.containsKey(subscriptionId));
                     return catchup.call();
@@ -372,7 +372,7 @@ class StreamCatchupSubscriptionModelTest {
         CountDownLatch replayReached = new CountDownLatch(1);
         CountDownLatch releaseReplay = new CountDownLatch(1);
 
-        Subscription started = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
+        SubscriptionHandle started = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
             replayReached.countDown();
             awaitLatch(releaseReplay);
         });
@@ -416,7 +416,7 @@ class StreamCatchupSubscriptionModelTest {
 
         CountDownLatch firstReplayReached = new CountDownLatch(1);
         CountDownLatch releaseFirstReplay = new CountDownLatch(1);
-        Subscription first = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
+        SubscriptionHandle first = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
             firstReplayReached.countDown();
             awaitLatch(releaseFirstReplay);
         });
@@ -428,7 +428,7 @@ class StreamCatchupSubscriptionModelTest {
 
         CountDownLatch secondReplayReached = new CountDownLatch(1);
         CountDownLatch releaseSecondReplay = new CountDownLatch(1);
-        Subscription second = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
+        SubscriptionHandle second = subscription.subscribe(subscriptionId, StartAtTime.beginningOfTime(), cloudEvent -> {
             secondReplayReached.countDown();
             awaitLatch(releaseSecondReplay);
         });
@@ -870,7 +870,7 @@ class StreamCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
             StartAt resolved = startAt.get(new StartAt.SubscriptionModelContext(InMemorySubscriptionModel.class));
             StartAt startAtToUse = resolved != null && resolved.isDefault() ? StartAt.subscriptionModelDefault() : StartAt.now();
             return delegate.subscribe(subscriptionId, filter, startAtToUse, action);
@@ -907,7 +907,7 @@ class StreamCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return delegate.resumeSubscription(subscriptionId);
         }
 

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModel.java
@@ -28,7 +28,7 @@ import org.occurrent.subscription.CatchupListener;
 import org.occurrent.subscription.StartAt.StartAtCheckpoint;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -176,7 +176,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
      * refusal of an unsupported filter included.
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -187,7 +187,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
         if (subscriptionOwners.putIfAbsent(subscriptionId, routed) != null) {
             throw new DuplicateSubscriptionIdException(subscriptionId);
         }
-        final Subscription subscription;
+        final SubscriptionHandle subscription;
         try {
             subscription = routed.subscribe(subscriptionId, filter, startAt, action);
         } catch (RuntimeException e) {
@@ -301,7 +301,7 @@ public class ReactorCatchupSubscriptionModel implements CheckpointAwareSubscript
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return ownerOf(subscriptionId).resumeSubscription(subscriptionId);
     }
 

--- a/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorDcbCatchupSubscriptionModel.java
@@ -28,7 +28,7 @@ import org.occurrent.subscription.*;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -180,7 +180,7 @@ class ReactorDcbCatchupSubscriptionModel implements CheckpointAwareSubscriptionM
      * model. Requires the wrapped model to manage named subscriptions itself.
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -225,7 +225,7 @@ class ReactorDcbCatchupSubscriptionModel implements CheckpointAwareSubscriptionM
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return namedSubscriptions.resumeSubscription(subscriptionId);
     }
 

--- a/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelOwnershipTest.java
+++ b/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelOwnershipTest.java
@@ -30,7 +30,7 @@ import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -130,7 +130,7 @@ class ReactorCatchupSubscriptionModelOwnershipTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             calls.add("subscribe:" + subscriptionId);
             return new StartedSubscription(subscriptionId);
         }
@@ -163,7 +163,7 @@ class ReactorCatchupSubscriptionModelOwnershipTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             calls.add("resumeSubscription:" + subscriptionId);
             return new StartedSubscription(subscriptionId);
         }
@@ -179,7 +179,7 @@ class ReactorCatchupSubscriptionModelOwnershipTest {
         }
     }
 
-    private record StartedSubscription(String id) implements Subscription {
+    private record StartedSubscription(String id) implements SubscriptionHandle {
         @Override
         public Mono<Void> waitUntilStarted() {
             return Mono.empty();

--- a/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelStartAtContextTest.java
+++ b/subscription/util/reactor/catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorCatchupSubscriptionModelStartAtContextTest.java
@@ -28,7 +28,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -140,7 +140,7 @@ class ReactorCatchupSubscriptionModelStartAtContextTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             return new StartedSubscription(subscriptionId);
         }
 
@@ -168,7 +168,7 @@ class ReactorCatchupSubscriptionModelStartAtContextTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             return new StartedSubscription(subscriptionId);
         }
 
@@ -181,7 +181,7 @@ class ReactorCatchupSubscriptionModelStartAtContextTest {
         }
     }
 
-    private record StartedSubscription(String id) implements Subscription {
+    private record StartedSubscription(String id) implements SubscriptionHandle {
         @Override
         public Mono<Void> waitUntilStarted() {
             return Mono.empty();

--- a/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/main/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModel.java
@@ -90,7 +90,7 @@ import static org.occurrent.subscription.CheckpointAwareCloudEvent.getCheckpoint
  * already stored when this model read for it is taken without a word, as before, so a node joining a subscription
  * another has been running is untouched. The refusal reaches the caller wherever that registration path already
  * reports a start it could not make. It is thrown from {@link #subscribe(String, SubscriptionFilter, StartAt, Function)}
- * when the wrapped model manages named subscriptions, and signalled on {@link Subscription#waitUntilStarted()},
+ * when the wrapped model manages named subscriptions, and signalled on {@link SubscriptionHandle#waitUntilStarted()},
  * with an {@code ERROR} logged, when this model drives the cold primitive itself. A storage that answers {@code false}
  * from {@link CheckpointStorage#evaluatesWriteConditionsFor(String)} cannot be written to conditionally, so that
  * write stays unconditional and is logged at {@code WARN} instead. See ADR 89. A {@code save(..)} for that first
@@ -113,7 +113,7 @@ import static org.occurrent.subscription.CheckpointAwareCloudEvent.getCheckpoint
  * The refusal is thrown from {@link #subscribe(String, SubscriptionFilter, StartAt, Function)} when the wrapped model
  * manages named subscriptions of its own, which is the caller's own call and needs no log to reach anybody. When this
  * model drives the cold primitive itself it cannot throw there, so the refusal is signalled on
- * {@link Subscription#waitUntilStarted()}, on the handle {@link #resumeSubscription(String)} returns and on the
+ * {@link SubscriptionHandle#waitUntilStarted()}, on the handle {@link #resumeSubscription(String)} returns and on the
  * registration handle as well once that registration asked for the model default and storage has confirmed it holds
  * nothing. A read that fails on the way there is logged at {@code WARN}, since a subscription with a checkpoint
  * already stored, or a start position of its own, still starts fine despite it.
@@ -209,7 +209,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -238,12 +238,12 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
      * subscription, which is what makes an unsupported filter refused here in {@code subscribe(..)} and a failing
      * action retried rather than fatal.
      */
-    private Subscription subscribeByDelegating(SubscriptionModel delegate, String subscriptionId, @Nullable SubscriptionFilter filter,
+    private SubscriptionHandle subscribeByDelegating(SubscriptionModel delegate, String subscriptionId, @Nullable SubscriptionFilter filter,
                                                StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         StartAt startAtToUse = durableStartAt(subscriptionId, startAt, delegate);
         // A null startAtToUse means a dynamic StartAt opted out of starting, so the wrapped model gets the original
         // position and the untouched action, and this model stays out of the way, exactly as the blocking twin does.
-        Subscription delegated = startAtToUse == null
+        SubscriptionHandle delegated = startAtToUse == null
                 ? delegate.subscribe(subscriptionId, filter, startAt, action)
                 : delegate.subscribe(subscriptionId, filter, startAtToUse, persistingAction(subscriptionId, action));
         delegatedSubscriptionIds.add(subscriptionId);
@@ -331,7 +331,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
                                          "when using the Spring Boot starter.");
     }
 
-    private Subscription startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt,
+    private SubscriptionHandle startInternalSubscription(String subscriptionId, @Nullable SubscriptionFilter filter, AtomicReference<StartAt> currentStartAt,
                                                    Function<CloudEvent, Mono<Void>> action, @Nullable Mono<Checkpoint> positionAtRegistration) {
         if (!running) {
             // The model is stopped: don't subscribe at all, so waitUntilStarted() doesn't complete for a subscription
@@ -555,7 +555,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
      * Start a subscription that was registered while this model was stopped, or resume one that was paused.
      * <p>
      * A subscription whose position could not be read when it was registered is refused here rather than started, and
-     * the refusal is signalled on the returned {@link Subscription#waitUntilStarted()}. Such a subscription is dropped
+     * the refusal is signalled on the returned {@link SubscriptionHandle#waitUntilStarted()}. Such a subscription is dropped
      * from this model, so asking again answers with {@link UnknownSubscriptionException} and getting it back means
      * registering it again.
      *
@@ -563,7 +563,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
      * @throws SubscriptionAlreadyRunningException If the subscription is already running.
      */
     @Override
-    public synchronized Subscription resumeSubscription(String subscriptionId) {
+    public synchronized SubscriptionHandle resumeSubscription(String subscriptionId) {
         if (delegate != null) {
             return delegate.resumeSubscription(subscriptionId);
         }
@@ -654,7 +654,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
      * <p>
      * A subscription whose position could not be read when it was registered is refused, and the rest are started all
      * the same, so one broken subscription does not withhold the others. Each refusal is signalled on that
-     * subscription's own {@link Subscription#waitUntilStarted()}, so this call does not report it.
+     * subscription's own {@link SubscriptionHandle#waitUntilStarted()}, so this call does not report it.
      *
      * @see SubscriptionModelLifeCycle#start(boolean)
      */
@@ -750,7 +750,7 @@ public class ReactorDurableSubscriptionModel implements CheckpointAwareSubscript
         }
     }
 
-    private static final class ReactorDurableSubscription implements Subscription {
+    private static final class ReactorDurableSubscription implements SubscriptionHandle {
         private final String subscriptionId;
         private final Mono<Void> started;
 

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/NamedCatchupPathTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/NamedCatchupPathTest.java
@@ -28,7 +28,7 @@ import org.occurrent.mongodb.timerepresentation.TimeRepresentation;
 import org.occurrent.subscription.GlobalCheckpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorCheckpointStorage;
 import org.occurrent.subscription.mongodb.spring.reactor.ReactorMongoSubscriptionModel;
 import org.occurrent.subscription.reactor.durable.catchup.ReactorCatchupSubscriptionModel;
@@ -132,7 +132,7 @@ class NamedCatchupPathTest {
         publish("e1", "e2", "e3");
         List<String> delivered = new CopyOnWriteArrayList<>();
 
-        Subscription subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
+        SubscriptionHandle subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
                 event -> Mono.fromRunnable(() -> delivered.add(event.getId())));
         subscription.waitUntilStarted().block(TIMEOUT);
 
@@ -148,7 +148,7 @@ class NamedCatchupPathTest {
         CountDownLatch firstReplayedEventReached = new CountDownLatch(1);
         CountDownLatch midReplayEventPublished = new CountDownLatch(1);
 
-        Subscription subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
+        SubscriptionHandle subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
                 event -> Mono.fromRunnable(() -> {
                     if (delivered.isEmpty()) {
                         firstReplayedEventReached.countDown();
@@ -197,7 +197,7 @@ class NamedCatchupPathTest {
         CountDownLatch modelStopped = new CountDownLatch(1);
         AtomicBoolean deliveredWhileStopped = new AtomicBoolean(false);
 
-        Subscription subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
+        SubscriptionHandle subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
                 event -> Mono.fromRunnable(() -> {
                     if (deliveredCounts.isEmpty()) {
                         firstReplayedEventReached.countDown();
@@ -231,7 +231,7 @@ class NamedCatchupPathTest {
     @Test
     void a_duplicate_subscription_id_on_the_catchup_path_is_refused_synchronously() {
         publish("e1");
-        Subscription subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
+        SubscriptionHandle subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
                 event -> Mono.empty());
         subscription.waitUntilStarted().block(TIMEOUT);
 
@@ -249,7 +249,7 @@ class NamedCatchupPathTest {
         CountDownLatch firstReplayedEventReached = new CountDownLatch(1);
         CountDownLatch cancelled = new CountDownLatch(1);
 
-        Subscription subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
+        SubscriptionHandle subscription = durableModel.subscribe(streamId, null, StartAt.checkpoint(GlobalCheckpoint.of(0)),
                 event -> Mono.fromRunnable(() -> {
                     delivered.add(event.getId());
                     if (delivered.size() == 1) {

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/NamedRecordingSubscriptionModel.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/NamedRecordingSubscriptionModel.java
@@ -22,7 +22,7 @@ import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -62,13 +62,13 @@ final class NamedRecordingSubscriptionModel implements CheckpointAwareSubscripti
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt,
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt,
                                   Function<CloudEvent, Mono<Void>> action) {
         subscribedIds.add(subscriptionId);
         // What the durable model hands a named model is the whole of what decides where the subscription begins on
         // this path, since this model resolves nothing further.
         startedAt.add(startAt);
-        return new Subscription() {
+        return new SubscriptionHandle() {
             @Override
             public String id() {
                 return subscriptionId;
@@ -109,7 +109,7 @@ final class NamedRecordingSubscriptionModel implements CheckpointAwareSubscripti
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         throw new UnsupportedOperationException();
     }
 

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelPinRefusalTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelPinRefusalTest.java
@@ -28,7 +28,7 @@ import org.occurrent.subscription.StartPositionAlreadyPinnedException;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
 import reactor.core.publisher.Mono;
 
@@ -81,7 +81,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         storage.whenTheFirstReadFindsNothing = () -> storage.writeWithoutScripting("landed-during-registration");
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .as("the position stored is not the one this registration read, so starting from it would skip whatever lies between them")
@@ -94,7 +94,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         storage.whenTheFirstReadFindsNothing = () -> storage.writeWithoutScripting("landed-during-registration");
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOfSatisfying(StartPositionAlreadyPinnedException.class, refusal -> {
@@ -118,7 +118,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         delegate.globalCheckpoint = new OrderedCheckpoint(10);
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThat(subscription.waitUntilStarted().block(TIMEOUT)).isNull();
         assertThat(storage.read(SUBSCRIPTION_ID).block(TIMEOUT).asString())
@@ -134,7 +134,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         CheckpointStorage storage = alwaysRefusingStorage(() -> Mono.error(unreachable));
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOfSatisfying(StartPositionAlreadyPinnedException.class, refusal -> {
@@ -151,7 +151,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         CheckpointStorage storage = alwaysRefusingStorage(Mono::empty);
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOfSatisfying(StartPositionAlreadyPinnedException.class, refusal -> {
@@ -176,7 +176,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         };
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isNotInstanceOf(StartPositionAlreadyPinnedException.class)
@@ -192,7 +192,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel("this-nodes-own-position");
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         subscription.waitUntilStarted().block(TIMEOUT);
         assertThat(startedAtCheckpoint(delegate)).isEqualTo("this-nodes-own-position");
@@ -209,7 +209,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
         storage.hideWhatIsStoredFromTheNextRead();
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         subscription.waitUntilStarted().block(TIMEOUT);
         assertThat(storage.readsAfterTheWrite).hasValue(0);
@@ -223,7 +223,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
         storage.hideWhatIsStoredFromTheNextRead();
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(StartPositionAlreadyPinnedException.class);
@@ -239,7 +239,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel("wherever-the-feed-is-now");
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         subscription.waitUntilStarted().block(TIMEOUT);
         assertThat(storage.conditions).isEmpty();
@@ -271,7 +271,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         storage.whenTheFirstReadFindsNothing = () -> storage.writeWithoutScripting("landed-during-registration");
         ReactorDurableSubscriptionModel model = coldModel(new RecordingSubscriptionModel("this-nodes-own-position"), storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         assertThat(model.isRunning(SUBSCRIPTION_ID)).isFalse();
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
@@ -288,7 +288,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         // Nothing is stored until the subscription starts, so the race is run at the point it is resumed.
         storage.whenTheFirstReadFindsNothing = () -> storage.writeWithoutScripting("landed-while-it-waited");
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(StartPositionAlreadyPinnedException.class);
@@ -304,7 +304,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel("at-registration");
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         subscription.waitUntilStarted().block(TIMEOUT);
         assertThat(storage.conditions).containsExactly(CheckpointWriteCondition.any());
@@ -324,7 +324,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel("at-registration");
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -352,7 +352,7 @@ class ReactorDurableSubscriptionModelPinRefusalTest {
         RecordingSubscriptionModel delegate = new RecordingSubscriptionModel("at-registration");
         ReactorDurableSubscriptionModel model = coldModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelReRegistrationTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelReRegistrationTest.java
@@ -26,7 +26,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -79,13 +79,13 @@ class ReactorDurableSubscriptionModelReRegistrationTest {
         DelayableSubscriptionModel delegate = new DelayableSubscriptionModel(firstAttemptRead.asMono(), secondAttemptPosition);
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, new InMemoryCheckpointStorage());
 
-        Subscription first = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle first = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         assertThat(model.isRunning(SUBSCRIPTION_ID)).isTrue();
 
         // Cancelling and registering again under the same id is the documented recovery from a registration that
         // has not settled, and the model allows it: nothing here waits for the first attempt to finish.
         model.cancelSubscription(SUBSCRIPTION_ID);
-        Subscription second = model.subscribe(SUBSCRIPTION_ID, null, StartAt.checkpoint(secondAttemptPosition), __ -> Mono.empty());
+        SubscriptionHandle second = model.subscribe(SUBSCRIPTION_ID, null, StartAt.checkpoint(secondAttemptPosition), __ -> Mono.empty());
         second.waitUntilStarted().block(TIMEOUT);
         assertThat(model.isRunning(SUBSCRIPTION_ID)).isTrue();
 

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelStartWhenNoStartPositionCanBeRecordedTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelStartWhenNoStartPositionCanBeRecordedTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.occurrent.subscription.StartAt;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
 import reactor.core.publisher.Mono;
 
@@ -48,7 +48,7 @@ class ReactorDurableSubscriptionModelStartWhenNoStartPositionCanBeRecordedTest {
         InMemoryCheckpointStorage storage = new InMemoryCheckpointStorage();
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage, overrideOn());
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         subscription.waitUntilStarted().block(TIMEOUT);
 
         assertThat(delegate.startedAt).hasSize(1);
@@ -92,7 +92,7 @@ class ReactorDurableSubscriptionModelStartWhenNoStartPositionCanBeRecordedTest {
         InMemoryCheckpointStorage storage = new InMemoryCheckpointStorage();
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage, overrideOn());
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         subscription.waitUntilStarted().block(TIMEOUT);
 
         assertThat(storage.read(SUBSCRIPTION_ID).block(TIMEOUT).asString()).isEqualTo("at-registration");

--- a/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelStoppedRegistrationTest.java
+++ b/subscription/util/reactor/durable-subscription/src/test/java/org/occurrent/subscription/reactor/durable/ReactorDurableSubscriptionModelStoppedRegistrationTest.java
@@ -23,7 +23,7 @@ import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.StringBasedCheckpoint;
 import org.occurrent.subscription.UnknownSubscriptionException;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.inmemory.reactor.InMemoryCheckpointStorage;
 import reactor.core.publisher.Mono;
 
@@ -159,7 +159,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         // Simulates another node rewriting the checkpoint to a later position while this one waited to be started.
         storage.writeWithoutScripting(new OrderedCheckpoint(50));
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT))
                 .as("the resolver's own failure reaches the caller instead of being read as the later checkpoint being safe")
@@ -183,7 +183,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         // the registration. Starting from that is the loss, which is why the read is not taken.
         delegate.failGlobalCheckpoint = false;
         delegate.globalCheckpoint = new StringBasedCheckpoint("much-later");
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT))
                 .as("the read that failed is what reaches the caller, unwrapped")
@@ -210,7 +210,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         delegate.globalCheckpoint = new StringBasedCheckpoint("much-later");
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -232,7 +232,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, new InMemoryCheckpointStorage());
         model.stop();
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> registration.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -247,7 +247,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, new InMemoryCheckpointStorage());
         model.stop();
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> registration.waitUntilStarted().block(Duration.ofMillis(200)))
                 .isInstanceOf(IllegalStateException.class)
@@ -266,7 +266,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
         model.stop();
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.checkpoint(new StringBasedCheckpoint("replay-from-here")), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.checkpoint(new StringBasedCheckpoint("replay-from-here")), __ -> Mono.empty());
         model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThat(delegate.globalCheckpointReads).hasValue(0);
@@ -288,12 +288,12 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
         model.stop();
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> registration.waitUntilStarted().block(Duration.ofMillis(200)))
                 .hasMessageContaining("Timeout on blocking read");
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         resumed.waitUntilStarted().block(TIMEOUT);
         assertThat(startedAtCheckpoint(delegate)).isEqualTo("from-a-previous-run");
@@ -320,12 +320,12 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
         model.stop();
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> registration.waitUntilStarted().block(Duration.ofMillis(200)))
                 .hasMessageContaining("Timeout on blocking read");
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         resumed.waitUntilStarted().block(TIMEOUT);
         assertThat(startedAtCheckpoint(delegate)).isEqualTo("from-a-previous-run");
@@ -341,7 +341,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
 
         delegate.failGlobalCheckpoint = false;
         delegate.globalCheckpoint = new StringBasedCheckpoint("much-later");
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT)).isInstanceOf(IllegalStateException.class);
         assertThat(delegate.globalCheckpointReads)
@@ -360,7 +360,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         model.stop();
         model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT)).isInstanceOf(IllegalStateException.class);
         assertThat(delegate.globalCheckpointReads).hasValue(1);
@@ -375,7 +375,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
         model.stop();
         model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT)).isInstanceOf(IllegalStateException.class);
 
         assertThatThrownBy(() -> model.resumeSubscription(SUBSCRIPTION_ID))
@@ -383,7 +383,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
 
         delegate.failGlobalCheckpoint = false;
         delegate.globalCheckpoint = new StringBasedCheckpoint("much-later");
-        Subscription fresh = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle fresh = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         fresh.waitUntilStarted().block(TIMEOUT);
         assertThat(startedAtCheckpoint(delegate))
@@ -401,7 +401,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         InMemoryCheckpointStorage storage = new InMemoryCheckpointStorage();
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
         model.stop();
-        Subscription refused = model.subscribe("refused", null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle refused = model.subscribe("refused", null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         model.subscribe("healthy", null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         model.start(true);
@@ -486,7 +486,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         SaveCountingCheckpointStorage storage = new SaveCountingCheckpointStorage();
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -507,11 +507,11 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         model.stop();
         StartAt dynamic = StartAt.dynamic(StartAt::subscriptionModelDefault);
 
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, dynamic, __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, dynamic, __ -> Mono.empty());
         assertThatThrownBy(() -> registration.waitUntilStarted().block(Duration.ofMillis(200)))
                 .hasMessageContaining("Timeout on blocking read");
 
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         assertThatThrownBy(() -> resumed.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -535,7 +535,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         StartAt dynamic = StartAt.dynamic(() -> StartAt.checkpoint(new StringBasedCheckpoint("replay-from-here")));
 
         model.subscribe(SUBSCRIPTION_ID, null, dynamic, __ -> Mono.empty());
-        Subscription resumed = model.resumeSubscription(SUBSCRIPTION_ID);
+        SubscriptionHandle resumed = model.resumeSubscription(SUBSCRIPTION_ID);
 
         resumed.waitUntilStarted().block(TIMEOUT);
         assertThat(startedAtCheckpoint(delegate)).isEqualTo("replay-from-here");
@@ -554,7 +554,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         SaveCountingCheckpointStorage storage = new SaveCountingCheckpointStorage();
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, storage);
 
-        Subscription subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle subscription = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
 
         assertThatThrownBy(() -> subscription.waitUntilStarted().block(TIMEOUT))
                 .isInstanceOf(IllegalStateException.class)
@@ -630,7 +630,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         delegate.failGlobalCheckpoint = true;
         ReactorDurableSubscriptionModel model = new ReactorDurableSubscriptionModel(delegate, new InMemoryCheckpointStorage());
         model.stop();
-        Subscription registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle registration = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         assertThatThrownBy(() -> registration.waitUntilStarted().block(TIMEOUT)).isInstanceOf(IllegalStateException.class);
 
         assertThatThrownBy(() -> model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty()))
@@ -639,7 +639,7 @@ class ReactorDurableSubscriptionModelStoppedRegistrationTest {
         model.cancelSubscription(SUBSCRIPTION_ID);
         delegate.failGlobalCheckpoint = false;
 
-        Subscription fresh = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
+        SubscriptionHandle fresh = model.subscribe(SUBSCRIPTION_ID, null, StartAt.subscriptionModelDefault(), __ -> Mono.empty());
         assertThat(model.isPaused(SUBSCRIPTION_ID)).isTrue();
         assertThatThrownBy(() -> fresh.waitUntilStarted().block(Duration.ofMillis(200)))
                 .hasMessageContaining("Timeout on blocking read");

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/NamedCatchupSupport.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/NamedCatchupSupport.java
@@ -27,7 +27,7 @@ import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionNotRunningException;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import org.occurrent.subscription.internal.BoundedIdCache;
 import reactor.core.Disposable;
@@ -54,7 +54,7 @@ import static java.util.Objects.requireNonNull;
  * unsupported filter. That is the point of the promotion (issues #547 and #550).
  * <p>
  * A failing action during the replay is deliberately not retried. The blocking catch-up models do not retry there
- * either, and the replay failure reaches whoever waits on {@link Subscription#waitUntilStarted()} rather than being
+ * either, and the replay failure reaches whoever waits on {@link SubscriptionHandle#waitUntilStarted()} rather than being
  * logged and swallowed. Live delivery, where retry matters, is the wrapped model's.
  * <p>
  * The wrapped model must itself manage named subscriptions (implement {@link SubscriptionModel}). A catch-up model
@@ -140,7 +140,7 @@ final class NamedCatchupSupport {
      * caller's {@code action} to each replayed event without retry, then hands the live half to the wrapped model's
      * named {@code subscribe(..)} resuming from a token captured before the replay, deduped against the replayed ids.
      */
-    Subscription subscribeWithCatchup(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
+    SubscriptionHandle subscribeWithCatchup(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
                                       CatchupReader reader, long windowSize, int handoverCacheSize, long startPosition,
                                       Function<CloudEvent, Mono<Void>> action) {
         SubscriptionModel delegate = requireNamed();
@@ -233,7 +233,7 @@ final class NamedCatchupSupport {
      * filtered in-process by {@code livePredicate} so a backend that does not honor the filter server-side still
      * only delivers matching events.
      */
-    Subscription subscribeStraightToLive(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
+    SubscriptionHandle subscribeStraightToLive(String subscriptionId, @Nullable SubscriptionFilter liveSubscriptionFilter, Predicate<CloudEvent> livePredicate,
                                          StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         SubscriptionModel delegate = requireNamed();
         return delegate.subscribe(subscriptionId, liveSubscriptionFilter, startAt,
@@ -257,7 +257,7 @@ final class NamedCatchupSupport {
                 state.replaying.set(null);
                 return;
             }
-            Subscription delegated = delegate.subscribe(subscriptionId, liveSubscriptionFilter, liveStartAt, liveAction);
+            SubscriptionHandle delegated = delegate.subscribe(subscriptionId, liveSubscriptionFilter, liveStartAt, liveAction);
             state.handedOver.set(true);
             if (state.pendingPause.get() && delegate.isRunning(subscriptionId)) {
                 delegate.pauseSubscription(subscriptionId);
@@ -354,7 +354,7 @@ final class NamedCatchupSupport {
         named.pauseSubscription(subscriptionId);
     }
 
-    Subscription resumeSubscription(String subscriptionId) {
+    SubscriptionHandle resumeSubscription(String subscriptionId) {
         CatchupState state = catchingUp.get(subscriptionId);
         if (state != null) {
             synchronized (state) {
@@ -431,7 +431,7 @@ final class NamedCatchupSupport {
         };
     }
 
-    private record NamedCatchupSubscription(String id, Mono<Void> started) implements Subscription {
+    private record NamedCatchupSubscription(String id, Mono<Void> started) implements SubscriptionHandle {
         @Override
         public Mono<Void> waitUntilStarted() {
             return started;

--- a/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/main/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModel.java
@@ -29,7 +29,7 @@ import org.occurrent.subscription.*;
 import org.occurrent.subscription.StartAt.SubscriptionModelContext;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.reactor.ReplayAwareSubscriptions;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -227,7 +227,7 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
      * model. Requires the wrapped model to manage named subscriptions itself.
      */
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         requireNonNull(subscriptionId, "subscriptionId cannot be null");
         requireNonNull(action, "Action cannot be null");
         requireNonNull(startAt, StartAt.class.getSimpleName() + " cannot be null");
@@ -273,7 +273,7 @@ public class ReactorStreamCatchupSubscriptionModel implements CheckpointAwareSub
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return namedSubscriptions.resumeSubscription(subscriptionId);
     }
 

--- a/subscription/util/reactor/stream-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModelTest.java
+++ b/subscription/util/reactor/stream-catchup-subscription/src/test/java/org/occurrent/subscription/reactor/durable/catchup/ReactorStreamCatchupSubscriptionModelTest.java
@@ -27,7 +27,7 @@ import org.occurrent.eventstore.api.reactor.PositionOrderedReader;
 import org.occurrent.filter.Filter;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.reactor.CheckpointAwareSubscriptionModel;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -49,7 +49,7 @@ class ReactorStreamCatchupSubscriptionModelTest {
         // runs below, which is exactly the race NamedCatchupSupport.cancelSubscription's "not yet handed over" branch covers.
         ReactorStreamCatchupSubscriptionModel catchup = new ReactorStreamCatchupSubscriptionModel(wrapped, new StuckPositionOrderedReader());
 
-        Subscription subscription = catchup.subscribe("sub", StreamSubscriptionFilter.filter(Filter.all()),
+        SubscriptionHandle subscription = catchup.subscribe("sub", StreamSubscriptionFilter.filter(Filter.all()),
                 StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> Mono.empty());
         catchup.cancelSubscription("sub");
 
@@ -88,7 +88,7 @@ class ReactorStreamCatchupSubscriptionModelTest {
         });
         assertThat(sendsThem).isTrue();
 
-        Subscription subscription = catchup.subscribe("sub", StreamSubscriptionFilter.filter(Filter.all()),
+        SubscriptionHandle subscription = catchup.subscribe("sub", StreamSubscriptionFilter.filter(Filter.all()),
                 StartAt.checkpoint(GlobalCheckpoint.of(0)), cloudEvent -> Mono.fromRunnable(() -> signals.add("delivered")));
         StepVerifier.create(subscription.waitUntilStarted()).verifyComplete();
 
@@ -249,9 +249,9 @@ class ReactorStreamCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+        public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
             subscribeCalls.add(subscriptionId);
-            return new Subscription() {
+            return new SubscriptionHandle() {
                 @Override
                 public String id() {
                     return subscriptionId;
@@ -293,7 +293,7 @@ class ReactorStreamCatchupSubscriptionModelTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new AssertionError("resumeSubscription must not be called in this test");
         }
 

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/InProcessDeliveryConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/InProcessDeliveryConformance.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.tck.ConformanceEvents;
 
 import java.util.ArrayList;
@@ -72,7 +72,7 @@ public abstract class InProcessDeliveryConformance extends SubscriptionModelSuit
      * it is the same wait shape the rest of the leaf uses and a second number for it would be the inconsistency the
      * declared budget exists to remove.
      */
-    private void awaitStarted(Subscription subscription) {
+    private void awaitStarted(SubscriptionHandle subscription) {
         assertThat(subscription.waitUntilStarted(deliveryTimeout()))
                 .as("the subscription did not start within " + deliveryTimeout())
                 .isTrue();

--- a/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelConformance.java
+++ b/tck/subscription-blocking/src/main/java/org/occurrent/tck/subscription/blocking/SubscriptionModelConformance.java
@@ -31,7 +31,7 @@ import org.occurrent.subscription.SubscriptionNotRunningException;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.UnsupportedStartAtException;
 import org.occurrent.subscription.UnsupportedSubscriptionFilterException;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import org.occurrent.tck.ConformanceEvents;
 
@@ -124,7 +124,7 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
      */
     private RecordedEvents subscribeAndWait(String subscriptionId, @Nullable SubscriptionFilter filter) {
         RecordedEvents recorded = new RecordedEvents();
-        Subscription subscription = subscriptionModel().subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), recorded);
+        SubscriptionHandle subscription = subscriptionModel().subscribe(subscriptionId, filter, StartAt.subscriptionModelDefault(), recorded);
         assertThat(subscription.waitUntilStarted(deliveryTimeout()))
                 .as("the subscription must report started within %s, or nothing published afterwards can be expected "
                         + "to arrive", deliveryTimeout())
@@ -202,7 +202,7 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
             // subscribe(id, action) documents itself as no filter plus the model's default start position, so a model
             // that reads either differently would deliver something other than everything.
             RecordedEvents recorded = new RecordedEvents();
-            Subscription subscription = subscriptionModel().subscribe(subscriptionId(), recorded);
+            SubscriptionHandle subscription = subscriptionModel().subscribe(subscriptionId(), recorded);
             assertThat(subscription.waitUntilStarted(deliveryTimeout())).isTrue();
             CloudEvent event = ConformanceEvents.event("1", "NameDefined");
 
@@ -259,7 +259,7 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
             // time CHECKPOINT ran, the earlier variants had published events of their own, so a change-stream model
             // started at that older position replayed them and the wait below was satisfied by a replayed event
             // instead of this variant's own.
-            Subscription subscription = subscriptionModel()
+            SubscriptionHandle subscription = subscriptionModel()
                     .subscribe(id, null, variant.startAt(() -> fixture().aCheckpointToStartFrom()), recorded);
             assertThat(subscription.waitUntilStarted(deliveryTimeout()))
                     .as("this model declares it accepts %s, so a subscription starting there must report started", variant)
@@ -321,7 +321,7 @@ public abstract class SubscriptionModelConformance extends SubscriptionModelSuit
             RecordedEvents afterTheFailure = new RecordedEvents();
             // Throws once. Never forever: a retrying model has no attempt cap by default, so a handler that always
             // throws would spin until the test timed out instead of failing with a reason.
-            Subscription subscription = subscriptionModel().subscribe(id, cloudEvent -> {
+            SubscriptionHandle subscription = subscriptionModel().subscribe(id, cloudEvent -> {
                 if (calls.incrementAndGet() == 1) {
                     throw new IllegalStateException("failing on purpose, once");
                 }

--- a/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/NoopSubscriptionModel.java
+++ b/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/NoopSubscriptionModel.java
@@ -23,7 +23,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.util.Set;
@@ -45,7 +45,7 @@ class NoopSubscriptionModel implements SubscriptionModel, IntrospectableSubscrip
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         throw new UnsupportedOperationException("NoopSubscriptionModel implements nothing on purpose");
     }
 
@@ -87,7 +87,7 @@ class NoopSubscriptionModel implements SubscriptionModel, IntrospectableSubscrip
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         throw new UnsupportedOperationException("NoopSubscriptionModel implements nothing on purpose");
     }
 

--- a/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingRestartableSubscriptionModel.java
+++ b/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingRestartableSubscriptionModel.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.SubscriptionFilterMatcher;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.time.Duration;
@@ -70,7 +70,7 @@ final class WorkingRestartableSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         Predicate<CloudEvent> matcher = SubscriptionFilterMatcher.matcherFor(filter);
         // Registering and recording where this subscription starts happen under one lock. Split apart, an append
         // landing between them would see the id registered with no starting position recorded yet, default it to the
@@ -167,7 +167,7 @@ final class WorkingRestartableSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         if (!isPaused(subscriptionId)) {
             throw new IllegalArgumentException("Subscription " + subscriptionId + " is not paused");
         }
@@ -195,7 +195,7 @@ final class WorkingRestartableSubscriptionModel implements SubscriptionModel {
     private record Registration(Predicate<CloudEvent> matcher, Consumer<CloudEvent> action) {
     }
 
-    private record StartedSubscription(String id) implements Subscription {
+    private record StartedSubscription(String id) implements SubscriptionHandle {
 
         @Override
         public boolean waitUntilStarted(Duration timeout) {

--- a/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingSubscriptionModel.java
+++ b/tck/subscription-blocking/src/test/java/org/occurrent/tck/subscription/blocking/WorkingSubscriptionModel.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.*;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 
 import java.time.Duration;
@@ -81,7 +81,7 @@ public class WorkingSubscriptionModel implements SubscriptionModel, Introspectab
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         // Built before the id is reserved, so a filter this model cannot apply is refused without leaving a half
         // registered subscription behind.
         Predicate<CloudEvent> matcher = SubscriptionFilterMatcher.matcherFor(filter);
@@ -191,7 +191,7 @@ public class WorkingSubscriptionModel implements SubscriptionModel, Introspectab
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         requireKnown(subscriptionId);
         if (!isPaused(subscriptionId)) {
             throw new SubscriptionAlreadyRunningException(subscriptionId);
@@ -235,7 +235,7 @@ public class WorkingSubscriptionModel implements SubscriptionModel, Introspectab
     private record Registration(Predicate<CloudEvent> matcher, Consumer<CloudEvent> action, ExecutorService dispatcher) {
     }
 
-    private record StartedSubscription(String id) implements Subscription {
+    private record StartedSubscription(String id) implements SubscriptionHandle {
 
         @Override
         public boolean waitUntilStarted(Duration timeout) {

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/BlockingSubscriptionOverReactive.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/BlockingSubscriptionOverReactive.java
@@ -24,7 +24,7 @@ import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
 import org.occurrent.subscription.api.blocking.CheckpointAwareSubscriptionModel;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModel;
 import reactor.core.publisher.Mono;
 
@@ -136,9 +136,9 @@ public class BlockingSubscriptionOverReactive implements SubscriptionModel, Intr
     // Subscribable
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Consumer<CloudEvent> action) {
         requireNonNull(action, "action cannot be null");
-        org.occurrent.subscription.api.reactor.Subscription subscription =
+        org.occurrent.subscription.api.reactor.SubscriptionHandle subscription =
                 subscriptionModel.subscribe(subscriptionId, filter, startAt, cloudEvent -> Mono.fromRunnable(() -> action.accept(cloudEvent)));
         return new BlockingSubscriptionOverReactiveSubscription(subscription);
     }
@@ -171,7 +171,7 @@ public class BlockingSubscriptionOverReactive implements SubscriptionModel, Intr
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         return new BlockingSubscriptionOverReactiveSubscription(subscriptionModel.resumeSubscription(subscriptionId));
     }
 
@@ -198,7 +198,7 @@ public class BlockingSubscriptionOverReactive implements SubscriptionModel, Intr
     }
 
     private record BlockingSubscriptionOverReactiveSubscription(
-            org.occurrent.subscription.api.reactor.Subscription subscription) implements Subscription {
+            org.occurrent.subscription.api.reactor.SubscriptionHandle subscription) implements SubscriptionHandle {
 
         private BlockingSubscriptionOverReactiveSubscription {
             requireNonNull(subscription, "Reactive subscription cannot be null");

--- a/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
+++ b/tck/subscription-reactor/src/main/java/org/occurrent/tck/subscription/reactor/ReactiveSubscriptionModelConformance.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import org.occurrent.tck.ConformanceEvents;
 import org.occurrent.tck.FailureNamesTheTestClass;
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Everything about what a model delivers, pauses, resumes and reports is asserted once, by the blocking suites running
  * over {@link BlockingSubscriptionOverReactive}, rather than described a second time in terms of {@code Mono}. What
  * that cannot reach is the reactor API's two publishers, the {@code Mono<Void>} an action returns, which the
- * <em>model</em> subscribes to, and {@link Subscription#waitUntilStarted()}. A model can get both wrong and still
+ * <em>model</em> subscribes to, and {@link SubscriptionHandle#waitUntilStarted()}. A model can get both wrong and still
  * pass every bridged suite, because the bridge's own action has already run by the time it hands back a {@code Mono},
  * whether or not anything subscribes to it, and the bridge blocks either way.
  * <p>
@@ -54,7 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>An action whose {@code Mono} errors must fail through the model's own error path, the same path the blocking
  *       fixture declares as retry-or-propagate. A model that lets it detonate somewhere unrelated, or that stops
  *       itself, turns one failed delivery into an outage.</li>
- *   <li>{@link Subscription#waitUntilStarted()} is promised to answer, and callers gate application startup on it. One
+ *   <li>{@link SubscriptionHandle#waitUntilStarted()} is promised to answer, and callers gate application startup on it. One
  *       that never completes hangs the caller. One that consumes its answer on first use never answers a second
  *       caller.</li>
  *   <li>Disposing a wait is a caller giving up on waiting, not on the subscription. A model that tears anything down
@@ -115,7 +115,7 @@ public abstract class ReactiveSubscriptionModelConformance {
         @Test
         void the_work_inside_the_actions_mono_runs_for_a_delivered_event() {
             RecordedEvents recorded = new RecordedEvents();
-            Subscription subscription = model().subscribe(SUBSCRIPTION,
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION,
                     cloudEvent -> Mono.fromRunnable(() -> recorded.accept(cloudEvent)));
             awaitStarted(subscription);
 
@@ -130,7 +130,7 @@ public abstract class ReactiveSubscriptionModelConformance {
         @Test
         void subscribing_alone_runs_no_action() {
             AtomicBoolean ran = new AtomicBoolean();
-            Subscription subscription = model().subscribe(SUBSCRIPTION,
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION,
                     cloudEvent -> Mono.fromRunnable(() -> ran.set(true)));
             awaitStarted(subscription);
 
@@ -146,7 +146,7 @@ public abstract class ReactiveSubscriptionModelConformance {
         void an_action_whose_mono_errors_fails_through_the_model_and_leaves_it_running() {
             RecordedEvents recorded = new RecordedEvents();
             AtomicBoolean failedOnce = new AtomicBoolean();
-            Subscription subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> {
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> {
                 if (failedOnce.compareAndSet(false, true)) {
                     return Mono.error(new IllegalStateException("simulated action failure"));
                 }
@@ -185,7 +185,7 @@ public abstract class ReactiveSubscriptionModelConformance {
 
         @Test
         void wait_until_started_answers_within_its_timeout() {
-            Subscription subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> Mono.empty());
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> Mono.empty());
 
             assertThat(subscription.waitUntilStarted(timeout()).block())
                     .as("waitUntilStarted is promised to answer, and callers gate startup on it")
@@ -194,7 +194,7 @@ public abstract class ReactiveSubscriptionModelConformance {
 
         @Test
         void asking_twice_answers_twice() {
-            Subscription subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> Mono.empty());
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION, cloudEvent -> Mono.empty());
             awaitStarted(subscription);
 
             assertThat(subscription.waitUntilStarted(timeout()).block())
@@ -205,7 +205,7 @@ public abstract class ReactiveSubscriptionModelConformance {
         @Test
         void disposing_a_wait_leaves_the_subscription_working() {
             RecordedEvents recorded = new RecordedEvents();
-            Subscription subscription = model().subscribe(SUBSCRIPTION,
+            SubscriptionHandle subscription = model().subscribe(SUBSCRIPTION,
                     cloudEvent -> Mono.fromRunnable(() -> recorded.accept(cloudEvent)));
 
             Disposable abandonedWait = subscription.waitUntilStarted().subscribe();
@@ -231,7 +231,7 @@ public abstract class ReactiveSubscriptionModelConformance {
         return requireNonNull(fixture, "fixture is not initialized");
     }
 
-    private void awaitStarted(Subscription subscription) {
+    private void awaitStarted(SubscriptionHandle subscription) {
         Boolean started = subscription.waitUntilStarted(timeout()).block();
         assertThat(started)
                 .as("the subscription must report started before the test can mean anything")

--- a/tck/subscription-reactor/src/test/java/org/occurrent/tck/subscription/reactor/NoopReactiveSubscriptionModel.java
+++ b/tck/subscription-reactor/src/test/java/org/occurrent/tck/subscription/reactor/NoopReactiveSubscriptionModel.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Mono;
 
@@ -42,7 +42,7 @@ final class NoopReactiveSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         throw honoursNothing();
     }
 
@@ -52,7 +52,7 @@ final class NoopReactiveSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         throw honoursNothing();
     }
 

--- a/tck/subscription-reactor/src/test/java/org/occurrent/tck/subscription/reactor/WorkingReactiveSubscriptionModel.java
+++ b/tck/subscription-reactor/src/test/java/org/occurrent/tck/subscription/reactor/WorkingReactiveSubscriptionModel.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.SubscriptionFilter;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModel;
 import reactor.core.publisher.Mono;
 
@@ -58,12 +58,12 @@ final class WorkingReactiveSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
+    public SubscriptionHandle subscribe(String subscriptionId, @Nullable SubscriptionFilter filter, StartAt startAt, Function<CloudEvent, Mono<Void>> action) {
         if (running.containsKey(subscriptionId) || paused.containsKey(subscriptionId)) {
             throw new IllegalArgumentException("Subscription " + subscriptionId + " is already defined.");
         }
         running.put(subscriptionId, action);
-        return new Subscription() {
+        return new SubscriptionHandle() {
             @Override
             public String id() {
                 return subscriptionId;
@@ -88,7 +88,7 @@ final class WorkingReactiveSubscriptionModel implements SubscriptionModel {
     }
 
     @Override
-    public Subscription resumeSubscription(String subscriptionId) {
+    public SubscriptionHandle resumeSubscription(String subscriptionId) {
         Function<CloudEvent, Mono<Void>> action = paused.remove(subscriptionId);
         if (action == null) {
             throw new IllegalArgumentException("Subscription " + subscriptionId + " isn't paused.");

--- a/testing/junit-jupiter-blocking/src/main/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtension.java
+++ b/testing/junit-jupiter-blocking/src/main/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtension.java
@@ -24,7 +24,7 @@ import org.occurrent.subscription.SubscriptionAlreadyRunningException;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModelLifeCycle;
 
 import java.time.Duration;
@@ -229,12 +229,12 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
      * Start one subscription and block until it is actually listening, so a write that follows cannot outrun it.
      *
      * @param subscriptionId the id of a currently stopped subscription, must not be {@code null}
-     * @return the running {@link Subscription}
+     * @return the running {@link SubscriptionHandle}
      * @throws UnknownSubscriptionException        if no model has a subscription with that id
      * @throws SubscriptionAlreadyRunningException if the model that has it reports it is already running
      * @throws IllegalStateException               if it does not start within {@link #withStartTimeout(Duration)}
      */
-    public Subscription start(String subscriptionId) {
+    public SubscriptionHandle start(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId must not be null");
         return resumeAndWait(subscriptionId);
     }
@@ -262,11 +262,11 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
     // A model that does not have the id says so with UnknownSubscriptionException, which is the one refusal worth
     // searching past. Every other refusal comes from the model that does own the id, so it is the answer rather than
     // something to keep looking behind.
-    private Subscription resumeAndWait(String subscriptionId) {
+    private SubscriptionHandle resumeAndWait(String subscriptionId) {
         List<UnknownSubscriptionException> notHere = new ArrayList<>();
         for (SubscriptionModelLifeCycle model : subscriptionModels) {
             try {
-                Subscription subscription = model.resumeSubscription(subscriptionId);
+                SubscriptionHandle subscription = model.resumeSubscription(subscriptionId);
                 knownIds.add(subscriptionId);
                 // Bounded rather than waitUntilStarted(), whose no-argument form waits forever. beforeEach runs this
                 // for every alwaysStart id, so a subscription that never starts would hang the run rather than fail

--- a/testing/junit-jupiter-blocking/src/test/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtensionTest.java
+++ b/testing/junit-jupiter-blocking/src/test/java/org/occurrent/testing/junit/blocking/OccurrentSubscriptionsExtensionTest.java
@@ -26,7 +26,7 @@ import org.occurrent.eventstore.inmemory.InMemoryEventStore;
 import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
-import org.occurrent.subscription.api.blocking.Subscription;
+import org.occurrent.subscription.api.blocking.SubscriptionHandle;
 import org.occurrent.subscription.api.blocking.SubscriptionModelLifeCycle;
 import org.occurrent.subscription.inmemory.InMemorySubscriptionModel;
 import org.occurrent.subscription.synchronous.blocking.SynchronousSubscriptionModel;
@@ -348,7 +348,7 @@ class OccurrentSubscriptionsExtensionTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new AssertionError("resumeSubscription must not be reached when the model cannot be enumerated");
         }
 
@@ -468,10 +468,10 @@ class OccurrentSubscriptionsExtensionTest {
                 .hasMessageContaining("positive");
     }
 
-    // A subscription whose Subscription never reports started, so resumeAndWait's bounded wait is what has to save
+    // A subscription whose SubscriptionHandle never reports started, so resumeAndWait's bounded wait is what has to save
     // the test from hanging rather than the id lookup or the model's own resumeSubscription.
     private static SubscriptionModelLifeCycle neverStartingModel() {
-        Subscription neverStartingSubscription = new Subscription() {
+        SubscriptionHandle neverStartingSubscription = new SubscriptionHandle() {
             @Override
             public String id() {
                 return "orders";

--- a/testing/junit-jupiter-reactor/src/main/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtension.java
+++ b/testing/junit-jupiter-reactor/src/main/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtension.java
@@ -24,7 +24,7 @@ import org.occurrent.subscription.SubscriptionAlreadyRunningException;
 import org.occurrent.subscription.UnknownSubscriptionException;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.api.reactor.IntrospectableSubscriptions;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModelLifeCycle;
 
 import java.time.Duration;
@@ -39,7 +39,7 @@ import java.util.*;
  * class started would otherwise still be running for the next.
  * <p>
  * <strong>Two differences from the blocking twin, both forced by the reactive types.</strong> Resuming a subscription
- * waits on {@link Subscription#waitUntilStarted()}, and clearing a checkpoint waits on
+ * waits on {@link SubscriptionHandle#waitUntilStarted()}, and clearing a checkpoint waits on
  * {@link CheckpointStorage#delete(String)}, both of which return a {@code Mono} rather than blocking the calling
  * thread. A JUnit {@code beforeEach} is synchronous, so this extension blocks on them itself, bounded by
  * {@link #withStartTimeout(Duration)} rather than waiting forever, instead of asking every test to. And there is no
@@ -243,12 +243,12 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
      * Start one subscription and block until it is actually listening, so a write that follows cannot outrun it.
      *
      * @param subscriptionId the id of a currently stopped subscription, must not be {@code null}
-     * @return the running {@link Subscription}
+     * @return the running {@link SubscriptionHandle}
      * @throws UnknownSubscriptionException        if no model has a subscription with that id
      * @throws SubscriptionAlreadyRunningException if the model that has it reports it is already running
      * @throws IllegalStateException               if it does not start within {@link #withStartTimeout(Duration)}
      */
-    public Subscription start(String subscriptionId) {
+    public SubscriptionHandle start(String subscriptionId) {
         Objects.requireNonNull(subscriptionId, "subscriptionId must not be null");
         return resumeAndWait(subscriptionId);
     }
@@ -276,11 +276,11 @@ public final class OccurrentSubscriptionsExtension implements BeforeEachCallback
     // A model that does not have the id says so with UnknownSubscriptionException, which is the one refusal worth
     // searching past. Every other refusal comes from the model that does own the id, so it is the answer rather than
     // something to keep looking behind.
-    private Subscription resumeAndWait(String subscriptionId) {
+    private SubscriptionHandle resumeAndWait(String subscriptionId) {
         List<UnknownSubscriptionException> notHere = new ArrayList<>();
         for (SubscriptionModelLifeCycle model : subscriptionModels) {
             try {
-                Subscription subscription = model.resumeSubscription(subscriptionId);
+                SubscriptionHandle subscription = model.resumeSubscription(subscriptionId);
                 knownIds.add(subscriptionId);
                 // waitUntilStarted(startTimeout) already resolves within startTimeout by its own internal timeout(),
                 // so block() here needs no separate deadline of its own; giving it one too would race the two clocks

--- a/testing/junit-jupiter-reactor/src/test/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtensionTest.java
+++ b/testing/junit-jupiter-reactor/src/test/java/org/occurrent/testing/junit/reactor/OccurrentSubscriptionsExtensionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.occurrent.subscription.Checkpoint;
 import org.occurrent.subscription.CheckpointWriteCondition;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
-import org.occurrent.subscription.api.reactor.Subscription;
+import org.occurrent.subscription.api.reactor.SubscriptionHandle;
 import org.occurrent.subscription.api.reactor.SubscriptionModelLifeCycle;
 import org.occurrent.subscription.synchronous.reactor.SynchronousSubscriptionModel;
 import reactor.core.publisher.Mono;
@@ -392,10 +392,10 @@ class OccurrentSubscriptionsExtensionTest {
         model.shutdown();
     }
 
-    // A subscription whose Subscription never reports started, so resumeAndWait's bounded wait is what has to save
+    // A subscription whose SubscriptionHandle never reports started, so resumeAndWait's bounded wait is what has to save
     // the test from hanging rather than the id lookup or the model's own resumeSubscription.
     private static SubscriptionModelLifeCycle neverStartingModel() {
-        Subscription neverStartingSubscription = new Subscription() {
+        SubscriptionHandle neverStartingSubscription = new SubscriptionHandle() {
             @Override
             public String id() {
                 return "orders";
@@ -444,7 +444,7 @@ class OccurrentSubscriptionsExtensionTest {
         }
 
         @Override
-        public Subscription resumeSubscription(String subscriptionId) {
+        public SubscriptionHandle resumeSubscription(String subscriptionId) {
             throw new AssertionError("resumeSubscription must not be reached when the model cannot be enumerated");
         }
 


### PR DESCRIPTION
I renamed `org.occurrent.subscription.api.blocking.Subscription` and its reactor twin to `SubscriptionHandle`. The type is what a caller holds after starting a subscription, not the subscription itself, and the old name said the opposite. See [ADR 127](doc/architecture/decisions/0127-a-subscription-is-a-descriptor-and-the-annotation-stops-naming-the-concept.md) decision 2.

This is a plain type rename with no signature or behavior change. I shipped a declarative `ChangeType` recipe (`rewrite/src/main/resources/META-INF/rewrite/renames-subscription-handle-0_35.yml`) alongside it, wired into `UpgradeToOccurrent_0_35`, following the pattern `renames-0_33.yml` already set for five subscription interfaces. I also added a migration guide section, [section 2 of the 0.35.0 upgrade guide](doc/migration/upgrading-to-0.35.0.md#2-subscription-becomes-subscriptionhandle).

The `changelog.md` entry isn't in this PR since a sibling branch is cutting 0.34.0 and would publish it as a 0.34.0 release note for an API that release doesn't contain. It lands after that tag.

A mechanical rename that only touches the API type sounds like it should be a pure text substitution, and my first pass treated it that way. It wasn't. The word "Subscription" carries three separate meanings in this codebase. There's the API type this PR renames, an unrelated annotation (`org.occurrent.annotation.Subscription`) that keeps its name, and plain prose referring to a subscription model as a concept. My first pass got three of each wrong, renaming `@Subscription` to a nonexistent `@SubscriptionHandle` in three places, and rewriting three javadoc lines that meant "this subscription model" into sentences naming the handle type instead. Every one of those compiled fine, since a broken javadoc reference or a slightly-wrong sentence doesn't fail a build. Both classes were caught only by review, not by the compiler, and both are fixed now. That's the concrete case for [#721](https://github.com/johanhaleby/occurrent/issues/721). The collision isn't a style complaint, it's a defect generator, and this rename produced instances of it while fixing the original one.
