### PR TITLE
A losing registration frees the winner's id, and a rescan registers handlers nothing checked

### DIFF
--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -356,8 +356,8 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         boolean registeredAnything = !subscriptionMethods.isEmpty() || !projectionMethods.isEmpty()
                 || !snapshotMethods.isEmpty() || !sagaMethods.isEmpty() || !beansToBuild.isEmpty();
         // Only a handler the loop above collected registers, which is what keeps every id going through
-        // claimSubscriptionId. The register step reads the bean's class again, and by then the bean exists, so that
-        // class can declare a handler the collecting pass never saw. Registering it here would take its id without
+        // claimSubscriptionId. The register step resolves the bean again, and the object it gets back can be of a
+        // class declaring a handler the collecting pass never saw. Registering that one would take its id without
         // checking it. It is left for the next pass instead, which collects it from the now recorded class.
         //
         // Marking happens after the registration it stands for, never before. A registration that throws while a

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/OccurrentBlockingAnnotationBeanPostProcessor.java
@@ -42,6 +42,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,8 +66,8 @@ import java.util.function.Supplier;
 class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware, SmartInitializingSingleton, DisposableBean {
 
     private ApplicationContext applicationContext;
-    // One shared duplicate-id registry across every registrar: all subscription ids are collected before projections,
-    // snapshots and sagas each check-and-add against it.
+    // Every id a registration holds, added by this class and by nothing else. All subscription ids are collected
+    // before projections, snapshots and sagas each add against it.
     private final Set<String> registeredIds = ConcurrentHashMap.newKeySet();
     // The class the container actually built for a bean, recorded as the container hands the object over. This is
     // the only source that cannot fall short of the real class, see resolveScanType below for why the prediction
@@ -115,9 +116,9 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         this.applicationContext = applicationContext;
         StartPositionSupport startPositionSupport = new StartPositionSupport(applicationContext);
         this.subscriptionRegistrar = new SubscriptionAnnotationRegistrar(applicationContext, startPositionSupport);
-        this.projectionRegistrar = new ProjectionAnnotationRegistrar(applicationContext, startPositionSupport, registeredIds);
-        this.snapshotRegistrar = new SnapshotAnnotationRegistrar(applicationContext, startPositionSupport, registeredIds);
-        this.sagaRegistrar = new SagaAnnotationRegistrar(applicationContext, startPositionSupport, registeredIds);
+        this.projectionRegistrar = new ProjectionAnnotationRegistrar(applicationContext, startPositionSupport);
+        this.snapshotRegistrar = new SnapshotAnnotationRegistrar(applicationContext, startPositionSupport);
+        this.sagaRegistrar = new SagaAnnotationRegistrar(applicationContext, startPositionSupport);
     }
 
     // The container hands over the raw instance here, before any proxy wraps it, so this is where a bean's real
@@ -294,9 +295,10 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         // though it stays in registeredIds for duplicate detection.
         // CheckpointStorageCannotFenceSubscriptionException's javadoc says exactly which ids that is.
         Set<String> idsToCheck = new HashSet<>();
-        // Iteration order of getBeanDefinitionNames() is deterministic, so a LinkedHashSet keeps registration order
-        // reproducible across runs.
-        Set<String> subscriptionBeanNames = new LinkedHashSet<>();
+        // The subscription handler methods this pass read and validated, per bean, and the only methods the
+        // registration below registers. Iteration order of getBeanDefinitionNames() is deterministic, so a
+        // LinkedHashMap keeps registration order reproducible across runs.
+        Map<String, List<Method>> subscriptionMethods = new LinkedHashMap<>();
         // Beans whose class is only predicted and whose prediction shows an annotation. Built at the end of this
         // pass so the next one can read their real class.
         Set<String> beansToBuild = new LinkedHashSet<>();
@@ -325,7 +327,7 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
                 if (isAlreadyRegistered(beanName, method)) {
                     continue;
                 }
-                collectSubscriptionId(beanName, method, idsToCheck, subscriptionBeanNames);
+                collectSubscriptionMethod(beanName, method, idsToCheck, subscriptionMethods);
                 refuseMoreThanOneHandlerAnnotation(type, method);
                 org.occurrent.annotation.Projection projection = AnnotationUtils.findAnnotation(method, org.occurrent.annotation.Projection.class);
                 if (projection != null) {
@@ -351,7 +353,7 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
                 }
             }
         }
-        boolean registeredAnything = !subscriptionBeanNames.isEmpty() || !projectionMethods.isEmpty()
+        boolean registeredAnything = !subscriptionMethods.isEmpty() || !projectionMethods.isEmpty()
                 || !snapshotMethods.isEmpty() || !sagaMethods.isEmpty() || !beansToBuild.isEmpty();
         // Only a handler the loop above collected registers, which is what keeps every id going through
         // claimSubscriptionId. The register step reads the bean's class again, and by then the bean exists, so that
@@ -371,12 +373,13 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
         if (!mayBlockForReplay) {
             CheckpointFencingConfigurationCheck.check(applicationContext, idsToCheck);
         }
-        for (String beanName : subscriptionBeanNames) {
+        for (Map.Entry<String, List<Method>> staged : subscriptionMethods.entrySet()) {
+            String beanName = staged.getKey();
             Object bean = beanResolver.apply(beanName);
-            // The class of the instance just resolved, not another lookup by name. A non-singleton bean is a new
-            // instance here, and a factory that can return different implementations would otherwise have this
-            // register one implementation's methods against another's instance.
-            subscriptionRegistrar.registerSubscriptions(bean, userClassOf(bean), handlerTargets.apply(beanName, bean), mayBlockForReplay,
+            // The methods the loop above read, never a fresh scan of the resolved instance. A non-singleton bean
+            // is a new instance here, and a factory free to return a different implementation would otherwise have
+            // this register a method whose id went through no duplicate check and no refusal.
+            subscriptionRegistrar.registerSubscriptions(bean, staged.getValue(), handlerTargets.apply(beanName, bean), mayBlockForReplay,
                     method -> markRegistered(beanName, method),
                     this::claimSubscriptionId,
                     method -> registeredHandlers.remove(handlerKey(beanName, method)),
@@ -386,23 +389,35 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
             CheckpointFencingConfigurationCheck.check(applicationContext, idsToCheck);
         }
         for (Object[] pm : projectionMethods) {
-            if (markRegistered((String) pm[0], (Method) pm[1])) {
-                registerDescriptor((String) pm[0], (Method) pm[1], ((org.occurrent.annotation.Projection) pm[2]).id(),
-                        () -> projectionRegistrar.processProjectionAnnotation(beanResolver.apply((String) pm[0]), (Method) pm[1], (org.occurrent.annotation.Projection) pm[2]));
+            String beanName = (String) pm[0];
+            Method method = (Method) pm[1];
+            org.occurrent.annotation.Projection projection = (org.occurrent.annotation.Projection) pm[2];
+            if (markRegistered(beanName, method)) {
+                registerDescriptor(beanName, method, projection.id(),
+                        "Duplicate subscription/projection id '%s' (used by @Projection on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(projection.id(), method.getDeclaringClass().getName(), method.getName()),
+                        () -> projectionRegistrar.processProjectionAnnotation(beanResolver.apply(beanName), method, projection));
             }
         }
         // Catch up each domain-push feed once, after all its projections are registered.
         projectionRegistrar.catchUpCollectedFeeds();
         for (Object[] sm : snapshotMethods) {
-            if (markRegistered((String) sm[0], (Method) sm[1])) {
-                registerDescriptor((String) sm[0], (Method) sm[1], ((org.occurrent.annotation.Snapshot) sm[2]).id(),
-                        () -> snapshotRegistrar.processSnapshotAnnotation(beanResolver.apply((String) sm[0]), (Method) sm[1], (org.occurrent.annotation.Snapshot) sm[2]));
+            String beanName = (String) sm[0];
+            Method method = (Method) sm[1];
+            org.occurrent.annotation.Snapshot snapshot = (org.occurrent.annotation.Snapshot) sm[2];
+            if (markRegistered(beanName, method)) {
+                registerDescriptor(beanName, method, snapshot.id(),
+                        "Duplicate subscription/projection/snapshot id '%s' (used by @Snapshot on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(snapshot.id(), method.getDeclaringClass().getName(), method.getName()),
+                        () -> snapshotRegistrar.processSnapshotAnnotation(beanResolver.apply(beanName), method, snapshot));
             }
         }
         for (Object[] gm : sagaMethods) {
-            if (markRegistered((String) gm[0], (Method) gm[1])) {
-                registerDescriptor((String) gm[0], (Method) gm[1], ((org.occurrent.annotation.Saga) gm[2]).id(),
-                        () -> sagaRegistrar.processSagaAnnotation(beanResolver.apply((String) gm[0]), (Method) gm[1], (org.occurrent.annotation.Saga) gm[2]));
+            String beanName = (String) gm[0];
+            Method method = (Method) gm[1];
+            org.occurrent.annotation.Saga saga = (org.occurrent.annotation.Saga) gm[2];
+            if (markRegistered(beanName, method)) {
+                registerDescriptor(beanName, method, saga.id(),
+                        "Duplicate subscription/projection/snapshot/saga id '%s' (used by @Saga on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(saga.id(), method.getDeclaringClass().getName(), method.getName()),
+                        () -> sagaRegistrar.processSagaAnnotation(beanResolver.apply(beanName), method, saga));
             }
         }
         for (String beanName : beansToBuild) {
@@ -429,25 +444,22 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
     }
 
 
-    // The descriptor registrars claim their own id inside registeredIds before they do the rest of their work, so a
-    // failure part way through would otherwise leave the id claimed by a registration that never happened, and the
-    // bean's next creation attempt would be refused as a duplicate of itself. The claim is released here instead.
-    // A DuplicateSubscriptionIdException is the one failure that must not release, because the id it names belongs
-    // to whoever claimed it first and releasing would hand it away.
-    private void registerDescriptor(String beanName, Method method, String id, Runnable registration) {
-        // Whether this attempt is the one holding the id, read before it runs, rather than inferred afterwards from
-        // the exception. A descriptor registrar adds the id itself and then calls the subscription model, which can
-        // throw DuplicateSubscriptionIdException for a programmatic subscription already using that id, so the
-        // exception type says nothing about whose claim this is. Releasing on it regardless would hand away an id
-        // another registration owns, and never releasing would keep a claim this attempt made and leave the bean
-        // refused for ever once the real duplicate is gone.
-        boolean heldByAnother = registeredIds.contains(id);
+    // The add is what says this call holds the id, so the catch takes back an id this call put there and never one
+    // another registration did. Reading the set before the attempt cannot say that, because two registrations for
+    // the same id both read it as free and the one that lost the add then took the winner's id back out.
+    //
+    // A DuplicateSubscriptionIdException from inside the registration comes from the subscription model instead,
+    // for a programmatic subscription already on that id, and the id this call added is still this call's to take
+    // back.
+    private void registerDescriptor(String beanName, Method method, String id, String duplicateIdMessage, Runnable registration) {
+        if (!registeredIds.add(id)) {
+            registeredHandlers.remove(handlerKey(beanName, method));
+            throw new DuplicateSubscriptionIdException(id, duplicateIdMessage);
+        }
         try {
             registration.run();
         } catch (RuntimeException | Error e) {
-            if (!heldByAnother) {
-                registeredIds.remove(id);
-            }
+            registeredIds.remove(id);
             registeredHandlers.remove(handlerKey(beanName, method));
             throw e;
         }
@@ -577,34 +589,33 @@ class OccurrentBlockingAnnotationBeanPostProcessor implements BeanPostProcessor,
     }
 
     // Only the three that reach CheckpointStorage go into idsToCheck. @SynchronousSubscription writes no checkpoint
-    // at all, so its id is checked for duplicates only, never asked about by the fencing check. A bean with any
-    // of the four annotations goes into subscriptionBeanNames so registerSubscriptions runs for it exactly once.
+    // at all, so its id is checked for duplicates only, never asked about by the fencing check. A method carrying
+    // any of the four is staged once, so a method carrying two of them still reaches the registrar that names both
+    // in its refusal.
     //
     // The id is refused here when something else already holds it, and joins registeredIds only once its own
     // registration has succeeded. Refusing here is what the startup ordering used to give for free, since every
     // subscription id was collected before the first projection, snapshot or saga checked one out. A subscription
     // registering after startup arrives long after all of those, so without this check it would take an id one of
     // them already holds and write to the same durable checkpoint key.
-    private void collectSubscriptionId(String beanName, Method method, Set<String> idsToCheck, Set<String> subscriptionBeanNames) {
+    private void collectSubscriptionMethod(String beanName, Method method, Set<String> idsToCheck, Map<String, List<Method>> subscriptionMethods) {
         StreamSubscription s = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
+        Subscription a = AnnotationUtils.findAnnotation(method, Subscription.class);
+        DcbSubscription d = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
+        SynchronousSubscription sy = AnnotationUtils.findAnnotation(method, SynchronousSubscription.class);
         if (s != null) {
             idsToCheck.add(s.id());
-            subscriptionBeanNames.add(beanName);
         }
-        Subscription a = AnnotationUtils.findAnnotation(method, Subscription.class);
         if (a != null) {
             idsToCheck.add(a.id());
-            subscriptionBeanNames.add(beanName);
         }
-        DcbSubscription d = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
         if (d != null) {
             idsToCheck.add(d.id());
-            subscriptionBeanNames.add(beanName);
         }
-        SynchronousSubscription sy = AnnotationUtils.findAnnotation(method, SynchronousSubscription.class);
-        if (sy != null) {
-            subscriptionBeanNames.add(beanName);
+        if (s == null && a == null && d == null && sy == null) {
+            return;
         }
+        subscriptionMethods.computeIfAbsent(beanName, name -> new ArrayList<>()).add(method);
     }
 
     // Claiming writes to registeredIds itself rather than to anything held aside for the length of a scan, so a

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/ProjectionAnnotationRegistrar.java
@@ -49,7 +49,6 @@ import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.CatchupThenLiveOptions;
 import org.occurrent.subscription.DcbStartAt;
-import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
@@ -74,7 +73,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -98,7 +96,6 @@ class ProjectionAnnotationRegistrar {
 
     private final ApplicationContext applicationContext;
     private final StartPositionSupport startPositionSupport;
-    private final Set<String> registeredIds;
     // Resolves the competing-consumer strategy lazily, on the first checkpoint write a catch-up-then-push projection
     // makes, so this registrar does not force the strategy bean into existence while singletons are still being
     // instantiated (ADR 116).
@@ -142,10 +139,9 @@ class ProjectionAnnotationRegistrar {
     private record BackgroundCatchUp(Future<?> task, Runnable stop) {
     }
 
-    ProjectionAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport, Set<String> registeredIds) {
+    ProjectionAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport) {
         this.applicationContext = applicationContext;
         this.startPositionSupport = startPositionSupport;
-        this.registeredIds = registeredIds;
         this.writeVersionSource = new CompetingConsumerCheckpointWriteVersionSource(applicationContext.getBeanProvider(CompetingConsumerStrategy.class),
                 () -> CheckpointFencingConfigurationCheck.fenceCheckpoints(applicationContext.getBeanProvider(OccurrentProperties.class)));
     }
@@ -508,9 +504,6 @@ class ProjectionAnnotationRegistrar {
     @SuppressWarnings("unchecked")
     <E, S, ID> void processProjectionAnnotation(Object bean, Method method, org.occurrent.annotation.Projection annotation) {
         String id = annotation.id();
-        if (!registeredIds.add(id)) {
-            throw new DuplicateSubscriptionIdException(id, "Duplicate subscription/projection id '%s' (used by @Projection on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(id, bean.getClass().getName(), method.getName()));
-        }
         if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException("@Projection factory method %s#%s must take no parameters and return a Projection or DcbProjection.".formatted(bean.getClass().getName(), method.getName()));
         }

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrar.java
@@ -34,7 +34,6 @@ import org.occurrent.springboot.common.AsynchronousSubscribables;
 import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.springboot.common.PushCatchupStatusImpl;
 import org.occurrent.springboot.common.SubscriptionAnnotations;
-import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.blocking.CheckpointStorage;
 import org.occurrent.subscription.api.blocking.CompetingConsumerStrategy;
@@ -60,7 +59,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.BooleanSupplier;
@@ -78,7 +76,6 @@ class SagaAnnotationRegistrar {
 
     private final ApplicationContext applicationContext;
     private final StartPositionSupport startPositionSupport;
-    private final Set<String> registeredIds;
     // Resolves the competing-consumer strategy lazily, on the first checkpoint write a catch-up-then-push saga makes,
     // so this registrar does not force the strategy bean into existence while singletons are still being instantiated
     // (ADR 116). Separate from resolveSagaCompetingConsumerStrategy below, which gates the saga timer poller and is
@@ -98,10 +95,9 @@ class SagaAnnotationRegistrar {
     // registration that shutdown has begun even in principle.
     private volatile boolean closing = false;
 
-    SagaAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport, Set<String> registeredIds) {
+    SagaAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport) {
         this.applicationContext = applicationContext;
         this.startPositionSupport = startPositionSupport;
-        this.registeredIds = registeredIds;
         this.writeVersionSource = new CompetingConsumerCheckpointWriteVersionSource(applicationContext.getBeanProvider(CompetingConsumerStrategy.class),
                 () -> CheckpointFencingConfigurationCheck.fenceCheckpoints(applicationContext.getBeanProvider(OccurrentProperties.class)));
     }
@@ -112,9 +108,6 @@ class SagaAnnotationRegistrar {
     @SuppressWarnings("unchecked")
     <E, S, C> void processSagaAnnotation(Object bean, Method method, org.occurrent.annotation.Saga annotation) {
         String id = annotation.id();
-        if (!registeredIds.add(id)) {
-            throw new DuplicateSubscriptionIdException(id, "Duplicate subscription/projection/snapshot/saga id '%s' (used by @Saga on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(id, bean.getClass().getName(), method.getName()));
-        }
         if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException("@Saga factory method %s#%s must take no parameters and return a Saga.".formatted(bean.getClass().getName(), method.getName()));
         }

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SnapshotAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SnapshotAnnotationRegistrar.java
@@ -40,7 +40,6 @@ import org.occurrent.filter.internal.EventTypeExpansion;
 import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
-import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
@@ -50,7 +49,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.occurrent.subscription.StreamSubscriptionFilter.filter;
 
@@ -63,12 +61,10 @@ class SnapshotAnnotationRegistrar {
 
     private final ApplicationContext applicationContext;
     private final StartPositionSupport startPositionSupport;
-    private final Set<String> registeredIds;
 
-    SnapshotAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport, Set<String> registeredIds) {
+    SnapshotAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport) {
         this.applicationContext = applicationContext;
         this.startPositionSupport = startPositionSupport;
-        this.registeredIds = registeredIds;
     }
 
     // A @Snapshot maintains a per-stream, resume-ready snapshot: for each handled event it folds the event onto the
@@ -78,9 +74,6 @@ class SnapshotAnnotationRegistrar {
     @SuppressWarnings("unchecked")
     <E, S> void processSnapshotAnnotation(Object bean, Method method, org.occurrent.annotation.Snapshot annotation) {
         String id = annotation.id();
-        if (!registeredIds.add(id)) {
-            throw new DuplicateSubscriptionIdException(id, "Duplicate subscription/projection/snapshot id '%s' (used by @Snapshot on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(id, bean.getClass().getName(), method.getName()));
-        }
         if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException("@Snapshot factory method %s#%s must take no parameters and return a SnapshotView.".formatted(bean.getClass().getName(), method.getName()));
         }

--- a/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SubscriptionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/main/java/org/occurrent/springboot/blocking/SubscriptionAnnotationRegistrar.java
@@ -164,12 +164,12 @@ class SubscriptionAnnotationRegistrar {
         }
     }
 
-    // userClass, not bean.getClass(): bean is already the resolved proxy, and a JDK interface proxy's class
-    // implements only interfaces, so scanning it here would miss a method declared on the concrete class.
+    // The methods are the ones the caller read the annotations from and validated, handed over rather than read
+    // again here. The object the caller resolved may be of another class than the one it read them from, so
+    // scanning that object would take in a method that went through no duplicate check and no refusal.
     //
-    // shouldRegister decides per method, so a bean scanned a second time (its real class revealing a handler the
-    // first scan's predicted type did not declare) registers only what is new. The validation above every branch
-    // still runs for every method, since a misconfigured handler must fail whether or not it registers.
+    // reserveHandler decides per method, so a bean scanned a second time (its real class revealing a handler the
+    // first scan's predicted type did not declare) registers only what is new.
     // mayBlockForReplay is false for a bean the container is still building. Waiting there would run the whole
     // history replay inside that bean's creation callback, delivering to a handler on an object the context has not
     // published yet, so advice a later BeanPostProcessor adds is not on it. Not waiting lets creation finish
@@ -177,7 +177,7 @@ class SubscriptionAnnotationRegistrar {
     // A replay on its own thread can still deliver before creation finishes, which is the race the coordinator and
     // ADR 127 both describe. It also matches what WAIT_UNTIL_STARTED means, which is finishing before the
     // application is up, and the application is already up by the time a lazily built bean is asked for.
-    void registerSubscriptions(Object bean, Class<?> userClass, Supplier<Object> handlerTarget, boolean mayBlockForReplay,
+    void registerSubscriptions(Object bean, List<Method> methods, Supplier<Object> handlerTarget, boolean mayBlockForReplay,
                                Predicate<Method> reserveHandler, Consumer<String> claimId,
                                Consumer<Method> releaseHandler, Consumer<String> releaseId) {
         // Tracked apart, because a call can hold a handler reservation without holding the id. claimId throws when
@@ -188,7 +188,7 @@ class SubscriptionAnnotationRegistrar {
         List<PendingRegistration> claimedIds = new ArrayList<>();
         List<PendingRegistration> pending = new ArrayList<>();
         try {
-            claimAndValidate(bean, userClass, handlerTarget, reserveHandler, claimId, pending, reservedHandlers, claimedIds);
+            claimAndValidate(bean, methods, handlerTarget, reserveHandler, claimId, pending, reservedHandlers, claimedIds);
         } catch (RuntimeException | Error e) {
             claimedIds.forEach(h -> releaseId.accept(h.id()));
             reservedHandlers.forEach(h -> releaseHandler.accept(h.method()));
@@ -219,17 +219,17 @@ class SubscriptionAnnotationRegistrar {
     // cannot be registered means the first one never subscribes, rather than being live against a bean whose
     // creation is about to fail. What stays outside this is a failure from subscribe itself, a store refusing for
     // example, since undoing that one needs the subscription cancelled rather than never started.
-    private void claimAndValidate(Object bean, Class<?> userClass, Supplier<Object> handlerTarget, Predicate<Method> reserveHandler,
+    private void claimAndValidate(Object bean, List<Method> methods, Supplier<Object> handlerTarget, Predicate<Method> reserveHandler,
                                   Consumer<String> claimId, List<PendingRegistration> pending,
                                   List<PendingRegistration> reservedHandlers, List<PendingRegistration> claimedIds) {
-        for (Method method : userClass.getDeclaredMethods()) {
+        for (Method method : methods) {
             StreamSubscription streamSubscription = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
             Subscription subscription = AnnotationUtils.findAnnotation(method, Subscription.class);
             DcbSubscription dcbSubscription = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
             SynchronousSubscription synchronousSubscription = AnnotationUtils.findAnnotation(method, SynchronousSubscription.class);
             long annotationCount = Stream.of(streamSubscription, subscription, dcbSubscription, synchronousSubscription).filter(Objects::nonNull).count();
             if (annotationCount > 1) {
-                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription, @DcbSubscription and @SynchronousSubscription, use only one.".formatted(userClass.getName(), method.getName()));
+                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription, @DcbSubscription and @SynchronousSubscription, use only one.".formatted(method.getDeclaringClass().getName(), method.getName()));
             }
             // Reserving is a single atomic add rather than a check followed by an add, so two threads building
             // the same prototype cannot both find the handler free. The one that loses the reservation skips it

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/DescriptorIdClaimTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/DescriptorIdClaimTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.blocking;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.subscription.DuplicateSubscriptionIdException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A {@code @Projection}, {@code @Snapshot} or {@code @Saga} id is added to the coordinator's registry by one call, and the call that gets
+ * past that add is the only one entitled to take the id back out. Two registrations declaring the same id used to
+ * decide that by reading the registry before the attempt, which both of them read as free, so the one that lost the
+ * add took the winner's id back out and left the durable checkpoint key free for a third registration.
+ * <p>
+ * The window between that read and the add is the whole defect, and no context can stage it. In one thread a read
+ * of false is always followed by an add that succeeds, and nothing runs in between on either registration path.
+ * These tests drive the coordinator's own registration step instead, which is where the rule now lives, the same
+ * way {@code LateRegistrationConcurrencyContractTest} reads the coordinator directly for a hazard it cannot
+ * reproduce.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DescriptorIdClaimTest {
+
+    @Test
+    void a_descriptor_registration_takes_its_id_and_a_later_one_for_that_id_is_refused_without_the_id_being_given_back() throws Exception {
+        OccurrentBlockingAnnotationBeanPostProcessor coordinator = new OccurrentBlockingAnnotationBeanPostProcessor();
+
+        registerDescriptor(coordinator, "winner", "shared-id", () -> {
+        });
+
+        assertThat(registeredIds(coordinator)).contains("shared-id");
+        assertThatThrownBy(() -> registerDescriptor(coordinator, "loser", "shared-id", () -> {
+        }))
+                .isInstanceOf(DuplicateSubscriptionIdException.class)
+                .hasMessageContaining("Duplicate subscription/projection id 'shared-id'");
+        assertThat(registeredIds(coordinator)).describedAs("the id the first registration holds").contains("shared-id");
+    }
+
+    @Test
+    void a_descriptor_registration_that_fails_gives_back_the_id_it_took() throws Exception {
+        OccurrentBlockingAnnotationBeanPostProcessor coordinator = new OccurrentBlockingAnnotationBeanPostProcessor();
+
+        assertThatThrownBy(() -> registerDescriptor(coordinator, "failing", "released-id", () -> {
+            throw new IllegalStateException("the descriptor factory blew up");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(registeredIds(coordinator)).doesNotContain("released-id");
+    }
+
+    // Whatever a registrar spells the field, it has to be able to hold the registry to add to it, so a type check
+    // catches a second claim written under any name. Object is left out because a registrar legitimately holds a
+    // lock object and takes the bean as Object.
+    @Test
+    void no_registrar_can_hold_the_coordinators_id_registry() {
+        Class<?> registry = ConcurrentHashMap.newKeySet().getClass();
+        for (Class<?> registrar : List.of(SubscriptionAnnotationRegistrar.class, ProjectionAnnotationRegistrar.class,
+                SnapshotAnnotationRegistrar.class, SagaAnnotationRegistrar.class)) {
+            for (Field field : registrar.getDeclaredFields()) {
+                assertThat(canHold(field.getType(), registry))
+                        .describedAs("%s.%s can hold the id registry".formatted(registrar.getSimpleName(), field.getName()))
+                        .isFalse();
+            }
+            for (Constructor<?> constructor : registrar.getDeclaredConstructors()) {
+                for (Class<?> parameter : constructor.getParameterTypes()) {
+                    assertThat(canHold(parameter, registry))
+                            .describedAs("a %s constructor parameter can hold the id registry".formatted(registrar.getSimpleName()))
+                            .isFalse();
+                }
+            }
+            for (Method method : registrar.getDeclaredMethods()) {
+                for (Class<?> parameter : method.getParameterTypes()) {
+                    assertThat(canHold(parameter, registry))
+                            .describedAs("a parameter of %s.%s can hold the id registry".formatted(registrar.getSimpleName(), method.getName()))
+                            .isFalse();
+                }
+            }
+        }
+    }
+
+    private static boolean canHold(Class<?> type, Class<?> registry) {
+        return type != Object.class && type.isAssignableFrom(registry);
+    }
+
+    // registerDescriptor is private, and it has to be, since the id rule only holds while nothing else adds to the
+    // registry. Reaching it reflectively is what lets the rule be asserted at all.
+    private static void registerDescriptor(OccurrentBlockingAnnotationBeanPostProcessor coordinator, String beanName, String id, Runnable registration) {
+        try {
+            Method method = OccurrentBlockingAnnotationBeanPostProcessor.class.getDeclaredMethod(
+                    "registerDescriptor", String.class, Method.class, String.class, String.class, Runnable.class);
+            method.setAccessible(true);
+            Method anyHandlerMethod = DescriptorIdClaimTest.class.getDeclaredMethod("canHold", Class.class, Class.class);
+            method.invoke(coordinator, beanName, anyHandlerMethod, id,
+                    "Duplicate subscription/projection id '%s', each id must be unique because it is the durable checkpoint key.".formatted(id),
+                    registration);
+        } catch (InvocationTargetException e) {
+            throw e.getCause() instanceof RuntimeException cause ? cause : new IllegalStateException(e.getCause());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> registeredIds(OccurrentBlockingAnnotationBeanPostProcessor coordinator) throws Exception {
+        Field field = OccurrentBlockingAnnotationBeanPostProcessor.class.getDeclaredField("registeredIds");
+        field.setAccessible(true);
+        return (Set<String>) field.get(coordinator);
+    }
+}

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrarTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/SagaAnnotationRegistrarTest.java
@@ -39,7 +39,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,7 +106,7 @@ class SagaAnnotationRegistrarTest {
         when(applicationContext.getBeanProvider(CompetingConsumerStrategy.class)).thenReturn(strategyProvider);
 
         StartPositionSupport startPositionSupport = new StartPositionSupport(applicationContext);
-        SagaAnnotationRegistrar registrar = new SagaAnnotationRegistrar(applicationContext, startPositionSupport, new HashSet<>());
+        SagaAnnotationRegistrar registrar = new SagaAnnotationRegistrar(applicationContext, startPositionSupport);
 
         Method factoryMethod = SagaHolder.class.getDeclaredMethod("saga");
         org.occurrent.annotation.Saga annotation = factoryMethod.getAnnotation(org.occurrent.annotation.Saga.class);

--- a/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/StagedSubscriptionMethodRegistrationTest.java
+++ b/framework/spring-boot-autoconfigure/blocking/src/test/java/org/occurrent/springboot/blocking/StagedSubscriptionMethodRegistrationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.blocking;
+
+import io.cloudevents.CloudEvent;
+import kotlin.jvm.functions.Function2;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.annotation.Subscription;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.subscription.blocking.Subscriptions;
+import org.occurrent.springboot.common.OccurrentProperties;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The scan reads a bean's handler methods from the class the container recorded for it, checks their ids for
+ * duplicates and refuses a method carrying two annotations, and then resolves the bean again to register them. A
+ * prototype whose factory method is free to return a different implementation makes those two classes differ, so
+ * registering whatever the resolved instance happens to declare would take in a handler that went through neither
+ * check, and its handler key would then make the next pass skip it, so nothing recovers the checks it missed.
+ * <p>
+ * Registration therefore acts on the methods the scan staged. Reproduced without a running store (no Docker).
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StagedSubscriptionMethodRegistrationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withBean(OccurrentBlockingAnnotationBeanPostProcessor.class, OccurrentBlockingAnnotationBeanPostProcessor::new);
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void a_prototype_registers_the_handler_the_scan_read_rather_than_the_one_the_instance_it_resolved_declares() {
+        runner.withUserConfiguration(SwitchingPrototypeConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Subscriptions<TestEvent> subscriptions = context.getBean(Subscriptions.class);
+            verify(subscriptions).subscribe(eq("checked-handler"), any(AgnosticSubscriptionFilter.class), any(), anyBoolean(), any(Function2.class));
+            verify(subscriptions, never()).subscribe(eq("unchecked-handler"), any(AgnosticSubscriptionFilter.class), any(), anyBoolean(), any(Function2.class));
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(OccurrentProperties.class)
+    static class SwitchingPrototypeConfiguration {
+
+        private final AtomicInteger instances = new AtomicInteger();
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter() {
+            return new NoopCloudEventConverter();
+        }
+
+        @Bean
+        @SuppressWarnings("unchecked")
+        Subscriptions<TestEvent> subscriptions() {
+            return mock(Subscriptions.class);
+        }
+
+        // The first instance is the one the container records the class of, and the scan reads its handler from
+        // that recording. Every instance after it is a different class declaring a different id, which is what the
+        // scan must not pick up when it resolves the bean to register against.
+        @Bean
+        @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+        Handler handler() {
+            return instances.getAndIncrement() == 0 ? new CheckedHandler() : new UncheckedHandler();
+        }
+
+        // Asks for the prototype during startup, so one instance exists before afterSingletonsInstantiated runs.
+        @Bean
+        HandlerHolder handlerHolder(Handler handler) {
+            return new HandlerHolder(handler);
+        }
+    }
+
+    interface Handler {
+        void on(TestEvent event);
+    }
+
+    static class CheckedHandler implements Handler {
+        @Override
+        @Subscription(id = "checked-handler")
+        public void on(TestEvent event) {
+        }
+    }
+
+    static class UncheckedHandler implements Handler {
+        @Override
+        @Subscription(id = "unchecked-handler")
+        public void on(TestEvent event) {
+        }
+    }
+
+    record HandlerHolder(Handler handler) {
+    }
+
+    record TestEvent() {
+    }
+
+    static class NoopCloudEventConverter implements CloudEventConverter<TestEvent> {
+        @Override
+        public CloudEvent toCloudEvent(TestEvent domainEvent) {
+            return null;
+        }
+
+        @Override
+        public TestEvent toDomainEvent(CloudEvent cloudEvent) {
+            return null;
+        }
+
+        @Override
+        public String getCloudEventType(Class<? extends TestEvent> type) {
+            return type.getSimpleName();
+        }
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -352,8 +352,8 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         boolean registeredAnything = !subscriptionMethods.isEmpty() || !projectionMethods.isEmpty()
                 || !snapshotMethods.isEmpty() || !beansToBuild.isEmpty();
         // Only a handler the loop above collected registers, which is what keeps every id going through
-        // claimSubscriptionId. The register step reads the bean's class again, and by then the bean exists, so that
-        // class can declare a handler the collecting pass never saw. Registering it here would take its id without
+        // claimSubscriptionId. The register step resolves the bean again, and the object it gets back can be of a
+        // class declaring a handler the collecting pass never saw. Registering that one would take its id without
         // checking it. It is left for the next pass instead, which collects it from the now recorded class.
         //
         // Marking happens after the registration it stands for, never before. A registration that throws while a

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/OccurrentReactiveAnnotationBeanPostProcessor.java
@@ -40,7 +40,7 @@ import org.springframework.util.ClassUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -75,9 +75,9 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
 
     private ApplicationContext applicationContext;
 
-    // Every subscription and projection id must be unique, since it is the durable checkpoint key. Subscription ids are
-    // added as their annotations are processed (before singletons finish), projection ids when they register below.
-    // Shared as a single instance across every registrar so id uniqueness is enforced across all annotation kinds.
+    // Every subscription and projection id must be unique, since it is the durable checkpoint key. Subscription ids
+    // are added as their annotations are processed (before singletons finish), projection ids when they register
+    // below. Added by this class and by nothing else, so one id is never claimed in two places.
     private final Set<String> registeredIds = ConcurrentHashMap.newKeySet();
 
     // The class the container actually built for a bean, recorded as the container hands the object over. This is
@@ -125,8 +125,8 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         this.applicationContext = applicationContext;
         StartPositionSupport startPositionSupport = new StartPositionSupport(applicationContext);
         this.subscriptionRegistrar = new SubscriptionAnnotationRegistrar(applicationContext, startPositionSupport);
-        this.projectionRegistrar = new ProjectionAnnotationRegistrar(applicationContext, registeredIds, startPositionSupport);
-        this.snapshotRegistrar = new SnapshotAnnotationRegistrar(applicationContext, registeredIds, startPositionSupport);
+        this.projectionRegistrar = new ProjectionAnnotationRegistrar(applicationContext, startPositionSupport);
+        this.snapshotRegistrar = new SnapshotAnnotationRegistrar(applicationContext, startPositionSupport);
     }
 
     // The container hands over the raw instance here, before any proxy wraps it, so this is where a bean's real
@@ -302,9 +302,10 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         boolean subscribableExists = applicationContext.getBeanNamesForType(Subscribable.class).length > 0;
         List<Object[]> projectionMethods = new ArrayList<>();
         List<Object[]> snapshotMethods = new ArrayList<>();
-        // Iteration order of getBeanDefinitionNames() is deterministic, so a LinkedHashSet keeps registration order
-        // reproducible across runs.
-        Set<String> subscriptionBeanNames = new LinkedHashSet<>();
+        // The subscription handler methods this pass read and validated, per bean, and the only methods the
+        // registration below registers. Iteration order of getBeanDefinitionNames() is deterministic, so a
+        // LinkedHashMap keeps registration order reproducible across runs.
+        Map<String, List<Method>> subscriptionMethods = new LinkedHashMap<>();
         // Beans whose class is only predicted and whose prediction shows an annotation. Built at the end of this
         // pass so the next one can read their real class.
         Set<String> beansToBuild = new LinkedHashSet<>();
@@ -333,7 +334,7 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
                 if (isAlreadyRegistered(beanName, method)) {
                     continue;
                 }
-                collectSubscriptionId(beanName, method, subscriptionBeanNames);
+                collectSubscriptionMethod(beanName, method, subscriptionMethods);
                 if (!subscribableExists) {
                     continue;
                 }
@@ -348,7 +349,7 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
                 }
             }
         }
-        boolean registeredAnything = !subscriptionBeanNames.isEmpty() || !projectionMethods.isEmpty()
+        boolean registeredAnything = !subscriptionMethods.isEmpty() || !projectionMethods.isEmpty()
                 || !snapshotMethods.isEmpty() || !beansToBuild.isEmpty();
         // Only a handler the loop above collected registers, which is what keeps every id going through
         // claimSubscriptionId. The register step reads the bean's class again, and by then the bean exists, so that
@@ -360,12 +361,13 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         // so asking for the bean again creates it again and runs this callback again. A handler marked ahead of
         // its own registration would be skipped on that second attempt, and the bean would then be published with
         // a handler that never registered, which is the loss this whole class exists to close.
-        for (String beanName : subscriptionBeanNames) {
+        for (Map.Entry<String, List<Method>> staged : subscriptionMethods.entrySet()) {
+            String beanName = staged.getKey();
             Object bean = beanResolver.apply(beanName);
-            // The class of the instance just resolved, not another lookup by name. A non-singleton bean is a new
-            // instance here, and a factory that can return different implementations would otherwise have this
-            // register one implementation's methods against another's instance.
-            subscriptionRegistrar.registerSubscriptions(bean, userClassOf(bean), handlerTargets.apply(beanName, bean), mayBlockForReplay,
+            // The methods the loop above read, never a fresh scan of the resolved instance. A non-singleton bean
+            // is a new instance here, and a factory free to return a different implementation would otherwise have
+            // this register a method whose id went through no duplicate check and no refusal.
+            subscriptionRegistrar.registerSubscriptions(bean, staged.getValue(), handlerTargets.apply(beanName, bean), mayBlockForReplay,
                     method -> markRegistered(beanName, method),
                     this::claimSubscriptionId,
                     method -> registeredHandlers.remove(handlerKey(beanName, method)),
@@ -374,17 +376,25 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
         // No early return here. The build step at the end of this method is what lets the loop above finish, so a
         // pass that skips registering must still reach it.
         for (Object[] pm : projectionMethods) {
-            if (markRegistered((String) pm[0], (Method) pm[1])) {
-                registerDescriptor((String) pm[0], (Method) pm[1], ((org.occurrent.annotation.Projection) pm[2]).id(),
-                        () -> projectionRegistrar.processProjectionAnnotation(beanResolver.apply((String) pm[0]), (Method) pm[1], (org.occurrent.annotation.Projection) pm[2]));
+            String beanName = (String) pm[0];
+            Method method = (Method) pm[1];
+            org.occurrent.annotation.Projection projection = (org.occurrent.annotation.Projection) pm[2];
+            if (markRegistered(beanName, method)) {
+                registerDescriptor(beanName, method, projection.id(),
+                        "Duplicate subscription/projection id '%s' (used by @Projection on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(projection.id(), method.getDeclaringClass().getName(), method.getName()),
+                        () -> projectionRegistrar.processProjectionAnnotation(beanResolver.apply(beanName), method, projection));
             }
         }
         // Catch up each domain-push feed once, after all its projections are registered.
         projectionRegistrar.catchUpCollectedFeeds();
         for (Object[] sm : snapshotMethods) {
-            if (markRegistered((String) sm[0], (Method) sm[1])) {
-                registerDescriptor((String) sm[0], (Method) sm[1], ((org.occurrent.annotation.Snapshot) sm[2]).id(),
-                        () -> snapshotRegistrar.processSnapshotAnnotation(beanResolver.apply((String) sm[0]), (Method) sm[1], (org.occurrent.annotation.Snapshot) sm[2]));
+            String beanName = (String) sm[0];
+            Method method = (Method) sm[1];
+            org.occurrent.annotation.Snapshot snapshot = (org.occurrent.annotation.Snapshot) sm[2];
+            if (markRegistered(beanName, method)) {
+                registerDescriptor(beanName, method, snapshot.id(),
+                        "Duplicate subscription/projection/snapshot id '%s' (used by @Snapshot on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(snapshot.id(), method.getDeclaringClass().getName(), method.getName()),
+                        () -> snapshotRegistrar.processSnapshotAnnotation(beanResolver.apply(beanName), method, snapshot));
             }
         }
         for (String beanName : beansToBuild) {
@@ -415,25 +425,22 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
     }
 
 
-    // The descriptor registrars claim their own id inside registeredIds before they do the rest of their work, so a
-    // failure part way through would otherwise leave the id claimed by a registration that never happened, and the
-    // bean's next creation attempt would be refused as a duplicate of itself. The claim is released here instead.
-    // A DuplicateSubscriptionIdException is the one failure that must not release, because the id it names belongs
-    // to whoever claimed it first and releasing would hand it away.
-    private void registerDescriptor(String beanName, Method method, String id, Runnable registration) {
-        // Whether this attempt is the one holding the id, read before it runs, rather than inferred afterwards from
-        // the exception. A descriptor registrar adds the id itself and then calls the subscription model, which can
-        // throw DuplicateSubscriptionIdException for a programmatic subscription already using that id, so the
-        // exception type says nothing about whose claim this is. Releasing on it regardless would hand away an id
-        // another registration owns, and never releasing would keep a claim this attempt made and leave the bean
-        // refused for ever once the real duplicate is gone.
-        boolean heldByAnother = registeredIds.contains(id);
+    // The add is what says this call holds the id, so the catch takes back an id this call put there and never one
+    // another registration did. Reading the set before the attempt cannot say that, because two registrations for
+    // the same id both read it as free and the one that lost the add then took the winner's id back out.
+    //
+    // A DuplicateSubscriptionIdException from inside the registration comes from the subscription model instead,
+    // for a programmatic subscription already on that id, and the id this call added is still this call's to take
+    // back.
+    private void registerDescriptor(String beanName, Method method, String id, String duplicateIdMessage, Runnable registration) {
+        if (!registeredIds.add(id)) {
+            registeredHandlers.remove(handlerKey(beanName, method));
+            throw new DuplicateSubscriptionIdException(id, duplicateIdMessage);
+        }
         try {
             registration.run();
         } catch (RuntimeException | Error e) {
-            if (!heldByAnother) {
-                registeredIds.remove(id);
-            }
+            registeredIds.remove(id);
             registeredHandlers.remove(handlerKey(beanName, method));
             throw e;
         }
@@ -569,30 +576,21 @@ class OccurrentReactiveAnnotationBeanPostProcessor implements BeanPostProcessor,
     private record ScanType(Class<?> type, boolean concrete) {
     }
 
-    // A bean with any of the four annotations goes into subscriptionBeanNames so registerSubscriptions runs for
-    // it exactly once, above.
+    // A method carrying any of the four is staged once, so a method carrying two of them still reaches the
+    // registrar that names both in its refusal.
     //
     // The id is refused here when something else already holds it, and joins registeredIds only once its own
     // registration has succeeded. Refusing here is what the startup ordering used to give for free, since every
     // subscription id was collected before the first projection or snapshot checked one out. A subscription
     // registering after startup arrives long after all of those, so without this check it would take an id one of
     // them already holds and write to the same durable checkpoint key.
-    private void collectSubscriptionId(String beanName, Method method, Set<String> subscriptionBeanNames) {
-        StreamSubscription s = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
-        if (s != null) {
-            subscriptionBeanNames.add(beanName);
-        }
-        Subscription a = AnnotationUtils.findAnnotation(method, Subscription.class);
-        if (a != null) {
-            subscriptionBeanNames.add(beanName);
-        }
-        DcbSubscription d = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
-        if (d != null) {
-            subscriptionBeanNames.add(beanName);
-        }
-        SynchronousSubscription sy = AnnotationUtils.findAnnotation(method, SynchronousSubscription.class);
-        if (sy != null) {
-            subscriptionBeanNames.add(beanName);
+    private void collectSubscriptionMethod(String beanName, Method method, Map<String, List<Method>> subscriptionMethods) {
+        boolean annotated = AnnotationUtils.findAnnotation(method, StreamSubscription.class) != null
+                || AnnotationUtils.findAnnotation(method, Subscription.class) != null
+                || AnnotationUtils.findAnnotation(method, DcbSubscription.class) != null
+                || AnnotationUtils.findAnnotation(method, SynchronousSubscription.class) != null;
+        if (annotated) {
+            subscriptionMethods.computeIfAbsent(beanName, name -> new ArrayList<>()).add(method);
         }
     }
 

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ProjectionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/ProjectionAnnotationRegistrar.java
@@ -45,7 +45,6 @@ import org.occurrent.springboot.common.OccurrentProperties;
 import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.CatchupThenLiveOptions;
 import org.occurrent.subscription.DcbStartAt;
-import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.occurrent.subscription.api.reactor.CheckpointStorage;
 import org.occurrent.subscription.api.reactor.FluxSubscriptionModel;
@@ -74,7 +73,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.Queue;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -97,7 +95,6 @@ class ProjectionAnnotationRegistrar {
     private static final Duration SHUTDOWN_CATCHUP_TIMEOUT = Duration.ofSeconds(5);
 
     private final ApplicationContext applicationContext;
-    private final Set<String> registeredIds;
     private final StartPositionSupport startPositionSupport;
 
     // Domain-push feeds collected during projection registration, caught up once after every projection is
@@ -131,9 +128,8 @@ class ProjectionAnnotationRegistrar {
     private record DomainFeedCatchUp(String id, DomainEventFeed<?> feed, boolean waitUntilStarted) {
     }
 
-    ProjectionAnnotationRegistrar(ApplicationContext applicationContext, Set<String> registeredIds, StartPositionSupport startPositionSupport) {
+    ProjectionAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport) {
         this.applicationContext = applicationContext;
-        this.registeredIds = registeredIds;
         this.startPositionSupport = startPositionSupport;
     }
 
@@ -194,9 +190,6 @@ class ProjectionAnnotationRegistrar {
     @SuppressWarnings("unchecked")
     <E, S, ID> void processProjectionAnnotation(Object bean, Method method, org.occurrent.annotation.Projection annotation) {
         String id = annotation.id();
-        if (!registeredIds.add(id)) {
-            throw new DuplicateSubscriptionIdException(id, "Duplicate subscription/projection id '%s' (used by @Projection on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(id, bean.getClass().getName(), method.getName()));
-        }
         if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException("@Projection factory method %s#%s must take no parameters and return a Projection or DcbProjection.".formatted(bean.getClass().getName(), method.getName()));
         }

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SnapshotAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SnapshotAnnotationRegistrar.java
@@ -39,7 +39,6 @@ import org.occurrent.filter.internal.EventTypeExpansion;
 import org.occurrent.springboot.common.SubscriptionAnnotations;
 import org.occurrent.subscription.AgnosticSubscriptionFilter;
 import org.occurrent.subscription.DcbStartAt;
-import org.occurrent.subscription.DuplicateSubscriptionIdException;
 import org.occurrent.subscription.StartAt;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
@@ -51,7 +50,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.occurrent.springboot.common.SubscriptionAnnotations.shouldWaitUntilStarted;
 import static org.occurrent.springboot.common.SubscriptionAnnotations.subscriptionsStartOnTheirOwn;
@@ -64,12 +62,10 @@ import static org.occurrent.subscription.StreamSubscriptionFilter.filter;
 class SnapshotAnnotationRegistrar {
 
     private final ApplicationContext applicationContext;
-    private final Set<String> registeredIds;
     private final StartPositionSupport startPositionSupport;
 
-    SnapshotAnnotationRegistrar(ApplicationContext applicationContext, Set<String> registeredIds, StartPositionSupport startPositionSupport) {
+    SnapshotAnnotationRegistrar(ApplicationContext applicationContext, StartPositionSupport startPositionSupport) {
         this.applicationContext = applicationContext;
-        this.registeredIds = registeredIds;
         this.startPositionSupport = startPositionSupport;
     }
 
@@ -80,9 +76,6 @@ class SnapshotAnnotationRegistrar {
     @SuppressWarnings("unchecked")
     <E, S> void processSnapshotAnnotation(Object bean, Method method, org.occurrent.annotation.Snapshot annotation) {
         String id = annotation.id();
-        if (!registeredIds.add(id)) {
-            throw new DuplicateSubscriptionIdException(id, "Duplicate subscription/projection/snapshot id '%s' (used by @Snapshot on %s#%s), each id must be unique because it is the durable checkpoint key.".formatted(id, bean.getClass().getName(), method.getName()));
-        }
         if (method.getParameterCount() != 0) {
             throw new IllegalArgumentException("@Snapshot factory method %s#%s must take no parameters and return a SnapshotView.".formatted(bean.getClass().getName(), method.getName()));
         }

--- a/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SubscriptionAnnotationRegistrar.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/main/java/org/occurrent/springboot/reactor/SubscriptionAnnotationRegistrar.java
@@ -172,12 +172,12 @@ class SubscriptionAnnotationRegistrar {
         }
     }
 
-    // userClass, not bean.getClass(): bean is already the resolved proxy, and a JDK interface proxy's class
-    // implements only interfaces, so scanning it here would miss a method declared on the concrete class.
+    // The methods are the ones the caller read the annotations from and validated, handed over rather than read
+    // again here. The object the caller resolved may be of another class than the one it read them from, so
+    // scanning that object would take in a method that went through no duplicate check and no refusal.
     //
-    // shouldRegister decides per method, so a bean scanned a second time (its real class revealing a handler the
-    // first scan's predicted type did not declare) registers only what is new. The validation above every branch
-    // still runs for every method, since a misconfigured handler must fail whether or not it registers.
+    // reserveHandler decides per method, so a bean scanned a second time (its real class revealing a handler the
+    // first scan's predicted type did not declare) registers only what is new.
     // mayBlockForReplay is false for a bean the container is still building. Waiting there would run the whole
     // history replay inside that bean's creation callback, delivering to a handler on an object the context has not
     // published yet, so advice a later BeanPostProcessor adds is not on it. Not waiting lets creation finish
@@ -185,7 +185,7 @@ class SubscriptionAnnotationRegistrar {
     // A replay on its own thread can still deliver before creation finishes, which is the race the coordinator and
     // ADR 127 both describe. It also matches what WAIT_UNTIL_STARTED means, which is finishing before the
     // application is up, and the application is already up by the time a lazily built bean is asked for.
-    void registerSubscriptions(Object bean, Class<?> userClass, Supplier<Object> handlerTarget, boolean mayBlockForReplay,
+    void registerSubscriptions(Object bean, List<Method> methods, Supplier<Object> handlerTarget, boolean mayBlockForReplay,
                                Predicate<Method> reserveHandler, Consumer<String> claimId,
                                Consumer<Method> releaseHandler, Consumer<String> releaseId) {
         // Tracked apart, because a call can hold a handler reservation without holding the id. claimId throws when
@@ -196,7 +196,7 @@ class SubscriptionAnnotationRegistrar {
         List<PendingRegistration> claimedIds = new ArrayList<>();
         List<PendingRegistration> pending = new ArrayList<>();
         try {
-            claimAndValidate(bean, userClass, handlerTarget, reserveHandler, claimId, pending, reservedHandlers, claimedIds);
+            claimAndValidate(bean, methods, handlerTarget, reserveHandler, claimId, pending, reservedHandlers, claimedIds);
         } catch (RuntimeException | Error e) {
             claimedIds.forEach(h -> releaseId.accept(h.id()));
             reservedHandlers.forEach(h -> releaseHandler.accept(h.method()));
@@ -227,17 +227,17 @@ class SubscriptionAnnotationRegistrar {
     // cannot be registered means the first one never subscribes, rather than being live against a bean whose
     // creation is about to fail. What stays outside this is a failure from subscribe itself, a store refusing for
     // example, since undoing that one needs the subscription cancelled rather than never started.
-    private void claimAndValidate(Object bean, Class<?> userClass, Supplier<Object> handlerTarget, Predicate<Method> reserveHandler,
+    private void claimAndValidate(Object bean, List<Method> methods, Supplier<Object> handlerTarget, Predicate<Method> reserveHandler,
                                   Consumer<String> claimId, List<PendingRegistration> pending,
                                   List<PendingRegistration> reservedHandlers, List<PendingRegistration> claimedIds) {
-        for (Method method : userClass.getDeclaredMethods()) {
+        for (Method method : methods) {
             StreamSubscription streamSubscription = AnnotationUtils.findAnnotation(method, StreamSubscription.class);
             Subscription subscription = AnnotationUtils.findAnnotation(method, Subscription.class);
             DcbSubscription dcbSubscription = AnnotationUtils.findAnnotation(method, DcbSubscription.class);
             SynchronousSubscription synchronousSubscription = AnnotationUtils.findAnnotation(method, SynchronousSubscription.class);
             long annotationCount = Stream.of(streamSubscription, subscription, dcbSubscription, synchronousSubscription).filter(Objects::nonNull).count();
             if (annotationCount > 1) {
-                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription, @DcbSubscription and @SynchronousSubscription, use only one.".formatted(userClass.getName(), method.getName()));
+                throw new IllegalArgumentException("Method %s#%s is annotated with more than one of @Subscription, @StreamSubscription, @DcbSubscription and @SynchronousSubscription, use only one.".formatted(method.getDeclaringClass().getName(), method.getName()));
             }
             // Reserving is a single atomic add rather than a check followed by an add, so two threads building
             // the same prototype cannot both find the handler free. The one that loses the reservation skips it

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/DescriptorIdClaimTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/DescriptorIdClaimTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.subscription.DuplicateSubscriptionIdException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A {@code @Projection} or {@code @Snapshot} id is added to the coordinator's registry by one call, and the call that gets
+ * past that add is the only one entitled to take the id back out. Two registrations declaring the same id used to
+ * decide that by reading the registry before the attempt, which both of them read as free, so the one that lost the
+ * add took the winner's id back out and left the durable checkpoint key free for a third registration.
+ * <p>
+ * The window between that read and the add is the whole defect, and no context can stage it. In one thread a read
+ * of false is always followed by an add that succeeds, and nothing runs in between on either registration path.
+ * These tests drive the coordinator's own registration step instead, which is where the rule now lives, the same
+ * way {@code LateRegistrationConcurrencyContractTest} reads the coordinator directly for a hazard it cannot
+ * reproduce. Reactive counterpart of the blocking {@code DescriptorIdClaimTest}.
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DescriptorIdClaimTest {
+
+    @Test
+    void a_descriptor_registration_takes_its_id_and_a_later_one_for_that_id_is_refused_without_the_id_being_given_back() throws Exception {
+        OccurrentReactiveAnnotationBeanPostProcessor coordinator = new OccurrentReactiveAnnotationBeanPostProcessor();
+
+        registerDescriptor(coordinator, "winner", "shared-id", () -> {
+        });
+
+        assertThat(registeredIds(coordinator)).contains("shared-id");
+        assertThatThrownBy(() -> registerDescriptor(coordinator, "loser", "shared-id", () -> {
+        }))
+                .isInstanceOf(DuplicateSubscriptionIdException.class)
+                .hasMessageContaining("Duplicate subscription/projection id 'shared-id'");
+        assertThat(registeredIds(coordinator)).describedAs("the id the first registration holds").contains("shared-id");
+    }
+
+    @Test
+    void a_descriptor_registration_that_fails_gives_back_the_id_it_took() throws Exception {
+        OccurrentReactiveAnnotationBeanPostProcessor coordinator = new OccurrentReactiveAnnotationBeanPostProcessor();
+
+        assertThatThrownBy(() -> registerDescriptor(coordinator, "failing", "released-id", () -> {
+            throw new IllegalStateException("the descriptor factory blew up");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(registeredIds(coordinator)).doesNotContain("released-id");
+    }
+
+    // Whatever a registrar spells the field, it has to be able to hold the registry to add to it, so a type check
+    // catches a second claim written under any name. Object is left out because a registrar legitimately holds a
+    // lock object and takes the bean as Object.
+    @Test
+    void no_registrar_can_hold_the_coordinators_id_registry() {
+        Class<?> registry = ConcurrentHashMap.newKeySet().getClass();
+        for (Class<?> registrar : List.of(SubscriptionAnnotationRegistrar.class, ProjectionAnnotationRegistrar.class,
+                SnapshotAnnotationRegistrar.class)) {
+            for (Field field : registrar.getDeclaredFields()) {
+                assertThat(canHold(field.getType(), registry))
+                        .describedAs("%s.%s can hold the id registry".formatted(registrar.getSimpleName(), field.getName()))
+                        .isFalse();
+            }
+            for (Constructor<?> constructor : registrar.getDeclaredConstructors()) {
+                for (Class<?> parameter : constructor.getParameterTypes()) {
+                    assertThat(canHold(parameter, registry))
+                            .describedAs("a %s constructor parameter can hold the id registry".formatted(registrar.getSimpleName()))
+                            .isFalse();
+                }
+            }
+            for (Method method : registrar.getDeclaredMethods()) {
+                for (Class<?> parameter : method.getParameterTypes()) {
+                    assertThat(canHold(parameter, registry))
+                            .describedAs("a parameter of %s.%s can hold the id registry".formatted(registrar.getSimpleName(), method.getName()))
+                            .isFalse();
+                }
+            }
+        }
+    }
+
+    private static boolean canHold(Class<?> type, Class<?> registry) {
+        return type != Object.class && type.isAssignableFrom(registry);
+    }
+
+    // registerDescriptor is private, and it has to be, since the id rule only holds while nothing else adds to the
+    // registry. Reaching it reflectively is what lets the rule be asserted at all.
+    private static void registerDescriptor(OccurrentReactiveAnnotationBeanPostProcessor coordinator, String beanName, String id, Runnable registration) {
+        try {
+            Method method = OccurrentReactiveAnnotationBeanPostProcessor.class.getDeclaredMethod(
+                    "registerDescriptor", String.class, Method.class, String.class, String.class, Runnable.class);
+            method.setAccessible(true);
+            Method anyHandlerMethod = DescriptorIdClaimTest.class.getDeclaredMethod("canHold", Class.class, Class.class);
+            method.invoke(coordinator, beanName, anyHandlerMethod, id,
+                    "Duplicate subscription/projection id '%s', each id must be unique because it is the durable checkpoint key.".formatted(id),
+                    registration);
+        } catch (InvocationTargetException e) {
+            throw e.getCause() instanceof RuntimeException cause ? cause : new IllegalStateException(e.getCause());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> registeredIds(OccurrentReactiveAnnotationBeanPostProcessor coordinator) throws Exception {
+        Field field = OccurrentReactiveAnnotationBeanPostProcessor.class.getDeclaredField("registeredIds");
+        field.setAccessible(true);
+        return (Set<String>) field.get(coordinator);
+    }
+}

--- a/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StagedSubscriptionMethodRegistrationTest.java
+++ b/framework/spring-boot-autoconfigure/reactor/src/test/java/org/occurrent/springboot/reactor/StagedSubscriptionMethodRegistrationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Johan Haleby
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.occurrent.springboot.reactor;
+
+import io.cloudevents.CloudEvent;
+import kotlin.jvm.functions.Function2;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.occurrent.annotation.StartupMode;
+import org.occurrent.annotation.Subscription;
+import org.occurrent.application.converter.CloudEventConverter;
+import org.occurrent.dsl.subscription.reactor.Subscriptions;
+import org.occurrent.springboot.common.OccurrentProperties;
+import org.occurrent.subscription.AgnosticSubscriptionFilter;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The scan reads a bean's handler methods from the class the container recorded for it, checks their ids for
+ * duplicates and refuses a method carrying two annotations, and then resolves the bean again to register them. A
+ * prototype whose factory method is free to return a different implementation makes those two classes differ, so
+ * registering whatever the resolved instance happens to declare would take in a handler that went through neither
+ * check, and its handler key would then make the next pass skip it, so nothing recovers the checks it missed.
+ * <p>
+ * Registration therefore acts on the methods the scan staged. Reactive counterpart of the blocking
+ * {@code StagedSubscriptionMethodRegistrationTest}, reproduced without a running store (no Docker).
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StagedSubscriptionMethodRegistrationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withBean(OccurrentReactiveAnnotationBeanPostProcessor.class, OccurrentReactiveAnnotationBeanPostProcessor::new);
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void a_prototype_registers_the_handler_the_scan_read_rather_than_the_one_the_instance_it_resolved_declares() {
+        runner.withUserConfiguration(SwitchingPrototypeConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Subscriptions<TestEvent> subscriptions = context.getBean(Subscriptions.class);
+            verify(subscriptions).subscribe(eq("checked-handler"), any(AgnosticSubscriptionFilter.class), any(), any(Function2.class));
+            verify(subscriptions, never()).subscribe(eq("unchecked-handler"), any(AgnosticSubscriptionFilter.class), any(), any(Function2.class));
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(OccurrentProperties.class)
+    static class SwitchingPrototypeConfiguration {
+
+        private final AtomicInteger instances = new AtomicInteger();
+
+        @Bean
+        CloudEventConverter<TestEvent> testEventCloudEventConverter() {
+            return new NoopCloudEventConverter();
+        }
+
+        @Bean
+        @SuppressWarnings("unchecked")
+        Subscriptions<TestEvent> subscriptions() {
+            return mock(Subscriptions.class);
+        }
+
+        // The first instance is the one the container records the class of, and the scan reads its handler from
+        // that recording. Every instance after it is a different class declaring a different id, which is what the
+        // scan must not pick up when it resolves the bean to register against.
+        @Bean
+        @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+        Handler handler() {
+            return instances.getAndIncrement() == 0 ? new CheckedHandler() : new UncheckedHandler();
+        }
+
+        // Asks for the prototype during startup, so one instance exists before afterSingletonsInstantiated runs.
+        @Bean
+        HandlerHolder handlerHolder(Handler handler) {
+            return new HandlerHolder(handler);
+        }
+    }
+
+    interface Handler {
+        void on(TestEvent event);
+    }
+
+    static class CheckedHandler implements Handler {
+        @Override
+        @Subscription(id = "checked-handler", startupMode = StartupMode.BACKGROUND)
+        public void on(TestEvent event) {
+        }
+    }
+
+    static class UncheckedHandler implements Handler {
+        @Override
+        @Subscription(id = "unchecked-handler", startupMode = StartupMode.BACKGROUND)
+        public void on(TestEvent event) {
+        }
+    }
+
+    record HandlerHolder(Handler handler) {
+    }
+
+    record TestEvent() {
+    }
+
+    static class NoopCloudEventConverter implements CloudEventConverter<TestEvent> {
+        @Override
+        public CloudEvent toCloudEvent(TestEvent domainEvent) {
+            return null;
+        }
+
+        @Override
+        public TestEvent toDomainEvent(CloudEvent cloudEvent) {
+            return null;
+        }
+
+        @Override
+        public String getCloudEventType(Class<? extends TestEvent> type) {
+            return type.getSimpleName();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #989.

Two defects, one mistake. The coordinator works something out, and the registrar then works it out again somewhere else, so the two answers disagree under a race or under a prototype factory. What the collecting pass determined is now what the registration acts on, whether that is which id it acquired or which methods it staged.

### The id claim

`registerDescriptor` read `registeredIds` before the attempt to decide whether it was the one holding the id, while the descriptor registrars did the atomic add. Two registrations declaring the same id both read the set as free, one added and won, and the other's catch took the winner's id back out, leaving a durable checkpoint key free for a third registration to take.

I moved the add into `registerDescriptor`, next to the release it pairs with, so getting past it is the whole ownership answer and nothing reconstructs it afterwards. The five descriptor registrars lose the `registeredIds` field and the constructor parameter, which is what makes this the third answer to this question rather than the fourth attempt at the same one. There is no second place that adds.

Completeness here is a claim about absence, and I established it from the coordinator rather than from the registrars. The set is a private field created in each coordinator, so nothing else can reach that object except through an argument the coordinator passes, and grepping one class enumerates every escape whatever the other side calls its field. Blocking had five, reactor four.

### The method list

`registerSubscriptions` rescanned `getDeclaredMethods` on the instance the resolver had just created. For a prototype whose factory can return a different implementation that class differs from the one the collecting pass read, so its handlers registered with ids that went through no duplicate check and annotations that went through no refusal, and their handler keys then made the next pass skip them, so nothing recovered the checks they missed.

It takes the staged methods instead. The signature loses `userClass` and takes `List<Method>`, a breaking change to a method whose feature has not shipped, so it needs no migration path.

### Tests

`StagedSubscriptionMethodRegistrationTest` starts a context whose prototype `@Bean` factory returns a different implementation on the second call and asserts which id reaches the subscription DSL.

`DescriptorIdClaimTest` drives `registerDescriptor` directly. The window between the read and the add is the whole id defect, and no context can stage it, since one thread that reads the set as free always goes on to an add that succeeds and nothing runs in between on either registration path. It also asserts that no registrar can hold the id registry, by type rather than by field name, so a second claim written as a `Collection` fails it too.

### Verification

`DOCKER_HOST` pointed at colima, `mvn -pl framework/spring-boot-autoconfigure/blocking,framework/spring-boot-autoconfigure/reactor -am test`.

### Changelog

No entry. Both halves refine the late registration path that is itself unreleased, and neither changes what the existing entries for #837, #965 and #981 describe, so per AGENTS.md there is nothing to add to those entries and no new entry to write.
