### PR TITLE
View.create and Kotlin's view(...) still required null for the state the other DSLs no longer do

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -97,6 +97,7 @@
   * The fix is the same on both. `DropRedundantYamlProperty` and `MigrateSubscriptionEnabledInYaml` are small imperative recipes, one no-arg subclass per property pair or per boolean, that re-check the specific `Yaml.Document` before rewriting it. The shipped recipe ids are unchanged, and the `.properties` half was never affected, since a `.properties` file has no multi-document concept for the bug to exploit.
 * **`Projection.builder()`, `Projection.singletonBuilder()`, `Saga.builder()` and `SnapshotView.builder()` gain a no-argument overload**, the shape `FlowSaga.builder()` already had. Call it instead of passing `null` when a fold starts from no state, the common case since most folds build their first state in the handler for the first event. Resolves [#956](https://github.com/johanhaleby/occurrent/issues/956).
   * Kotlin's `projection { }`, `singletonProjection { }`, `saga { }` and `snapshotView { }` gain the same no-argument form, matching the flow DSL's `saga { }`.
+  * `View.create(BiFunction)` and `View.create(Fold)` gain the same no-argument form in Java, and Kotlin's `view { }` overloads gain it too. Kotlin's forces the block and the returned `View` to a nullable state (`S?`), so a handler that assumes a non-null state fails to compile instead of throwing on the first event. Java has no way to express that distinction, so it stays as unchecked as `builder(null)` always was.
 
 #### Breaking changes
 

--- a/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
+++ b/dsl/view-dsl/src/main/java/org/occurrent/dsl/view/View.java
@@ -165,6 +165,14 @@ public interface View<S extends @Nullable Object, E> {
     }
 
     /**
+     * Creates a {@code View} whose fold begins from no state. The state stays {@code null} until {@code evolve}
+     * replaces it. See {@link #create(Object, BiFunction)} for the fold.
+     */
+    static <S extends @Nullable Object, E> View<S, E> create(@NonNull BiFunction<S, E, S> evolve) {
+        return create(null, evolve);
+    }
+
+    /**
      * Creates a metadata-aware view from a three-argument {@link Fold}. Its {@link #evolve(Object, EventMetadata, Object)}
      * applies the fold with the event's metadata, and its metadata-less {@link #evolve(Object, Object)} applies the fold
      * with {@link EventMetadata#empty()}, so the same fold drives both the CloudEvent-fed paths (with real metadata) and
@@ -187,5 +195,13 @@ public interface View<S extends @Nullable Object, E> {
                 return fold.evolve(state, metadata, event);
             }
         };
+    }
+
+    /**
+     * Creates a metadata-aware {@code View} (see {@link #create(Object, Fold)}) whose fold begins from no state.
+     * The state stays {@code null} until {@code fold} replaces it.
+     */
+    static <S extends @Nullable Object, E> View<S, E> create(@NonNull Fold<S, E> fold) {
+        return create(null, fold);
     }
 }

--- a/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/ViewExtensions.kt
+++ b/dsl/view-dsl/src/main/kotlin/org/occurrent/dsl/view/ViewExtensions.kt
@@ -22,12 +22,25 @@ import org.occurrent.cloudevents.EventMetadata
 fun <S, E : Any> view(initialState: S, updateState: (S, E) -> S): View<S, E> = View.create(initialState, updateState)
 
 /**
+ * Builds a [View] whose fold begins from no state. The block and the returned `View` see `S?` rather than `S`,
+ * since the fold starts from `null` until `updateState` replaces it. See [view] for the fold.
+ */
+fun <S, E : Any> view(updateState: (S?, E) -> S?): View<S?, E> = view(null, updateState)
+
+/**
  * Builds a metadata-aware [View]: the fold sees the event's [EventMetadata] (stream id and version, global position,
  * DCB tags, CloudEvent extensions) as well as the event. Metadata is only available on the CloudEvent-fed paths; the
  * query/replay `evolve` overloads fold with [EventMetadata.empty].
  */
 fun <S, E : Any> view(initialState: S, updateState: (S, EventMetadata, E) -> S): View<S, E> =
     View.create(initialState, View.Fold { state, metadata, event -> updateState(state, metadata, event) })
+
+/**
+ * Builds a metadata-aware [View] whose fold begins from no state. The block and the returned `View` see `S?`
+ * rather than `S`, since the fold starts from `null` until `updateState` replaces it. See [view] for what
+ * metadata-aware means.
+ */
+fun <S, E : Any> view(updateState: (S?, EventMetadata, E) -> S?): View<S?, E> = view(null, updateState)
 
 // =========================
 // Single event (convenience)

--- a/dsl/view-dsl/src/test/java/org/occurrent/dsl/view/ViewMetadataTest.java
+++ b/dsl/view-dsl/src/test/java/org/occurrent/dsl/view/ViewMetadataTest.java
@@ -113,4 +113,22 @@ class ViewMetadataTest {
             assertThat(store).containsEntry("a", 2);
         }
     }
+
+    @Nested
+    class NoArgCreate {
+
+        @Test
+        void create_with_no_argument_starts_from_null_like_create_of_null() {
+            View<Boolean, Registered> view = View.create((state, event) -> !state);
+
+            assertThat(view.initialState()).isNull();
+        }
+
+        @Test
+        void metadata_aware_create_with_no_argument_starts_from_null_like_create_of_null() {
+            View<Long, Registered> view = View.create((Long state, EventMetadata m, Registered event) -> m.getPosition());
+
+            assertThat(view.initialState()).isNull();
+        }
+    }
 }

--- a/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/ViewTest.kt
+++ b/dsl/view-dsl/src/test/kotlin/org/occurrent/dsl/view/ViewTest.kt
@@ -523,4 +523,28 @@ class ViewTest {
         }
 
     }
+
+    @Nested
+    inner class NoArgDsl {
+
+        @Test
+        fun `view with no argument starts from null like initialState null`() {
+            // A witness with no ? still receives a nullable state, since the no-argument overload forces S?.
+            val view = view<NameState, DomainEvent> { s, e ->
+                when (e) {
+                    is NameDefined -> NameState(e.userId(), e.name)
+                    is NameWasChanged -> s?.copy(name = e.name)
+                }
+            }
+
+            assertThat(view.initialState()).isNull()
+        }
+
+        @Test
+        fun `metadata-aware view with no argument starts from null like initialState null`() {
+            val view = view<Long, DomainEvent> { s, metadata, _ -> metadata.position ?: s }
+
+            assertThat(view.initialState()).isNull()
+        }
+    }
 }


### PR DESCRIPTION
Part of #956.

`View.create(BiFunction)`, `View.create(Fold)` and Kotlin's two `view(...)` overloads all still take an explicit initial state, the same as `Projection.builder(S)`, `Saga.builder(S)` and `SnapshotView.builder(S)` before #958, and `projection(initialState, block)` and friends before #960.

I checked whether these four entry points are new this release or already shipped, since it decides whether this gets its own changelog entry or joins the existing one. Both `View.create` overloads and both `view(...)` overloads are unchanged since `occurrent-0.33.0`, same line numbers and all, so I added this to the existing entry rather than starting a new one.

Added a no-argument overload to each of the four, delegating to the existing one with `null`.

On the Kotlin side I did not use the `@Suppress("UNCHECKED_CAST")` pattern the review caught on #960. I probed the compiler on a scratch file before writing the real overload, the same way as last time. A plain `S` no-argument overload compiles a handler that treats state as non-null, then throws on the first event. So both `view(...)` overloads expose the block and the returned `View` as `S?` rather than `S`, no cast needed, confirmed the same probe now refuses to compile the unsafe handler. Java has no way to express that distinction, so `View.create`'s two new overloads stay a plain no-argument form, matching what #958 shipped for the other three.

One test per overload, in each file's existing convention. `ViewMetadataTest` gets a new `NoArgCreate` nested class for the two Java overloads, `ViewTest.kt` gets a new `NoArgDsl` nested class for the two Kotlin ones, each using a plain (non-`?`) witness with a null-safe handler so the passing test demonstrates the forced nullability rather than sidestepping it.

Verification, same colima workaround as the last two rounds:
- `mvn -pl dsl/view-dsl -am test`: 79 tests, 0 failures

The two remaining `view(initialState = null)` examples in `pages/docs/docs.md` are on the held branch at occurrent-org/occurrent-org.github.io#79, the same branch #958 and #960 already used. #956 stays open until that branch merges.
