### PR TITLE
Two runbooks mislead an operator who follows them

### DIFF
--- a/doc/runbooks/position-backfill.md
+++ b/doc/runbooks/position-backfill.md
@@ -15,9 +15,9 @@ entirely, and an event with no position is exactly what the backfill below looks
 The backfill cannot tell those two apart. An event written before position existed and an event whose position
 `updateEvent` dropped both have no `position` field, so the backfill positions the second one too.
 
-The position it hands out is a fresh one, above everything the store had already assigned. So the event ends up
-reading as the newest in the collection instead of one from whenever it actually happened, and nothing afterwards
-distinguishes it from an event that was positioned correctly.
+The position it hands out comes from a block it reserves as it goes, so it sits above everything assigned before that
+block and bears no relation to where the event belongs. The event is read as having happened around whenever the
+backfill reached it, and nothing afterwards distinguishes it from an event that was positioned correctly.
 
 The repair runbook has the queries for the damage that can be detected. For the events nothing can detect, it tells
 you to decide from your own records which ones predate position. That is also where your store's own startup messages

--- a/doc/runbooks/position-backfill.md
+++ b/doc/runbooks/position-backfill.md
@@ -6,6 +6,25 @@ Anyone upgrading an existing Occurrent MongoDB event store deployment to a versi
 Stream position is optional but on by default, and this only matters for a deployment that already has events in
 its collection. A store with no events, or a brand-new deployment, needs no backfill.
 
+## Read this before you start
+
+**If this application ever called `EventStoreOperations.updateEvent` while running Occurrent 0.33.0 or earlier, read
+[the `updateEvent` repair runbook](update-event-repair.md) first.** That defect could drop an event's position
+entirely, and an event with no position is exactly what the backfill below looks for.
+
+The backfill cannot tell those two apart. An event written before position existed and an event whose position
+`updateEvent` dropped both have no `position` field, so the backfill positions the second one too.
+
+The position it hands out is a fresh one, above everything the store had already assigned. So the event ends up
+reading as the newest in the collection instead of one from whenever it actually happened, and nothing afterwards
+distinguishes it from an event that was positioned correctly.
+
+The repair runbook has the queries for the damage that can be detected. For the events nothing can detect, it tells
+you to decide from your own records which ones predate position. That is also where your store's own startup messages
+point when they warn about events without a position.
+
+Do this before step 1 below, not after step 4. By step 4 the positions are assigned.
+
 ## Why this is needed
 
 `position` is a global, monotonically increasing integer on every event. It replaces the wall-clock/`$natural`
@@ -72,6 +91,9 @@ position left on its default. Once every event has a `position` the default stor
 the explicit setting is not needed in that case.
 
 ### 4. Run the backfill
+
+This is the step that cannot be undone. If you skipped "Read this before you start" and this application ever called
+`updateEvent` on Occurrent 0.33.0 or earlier, go back to it now.
 
 Run the throttled, resumable, idempotent backfill against the same collection:
 

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -284,21 +284,27 @@ ends:
 
 ```javascript
 db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })
+       .sort({ position: 1 })
 ```
 
 If any run did not finish on its own there is no usable range, so read everything the consumer has already processed
 instead:
 
 ```javascript
-db.events.find({ position: { $lte: NumberLong(<the consumer's current checkpoint>) } })
+db.events.find({ position: { $lte: NumberLong(<the consumer's current checkpoint>) } }).sort({ position: 1 })
 ```
 
-That query returns candidates rather than only repaired events. A range is a floor and a ceiling, so it also returns
+These queries return candidates rather than only repaired events. A range is a floor and a ceiling, so it also returns
 every event sitting between the two that the run left alone because nothing was wrong with it.
 
-Feed only the ones the consumer actually missed into its logic once, by hand or with a targeted script, leaving its
-checkpoint where it is. `NumberLong` matters once a store's position passes 2^53, since mongosh reads a bare number as
-a JavaScript double and a comparison against a `position` that large silently rounds.
+The ranges can also overlap, since a position you set by hand can sit inside a run's range and two runs' ranges can
+cover the same stretch, so one event can come back from more than one query. The sort is there because a consumer's
+logic depends on position order and MongoDB returns no particular order without it.
+
+Feed only the ones the consumer actually missed into its logic, once each however many queries returned them, by hand
+or with a targeted script, leaving its checkpoint where it is. `NumberLong` matters once a store's position passes
+2^53, since mongosh reads a bare number as a JavaScript double and a comparison against a `position` that large
+silently rounds.
 
 ## The damage this cannot find
 

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -183,6 +183,12 @@ not to DCB reads, and it silences the startup warning, which then tells you noth
 the same two numbers. A run that finishes deletes its checkpoint, so the next run starts with no range and reports
 only the positions it repaired itself. Step 7 needs the range of every run you ran.
 
+**Write down every position you set by hand as well, because only one of these reasons puts it back in a later run's
+range.** `POSITION_ALREADY_TAKEN` does, since the rejected update left the tag array alone and the event still looks
+damaged afterward. For `POSITION_LOST`, `POSITION_NOT_A_NUMBER`, `POSITION_NOT_POSITIVE` and `POSITION_ABOVE_COUNTER`
+the run rebuilt the tag array already, so once you set the position the event matches neither half of what the repair
+looks for, and no run will ever report it. Step 7 needs those positions from you.
+
 ### 6. [you] Verify
 
 ```javascript
@@ -237,7 +243,7 @@ so neither that minimum nor the consumer's position at the time of the repair na
 consumer has already read is a candidate, so replay it from the beginning, or reconcile over its whole positioned
 history up to its current checkpoint. The guidance further down says which of the two is safe for a given consumer.
 
-What follows, up to and including the comparison against the lowest minimum, is for a repair where every run finished.
+What follows, up to and including the comparison against the lowest number, is for a repair where every run finished.
 If one did not, pick up again at "Decide between replaying and reconciling", which applies either way.
 
 A position in one of those ranges can be one the repair restored, or one that was already correct on an event only its
@@ -245,34 +251,46 @@ tag array needed rebuilding for, which is what a run after a hand-set `POSITION_
 like.
 
 Both numbers are `null` when a run touched nothing with a readable position, whether because it found nothing to
-repair or because every event it touched had a position step 5 left you to deal with by hand. A `null` from every run
-you ran means no consumer needs anything from you.
+repair or because every event it touched had a position step 5 left you to deal with by hand.
 
-Otherwise, take the lowest minimum across those runs. A consumer whose checkpoint sits below it has not reached a
-repaired event yet, so it will pick up every one of them on its own the next time it resumes and needs nothing from
-you. One whose checkpoint sits at or above it may already have skipped one, and that is the one to check next.
+A `null` from every run says nothing about the positions you set by hand in step 5, and only one of those comes back
+into a later run's range. So a repair is clear of consumer work when every run reported `null` and you set no position
+by hand. If you set any, each one counts as a range of its own, covering that single position.
+
+Otherwise, take the lowest number across every run's minimum and every position you set by hand. A consumer whose
+checkpoint sits below it has not reached a repaired event yet, so it will pick up every one of them on its own the next
+time it resumes and needs nothing from you. One whose checkpoint sits at or above it may already have skipped one, and
+that is the one to check next.
 
 Read that checkpoint the way you would for any other purpose, a durable subscription's checkpoint storage collection,
-or wherever a hand-rolled consumer keeps the position it last processed, and compare it to that lowest minimum.
+or wherever a hand-rolled consumer keeps the position it last processed, and compare it to that lowest number.
 
 Decide between replaying and reconciling before you touch anything, because a side effect a replay reruns cannot be
 taken back afterward. Replaying a consumer redelivers every event from its restart point onward, not only the
 repaired one.
 
 Replaying is safe for a consumer that only overwrites or upserts its own state on each delivery, since writing the
-same value twice produces the same document as writing it once. Rewind its checkpoint to below the lowest minimum, or
-restart it from the beginning if that is simpler, and let it catch up.
+same value twice produces the same document as writing it once. Rewind its checkpoint to below that lowest number, or
+restart it from the beginning if that is simpler, and let it catch up. A repair where a run did not finish needs the
+restart from the beginning rather than the rewind.
 
 Replaying is not safe for a consumer that causes a side effect outside its own state which cannot run twice, sending
 an email, charging a card, calling another system, since rewinding it reruns that side effect for every event since
 the restart point, not only the repaired one. Reconcile that consumer instead of replaying it.
 
-Read each run's range directly, one query per range rather than one query spanning all of them, so you do not read the
-stretch between two runs that neither of them touched. If any run did not finish on its own there is no usable range at
-all, so read everything up to the consumer's current checkpoint rather than a range:
+Read each range directly, one query per range rather than one query spanning all of them, so you do not read the
+stretch between two of them that nothing touched. A position you set by hand is a range with the same number at both
+ends:
 
 ```javascript
 db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })
+```
+
+If any run did not finish on its own there is no usable range, so read everything the consumer has already processed
+instead:
+
+```javascript
+db.events.find({ position: { $lte: NumberLong(<the consumer's current checkpoint>) } })
 ```
 
 That query returns candidates rather than only repaired events. A range is a floor and a ceiling, so it also returns

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -178,6 +178,11 @@ outside Occurrent. The run continues past it, so one such event does not hold up
 the rejected update covered both fields together. Setting its position by hand makes it visible to position queries but
 not to DCB reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag array.
 
+**Write down the range this run reported before you start another one.** The finished-run log line names it,
+`Repaired positions ranged from X to Y`, and `result.minRepairedPosition()` and `result.maxRepairedPosition()` hold
+the same two numbers. A run that finishes deletes its checkpoint, so the next run starts with no range and reports
+only the positions it repaired itself. Step 7 needs the range of every run you ran.
+
 ### 6. [you] Verify
 
 ```javascript
@@ -191,46 +196,64 @@ startup warning is gone.
 ### 7. [you] Recover consumers that read past a repaired position
 
 Repair fixes documents. It does not touch any subscription's stored checkpoint, so a consumer that had already
-resumed past a repaired event's position before you ran step 4 is still past it. A position-ordered stream read and
-position-based catch-up both resume strictly after their checkpoint, so a repaired position below that checkpoint is
-never delivered to them. This is a live consequence of the same damage "Why this is needed" describes for a read, not
-a new kind of damage, and it applies to the same stores, one with stream position on or one reading DCB. Time-ordered
-legacy catch-up is unaffected, because the event's time was never touched.
+resumed past a repaired event's position before the repair reached that event is still past it. A position-ordered
+stream read and position-based catch-up both resume strictly after their checkpoint, so a repaired position below that
+checkpoint is never delivered to them. This is a live consequence of the same damage "Why this is needed" describes
+for a read, not a new kind of damage, and it applies to the same stores, one with stream position on or one reading
+DCB. Time-ordered legacy catch-up is unaffected, because the event's time was never touched.
 
-`result.minRepairedPosition()` and `result.maxRepairedPosition()`, the same range the finished-run log line prints,
-bound the position of every event the repair touched and could read a position for, across the whole repair rather
-than only the last call to it. A killed and resumed repair stores this range in its checkpoint the same way it stores
-the unrecoverable count, so the numbers a finished run reports cover the segment an earlier, interrupted call walked
-as well as the one that finished it, not only the latter.
+`result.minRepairedPosition()` and `result.maxRepairedPosition()`, the same two numbers the finished-run log line
+prints, bound the position of every event that one run repaired and could read a position for.
 
-That position can be one the repair restored, or one that was already correct on an event only its tag array needed
-rebuilding for, which is what a run after a hand-set `POSITION_ALREADY_TAKEN` fix (step 5) looks like. Both are `null`
-when the whole repair touched nothing with a readable position, whether because it found nothing to repair or because
-every event it touched had a position step 5 left you to deal with by hand, and `null` there means no consumer needs
-anything from you. Otherwise, a consumer whose checkpoint sits below `minRepairedPosition` has not read that far yet,
-so it will pick up every repaired event on its own the next time it resumes and needs nothing from you. One whose
-checkpoint sits at or above `minRepairedPosition` may already have skipped one, and that is the one to check next.
+A killed and resumed repair stores that range in its checkpoint the same way it stores the unrecoverable count, so
+the numbers a resumed run reports cover the segment the interrupted call walked as well as the one that finished it.
+
+They do not reach back past a run that finished. A run deletes its checkpoint once it has walked the collection, so
+the next run starts with no range and reports only the positions it repaired itself. That is what the second run in
+step 5 does. A first run repairs positions 100 to 5000, you hand-fix one event at 7000, and the second run reports
+7000 to 7000. If you only check consumers at or above 7000, every consumer that had already resumed past an event
+between 100 and 5000 keeps missing it permanently.
+
+So use the range of every run you ran, not only the last one. Each finished run prints its own in its finished-run log
+line, so a range you did not write down at the time is still in the logs.
+
+A position in one of those ranges can be one the repair restored, or one that was already correct on an event only its
+tag array needed rebuilding for, which is what a run after a hand-set `POSITION_ALREADY_TAKEN` fix (step 5) looks
+like.
+
+Both numbers are `null` when a run touched nothing with a readable position, whether because it found nothing to
+repair or because every event it touched had a position step 5 left you to deal with by hand. A `null` from every run
+you ran means no consumer needs anything from you.
+
+Otherwise, take the lowest minimum across those runs. A consumer whose checkpoint sits below it has not reached a
+repaired event yet, so it will pick up every one of them on its own the next time it resumes and needs nothing from
+you. One whose checkpoint sits at or above it may already have skipped one, and that is the one to check next.
 
 Read that checkpoint the way you would for any other purpose, a durable subscription's checkpoint storage collection,
-or wherever a hand-rolled consumer keeps the position it last processed, and compare it to the range above.
+or wherever a hand-rolled consumer keeps the position it last processed, and compare it to that lowest minimum.
 
 Decide between replaying and reconciling before you touch anything, because a side effect a replay reruns cannot be
 taken back afterward. Replaying a consumer redelivers every event from its restart point onward, not only the
 repaired one.
 
 Replaying is safe for a consumer that only overwrites or upserts its own state on each delivery, since writing the
-same value twice produces the same document as writing it once. Rewind its checkpoint to before
-`minRepairedPosition`, or restart it from the beginning if that is simpler, and let it catch up.
+same value twice produces the same document as writing it once. Rewind its checkpoint to below the lowest minimum, or
+restart it from the beginning if that is simpler, and let it catch up.
 
 Replaying is not safe for a consumer that causes a side effect outside its own state which cannot run twice, sending
 an email, charging a card, calling another system, since rewinding it reruns that side effect for every event since
 the restart point, not only the repaired one. Reconcile that consumer instead of replaying it.
 
-Read the events in the repaired range directly, for example
-`db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })`,
-and feed only the ones the consumer actually missed into its logic once, by hand or with a targeted script, leaving
-its checkpoint where it is. `NumberLong` matters once a store's position passes 2^53, since mongosh reads a bare
-number as a JavaScript double and a comparison against a `position` that large silently rounds.
+Read the events each run repaired directly, one query per run's own range rather than one query spanning all of them,
+so you do not read a stretch between two runs that no run touched:
+
+```javascript
+db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })
+```
+
+Feed only the ones the consumer actually missed into its logic once, by hand or with a targeted script, leaving its
+checkpoint where it is. `NumberLong` matters once a store's position passes 2^53, since mongosh reads a bare number as
+a JavaScript double and a comparison against a `position` that large silently rounds.
 
 ## The damage this cannot find
 

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -205,17 +205,31 @@ DCB. Time-ordered legacy catch-up is unaffected, because the event's time was ne
 `result.minRepairedPosition()` and `result.maxRepairedPosition()`, the same two numbers the finished-run log line
 prints, bound the position of every event that one run repaired and could read a position for.
 
-A killed and resumed repair stores that range in its checkpoint the same way it stores the unrecoverable count, so
-the numbers a resumed run reports cover the segment the interrupted call walked as well as the one that finished it.
+A killed and resumed repair stores that range in its checkpoint the same way it stores the unrecoverable count, so the
+numbers a resumed run reports cover the batches the interrupted call checkpointed as well as the ones that finished it.
 
-They do not reach back past a run that finished. A run deletes its checkpoint once it has walked the collection, so
-the next run starts with no range and reports only the positions it repaired itself. That is what the second run in
-step 5 does. A first run repairs positions 100 to 5000, you hand-fix one event at 7000, and the second run reports
-7000 to 7000. If you only check consumers at or above 7000, every consumer that had already resumed past an event
-between 100 and 5000 keeps missing it permanently.
+The range has two limits, and both of them are why step 7 exists.
 
-So use the range of every run you ran, not only the last one. Each finished run prints its own in its finished-run log
-line, so a range you did not write down at the time is still in the logs.
+The first is that it does not reach past a run that finished. A run deletes its checkpoint once it has walked the
+collection, so the next run starts with no range and reports only the positions it repaired itself. That is what the
+second run in step 5 does. A first run repairs positions 100 to 5000, you hand-fix one event at 7000, and the second
+run reports 7000 to 7000. If you only check consumers at or above 7000, every consumer that had already resumed past an
+event between 100 and 5000 keeps missing it permanently. So use the range of every run you ran, not only the last one.
+Each finished run prints its own in its finished-run log line, so a range you did not write down at the time is still
+in the logs.
+
+The second is that it does not cover the batch a process died in. The checkpoint is written once per batch, after every
+event in that batch has already been updated, so a kill part way through one loses the positions it had just repaired.
+Those events no longer look damaged, so no resumed run and no later run finds them again, and nothing records where
+they were.
+
+**If any run was interrupted, stop here and skip the comparison below.** The range is then a floor rather than a bound,
+and no number the tool reports tells you which consumers are affected. The resuming run says it was one, in its log,
+`Resuming the repair of collection ... from an earlier run that did not finish`. Treat every consumer as possibly
+affected, and replay or reconcile from before the first repair started, using the guidance further down on which of
+the two is safe for a given consumer.
+
+The rest of this step is for a repair where no run was interrupted.
 
 A position in one of those ranges can be one the repair restored, or one that was already correct on an event only its
 tag array needed rebuilding for, which is what a run after a hand-set `POSITION_ALREADY_TAKEN` fix (step 5) looks
@@ -244,12 +258,16 @@ Replaying is not safe for a consumer that causes a side effect outside its own s
 an email, charging a card, calling another system, since rewinding it reruns that side effect for every event since
 the restart point, not only the repaired one. Reconcile that consumer instead of replaying it.
 
-Read the events each run repaired directly, one query per run's own range rather than one query spanning all of them,
-so you do not read a stretch between two runs that no run touched:
+Read each run's range directly, one query per range rather than one query spanning all of them, so you do not read the
+stretch between two runs that neither of them touched. After an interrupted repair there is no usable range, so read
+from where the consumer's checkpoint stood before the repair instead of from a minimum:
 
 ```javascript
 db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })
 ```
+
+That query returns candidates rather than only repaired events. A range is a floor and a ceiling, so it also returns
+every event sitting between the two that the run left alone because nothing was wrong with it.
 
 Feed only the ones the consumer actually missed into its logic once, by hand or with a targeted script, leaving its
 checkpoint where it is. `NumberLong` matters once a store's position passes 2^53, since mongosh reads a bare number as

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -280,11 +280,17 @@ the restart point, not only the repaired one. Reconcile that consumer instead of
 
 Read each range directly, one query per range rather than one query spanning all of them, so you do not read the
 stretch between two of them that nothing touched. A position you set by hand is a range with the same number at both
-ends:
+ends.
+
+Take the ranges in ascending order of their lower bound, because sorting inside one query does not order the events
+across several of them. Cap each query at the consumer's current checkpoint too, since anything above it was never
+skipped and arrives through ordinary catch-up without your help. A range sitting wholly above that checkpoint then
+returns nothing, which is the right answer for it.
 
 ```javascript
-db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })
-       .sort({ position: 1 })
+db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>),
+                             $lte: NumberLong(<maxRepairedPosition, or the checkpoint if that is lower>) } })
+         .sort({ position: 1 })
 ```
 
 If any run did not finish on its own there is no usable range, so read everything the consumer has already processed
@@ -298,8 +304,8 @@ These queries return candidates rather than only repaired events. A range is a f
 every event sitting between the two that the run left alone because nothing was wrong with it.
 
 The ranges can also overlap, since a position you set by hand can sit inside a run's range and two runs' ranges can
-cover the same stretch, so one event can come back from more than one query. The sort is there because a consumer's
-logic depends on position order and MongoDB returns no particular order without it.
+cover the same stretch, so one event can come back from more than one query. The sort and the ordering both matter
+because a consumer's logic depends on position order and MongoDB returns no particular order without being asked.
 
 Feed only the ones the consumer actually missed into its logic, once each however many queries returned them, by hand
 or with a targeted script, leaving its checkpoint where it is. `NumberLong` matters once a store's position passes

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -183,11 +183,11 @@ not to DCB reads, and it silences the startup warning, which then tells you noth
 the same two numbers. A run that finishes deletes its checkpoint, so the next run starts with no range and reports
 only the positions it repaired itself. Step 7 needs the range of every run you ran.
 
-**Write down every position you set by hand as well, because only one of these reasons puts it back in a later run's
-range.** `POSITION_ALREADY_TAKEN` does, since the rejected update left the tag array alone and the event still looks
-damaged afterward. For `POSITION_LOST`, `POSITION_NOT_A_NUMBER`, `POSITION_NOT_POSITIVE` and `POSITION_ABOVE_COUNTER`
-the run rebuilt the tag array already, so once you set the position the event matches neither half of what the repair
-looks for, and no run will ever report it. Step 7 needs those positions from you.
+**Write down every position you set by hand as well, because the repair will usually never mention it again.**
+Setting a position by hand is itself what stops an event looking damaged, so after the fix it matches neither half of
+what the repair looks for and no later run reports it. A `POSITION_ALREADY_TAKEN` event with DCB tags can still come
+back, because the rejected update left its tag array unwritten too. Working out which of your fixes fall that way buys
+you nothing, so record every position you set. Step 7 needs them from you.
 
 ### 6. [you] Verify
 
@@ -247,15 +247,14 @@ What follows, up to and including the comparison against the lowest number, is f
 If one did not, pick up again at "Decide between replaying and reconciling", which applies either way.
 
 A position in one of those ranges can be one the repair restored, or one that was already correct on an event only its
-tag array needed rebuilding for, which is what a run after a hand-set `POSITION_ALREADY_TAKEN` fix (step 5) looks
-like.
+tag array needed rebuilding for, which is what a run after a hand-set fix on an event with DCB tags can look like.
 
 Both numbers are `null` when a run touched nothing with a readable position, whether because it found nothing to
 repair or because every event it touched had a position step 5 left you to deal with by hand.
 
-A `null` from every run says nothing about the positions you set by hand in step 5, and only one of those comes back
-into a later run's range. So a repair is clear of consumer work when every run reported `null` and you set no position
-by hand. If you set any, each one counts as a range of its own, covering that single position.
+A `null` from every run says nothing about the positions you set by hand in step 5, most of which no run ever reports.
+So a repair is clear of consumer work only when every run reported `null` and you set no position by hand. Each one you
+did set counts as a range of its own, covering that single position, whether or not a run happened to name it too.
 
 Otherwise, take the lowest number across every run's minimum and every position you set by hand. A consumer whose
 checkpoint sits below it has not reached a repaired event yet, so it will pick up every one of them on its own the next

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -186,9 +186,11 @@ what the repair looks for and no later run reports it. A `POSITION_ALREADY_TAKEN
 back, because the rejected update left its tag array unwritten too. Working out which of your fixes fall that way buys
 you nothing, so record every position you set. Step 7 needs them from you.
 
-**Then run the repair once more.** A `POSITION_ALREADY_TAKEN` event still has no tag array, because the rejected
-update covered both fields together. Setting its position by hand makes it visible to position queries but not to DCB
-reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag array.
+**Then run the repair once more.** A `POSITION_ALREADY_TAKEN` event with DCB tags still has no tag array, because the
+rejected update covered both fields together. Setting its position by hand makes it visible to position queries but
+not to DCB reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag
+array. A plain stream event has no tag array to rebuild, so the run does nothing for it and the position you recorded
+above is the only record of it.
 
 ### 6. [you] Verify
 
@@ -219,9 +221,10 @@ The range has two limits, and both of them are why step 7 exists.
 
 The first is that it does not reach past a run that finished. A run deletes its checkpoint once it has walked the
 collection, so the next run starts with no range and reports only the positions it repaired itself. That is what the
-second run in step 5 does. A first run repairs positions 100 to 5000, you hand-fix one event at 7000, and the second
-run reports 7000 to 7000. If you only check consumers at or above 7000, every consumer that had already resumed past an
-event between 100 and 5000 keeps missing it permanently. So use the range of every run you ran, not only the last one.
+second run in step 5 does. A first run repairs positions 100 to 5000, you hand-fix a DCB event at 7000, and the second
+run reports 7000 to 7000, because that event still has a tag array to rebuild. If you only check consumers at or above
+7000, every consumer that had already resumed past an event between 100 and 5000 keeps missing it permanently. So use
+the range of every run you ran, not only the last one.
 Each finished run logs its own outcome, either `Repaired positions ranged from X to Y` or `No position was repaired`,
 so a range you did not write down at the time is still in the logs.
 

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -223,16 +223,19 @@ event in that batch has already been updated, so a kill part way through one los
 Those events no longer look damaged, so no resumed run and no later run finds them again, and nothing records where
 they were.
 
-**If any run was interrupted, stop here and skip the comparison below.** The range is then a floor rather than a bound,
-and no number the tool reports tells you which consumers are affected. The resuming run says it was one, in its log,
-`Resuming the repair of collection ... from an earlier run that did not finish`. Treat every consumer as possibly
-affected.
+**If any run did not finish on its own, stop here and skip the comparison below.** The range it reports is then
+incomplete in a way no number tells you about, so treat every consumer as possibly affected.
+
+The criterion is a run you had to start again, not anything in the log. A run interrupted during its first batch wrote
+no checkpoint at all, so the next one loads nothing and prints no `Resuming the repair of collection ...` line, while
+still having lost the positions that first batch repaired. Silence there means the checkpoint was gone, not that
+nothing was lost. You are the only record of which runs completed, so note it when one does not.
 
 A repair walks `_id` order, which is not position order, so an event the lost batch repaired can sit anywhere in
-history. It can sit far below where a consumer had already read, which is why starting from that consumer's position
-at the time of the repair is not good enough either. Everything the consumer has already read is a candidate, so
-replay it from the beginning, or reconcile over its whole positioned history up to its current checkpoint. The
-guidance further down says which of the two is safe for a given consumer.
+history. It can sit below the minimum the run did report, and it can sit far below where a consumer had already read,
+so neither that minimum nor the consumer's position at the time of the repair narrows anything. Everything the
+consumer has already read is a candidate, so replay it from the beginning, or reconcile over its whole positioned
+history up to its current checkpoint. The guidance further down says which of the two is safe for a given consumer.
 
 The rest of this step is for a repair where no run was interrupted.
 
@@ -264,8 +267,8 @@ an email, charging a card, calling another system, since rewinding it reruns tha
 the restart point, not only the repaired one. Reconcile that consumer instead of replaying it.
 
 Read each run's range directly, one query per range rather than one query spanning all of them, so you do not read the
-stretch between two runs that neither of them touched. After an interrupted repair there is no usable range at all, so
-read everything up to the consumer's current checkpoint rather than a range:
+stretch between two runs that neither of them touched. If any run did not finish on its own there is no usable range at
+all, so read everything up to the consumer's current checkpoint rather than a range:
 
 ```javascript
 db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -175,10 +175,10 @@ ceiling to compare against and this is never reported.
 outside Occurrent. The run continues past it, so one such event does not hold up the rest.
 
 **Write down the range this run reported before you do anything else.** The finished-run log line names it,
-`Repaired positions ranged from X to Y`, or says `No position was repaired` when the run restored none it could read.
-`result.minRepairedPosition()` and `result.maxRepairedPosition()` hold the same two numbers, or both `null`. A run that
-finishes deletes its checkpoint, so any further run starts with no range and reports only the positions it repaired
-itself. Step 7 needs the range of every run you ran.
+`Repaired positions ranged from X to Y`, or says `No position was repaired` when no event it repaired had a position it
+could read. `result.minRepairedPosition()` and `result.maxRepairedPosition()` hold the same two numbers, or both
+`null`. A run that finishes deletes its checkpoint, so any further run starts with no range and reports only the
+positions it repaired itself. Step 7 needs the range of every run you ran.
 
 **Write down every position you set by hand as well, because the repair will usually never mention it again.**
 Setting a position by hand is itself what stops an event looking damaged, so after the fix it matches neither half of

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -179,9 +179,10 @@ the rejected update covered both fields together. Setting its position by hand m
 not to DCB reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag array.
 
 **Write down the range this run reported before you start another one.** The finished-run log line names it,
-`Repaired positions ranged from X to Y`, and `result.minRepairedPosition()` and `result.maxRepairedPosition()` hold
-the same two numbers. A run that finishes deletes its checkpoint, so the next run starts with no range and reports
-only the positions it repaired itself. Step 7 needs the range of every run you ran.
+`Repaired positions ranged from X to Y`, or says `No position was repaired` when the run restored none it could read.
+`result.minRepairedPosition()` and `result.maxRepairedPosition()` hold the same two numbers, or both `null`. A run that
+finishes deletes its checkpoint, so the next run starts with no range and reports only the positions it repaired
+itself. Step 7 needs the range of every run you ran.
 
 **Write down every position you set by hand as well, because the repair will usually never mention it again.**
 Setting a position by hand is itself what stops an event looking damaged, so after the fix it matches neither half of
@@ -221,8 +222,8 @@ collection, so the next run starts with no range and reports only the positions 
 second run in step 5 does. A first run repairs positions 100 to 5000, you hand-fix one event at 7000, and the second
 run reports 7000 to 7000. If you only check consumers at or above 7000, every consumer that had already resumed past an
 event between 100 and 5000 keeps missing it permanently. So use the range of every run you ran, not only the last one.
-Each finished run prints its own in its finished-run log line, so a range you did not write down at the time is still
-in the logs.
+Each finished run logs its own outcome, either `Repaired positions ranged from X to Y` or `No position was repaired`,
+so a range you did not write down at the time is still in the logs.
 
 The second is that it does not cover the batch a process died in. The checkpoint is written once per batch, after every
 event in that batch has already been updated, so a kill part way through one loses the positions it had just repaired.

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -226,8 +226,13 @@ they were.
 **If any run was interrupted, stop here and skip the comparison below.** The range is then a floor rather than a bound,
 and no number the tool reports tells you which consumers are affected. The resuming run says it was one, in its log,
 `Resuming the repair of collection ... from an earlier run that did not finish`. Treat every consumer as possibly
-affected, and replay or reconcile from before the first repair started, using the guidance further down on which of
-the two is safe for a given consumer.
+affected.
+
+A repair walks `_id` order, which is not position order, so an event the lost batch repaired can sit anywhere in
+history. It can sit far below where a consumer had already read, which is why starting from that consumer's position
+at the time of the repair is not good enough either. Everything the consumer has already read is a candidate, so
+replay it from the beginning, or reconcile over its whole positioned history up to its current checkpoint. The
+guidance further down says which of the two is safe for a given consumer.
 
 The rest of this step is for a repair where no run was interrupted.
 
@@ -259,8 +264,8 @@ an email, charging a card, calling another system, since rewinding it reruns tha
 the restart point, not only the repaired one. Reconcile that consumer instead of replaying it.
 
 Read each run's range directly, one query per range rather than one query spanning all of them, so you do not read the
-stretch between two runs that neither of them touched. After an interrupted repair there is no usable range, so read
-from where the consumer's checkpoint stood before the repair instead of from a minimum:
+stretch between two runs that neither of them touched. After an interrupted repair there is no usable range at all, so
+read everything up to the consumer's current checkpoint rather than a range:
 
 ```javascript
 db.events.find({ position: { $gte: NumberLong(<minRepairedPosition>), $lte: NumberLong(<maxRepairedPosition>) } })

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -174,14 +174,10 @@ ceiling to compare against and this is never reported.
 **`UNREADABLE`.** The tool could not read the event well enough to repair it, which means its `dcbtags` was edited
 outside Occurrent. The run continues past it, so one such event does not hold up the rest.
 
-**Run the repair once more after any hand fix.** A `POSITION_ALREADY_TAKEN` event still has no tag array, because
-the rejected update covered both fields together. Setting its position by hand makes it visible to position queries but
-not to DCB reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag array.
-
-**Write down the range this run reported before you start another one.** The finished-run log line names it,
+**Write down the range this run reported before you do anything else.** The finished-run log line names it,
 `Repaired positions ranged from X to Y`, or says `No position was repaired` when the run restored none it could read.
 `result.minRepairedPosition()` and `result.maxRepairedPosition()` hold the same two numbers, or both `null`. A run that
-finishes deletes its checkpoint, so the next run starts with no range and reports only the positions it repaired
+finishes deletes its checkpoint, so any further run starts with no range and reports only the positions it repaired
 itself. Step 7 needs the range of every run you ran.
 
 **Write down every position you set by hand as well, because the repair will usually never mention it again.**
@@ -189,6 +185,10 @@ Setting a position by hand is itself what stops an event looking damaged, so aft
 what the repair looks for and no later run reports it. A `POSITION_ALREADY_TAKEN` event with DCB tags can still come
 back, because the rejected update left its tag array unwritten too. Working out which of your fixes fall that way buys
 you nothing, so record every position you set. Step 7 needs them from you.
+
+**Then run the repair once more.** A `POSITION_ALREADY_TAKEN` event still has no tag array, because the rejected
+update covered both fields together. Setting its position by hand makes it visible to position queries but not to DCB
+reads, and it silences the startup warning, which then tells you nothing. A second run rebuilds the tag array.
 
 ### 6. [you] Verify
 

--- a/doc/runbooks/update-event-repair.md
+++ b/doc/runbooks/update-event-repair.md
@@ -237,7 +237,8 @@ so neither that minimum nor the consumer's position at the time of the repair na
 consumer has already read is a candidate, so replay it from the beginning, or reconcile over its whole positioned
 history up to its current checkpoint. The guidance further down says which of the two is safe for a given consumer.
 
-The rest of this step is for a repair where no run was interrupted.
+What follows, up to and including the comparison against the lowest minimum, is for a repair where every run finished.
+If one did not, pick up again at "Decide between replaying and reconciling", which applies either way.
 
 A position in one of those ranges can be one the repair restored, or one that was already correct on an event only its
 tag array needed rebuilding for, which is what a run after a hand-set `POSITION_ALREADY_TAKEN` fix (step 5) looks

--- a/eventstore/migration/position-backfill/README.md
+++ b/eventstore/migration/position-backfill/README.md
@@ -7,6 +7,12 @@ Maven coordinates: `org.occurrent:occurrent-eventstore-mongodb-position-backfill
 
 Upgrading to 0.30.0? Start with the [upgrade guide](../../../doc/migration/upgrading-to-0.30.0.md) and the [operational runbook](../../../doc/runbooks/position-backfill.md), which place this tool in the full upgrade sequence (create the index, seed, deploy, backfill, verify).
 
+**If this application ever called `EventStoreOperations.updateEvent` while running Occurrent 0.33.0 or earlier, read
+[the `updateEvent` repair runbook](../../../doc/runbooks/update-event-repair.md) before you run this tool.** That
+defect could drop an event's position entirely, and an event with no position is exactly what this tool looks for. It
+cannot tell such an event apart from one written before position existed, so it gives it a position it never had,
+above everything the store had already assigned, and nothing undoes that.
+
 ## The problem
 
 Occurrent gives every event a global, always-increasing `position`. Position is what lets catch-up


### PR DESCRIPTION
Fixes #1000.

I corrected two operational runbooks that mislead an operator who follows them. Documentation only, no code changed.

## Step 7 of the repair runbook reported a range that misses most of the repair

Step 7 said `result.minRepairedPosition()` and `result.maxRepairedPosition()` bound every event the repair touched "across the whole repair rather than only the last call to it". That is false for the sequence step 5 orders.

`UpdateEventRepair.run()` seeds the range from its checkpoint document and rewrites it after every batch, then calls `deleteCheckpoint()` once the collection has been walked. So a fresh run after a completed one starts with no range and reports only what it repaired itself. The method's own comment already says so, it scopes the range to "this call and, once resumed, every earlier segment of this same run".

Step 7 now states three limits on the range instead of one.

**It does not reach past a run that finished.** A first run repairs 100 to 5000, you hand-fix a DCB event at 7000, the second run reports 7000 to 7000, and a consumer past an event between 100 and 5000 keeps missing it permanently if you only check consumers at or above 7000. Use every run's range.

**It does not cover the batch a process died in.** The checkpoint is written once per batch, after the loop has already updated every document in it, so a kill part way through loses the positions it just repaired. Those events stop matching `damagedEventFilter()`, so nothing rediscovers them. The criterion is a run you had to start again rather than the `Resuming the repair of collection ...` log line, because a run interrupted during its first batch writes no checkpoint and so prints nothing on the next attempt.

**It says nothing about positions set by hand in step 5.** Setting a position by hand is itself what stops an event looking damaged, so no later run reports it. Step 5 now asks for every hand-set position to be written down, and step 7 counts each as a range with the same number at both ends.

Step 5 also had the ordering the issue is about, backwards. "Run the repair once more" came before the paragraph telling the operator to record the range, so they could start the second run and lose the first one's numbers. The recording instructions come first now.

## The backfill runbook was missing the caveat its own validator demands

`PositionBackfillValidator` puts the `updateEvent` caveat ahead of the backfill instruction in all three startup messages, and the comment says why, a reader acting on the first remedy named must not be acting on the irreversible one. Neither `doc/runbooks/position-backfill.md` nor the backfill tool's README mentioned `updateEvent` at all.

Both now have it. In the runbook it is a section before the upgrade sequence, with a second pointer at step 4, which is the write that cannot be undone. Every inbound link (ADR 45, the 0.30.0 upgrade guide, both README links, the changelog) points a reader at the top of the runbook, so one placement there covers all of them, and the README has its own copy because it has runnable commands and a reader can act from it without opening the runbook.

The prose names the actual harm. `backfillBatch` reserves a block of positions and assigns it in `_id` order, so a damaged event gets a position above everything assigned before that block and unrelated to where it belongs, and nothing afterwards distinguishes it from an event positioned correctly.

## Verification

No test reads this prose and no build touches markdown, so the evidence is a walkthrough of the sequence against the code.

First run, no checkpoint, so min and max start null. The string-position events at 100 to 5000 fill `repairedPosition`, the `POSITION_ALREADY_TAKEN` event does not, because `repairedPosition` is only filled when `wrote && readablePosition != null` and the duplicate-key rejection returns `false` with neither field written. `deleteCheckpoint()`, then the log line reads `Repaired positions ranged from 100 to 5000`.

The hand fix sets that event's position to 7000. It is a DCB event, so the rejected update left it with no `dcbTags` and it still matches `damagedEventFilter()`.

Second run loads no checkpoint. `repairEvent` takes the `storedPosition instanceof Number` branch, validates 7000 as positive and at or below the counter, rebuilds the tag array, and the update succeeds, so the range is 7000 to 7000. That is what the corrected step 7 describes. Lowest across the two runs is 100, which is what it tells the operator to compare checkpoints against.

A plain stream `POSITION_ALREADY_TAKEN` event takes the other path. It has no `dcbtags`, so there is no tag array to rebuild, and once its position is set by hand it matches neither half of the filter and no run reports it again. Without the operator's own record of that position, nothing in the store or the logs names it.

## Review rounds

Copilot found eight real defects across twelve rounds, every one of them in prose I wrote or in prose my change made inconsistent, and every one confirmed against the code before I acted on it. The largest was that a `null` range from every run did not prove no consumer needed anything, because four of the five position findings leave an event the repair can no longer see once an operator sets its position. All eight threads are resolved.

I declined one half of one suggestion, persisting the range atomically with the repair, because that is a code change and this unit is documentation only. It is worth its own issue if the documented workaround is not enough.

## Changelog

No entry. Step 7, the repair module and the validator's caveat text are all new in 0.34.0 and unreleased, so per `AGENTS.md` this is a refinement to a feature that has not shipped rather than a change an operator upgrading needs to know about. Nobody read the wrong step 7 in a release. `changelog.md:65` already says "the lowest and highest `position` a run restored", which is correct, so it needs no edit either.

## Surfaces that were already correct

`UpdateEventRepairResult`'s javadoc says "every event this call successfully repaired" and scopes the resume correctly. Section 10 of the 0.34.0 upgrade guide does not repeat the range claim and already states the backfill caveat. No held docs branch in `occurrent-org.github.io` mentions `minRepairedPosition`, `maxRepairedPosition` or the consumer-recovery story, so nothing there is falsified by this change.

## CI

Nothing should run, and nothing did. `maven.yml` triggers on `push` with `paths-ignore: '**/*.md'` and has no `pull_request` trigger, and `adr-numbering`, `ci-runnable-tests` and `mongo-test-containers` all filter on paths this diff does not touch (`doc/architecture/decisions/**` and `**/src/test/**`). The one check on the head commit is Copilot's own review agent. A green merge state here means no workflow was asked to run, not that a build passed.
